### PR TITLE
Add editorType for post.

### DIFF
--- a/src/main/java/run/halo/app/controller/admin/api/SheetController.java
+++ b/src/main/java/run/halo/app/controller/admin/api/SheetController.java
@@ -8,9 +8,11 @@ import org.springframework.data.web.PageableDefault;
 import org.springframework.web.bind.annotation.*;
 import run.halo.app.cache.StringCacheStore;
 import run.halo.app.model.dto.InternalSheetDTO;
+import run.halo.app.model.dto.post.BasePostDetailDTO;
 import run.halo.app.model.dto.post.BasePostMinimalDTO;
 import run.halo.app.model.entity.Sheet;
 import run.halo.app.model.enums.PostStatus;
+import run.halo.app.model.params.PostContentParam;
 import run.halo.app.model.params.SheetParam;
 import run.halo.app.model.vo.SheetDetailVO;
 import run.halo.app.model.vo.SheetListVO;
@@ -106,6 +108,17 @@ public class SheetController {
 
         // Update
         sheetService.update(sheet);
+    }
+
+    @PutMapping("{sheetId:\\d+}/status/draft/content")
+    @ApiOperation("Updates draft")
+    public BasePostDetailDTO updateDraftBy(
+        @PathVariable("sheetId") Integer sheetId,
+        @RequestBody PostContentParam contentParam) {
+        // Update draft content
+        Sheet sheet = sheetService.updateDraftContent(contentParam.getContent(), sheetId);
+
+        return new BasePostDetailDTO().convertFrom(sheet);
     }
 
     @DeleteMapping("{sheetId:\\d+}")

--- a/src/main/java/run/halo/app/controller/content/model/PostModel.java
+++ b/src/main/java/run/halo/app/controller/content/model/PostModel.java
@@ -13,6 +13,7 @@ import run.halo.app.model.entity.Category;
 import run.halo.app.model.entity.Post;
 import run.halo.app.model.entity.PostMeta;
 import run.halo.app.model.entity.Tag;
+import run.halo.app.model.enums.PostEditorType;
 import run.halo.app.model.enums.PostStatus;
 import run.halo.app.model.support.HaloConst;
 import run.halo.app.model.vo.AdjacentPostVO;
@@ -84,7 +85,11 @@ public class PostModel {
             if (!cachedToken.equals(token)) {
                 throw new ForbiddenException("您没有该文章的访问权限");
             }
-            post.setFormatContent(MarkdownUtils.renderHtml(post.getOriginalContent()));
+            if (post.getEditorType().equals(PostEditorType.MARKDOWN)) {
+                post.setFormatContent(MarkdownUtils.renderHtml(post.getOriginalContent()));
+            } else {
+                post.setFormatContent(post.getOriginalContent());
+            }
         }
 
         postService.publishVisitEvent(post.getId());

--- a/src/main/java/run/halo/app/controller/content/model/SheetModel.java
+++ b/src/main/java/run/halo/app/controller/content/model/SheetModel.java
@@ -7,6 +7,7 @@ import org.springframework.ui.Model;
 import run.halo.app.cache.StringCacheStore;
 import run.halo.app.exception.ForbiddenException;
 import run.halo.app.model.entity.Sheet;
+import run.halo.app.model.enums.PostEditorType;
 import run.halo.app.model.enums.PostStatus;
 import run.halo.app.model.support.HaloConst;
 import run.halo.app.model.vo.SheetDetailVO;
@@ -46,7 +47,11 @@ public class SheetModel {
                 throw new ForbiddenException("您没有该页面的访问权限");
             }
             // render markdown to html when preview sheet
-            sheet.setFormatContent(MarkdownUtils.renderHtml(sheet.getOriginalContent()));
+            if (sheet.getEditorType().equals(PostEditorType.MARKDOWN)) {
+                sheet.setFormatContent(MarkdownUtils.renderHtml(sheet.getOriginalContent()));
+            } else {
+                sheet.setFormatContent(sheet.getOriginalContent());
+            }
         }
 
         sheetService.publishVisitEvent(sheet.getId());

--- a/src/main/java/run/halo/app/model/dto/post/BasePostMinimalDTO.java
+++ b/src/main/java/run/halo/app/model/dto/post/BasePostMinimalDTO.java
@@ -5,6 +5,7 @@ import lombok.EqualsAndHashCode;
 import lombok.ToString;
 import run.halo.app.model.dto.base.OutputConverter;
 import run.halo.app.model.entity.BasePost;
+import run.halo.app.model.enums.PostEditorType;
 import run.halo.app.model.enums.PostStatus;
 
 import java.util.Date;
@@ -31,6 +32,8 @@ public class BasePostMinimalDTO implements OutputConverter<BasePostMinimalDTO, B
     private String url;
 
     private String slug;
+
+    private PostEditorType editorType;
 
     private Date updateTime;
 

--- a/src/main/java/run/halo/app/model/entity/BasePost.java
+++ b/src/main/java/run/halo/app/model/entity/BasePost.java
@@ -4,6 +4,7 @@ import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 import run.halo.app.model.enums.PostCreateFrom;
+import run.halo.app.model.enums.PostEditorType;
 import run.halo.app.model.enums.PostStatus;
 
 import javax.persistence.*;
@@ -51,6 +52,12 @@ public class BasePost extends BaseEntity {
      */
     @Column(name = "slug", columnDefinition = "varchar(255)", unique = true)
     private String slug;
+
+    /**
+     * Post editor type.
+     */
+    @Column(name = "editor_type", columnDefinition = "int default 0")
+    private PostEditorType editorType;
 
     /**
      * Original content,not format.
@@ -183,6 +190,10 @@ public class BasePost extends BaseEntity {
 
         if (formatContent == null) {
             formatContent = "";
+        }
+
+        if (editorType == null) {
+            editorType = PostEditorType.MARKDOWN;
         }
     }
 

--- a/src/main/java/run/halo/app/model/enums/PostEditorType.java
+++ b/src/main/java/run/halo/app/model/enums/PostEditorType.java
@@ -1,0 +1,34 @@
+package run.halo.app.model.enums;
+
+/**
+ * @author ryanwang
+ * @date 2020-02-28
+ */
+public enum PostEditorType implements ValueEnum<Integer> {
+
+    /**
+     * Markdown editor.
+     */
+    MARKDOWN(0),
+
+    /**
+     * Rich text editor.
+     */
+    RICHTEXT(1);
+
+    private Integer value;
+
+    PostEditorType(Integer value) {
+        this.value = value;
+    }
+
+    /**
+     * Get enum value.
+     *
+     * @return enum value
+     */
+    @Override
+    public Integer getValue() {
+        return value;
+    }
+}

--- a/src/main/java/run/halo/app/model/params/PostParam.java
+++ b/src/main/java/run/halo/app/model/params/PostParam.java
@@ -7,6 +7,7 @@ import run.halo.app.model.dto.base.InputConverter;
 import run.halo.app.model.entity.Post;
 import run.halo.app.model.entity.PostMeta;
 import run.halo.app.model.enums.PostCreateFrom;
+import run.halo.app.model.enums.PostEditorType;
 import run.halo.app.model.enums.PostStatus;
 import run.halo.app.utils.SlugUtils;
 
@@ -39,6 +40,8 @@ public class PostParam implements InputConverter<Post> {
 
     @Size(max = 255, message = "文章别名的字符长度不能超过 {max}")
     private String slug;
+
+    private PostEditorType editorType;
 
     private String originalContent;
 
@@ -76,6 +79,10 @@ public class PostParam implements InputConverter<Post> {
             thumbnail = "";
         }
 
+        if (null == editorType) {
+            editorType = PostEditorType.MARKDOWN;
+        }
+
         return InputConverter.super.convertTo();
     }
 
@@ -85,6 +92,10 @@ public class PostParam implements InputConverter<Post> {
 
         if (null == thumbnail) {
             thumbnail = "";
+        }
+
+        if (null == editorType) {
+            editorType = PostEditorType.MARKDOWN;
         }
 
         InputConverter.super.update(post);

--- a/src/main/java/run/halo/app/model/params/SheetParam.java
+++ b/src/main/java/run/halo/app/model/params/SheetParam.java
@@ -6,6 +6,7 @@ import org.springframework.util.CollectionUtils;
 import run.halo.app.model.dto.base.InputConverter;
 import run.halo.app.model.entity.Sheet;
 import run.halo.app.model.entity.SheetMeta;
+import run.halo.app.model.enums.PostEditorType;
 import run.halo.app.model.enums.PostStatus;
 import run.halo.app.utils.SlugUtils;
 
@@ -38,6 +39,8 @@ public class SheetParam implements InputConverter<Sheet> {
     @Size(max = 255, message = "页面别名的字符长度不能超过 {max}")
     private String slug;
 
+    private PostEditorType editorType;
+
     private String originalContent;
 
     private String summary;
@@ -68,6 +71,10 @@ public class SheetParam implements InputConverter<Sheet> {
             thumbnail = "";
         }
 
+        if (null == editorType) {
+            editorType = PostEditorType.MARKDOWN;
+        }
+
         return InputConverter.super.convertTo();
     }
 
@@ -77,6 +84,10 @@ public class SheetParam implements InputConverter<Sheet> {
 
         if (null == thumbnail) {
             thumbnail = "";
+        }
+
+        if (null == editorType) {
+            editorType = PostEditorType.MARKDOWN;
         }
 
         InputConverter.super.update(sheet);

--- a/src/main/java/run/halo/app/model/properties/OtherProperties.java
+++ b/src/main/java/run/halo/app/model/properties/OtherProperties.java
@@ -1,5 +1,7 @@
 package run.halo.app.model.properties;
 
+import run.halo.app.model.enums.PostEditorType;
+
 /**
  * Other properties.
  *
@@ -27,7 +29,12 @@ public enum OtherProperties implements PropertyEnum {
     /**
      * Global absolute path enabled.
      */
-    GLOBAL_ABSOLUTE_PATH_ENABLED("global_absolute_path_enabled", Boolean.class, "true");
+    GLOBAL_ABSOLUTE_PATH_ENABLED("global_absolute_path_enabled", Boolean.class, "true"),
+
+    /**
+     * Default post editor.
+     */
+    DEFAULT_EDITOR("default_editor", PostEditorType.class, PostEditorType.MARKDOWN.name());
 
     private final String value;
 

--- a/src/main/java/run/halo/app/service/impl/BasePostServiceImpl.java
+++ b/src/main/java/run/halo/app/service/impl/BasePostServiceImpl.java
@@ -18,6 +18,7 @@ import run.halo.app.model.dto.post.BasePostDetailDTO;
 import run.halo.app.model.dto.post.BasePostMinimalDTO;
 import run.halo.app.model.dto.post.BasePostSimpleDTO;
 import run.halo.app.model.entity.BasePost;
+import run.halo.app.model.enums.PostEditorType;
 import run.halo.app.model.enums.PostStatus;
 import run.halo.app.model.properties.PostProperties;
 import run.halo.app.repository.base.BasePostRepository;
@@ -231,8 +232,10 @@ public abstract class BasePostServiceImpl<POST extends BasePost> extends Abstrac
         Assert.notNull(post, "Post must not be null");
 
         // Render content
-        if (post.getStatus() == PostStatus.PUBLISHED) {
+        if (post.getEditorType().equals(PostEditorType.MARKDOWN)) {
             post.setFormatContent(MarkdownUtils.renderHtml(post.getOriginalContent()));
+        } else {
+            post.setFormatContent(post.getOriginalContent());
         }
 
         // if password is not empty,change status to intimate

--- a/src/main/java/run/halo/app/service/impl/PostServiceImpl.java
+++ b/src/main/java/run/halo/app/service/impl/PostServiceImpl.java
@@ -27,6 +27,7 @@ import run.halo.app.model.entity.*;
 import run.halo.app.model.enums.LogType;
 import run.halo.app.model.enums.PostPermalinkType;
 import run.halo.app.model.enums.PostStatus;
+import run.halo.app.model.params.PostParam;
 import run.halo.app.model.params.PostQuery;
 import run.halo.app.model.properties.PostProperties;
 import run.halo.app.model.vo.*;
@@ -309,7 +310,7 @@ public class PostServiceImpl extends BasePostServiceImpl<Post> implements PostSe
         // Gets frontMatter
         Map<String, List<String>> frontMatter = MarkdownUtils.getFrontMatter(markdown);
 
-        Post post = new Post();
+        PostParam post = new PostParam();
 
         List<String> elementValue;
 
@@ -327,9 +328,6 @@ public class PostServiceImpl extends BasePostServiceImpl<Post> implements PostSe
                             break;
                         case "date":
                             post.setCreateTime(DateUtil.parse(ele));
-                            break;
-                        case "updated":
-                            post.setUpdateTime(DateUtil.parse(ele));
                             break;
                         case "permalink":
                             post.setSlug(ele);
@@ -385,7 +383,7 @@ public class PostServiceImpl extends BasePostServiceImpl<Post> implements PostSe
 
         post.setOriginalContent(markdown);
 
-        return createBy(post, tagIds, categoryIds, false);
+        return createBy(post.convertTo(), tagIds, categoryIds, false);
     }
 
     @Override


### PR DESCRIPTION
简述流程：

1. 添加 editorType 字段，默认为 Markdown(0)。
2. 在保存的时候，当 editorType 为 `MARKDOWN` 时，使用 MarkdownUtils 渲染 `originalContent` 的内容到 `formatContent`。当 editorType 为 `RICHTEXT` 时，直接保存 `originalContent` 字段的内容到 `formatContent`。也就是接口还是只传入 `originalContent`，只是额外增加了个 `editorType`。

