### PR TITLE
Refactor post month path type.

### DIFF
--- a/src/main/java/run/halo/app/service/impl/PostCommentServiceImpl.java
+++ b/src/main/java/run/halo/app/service/impl/PostCommentServiceImpl.java
@@ -104,12 +104,20 @@ public class PostCommentServiceImpl extends BaseCommentServiceImpl<PostComment> 
             }).collect(Collectors.toList());
     }
 
-    private BasePostMinimalDTO buildPostFullPath(BasePostMinimalDTO basePostMinimalDTO) {
+    private BasePostMinimalDTO buildPostFullPath(BasePostMinimalDTO post) {
         PostPermalinkType permalinkType = optionService.getPostPermalinkType();
 
         String pathSuffix = optionService.getPathSuffix();
 
         String archivesPrefix = optionService.getArchivesPrefix();
+
+        int month = DateUtil.month(post.getCreateTime()) + 1;
+
+        String monthString = month < 10 ? "0" + month : String.valueOf(month);
+
+        int day = DateUtil.dayOfMonth(post.getCreateTime());
+
+        String dayString = day < 10 ? "0" + day : String.valueOf(day);
 
         StringBuilder fullPath = new StringBuilder();
 
@@ -122,32 +130,32 @@ public class PostCommentServiceImpl extends BaseCommentServiceImpl<PostComment> 
         if (permalinkType.equals(PostPermalinkType.DEFAULT)) {
             fullPath.append(archivesPrefix)
                 .append("/")
-                .append(basePostMinimalDTO.getSlug())
+                .append(post.getSlug())
                 .append(pathSuffix);
         } else if (permalinkType.equals(PostPermalinkType.ID)) {
             fullPath.append("?p=")
-                .append(basePostMinimalDTO.getId());
+                .append(post.getId());
         } else if (permalinkType.equals(PostPermalinkType.DATE)) {
-            fullPath.append(DateUtil.year(basePostMinimalDTO.getCreateTime()))
+            fullPath.append(DateUtil.year(post.getCreateTime()))
                 .append("/")
-                .append(DateUtil.month(basePostMinimalDTO.getCreateTime()) + 1)
+                .append(monthString)
                 .append("/")
-                .append(basePostMinimalDTO.getSlug())
+                .append(post.getSlug())
                 .append(pathSuffix);
         } else if (permalinkType.equals(PostPermalinkType.DAY)) {
-            fullPath.append(DateUtil.year(basePostMinimalDTO.getCreateTime()))
+            fullPath.append(DateUtil.year(post.getCreateTime()))
                 .append("/")
-                .append(DateUtil.month(basePostMinimalDTO.getCreateTime()) + 1)
+                .append(monthString)
                 .append("/")
-                .append(DateUtil.dayOfMonth(basePostMinimalDTO.getCreateTime()))
+                .append(dayString)
                 .append("/")
-                .append(basePostMinimalDTO.getSlug())
+                .append(post.getSlug())
                 .append(pathSuffix);
         }
 
-        basePostMinimalDTO.setFullPath(fullPath.toString());
+        post.setFullPath(fullPath.toString());
 
-        return basePostMinimalDTO;
+        return post;
     }
 
     @Override

--- a/src/main/java/run/halo/app/service/impl/PostServiceImpl.java
+++ b/src/main/java/run/halo/app/service/impl/PostServiceImpl.java
@@ -871,6 +871,14 @@ public class PostServiceImpl extends BasePostServiceImpl<Post> implements PostSe
 
         String archivesPrefix = optionService.getArchivesPrefix();
 
+        int month = DateUtil.month(post.getCreateTime()) + 1;
+
+        String monthString = month < 10 ? "0" + month : String.valueOf(month);
+
+        int day = DateUtil.dayOfMonth(post.getCreateTime());
+
+        String dayString = day < 10 ? "0" + day : String.valueOf(day);
+
         StringBuilder fullPath = new StringBuilder();
 
         if (optionService.isEnabledAbsolutePath()) {
@@ -890,16 +898,16 @@ public class PostServiceImpl extends BasePostServiceImpl<Post> implements PostSe
         } else if (permalinkType.equals(PostPermalinkType.DATE)) {
             fullPath.append(DateUtil.year(post.getCreateTime()))
                 .append("/")
-                .append(DateUtil.month(post.getCreateTime()) + 1)
+                .append(monthString)
                 .append("/")
                 .append(post.getSlug())
                 .append(pathSuffix);
         } else if (permalinkType.equals(PostPermalinkType.DAY)) {
             fullPath.append(DateUtil.year(post.getCreateTime()))
                 .append("/")
-                .append(DateUtil.month(post.getCreateTime()) + 1)
+                .append(monthString)
                 .append("/")
-                .append(DateUtil.dayOfMonth(post.getCreateTime()))
+                .append(dayString)
                 .append("/")
                 .append(post.getSlug())
                 .append(pathSuffix);


### PR DESCRIPTION
文章路径类型为 `年月型` 和 `年月日型`。

如果月和日为个数，在前面加个 0。

如：/2020/03/07。

主要考虑到从其他平台迁移过来的用户，基本都为这种类型。防止造成死链。