### PR TITLE
style: collate configuration files.

### DIFF
--- a/src/main/resources/application-dev.yaml
+++ b/src/main/resources/application-dev.yaml
@@ -3,7 +3,6 @@ server:
   forward-headers-strategy: native
   compression:
     enabled: false
-    mime-types: application/javascript,text/css,application/json,application/xml,text/html,text/xml,text/plain
 spring:
   jackson:
     date-format: yyyy-MM-dd HH:mm:ss
@@ -13,13 +12,13 @@ spring:
   datasource:
     type: com.zaxxer.hikari.HikariDataSource
 
-    # H2 Database 配置
+    # H2 database configuration.
     driver-class-name: org.h2.Driver
     url: jdbc:h2:file:~/halo-dev/db/halo
     username: admin
     password: 123456
 
-    # MySQL 配置
+    # MySQL database configuration.
 #    driver-class-name: com.mysql.cj.jdbc.Driver
 #    url: jdbc:mysql://127.0.0.1:3306/halo_dev?characterEncoding=utf8&useSSL=false&serverTimezone=Asia/Shanghai&allowPublicKeyRetrieval=true
 #    username: root

--- a/src/main/resources/application-user.yaml
+++ b/src/main/resources/application-user.yaml
@@ -1,25 +1,37 @@
 server:
   port: 8090
+
+  # Response data gzip.
+  compression:
+    enabled: false
 spring:
   datasource:
-    type: com.zaxxer.hikari.HikariDataSource
 
-    # H2 Database 配置，如果你需要使用 MySQL，请注释掉该配置并取消注释 MySQL 的配置。
+    # H2 database configuration.
     driver-class-name: org.h2.Driver
     url: jdbc:h2:file:~/.halo/db/halo
     username: admin
     password: 123456
 
-    # MySQL 配置，如果你需要使用 H2 Database，请注释掉该配置并取消注释上方 H2 Database 的配置。
+    # MySQL database configuration.
 #    driver-class-name: com.mysql.cj.jdbc.Driver
 #    url: jdbc:mysql://127.0.0.1:3306/halodb?characterEncoding=utf8&useSSL=false&serverTimezone=Asia/Shanghai&allowPublicKeyRetrieval=true
 #    username: root
 #    password: 123456
 
-  # H2 Database 的控制台相关配置，如果你使用的是 MySQL ，请注释掉下方内容。
+  # H2 database console configuration.
   h2:
     console:
       settings:
         web-allow-others: false
       path: /h2-console
       enabled: false
+
+halo:
+
+  # Your admin client path is https://your-domain/{admin-path}
+  admin-path: admin
+
+  # memory or level
+  cache: memory
+

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -3,7 +3,6 @@ server:
   forward-headers-strategy: native
   compression:
     enabled: false
-    mime-types: application/javascript,text/css,application/json,application/xml,text/html,text/xml,text/plain
 spring:
   jackson:
     date-format: yyyy-MM-dd HH:mm:ss
@@ -15,17 +14,17 @@ spring:
   datasource:
     type: com.zaxxer.hikari.HikariDataSource
 
-    # H2 Database 配置
+    # H2 database configuration.
     driver-class-name: org.h2.Driver
     url: jdbc:h2:file:~/.halo/db/halo
     username: admin
     password: 123456
 
-    # MySQL 配置
-  #  driver-class-name: com.mysql.cj.jdbc.Driver
-  #  url: jdbc:mysql://127.0.0.1:3306/halodb?characterEncoding=utf8&useSSL=false&serverTimezone=Asia/Shanghai&allowPublicKeyRetrieval=true
-  #  username: root
-  #  password: 123456
+    # MySQL database configuration.
+#    driver-class-name: com.mysql.cj.jdbc.Driver
+#    url: jdbc:mysql://127.0.0.1:3306/halodb?characterEncoding=utf8&useSSL=false&serverTimezone=Asia/Shanghai&allowPublicKeyRetrieval=true
+#    username: root
+#    password: 123456
 
   h2:
     console:


### PR DESCRIPTION
修改一些 application.yaml 的内容。

主要将中文注释改为了英文，因为最近发现，用户下载配置文件的时候，中文注释可能会乱码。

`halo-common` 以及 oss 上的配置文件均已修改：https://github.com/halo-dev/halo-common/blob/master/application-template.yaml

文档也已修改：https://halo.run/guide/install/install-with-linux.html#%E4%BF%AE%E6%94%B9%E9%85%8D%E7%BD%AE%E6%96%87%E4%BB%B6