### PR TITLE
feat: support set attachment path type.

### DIFF
--- a/src/main/java/run/halo/app/service/impl/AttachmentServiceImpl.java
+++ b/src/main/java/run/halo/app/service/impl/AttachmentServiceImpl.java
@@ -18,6 +18,7 @@ import run.halo.app.model.entity.Attachment;
 import run.halo.app.model.enums.AttachmentType;
 import run.halo.app.model.params.AttachmentQuery;
 import run.halo.app.model.properties.AttachmentProperties;
+import run.halo.app.model.properties.OtherProperties;
 import run.halo.app.model.support.UploadResult;
 import run.halo.app.repository.AttachmentRepository;
 import run.halo.app.service.AttachmentService;
@@ -157,13 +158,15 @@ public class AttachmentServiceImpl extends AbstractCrudService<Attachment, Integ
         // Get blog base url
         String blogBaseUrl = optionService.getBlogBaseUrl();
 
+        Boolean enabledAbsolutePath = optionService.getByPropertyOrDefault(OtherProperties.GLOBAL_ABSOLUTE_PATH_ENABLED, Boolean.class, true);
+
         // Convert to output dto
         AttachmentDTO attachmentDTO = new AttachmentDTO().convertFrom(attachment);
 
         if (Objects.equals(attachmentDTO.getType(), AttachmentType.LOCAL)) {
             // Append blog base url to path and thumbnail
-            String fullPath = StringUtils.join(blogBaseUrl, "/", attachmentDTO.getPath());
-            String fullThumbPath = StringUtils.join(blogBaseUrl, "/", attachmentDTO.getThumbPath());
+            String fullPath = StringUtils.join(enabledAbsolutePath ? blogBaseUrl : "", "/", attachmentDTO.getPath());
+            String fullThumbPath = StringUtils.join(enabledAbsolutePath ? blogBaseUrl : "", "/", attachmentDTO.getThumbPath());
 
             // Set full path and full thumb path
             attachmentDTO.setPath(fullPath);


### PR DESCRIPTION
需要注意的是，此方法仅仅修改了后台附件列表所展示的路径类型，以及上传文件返回的路径类型（主要体现在编辑器），并未实现修改已有文章内图片的路径类型，且并不建议去实现。

示例：

- 相对路径：`/upload/2020/2/image-6ab5b2de1e714506996f2789c6bf95fa.png`。
- 绝对路径：`http://localhost:8090/upload/2020/2/image-6ab5b2de1e714506996f2789c6bf95fa.png`