### PR TITLE
在dev分支上解决缺省文章路径未进行URL转义的问题

### DIFF
--- a/src/main/java/run/halo/app/model/params/PostParam.java
+++ b/src/main/java/run/halo/app/model/params/PostParam.java
@@ -11,6 +11,7 @@ import run.halo.app.model.enums.PostStatus;
 import javax.validation.constraints.Min;
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.Size;
+import java.net.URLEncoder;
 import java.util.Date;
 import java.util.Set;
 
@@ -62,7 +63,7 @@ public class PostParam implements InputConverter<Post> {
     @Override
     public Post convertTo() {
         if (StringUtils.isBlank(url)) {
-            url = title.replace(".","");
+            url = URLEncoder.encode(title.replace(".",""));
         }
         if (null == thumbnail) {
             thumbnail = "";
@@ -74,7 +75,7 @@ public class PostParam implements InputConverter<Post> {
     @Override
     public void update(Post post) {
         if (StringUtils.isBlank(url)) {
-            url = title.replace(".","");
+            url = URLEncoder.encode(title.replace(".",""));
         }
         if (null == thumbnail) {
             thumbnail = "";


### PR DESCRIPTION
解决缺省文章路径未进行URL转义的问题。
这个问题的本质是我们可以设置文章页的路径，且如果不设置系统默认将文章标题设置为路径。
如果文章标题包含如‘/’字符如aaa/bbb，则用户访问文章路径就会出错, 系统将会访问aaa子路径下的bbb页面，从而报错404 not found。
只需要在保存路径时对title先进行url转义在设置到url即可解决。本此修改至少可解决包含以下几种字符的转义问题：
1.+   
2. 空格  
3. / 
4. ? 
5. %
6. #
7. &   
8. =
#350 