### PR TITLE
feat: support freemarker template Inheritance #534

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -62,6 +62,7 @@ ext {
     levelDbVersion = '0.12'
     jsonVersion = '20190722'
     fastJsonVersion = '1.2.56'
+    templateInheritance = "0.4.RELEASE"
 }
 
 dependencies {
@@ -70,6 +71,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-undertow'
     implementation 'org.springframework.boot:spring-boot-starter-freemarker'
+    implementation "kr.pe.kwonnam.freemarker:freemarker-template-inheritance:$templateInheritance"
 
     implementation "io.github.biezhi:oh-my-email:$ohMyEmailVersion"
     implementation "cn.hutool:hutool-core:$hutoolVersion"

--- a/src/main/java/run/halo/app/config/WebMvcAutoConfiguration.java
+++ b/src/main/java/run/halo/app/config/WebMvcAutoConfiguration.java
@@ -4,6 +4,10 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import freemarker.core.TemplateClassResolver;
 import freemarker.template.TemplateException;
 import freemarker.template.TemplateExceptionHandler;
+import freemarker.template.TemplateModel;
+import kr.pe.kwonnam.freemarker.inheritance.BlockDirective;
+import kr.pe.kwonnam.freemarker.inheritance.ExtendsDirective;
+import kr.pe.kwonnam.freemarker.inheritance.PutDirective;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.boot.jackson.JsonComponentModule;
 import org.springframework.context.annotation.Bean;
@@ -29,7 +33,9 @@ import run.halo.app.model.support.HaloConst;
 import run.halo.app.security.resolver.AuthenticationArgumentResolver;
 
 import java.io.IOException;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Properties;
 
 import static run.halo.app.model.support.HaloConst.FILE_SEPARATOR;
@@ -114,6 +120,16 @@ public class WebMvcAutoConfiguration implements WebMvcConfigurer {
         registry.addConverterFactory(new StringToEnumConverterFactory());
     }
 
+    @Bean
+    public Map<String, TemplateModel> freemarkerLayoutDirectives() {
+        Map<String, TemplateModel> freemarkerLayoutDirectives = new HashMap<>(3);
+        freemarkerLayoutDirectives.put("extends", new ExtendsDirective());
+        freemarkerLayoutDirectives.put("block", new BlockDirective());
+        freemarkerLayoutDirectives.put("put", new PutDirective());
+
+        return freemarkerLayoutDirectives;
+    }
+
     /**
      * Configuring freemarker template file path.
      *
@@ -141,6 +157,13 @@ public class WebMvcAutoConfiguration implements WebMvcConfigurer {
 
         // Set predefined freemarker configuration
         configurer.setConfiguration(configuration);
+
+        // Set layout variable
+        Map<String, Object> freemarkerVariables = new HashMap<>(1);
+
+        freemarkerVariables.put("layout", freemarkerLayoutDirectives());
+
+        configurer.setFreemarkerVariables(freemarkerVariables);
 
         return configurer;
     }

--- a/src/main/java/run/halo/app/config/WebMvcAutoConfiguration.java
+++ b/src/main/java/run/halo/app/config/WebMvcAutoConfiguration.java
@@ -122,7 +122,7 @@ public class WebMvcAutoConfiguration implements WebMvcConfigurer {
 
     @Bean
     public Map<String, TemplateModel> freemarkerLayoutDirectives() {
-        Map<String, TemplateModel> freemarkerLayoutDirectives = new HashMap<>(3);
+        Map<String, TemplateModel> freemarkerLayoutDirectives = new HashMap<>(5);
         freemarkerLayoutDirectives.put("extends", new ExtendsDirective());
         freemarkerLayoutDirectives.put("block", new BlockDirective());
         freemarkerLayoutDirectives.put("put", new PutDirective());
@@ -159,7 +159,7 @@ public class WebMvcAutoConfiguration implements WebMvcConfigurer {
         configurer.setConfiguration(configuration);
 
         // Set layout variable
-        Map<String, Object> freemarkerVariables = new HashMap<>(1);
+        Map<String, Object> freemarkerVariables = new HashMap<>(5);
 
         freemarkerVariables.put("layout", freemarkerLayoutDirectives());
 


### PR DESCRIPTION
让模板支持以下写法：

```
<!DOCTYPE html>
<html>
    <head>
        <title>Base Layout</title>
        <@layout.block name="head">
            <script type="text/javascript" src="http://code.jquery.com/jquery-1.10.1.min.js"></script>
        </@layout.block>
    </head>
    <body>
        <@layout.block name="header">
            <h1>Base Layout</h1>
        </@layout.block>
        <div class="base">
            <@layout.block name="contents">
                <h2>Contents will be here</h2>
            </@layout.block>
        </div>
        <@layout.block name="footer">
            <div>Footer base</div>
        </@layout.block>
    </body>
</html>
```

```
<@layout.extends name="layouts/base.ftl">
    <@layout.put block="head">
        <script src="//ajax.googleapis.com/ajax/libs/mootools/1.4.5/mootools-yui-compressed.js"></script>
    </@layout.put>
    <@layout.put block="header" type="prepend">
        <h2>Index Page</h2>
    </@layout.put>
    <@layout.put block="contents">
        <p>blah.. blah..</p>
    </@layout.put>
    <@layout.put block="footer" type="replace">
        <hr/>
        <div class="footer">Footer replaced by index</div>
    </@layout.put>
</@layout.extends>
```