### PR TITLE
feat: change themes assets base path

### DIFF
--- a/src/main/java/run/halo/app/config/WebMvcAutoConfiguration.java
+++ b/src/main/java/run/halo/app/config/WebMvcAutoConfiguration.java
@@ -43,7 +43,7 @@ import static run.halo.app.model.support.HaloConst.HALO_ADMIN_RELATIVE_PATH;
 import static run.halo.app.utils.HaloUtils.*;
 
 /**
- * Mvc configuration.
+ * Spring mvc configuration.
  *
  * @author ryanwang
  * @date 2018-01-02
@@ -90,11 +90,16 @@ public class WebMvcAutoConfiguration implements WebMvcConfigurer {
     @Override
     public void addResourceHandlers(ResourceHandlerRegistry registry) {
         String workDir = FILE_PROTOCOL + ensureSuffix(haloProperties.getWorkDir(), FILE_SEPARATOR);
+
+        // register /** resource handler.
         registry.addResourceHandler("/**")
-                .addResourceLocations(workDir + "templates/themes/")
                 .addResourceLocations(workDir + "templates/admin/")
                 .addResourceLocations("classpath:/admin/")
                 .addResourceLocations(workDir + "static/");
+
+        // register /themes/** resource handler.
+        registry.addResourceHandler("/themes/**")
+                .addResourceLocations(workDir + "templates/themes/");
 
         String uploadUrlPattern = ensureBoth(haloProperties.getUploadUrlPrefix(), URL_SEPARATOR) + "**";
         String adminPathPattern = ensureSuffix(haloProperties.getAdminPath(), URL_SEPARATOR) + "**";
@@ -159,7 +164,7 @@ public class WebMvcAutoConfiguration implements WebMvcConfigurer {
         configurer.setConfiguration(configuration);
 
         // Set layout variable
-        Map<String, Object> freemarkerVariables = new HashMap<>(5);
+        Map<String, Object> freemarkerVariables = new HashMap<>(3);
 
         freemarkerVariables.put("layout", freemarkerLayoutDirectives());
 

--- a/src/main/java/run/halo/app/listener/freemarker/FreemarkerConfigAwareListener.java
+++ b/src/main/java/run/halo/app/listener/freemarker/FreemarkerConfigAwareListener.java
@@ -103,8 +103,15 @@ public class FreemarkerConfigAwareListener {
 
         Boolean enabledAbsolutePath = optionService.getByPropertyOrDefault(OtherProperties.GLOBAL_ABSOLUTE_PATH_ENABLED, Boolean.class, true);
 
+        String themeBasePath = (enabledAbsolutePath ? optionService.getBlogBaseUrl() : "") + "/themes/" + activatedTheme.getFolderName();
+
         configuration.setSharedVariable("theme", activatedTheme);
-        configuration.setSharedVariable("static", (enabledAbsolutePath ? optionService.getBlogBaseUrl() : "") + "/themesv/" + activatedTheme.getFolderName());
+
+        // TODO: It will be removed in future versions
+        configuration.setSharedVariable("static", themeBasePath);
+
+        configuration.setSharedVariable("theme_base", themeBasePath);
+
         configuration.setSharedVariable("settings", themeSettingService.listAsMapBy(themeService.getActivatedThemeId()));
         log.debug("Loaded theme and settings");
     }

--- a/src/main/java/run/halo/app/listener/freemarker/FreemarkerConfigAwareListener.java
+++ b/src/main/java/run/halo/app/listener/freemarker/FreemarkerConfigAwareListener.java
@@ -104,7 +104,7 @@ public class FreemarkerConfigAwareListener {
         Boolean enabledAbsolutePath = optionService.getByPropertyOrDefault(OtherProperties.GLOBAL_ABSOLUTE_PATH_ENABLED, Boolean.class, true);
 
         configuration.setSharedVariable("theme", activatedTheme);
-        configuration.setSharedVariable("static", (enabledAbsolutePath ? optionService.getBlogBaseUrl() : "") + "/" + activatedTheme.getFolderName());
+        configuration.setSharedVariable("static", (enabledAbsolutePath ? optionService.getBlogBaseUrl() : "") + "/themesv/" + activatedTheme.getFolderName());
         configuration.setSharedVariable("settings", themeSettingService.listAsMapBy(themeService.getActivatedThemeId()));
         log.debug("Loaded theme and settings");
     }


### PR DESCRIPTION
修改：
1. 修改主题资源文件的根目录，原来为 `/**`，变更为 `/themes/**`。

新增：
1. 新增一个变量代表原来的 `static`，兼容原来的主题，后续可能的话，可以去掉原来的 `static` 变量。