### PR TITLE
feat: support theme require halo version.

### DIFF
--- a/src/main/java/run/halo/app/exception/ThemeNotSupportException.java
+++ b/src/main/java/run/halo/app/exception/ThemeNotSupportException.java
@@ -1,0 +1,18 @@
+package run.halo.app.exception;
+
+/**
+ * Theme not support exception.
+ *
+ * @author ryanwang
+ * @date 2020-02-03
+ */
+public class ThemeNotSupportException extends BadRequestException {
+
+    public ThemeNotSupportException(String message) {
+        super(message);
+    }
+
+    public ThemeNotSupportException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/run/halo/app/handler/theme/config/support/ThemeProperty.java
+++ b/src/main/java/run/halo/app/handler/theme/config/support/ThemeProperty.java
@@ -55,6 +55,11 @@ public class ThemeProperty {
     private String version;
 
     /**
+     * Require halo version.
+     */
+    private String require;
+
+    /**
      * Theme author.
      */
     private Author author;

--- a/src/main/java/run/halo/app/service/impl/ThemeServiceImpl.java
+++ b/src/main/java/run/halo/app/service/impl/ThemeServiceImpl.java
@@ -541,7 +541,7 @@ public class ThemeServiceImpl implements ThemeService {
             pullFromGit(updatingTheme);
         } catch (Exception e) {
             if (e instanceof ThemeNotSupportException) {
-                throw new ThemeNotSupportException(e.getMessage());
+                throw (ThemeNotSupportException) e;
             }
             throw new ThemeUpdateException("主题更新失败！您与主题作者可能同时更改了同一个文件，您也可以尝试删除主题并重新拉取最新的主题", e).setErrorData(themeId);
         }

--- a/src/main/java/run/halo/app/service/impl/ThemeServiceImpl.java
+++ b/src/main/java/run/halo/app/service/impl/ThemeServiceImpl.java
@@ -36,10 +36,7 @@ import run.halo.app.model.support.HaloConst;
 import run.halo.app.model.support.ThemeFile;
 import run.halo.app.service.OptionService;
 import run.halo.app.service.ThemeService;
-import run.halo.app.utils.FileUtils;
-import run.halo.app.utils.FilenameUtils;
-import run.halo.app.utils.GitUtils;
-import run.halo.app.utils.HaloUtils;
+import run.halo.app.utils.*;
 
 import java.io.IOException;
 import java.net.URISyntaxException;
@@ -483,7 +480,7 @@ public class ThemeServiceImpl implements ThemeService {
         }
 
         // Not support current halo version.
-        if (StringUtils.isNotEmpty(tmpThemeProperty.getRequire()) && !HaloUtils.compareVersion(HaloConst.HALO_VERSION, tmpThemeProperty.getRequire())) {
+        if (StringUtils.isNotEmpty(tmpThemeProperty.getRequire()) && !VersionUtil.compareVersion(HaloConst.HALO_VERSION, tmpThemeProperty.getRequire())) {
             throw new ThemeNotSupportException("当前主题仅支持 Halo " + tmpThemeProperty.getRequire() + " 以上的版本");
         }
 
@@ -593,7 +590,7 @@ public class ThemeServiceImpl implements ThemeService {
             }
 
             // Not support current halo version.
-            if (StringUtils.isNotEmpty(prepareThemeProperty.getRequire()) && !HaloUtils.compareVersion(HaloConst.HALO_VERSION, prepareThemeProperty.getRequire())) {
+            if (StringUtils.isNotEmpty(prepareThemeProperty.getRequire()) && !VersionUtil.compareVersion(HaloConst.HALO_VERSION, prepareThemeProperty.getRequire())) {
                 throw new ThemeNotSupportException("新版本主题仅支持 Halo " + prepareThemeProperty.getRequire() + " 以上的版本");
             }
 
@@ -679,7 +676,7 @@ public class ThemeServiceImpl implements ThemeService {
             ThemeProperty updatedThemeProperty = getProperty(Paths.get(themeProperty.getThemePath()));
 
             // Not support current halo version.
-            if (StringUtils.isNotEmpty(updatedThemeProperty.getRequire()) && !HaloUtils.compareVersion(HaloConst.HALO_VERSION, updatedThemeProperty.getRequire())) {
+            if (StringUtils.isNotEmpty(updatedThemeProperty.getRequire()) && !VersionUtil.compareVersion(HaloConst.HALO_VERSION, updatedThemeProperty.getRequire())) {
                 // reset theme version
                 git.reset()
                         .setMode(ResetCommand.ResetType.HARD)

--- a/src/main/java/run/halo/app/utils/HaloUtils.java
+++ b/src/main/java/run/halo/app/utils/HaloUtils.java
@@ -1,6 +1,5 @@
 package run.halo.app.utils;
 
-import com.sun.xml.internal.ws.util.VersionUtil;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.lang.NonNull;
@@ -217,17 +216,6 @@ public class HaloUtils {
     @NonNull
     public static String randomUUIDWithoutDash() {
         return StringUtils.remove(UUID.randomUUID().toString(), '-');
-    }
-
-    /**
-     * Compare version.
-     *
-     * @param current current version.
-     * @param require require version.
-     * @return true or false.
-     */
-    public static boolean compareVersion(String current, String require) {
-        return VersionUtil.compare(current, require) >= 0;
     }
 
     /**

--- a/src/main/java/run/halo/app/utils/HaloUtils.java
+++ b/src/main/java/run/halo/app/utils/HaloUtils.java
@@ -1,5 +1,6 @@
 package run.halo.app.utils;
 
+import com.sun.xml.internal.ws.util.VersionUtil;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.lang.NonNull;
@@ -17,7 +18,7 @@ import static run.halo.app.model.support.HaloConst.FILE_SEPARATOR;
  *
  * @author ryanwang
  * @author johnniang
- * @date 2017/12/22
+ * @date 2017-12-22
  */
 @Slf4j
 public class HaloUtils {
@@ -219,6 +220,17 @@ public class HaloUtils {
     }
 
     /**
+     * Compare version.
+     *
+     * @param current current version.
+     * @param require require version.
+     * @return true or false.
+     */
+    public static boolean compareVersion(String current, String require) {
+        return VersionUtil.compare(current, require) >= 0;
+    }
+
+    /**
      * Initialize url if blank.
      *
      * @param url url can be blank
@@ -230,22 +242,6 @@ public class HaloUtils {
             return url;
         }
         return String.valueOf(System.currentTimeMillis());
-    }
-
-    /**
-     * Normalize url.
-     *
-     * @param url url must not be blank
-     * @return normalized url
-     */
-    @NonNull
-    public static String normalizeUrl(@NonNull String url) {
-        Assert.hasText(url, "Url must not be blank");
-
-        StringUtils.removeEnd(url, "html");
-        StringUtils.removeEnd(url, "htm");
-
-        return SlugUtils.slugify(url);
     }
 
     /**

--- a/src/main/java/run/halo/app/utils/VersionUtil.java
+++ b/src/main/java/run/halo/app/utils/VersionUtil.java
@@ -76,6 +76,6 @@ public class VersionUtil {
      * @return true or false.
      */
     public static boolean compareVersion(String current, String require) {
-        return com.sun.xml.internal.ws.util.VersionUtil.compare(current, require) >= 0;
+        return compare(current, require) >= 0;
     }
 }

--- a/src/main/java/run/halo/app/utils/VersionUtil.java
+++ b/src/main/java/run/halo/app/utils/VersionUtil.java
@@ -1,0 +1,81 @@
+package run.halo.app.utils;
+
+import cn.hutool.core.util.StrUtil;
+
+import java.util.StringTokenizer;
+
+/**
+ * @author ryanwang
+ * @date 2020-02-03
+ * @see com.sun.xml.internal.ws.util.VersionUtil
+ */
+public class VersionUtil {
+
+    public VersionUtil() {
+    }
+
+    public static int[] getCanonicalVersion(String version) {
+        int[] canonicalVersion = new int[]{1, 1, 0, 0};
+        StringTokenizer tokenizer = new StringTokenizer(version, ".");
+        String token = tokenizer.nextToken();
+        canonicalVersion[0] = Integer.parseInt(token);
+        token = tokenizer.nextToken();
+        StringTokenizer subTokenizer;
+        if (!token.contains(StrUtil.UNDERLINE)) {
+            canonicalVersion[1] = Integer.parseInt(token);
+        } else {
+            subTokenizer = new StringTokenizer(token, "_");
+            canonicalVersion[1] = Integer.parseInt(subTokenizer.nextToken());
+            canonicalVersion[3] = Integer.parseInt(subTokenizer.nextToken());
+        }
+
+        if (tokenizer.hasMoreTokens()) {
+            token = tokenizer.nextToken();
+            if (!token.contains(StrUtil.UNDERLINE)) {
+                canonicalVersion[2] = Integer.parseInt(token);
+                if (tokenizer.hasMoreTokens()) {
+                    canonicalVersion[3] = Integer.parseInt(tokenizer.nextToken());
+                }
+            } else {
+                subTokenizer = new StringTokenizer(token, "_");
+                canonicalVersion[2] = Integer.parseInt(subTokenizer.nextToken());
+                canonicalVersion[3] = Integer.parseInt(subTokenizer.nextToken());
+            }
+        }
+
+        return canonicalVersion;
+    }
+
+    public static int compare(String version1, String version2) {
+        int[] canonicalVersion1 = getCanonicalVersion(version1);
+        int[] canonicalVersion2 = getCanonicalVersion(version2);
+        if (canonicalVersion1[0] < canonicalVersion2[0]) {
+            return -1;
+        } else if (canonicalVersion1[0] > canonicalVersion2[0]) {
+            return 1;
+        } else if (canonicalVersion1[1] < canonicalVersion2[1]) {
+            return -1;
+        } else if (canonicalVersion1[1] > canonicalVersion2[1]) {
+            return 1;
+        } else if (canonicalVersion1[2] < canonicalVersion2[2]) {
+            return -1;
+        } else if (canonicalVersion1[2] > canonicalVersion2[2]) {
+            return 1;
+        } else if (canonicalVersion1[3] < canonicalVersion2[3]) {
+            return -1;
+        } else {
+            return canonicalVersion1[3] > canonicalVersion2[3] ? 1 : 0;
+        }
+    }
+
+    /**
+     * Compare version.
+     *
+     * @param current current version.
+     * @param require require version.
+     * @return true or false.
+     */
+    public static boolean compareVersion(String current, String require) {
+        return com.sun.xml.internal.ws.util.VersionUtil.compare(current, require) >= 0;
+    }
+}

--- a/src/test/java/run/halo/app/utils/HaloUtilsTest.java
+++ b/src/test/java/run/halo/app/utils/HaloUtilsTest.java
@@ -15,7 +15,8 @@ import static org.junit.Assert.assertThat;
  * Halo utilities test.
  *
  * @author johnniang
- * @date 3/29/19
+ * @author ryanwang
+ * @date 2019-03-29
  */
 @Slf4j
 public class HaloUtilsTest {
@@ -142,5 +143,20 @@ public class HaloUtilsTest {
 
         url = HaloUtils.compositeHttpUrl("https://halo.run/", "/path1/", "/path2/");
         assertEquals("https://halo.run/path1/path2", url);
+    }
+
+    @Test
+    public void compareVersion() {
+        Assert.assertTrue(HaloUtils.compareVersion("1.2.0","1.1.1"));
+
+        Assert.assertTrue(HaloUtils.compareVersion("1.2.1","1.2.0"));
+
+        Assert.assertTrue(HaloUtils.compareVersion("1.2.0","1.1.1.0"));
+
+        Assert.assertTrue(HaloUtils.compareVersion("1.2.0","0.4.4"));
+
+        Assert.assertFalse(HaloUtils.compareVersion("1.1.1","1.2.0"));
+
+        Assert.assertFalse(HaloUtils.compareVersion("0.0.1","1.2.0"));
     }
 }

--- a/src/test/java/run/halo/app/utils/HaloUtilsTest.java
+++ b/src/test/java/run/halo/app/utils/HaloUtilsTest.java
@@ -2,7 +2,6 @@ package run.halo.app.utils;
 
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.RandomUtils;
-import org.junit.Assert;
 import org.junit.Test;
 
 import java.util.stream.IntStream;
@@ -143,20 +142,5 @@ public class HaloUtilsTest {
 
         url = HaloUtils.compositeHttpUrl("https://halo.run/", "/path1/", "/path2/");
         assertEquals("https://halo.run/path1/path2", url);
-    }
-
-    @Test
-    public void compareVersion() {
-        Assert.assertTrue(HaloUtils.compareVersion("1.2.0","1.1.1"));
-
-        Assert.assertTrue(HaloUtils.compareVersion("1.2.1","1.2.0"));
-
-        Assert.assertTrue(HaloUtils.compareVersion("1.2.0","1.1.1.0"));
-
-        Assert.assertTrue(HaloUtils.compareVersion("1.2.0","0.4.4"));
-
-        Assert.assertFalse(HaloUtils.compareVersion("1.1.1","1.2.0"));
-
-        Assert.assertFalse(HaloUtils.compareVersion("0.0.1","1.2.0"));
     }
 }

--- a/src/test/java/run/halo/app/utils/VersionUtilTest.java
+++ b/src/test/java/run/halo/app/utils/VersionUtilTest.java
@@ -1,0 +1,26 @@
+package run.halo.app.utils;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * @author ryanwang
+ * @date 2020-02-03
+ */
+public class VersionUtilTest {
+
+    @Test
+    public void compareVersion() {
+        Assert.assertTrue(VersionUtil.compareVersion("1.2.0", "1.1.1"));
+
+        Assert.assertTrue(VersionUtil.compareVersion("1.2.1", "1.2.0"));
+
+        Assert.assertTrue(VersionUtil.compareVersion("1.2.0", "1.1.1.0"));
+
+        Assert.assertTrue(VersionUtil.compareVersion("1.2.0", "0.4.4"));
+
+        Assert.assertFalse(VersionUtil.compareVersion("1.1.1", "1.2.0"));
+
+        Assert.assertFalse(VersionUtil.compareVersion("0.0.1", "1.2.0"));
+    }
+}


### PR DESCRIPTION
一共四种情况需要判断。

1. 安装本地主题的时候。
2. 使用本地主题更新的时候。
3. 在线拉取 Github 仓库的主题的时候。
4. 在线更新的时候，如果不支持当前 Halo 版本，会自动回滚到更新前的状态。


另外还有一项修复：

在 https://github.com/halo-dev/halo/pull/538 中修改了主题资源的根路径，但是没有修改后台主题缩略图的路径设置，此提交修复了。

