### PR TITLE
Fix UpYun oss

### DIFF
--- a/src/main/java/run/halo/app/handler/file/UpYunFileHandler.java
+++ b/src/main/java/run/halo/app/handler/file/UpYunFileHandler.java
@@ -100,7 +100,7 @@ public class UpYunFileHandler implements FileHandler {
         Assert.notNull(key, "File key must not be blank");
 
         // Get config
-        String ossSource = optionService.getByPropertyOfNonNull(UpYunProperties.OSS_SOURCE).toString();
+        // String ossSource = optionService.getByPropertyOfNonNull(UpYunProperties.OSS_SOURCE).toString();
         String ossPassword = optionService.getByPropertyOfNonNull(UpYunProperties.OSS_PASSWORD).toString();
         String ossBucket = optionService.getByPropertyOfNonNull(UpYunProperties.OSS_BUCKET).toString();
         String ossOperator = optionService.getByPropertyOfNonNull(UpYunProperties.OSS_OPERATOR).toString();
@@ -111,11 +111,10 @@ public class UpYunFileHandler implements FileHandler {
         upYun.setApiDomain(UpYun.ED_AUTO);
 
         try {
-            String filePath = ossSource + key;
             // Delete the file
-            boolean deleteResult = upYun.deleteFile(filePath);
+            boolean deleteResult = upYun.deleteFile(key);
             if (!deleteResult) {
-                log.warn("Failed to delete file " + filePath + " from UpYun");
+                log.warn("Failed to delete file " + key + " from UpYun");
             }
         } catch (Exception e) {
             throw new FileOperationException("附件从又拍云删除失败", e);


### PR DESCRIPTION
key包含了又拍云文件的目录，重复设置导致删除时出现报错。
阿里云、七牛云部分代码似乎存在相同问题，但是我没有账号，没有做测试。