### PR TITLE
增加toc支持的标题层级,目前不支持h4级标题以上(包括)-dev

### DIFF
--- a/src/main/java/run/halo/app/utils/MarkdownUtils.java
+++ b/src/main/java/run/halo/app/utils/MarkdownUtils.java
@@ -49,6 +49,7 @@ public class MarkdownUtils {
                     TocExtension.create(),
                     YamlFrontMatterExtension.create())
             )
+            .set(TocExtension.LEVELS, 255)
             .set(TablesExtension.WITH_CAPTION, false)
             .set(TablesExtension.COLUMN_SPANS, false)
             .set(TablesExtension.MIN_HEADER_ROWS, 1)


### PR DESCRIPTION
增加toc支持的标题层级,目前不支持h4级标题以上