### PR TITLE
内存缓存 修改为leveldb 本地缓存

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -59,6 +59,7 @@ ext {
     image4jVersion = '0.7zensight1'
     flywayVersion = '6.1.0'
     h2Version = '1.4.196'
+    levelDbVersion = '0.12'
 }
 
 dependencies {
@@ -102,6 +103,7 @@ dependencies {
     implementation "net.coobird:thumbnailator:$thumbnailatorVersion"
     implementation "net.sf.image4j:image4j:$image4jVersion"
     implementation "org.flywaydb:flyway-core:$flywayVersion"
+    implementation "org.iq80.leveldb:leveldb:$levelDbVersion"
 
     runtimeOnly "com.h2database:h2:$h2Version"
     runtimeOnly 'mysql:mysql-connector-java'

--- a/src/main/java/run/halo/app/cache/LevelCacheStore.java
+++ b/src/main/java/run/halo/app/cache/LevelCacheStore.java
@@ -1,0 +1,154 @@
+package run.halo.app.cache;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import lombok.extern.slf4j.Slf4j;
+import org.iq80.leveldb.*;
+import org.iq80.leveldb.impl.Iq80DBFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.util.Assert;
+import org.springframework.util.StringUtils;
+import run.halo.app.utils.JsonUtils;
+
+import javax.annotation.PostConstruct;
+import javax.annotation.PreDestroy;
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.Charset;
+import java.util.*;
+
+/**
+ * level-db cache store
+ * Create by Pencilso on 2020/1/8 9:58 下午
+ */
+@Slf4j
+public class LevelCacheStore extends StringCacheStore {
+
+    @Value("${leveldb.storefolder}")
+    private String folderPath;
+
+    /**
+     * Cleaner schedule period. (ms)
+     */
+    private final static long PERIOD = 60 * 1000;
+
+    private DB leveldb;
+
+    private Timer timer;
+
+
+    @PostConstruct
+    public void init() throws IOException {
+        File folder = new File(this.folderPath);
+        folder.mkdirs();
+        DBFactory factory = new Iq80DBFactory();
+        Options options = new Options();
+        options.createIfMissing(true);
+        //folder 是db存储目录
+        leveldb = factory.open(folder, options);
+        timer = new Timer();
+        timer.scheduleAtFixedRate(new CacheExpiryCleaner(), 0, PERIOD);
+    }
+
+    /**
+     * 销毁
+     */
+    @PreDestroy
+    public void preDestroy() {
+        try {
+            leveldb.close();
+            timer.cancel();
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
+
+    @Override
+    Optional<CacheWrapper<String>> getInternal(String key) {
+        Assert.hasText(key, "Cache key must not be blank");
+        byte[] bytes = leveldb.get(stringToBytes(key));
+        if (bytes != null) {
+            String valueJson = bytesToString(bytes);
+            return StringUtils.isEmpty(valueJson) ? Optional.empty() : jsonToCacheWrapper(valueJson);
+        }
+        return Optional.empty();
+    }
+
+    @Override
+    void putInternal(String key, CacheWrapper<String> cacheWrapper) {
+        putInternalIfAbsent(key, cacheWrapper);
+    }
+
+    @Override
+    Boolean putInternalIfAbsent(String key, CacheWrapper<String> cacheWrapper) {
+        Assert.hasText(key, "Cache key must not be blank");
+        Assert.notNull(cacheWrapper, "Cache wrapper must not be null");
+        try {
+            leveldb.put(
+                    stringToBytes(key),
+                    stringToBytes(JsonUtils.objectToJson(cacheWrapper))
+            );
+            return true;
+        } catch (JsonProcessingException e) {
+            e.printStackTrace();
+        }
+        log.debug("cache key: [{}], original cache wrapper: [{}]", key, cacheWrapper);
+        return false;
+    }
+
+    @Override
+    public void delete(String key) {
+        leveldb.delete(stringToBytes(key));
+    }
+
+
+    private byte[] stringToBytes(String str) {
+        return str.getBytes(Charset.defaultCharset());
+    }
+
+    private String bytesToString(byte[] bytes) {
+        return new String(bytes, Charset.defaultCharset());
+    }
+
+    private Optional<CacheWrapper<String>> jsonToCacheWrapper(String json) {
+        Assert.hasText(json, "json value must not be null");
+        CacheWrapper<String> cacheWrapper = null;
+        try {
+            cacheWrapper = JsonUtils.jsonToObject(json, CacheWrapper.class);
+        } catch (IOException e) {
+            e.printStackTrace();
+            log.debug("cache value bytes: [{}]", json);
+        }
+        return Optional.ofNullable(cacheWrapper);
+    }
+
+    private class CacheExpiryCleaner extends TimerTask {
+
+        @Override
+        public void run() {
+            //batch
+            WriteBatch writeBatch = leveldb.createWriteBatch();
+
+            DBIterator iterator = leveldb.iterator();
+            long currentTimeMillis = System.currentTimeMillis();
+            while (iterator.hasNext()) {
+                Map.Entry<byte[], byte[]> next = iterator.next();
+                if (next.getKey() == null || next.getValue() == null) continue;
+                String valueJson = bytesToString(next.getValue());
+                Optional<CacheWrapper<String>> stringCacheWrapper = StringUtils.isEmpty(valueJson) ? Optional.empty() : jsonToCacheWrapper(valueJson);
+                if (stringCacheWrapper.isPresent()) {
+                    Long expireAtTime = stringCacheWrapper
+                            .map(CacheWrapper::getExpireAt)
+                            .map(Date::getTime)
+                            .orElse(0L);
+                    if (expireAtTime != 0 && currentTimeMillis > expireAtTime) {
+                        writeBatch.delete(next.getKey());
+                        log.debug("Deleted the cache: [{}] for expiration", bytesToString(next.getKey()));
+                    }
+                }
+
+            }
+
+            leveldb.write(writeBatch);
+        }
+    }
+}

--- a/src/main/java/run/halo/app/config/HaloConfiguration.java
+++ b/src/main/java/run/halo/app/config/HaloConfiguration.java
@@ -14,6 +14,7 @@ import org.springframework.http.client.HttpComponentsClientHttpRequestFactory;
 import org.springframework.http.converter.json.Jackson2ObjectMapperBuilder;
 import org.springframework.web.client.RestTemplate;
 import run.halo.app.cache.InMemoryCacheStore;
+import run.halo.app.cache.LevelCacheStore;
 import run.halo.app.cache.StringCacheStore;
 import run.halo.app.config.properties.HaloProperties;
 import run.halo.app.filter.CorsFilter;
@@ -63,7 +64,7 @@ public class HaloConfiguration {
     @Bean
     @ConditionalOnMissingBean
     public StringCacheStore stringCacheStore() {
-        return new InMemoryCacheStore();
+        return new LevelCacheStore();
     }
 
     /**

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -58,3 +58,6 @@ logging:
 
 halo:
   download-timeout: 5m
+
+leveldb:
+  storefolder: ~/.halo/leveldb/


### PR DESCRIPTION
之前的缓存为InMemoryCacheStore 内存缓存，但是对于调试来说，非常不便，项目重新编译后，管理系统又要重新登录。觉得有些麻烦，于是接入了一个leveldb库，用来存储key，value  缓存，新增LevelCacheStore 缓存实现类。
