### PR TITLE
Refactor hibernate column build.

### DIFF
--- a/src/main/java/run/halo/app/handler/file/LocalFileHandler.java
+++ b/src/main/java/run/halo/app/handler/file/LocalFileHandler.java
@@ -139,7 +139,7 @@ public class LocalFileHandler implements FileHandler {
             uploadResult.setSize(file.getSize());
 
             // TODO refactor this: if image is svg ext. extension
-            boolean isSvg = "svg" .equals(extension);
+            boolean isSvg = "svg".equals(extension);
 
             // Check file type
             if (FileHandler.isImageType(uploadResult.getMediaType()) && !isSvg) {

--- a/src/main/java/run/halo/app/listener/StartedListener.java
+++ b/src/main/java/run/halo/app/listener/StartedListener.java
@@ -86,6 +86,7 @@ public class StartedListener implements ApplicationListener<ApplicationStartedEv
             .baselineOnMigrate(true)
             .dataSource(url, username, password)
             .load();
+        flyway.repair();
         flyway.migrate();
         log.info("Migrate database succeed.");
     }

--- a/src/main/java/run/halo/app/model/dto/StatisticWithUserDTO.java
+++ b/src/main/java/run/halo/app/model/dto/StatisticWithUserDTO.java
@@ -1,6 +1,7 @@
 package run.halo.app.model.dto;
 
 import lombok.Data;
+import lombok.EqualsAndHashCode;
 import run.halo.app.model.dto.base.OutputConverter;
 
 /**
@@ -10,6 +11,7 @@ import run.halo.app.model.dto.base.OutputConverter;
  * @date 2019-12-16
  */
 @Data
+@EqualsAndHashCode(callSuper = true)
 public class StatisticWithUserDTO extends StatisticDTO implements OutputConverter<StatisticWithUserDTO, StatisticDTO> {
 
     private UserDTO user;

--- a/src/main/java/run/halo/app/model/entity/Attachment.java
+++ b/src/main/java/run/halo/app/model/entity/Attachment.java
@@ -3,6 +3,7 @@ package run.halo.app.model.entity;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
+import org.hibernate.annotations.ColumnDefault;
 import run.halo.app.model.enums.AttachmentType;
 
 import javax.persistence.*;
@@ -28,61 +29,64 @@ public class Attachment extends BaseEntity {
     /**
      * Attachment name.
      */
-    @Column(name = "name", columnDefinition = "varchar(255) not null")
+    @Column(name = "name", nullable = false)
     private String name;
 
     /**
      * Attachment access path.
      */
-    @Column(name = "path", columnDefinition = "varchar(1023) not null")
+    @Column(name = "path", length = 1023, nullable = false)
     private String path;
 
     /**
      * File key: oss file key or local file key (Just for deleting)
      */
-    @Column(name = "file_key", columnDefinition = "varchar(2047) default ''")
+    @Column(name = "file_key", length = 2047)
     private String fileKey;
 
     /**
      * Thumbnail access path.
      */
-    @Column(name = "thumb_path", columnDefinition = "varchar(1023) default ''")
+    @Column(name = "thumb_path", length = 1023)
     private String thumbPath;
 
     /**
      * Attachment media type.
      */
-    @Column(name = "media_type", columnDefinition = "varchar(127) not null")
+    @Column(name = "media_type", length = 127, nullable = false)
     private String mediaType;
 
     /**
      * Attachment suffix,such as png, zip, mp4, jpge.
      */
-    @Column(name = "suffix", columnDefinition = "varchar(50) default ''")
+    @Column(name = "suffix", length = 50)
     private String suffix;
 
     /**
      * Attachment width.
      */
-    @Column(name = "width", columnDefinition = "int default 0")
+    @Column(name = "width")
+    @ColumnDefault("0")
     private Integer width;
 
     /**
      * Attachment height.
      */
-    @Column(name = "height", columnDefinition = "int default 0")
+    @Column(name = "height")
+    @ColumnDefault("0")
     private Integer height;
 
     /**
      * Attachment size.
      */
-    @Column(name = "size", columnDefinition = "bigint not null")
+    @Column(name = "size", nullable = false)
     private Long size;
 
     /**
      * Attachment upload type,LOCAL,UPYUN or QNYUN.
      */
-    @Column(name = "type", columnDefinition = "int default 0")
+    @Column(name = "type")
+    @ColumnDefault("0")
     private AttachmentType type;
 
     @Override

--- a/src/main/java/run/halo/app/model/entity/BaseComment.java
+++ b/src/main/java/run/halo/app/model/entity/BaseComment.java
@@ -3,6 +3,7 @@ package run.halo.app.model.entity;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
+import org.hibernate.annotations.ColumnDefault;
 import run.halo.app.model.enums.CommentStatus;
 import run.halo.app.utils.ServiceUtils;
 
@@ -30,88 +31,89 @@ public class BaseComment extends BaseEntity {
     /**
      * Commentator's name.
      */
-    @Column(name = "author", columnDefinition = "varchar(50) not null")
+    @Column(name = "author", length = 50, nullable = false)
     private String author;
 
     /**
      * Commentator's email.
      */
-    @Column(name = "email", columnDefinition = "varchar(255) not null")
+    @Column(name = "email", nullable = false)
     private String email;
 
     /**
      * Commentator's ip address.
      */
-    @Column(name = "ip_address", columnDefinition = "varchar(127) default ''")
+    @Column(name = "ip_address", length = 127)
     private String ipAddress;
 
     /**
      * Commentator's website.
      */
-    @Column(name = "author_url", columnDefinition = "varchar(512) default ''")
+    @Column(name = "author_url", length = 511)
     private String authorUrl;
 
     /**
      * Gravatar md5
      */
-    @Column(name = "gravatar_md5", columnDefinition = "varchar(128) default ''")
+    @Column(name = "gravatar_md5", length = 127)
     private String gravatarMd5;
 
     /**
      * Comment content.
      */
-    @Column(name = "content", columnDefinition = "varchar(1023) not null")
+    @Column(name = "content", length = 1023, nullable = false)
     private String content;
 
     /**
      * Comment status.
      */
-    @Column(name = "status", columnDefinition = "int default 1")
+    @Column(name = "status")
+    @ColumnDefault("1")
     private CommentStatus status;
 
     /**
      * Commentator's userAgent.
      */
-    @Column(name = "user_agent", columnDefinition = "varchar(512) default ''")
+    @Column(name = "user_agent", length = 511)
     private String userAgent;
 
     /**
      * Is admin's comment.
      */
-    @Column(name = "is_admin", columnDefinition = "tinyint default 0")
+    @Column(name = "is_admin")
+    @ColumnDefault("0")
     private Boolean isAdmin;
 
     /**
      * Allow notification.
      */
-    @Column(name = "allow_notification", columnDefinition = "tinyint default 1")
+    @Column(name = "allow_notification")
+    @ColumnDefault("1")
     private Boolean allowNotification;
 
     /**
      * Post id.
      */
-    @Column(name = "post_id", columnDefinition = "int not null")
+    @Column(name = "post_id", nullable = false)
     private Integer postId;
 
     /**
      * Whether to top the comment.
      */
-    @Column(name = "top_priority", columnDefinition = "int default 0")
+    @Column(name = "top_priority")
+    @ColumnDefault("0")
     private Integer topPriority;
 
     /**
      * Parent comment.
      */
-    @Column(name = "parent_id", columnDefinition = "bigint default 0")
+    @Column(name = "parent_id")
+    @ColumnDefault("0")
     private Long parentId;
 
     @Override
     public void prePersist() {
         super.prePersist();
-
-        if (ServiceUtils.isEmptyId(id)) {
-            id = null;
-        }
 
         if (ServiceUtils.isEmptyId(parentId)) {
             parentId = 0L;

--- a/src/main/java/run/halo/app/model/entity/BaseEntity.java
+++ b/src/main/java/run/halo/app/model/entity/BaseEntity.java
@@ -23,26 +23,19 @@ public class BaseEntity {
     /**
      * Create time.
      */
-    @Column(name = "create_time", columnDefinition = "timestamp default CURRENT_TIMESTAMP")
+    @Column(name = "create_time")
     @Temporal(TemporalType.TIMESTAMP)
     private Date createTime;
 
     /**
      * Update time.
      */
-    @Column(name = "update_time", columnDefinition = "timestamp default CURRENT_TIMESTAMP")
+    @Column(name = "update_time")
     @Temporal(TemporalType.TIMESTAMP)
     private Date updateTime;
 
-    /**
-     * Delete flag.
-     */
-    @Column(name = "deleted", columnDefinition = "TINYINT default 0")
-    private Boolean deleted = false;
-
     @PrePersist
     protected void prePersist() {
-        deleted = false;
         Date now = DateUtils.now();
         if (createTime == null) {
             createTime = now;

--- a/src/main/java/run/halo/app/model/entity/BaseMeta.java
+++ b/src/main/java/run/halo/app/model/entity/BaseMeta.java
@@ -29,18 +29,18 @@ public class BaseMeta extends BaseEntity {
     /**
      * Post id.
      */
-    @Column(name = "post_id", columnDefinition = "int not null")
+    @Column(name = "post_id", nullable = false)
     private Integer postId;
 
     /**
      * meta key
      */
-    @Column(name = "meta_key", columnDefinition = "varchar(100) not null")
+    @Column(name = "meta_key", nullable = false)
     private String key;
 
     /**
      * meta value
      */
-    @Column(name = "meta_value", columnDefinition = "varchar(1023) not null")
+    @Column(name = "meta_value", length = 1023, nullable = false)
     private String value;
 }

--- a/src/main/java/run/halo/app/model/entity/BasePost.java
+++ b/src/main/java/run/halo/app/model/entity/BasePost.java
@@ -3,6 +3,7 @@ package run.halo.app.model.entity;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
+import org.hibernate.annotations.ColumnDefault;
 import run.halo.app.model.enums.PostEditorType;
 import run.halo.app.model.enums.PostStatus;
 
@@ -30,120 +31,125 @@ public class BasePost extends BaseEntity {
     /**
      * Post title.
      */
-    @Column(name = "title", columnDefinition = "varchar(100) not null")
+    @Column(name = "title", nullable = false)
     private String title;
 
     /**
      * Post status.
      */
-    @Column(name = "status", columnDefinition = "int default 1")
+    @Column(name = "status")
+    @ColumnDefault("1")
     private PostStatus status;
 
     /**
      * Post url.
      */
     @Deprecated
-    @Column(name = "url", columnDefinition = "varchar(255) not null")
+    @Column(name = "url")
     private String url;
 
     /**
      * Post slug.
      */
-    @Column(name = "slug", columnDefinition = "varchar(255)", unique = true)
+    @Column(name = "slug", unique = true)
     private String slug;
 
     /**
      * Post editor type.
      */
-    @Column(name = "editor_type", columnDefinition = "int default 0")
+    @Column(name = "editor_type")
+    @ColumnDefault("0")
     private PostEditorType editorType;
 
     /**
      * Original content,not format.
      */
-    @Column(name = "original_content", columnDefinition = "longtext not null")
+    @Column(name = "original_content", nullable = false)
+    @Lob
     private String originalContent;
 
     /**
      * Rendered content.
-     *
-     * @see run.halo.app.utils.MarkdownUtils#renderHtml(String)
      */
-    @Column(name = "format_content", columnDefinition = "longtext not null")
+    @Column(name = "format_content")
+    @Lob
     private String formatContent;
 
     /**
      * Post summary.
      */
-    @Column(name = "summary", columnDefinition = "longtext default ''")
+    @Column(name = "summary")
+    @Lob
     private String summary;
 
     /**
      * Cover thumbnail of the post.
      */
-    @Column(name = "thumbnail", columnDefinition = "varchar(1023) default ''")
+    @Column(name = "thumbnail", length = 1023)
     private String thumbnail;
 
     /**
      * Post visits.
      */
-    @Column(name = "visits", columnDefinition = "bigint default 0")
+    @Column(name = "visits")
+    @ColumnDefault("0")
     private Long visits;
 
     /**
      * Whether to allow comments.
      */
-    @Column(name = "disallow_comment", columnDefinition = "int default 0")
+    @Column(name = "disallow_comment")
+    @ColumnDefault("0")
     private Boolean disallowComment;
 
     /**
      * Post password.
      */
-    @Column(name = "password", columnDefinition = "varchar(255) default ''")
+    @Column(name = "password")
     private String password;
 
     /**
      * Custom template.
      */
-    @Column(name = "template", columnDefinition = "varchar(255) default ''")
+    @Column(name = "template")
     private String template;
 
     /**
      * Whether to top the post.
      */
-    @Column(name = "top_priority", columnDefinition = "int default 0")
+    @Column(name = "top_priority")
+    @ColumnDefault("0")
     private Integer topPriority;
 
     /**
      * Likes
      */
-    @Column(name = "likes", columnDefinition = "bigint default 0")
+    @Column(name = "likes")
+    @ColumnDefault("0")
     private Long likes;
 
     /**
      * Edit time.
      */
-    @Column(name = "edit_time", columnDefinition = "timestamp default CURRENT_TIMESTAMP")
+    @Column(name = "edit_time")
     @Temporal(TemporalType.TIMESTAMP)
     private Date editTime;
 
     /**
      * Meta keywords.
      */
-    @Column(name = "meta_keywords", columnDefinition = "varchar(500) default ''")
+    @Column(name = "meta_keywords", length = 511)
     private String metaKeywords;
 
     /**
      * Meta description.
      */
-    @Column(name = "meta_description", columnDefinition = "varchar(1023) default ''")
+    @Column(name = "meta_description", length = 1023)
     private String metaDescription;
 
     @Override
     public void prePersist() {
         super.prePersist();
-
-        id = null;
 
         if (editTime == null) {
             editTime = getCreateTime();

--- a/src/main/java/run/halo/app/model/entity/Category.java
+++ b/src/main/java/run/halo/app/model/entity/Category.java
@@ -3,6 +3,7 @@ package run.halo.app.model.entity;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
+import org.hibernate.annotations.ColumnDefault;
 
 import javax.persistence.*;
 
@@ -27,44 +28,44 @@ public class Category extends BaseEntity {
     /**
      * Category name.
      */
-    @Column(name = "name", columnDefinition = "varchar(255) not null")
+    @Column(name = "name", nullable = false)
     private String name;
 
     /**
      * Category slug name.
      */
     @Deprecated
-    @Column(name = "slug_name", columnDefinition = "varchar(50) not null", unique = true)
+    @Column(name = "slug_name")
     private String slugName;
 
     /**
      * Category slug.
      */
-    @Column(name = "slug", columnDefinition = "varchar(255)", unique = true)
+    @Column(name = "slug", unique = true)
     private String slug;
 
     /**
      * Description,can be display on category page.
      */
-    @Column(name = "description", columnDefinition = "varchar(100) default ''")
+    @Column(name = "description", length = 100)
     private String description;
 
     /**
      * Cover thumbnail of the category.
      */
-    @Column(name = "thumbnail", columnDefinition = "varchar(1023) default ''")
+    @Column(name = "thumbnail", length = 1023)
     private String thumbnail;
 
     /**
      * Parent category.
      */
-    @Column(name = "parent_id", columnDefinition = "int default 0")
+    @Column(name = "parent_id")
+    @ColumnDefault("0")
     private Integer parentId;
 
     @Override
     public void prePersist() {
         super.prePersist();
-        id = null;
 
         if (description == null) {
             description = "";

--- a/src/main/java/run/halo/app/model/entity/CommentBlackList.java
+++ b/src/main/java/run/halo/app/model/entity/CommentBlackList.java
@@ -23,7 +23,7 @@ public class CommentBlackList extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(name = "ip_address", columnDefinition = "VARCHAR(127) NOT NULL")
+    @Column(name = "ip_address", length = 127, nullable = false)
     private String ipAddress;
 
     /**

--- a/src/main/java/run/halo/app/model/entity/Journal.java
+++ b/src/main/java/run/halo/app/model/entity/Journal.java
@@ -3,6 +3,7 @@ package run.halo.app.model.entity;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
+import org.hibernate.annotations.ColumnDefault;
 import run.halo.app.model.enums.JournalType;
 
 import javax.persistence.*;
@@ -25,23 +26,25 @@ public class Journal extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Integer id;
 
-    @Column(name = "source_content", columnDefinition = "varchar(1023) not null default ''")
+    @Column(name = "source_content", nullable = false)
+    @Lob
     private String sourceContent;
 
-    @Column(name = "content", columnDefinition = "text not null")
+    @Column(name = "content", nullable = false)
+    @Lob
     private String content;
 
-    @Column(name = "likes", columnDefinition = "bigint default 0")
+    @Column(name = "likes")
+    @ColumnDefault("0")
     private Long likes;
 
-    @Column(name = "type", columnDefinition = "int default 1")
+    @Column(name = "type")
+    @ColumnDefault("1")
     private JournalType type;
 
     @Override
     public void prePersist() {
         super.prePersist();
-
-        id = null;
 
         if (likes == null || likes < 0) {
             likes = 0L;

--- a/src/main/java/run/halo/app/model/entity/Link.java
+++ b/src/main/java/run/halo/app/model/entity/Link.java
@@ -3,6 +3,7 @@ package run.halo.app.model.entity;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
+import org.hibernate.annotations.ColumnDefault;
 
 import javax.persistence.*;
 
@@ -27,44 +28,43 @@ public class Link extends BaseEntity {
     /**
      * Link name.
      */
-    @Column(name = "name", columnDefinition = "varchar(255) not null")
+    @Column(name = "name", nullable = false)
     private String name;
 
     /**
      * Link website address.
      */
-    @Column(name = "url", columnDefinition = "varchar(1023) not null")
+    @Column(name = "url", length = 1023, nullable = false)
     private String url;
 
     /**
      * Website logo.
      */
-    @Column(name = "logo", columnDefinition = "varchar(1023) default ''")
+    @Column(name = "logo", length = 1023)
     private String logo;
 
     /**
      * Website description.
      */
-    @Column(name = "description", columnDefinition = "varchar(255) default ''")
+    @Column(name = "description")
     private String description;
 
     /**
      * Link team name.
      */
-    @Column(name = "team", columnDefinition = "varchar(255) default ''")
+    @Column(name = "team")
     private String team;
 
     /**
      * Sort.
      */
-    @Column(name = "priority", columnDefinition = "int default 0")
+    @Column(name = "priority")
+    @ColumnDefault("0")
     private Integer priority;
 
     @Override
     public void prePersist() {
         super.prePersist();
-
-        id = null;
 
         if (priority == null) {
             priority = 0;

--- a/src/main/java/run/halo/app/model/entity/Log.java
+++ b/src/main/java/run/halo/app/model/entity/Log.java
@@ -27,32 +27,31 @@ public class Log extends BaseEntity {
     /**
      * Log key.
      */
-    @Column(name = "log_key", columnDefinition = "varchar(1023) default ''")
+    @Column(name = "log_key", length = 1023)
     private String logKey;
 
     /**
      * Log type.
      */
-    @Column(name = "type", columnDefinition = "int not null")
+    @Column(name = "type", nullable = false)
     private LogType type;
 
     /**
      * Log content.
      */
-    @Column(name = "content", columnDefinition = "varchar(1023) not null")
+    @Column(name = "content", length = 1023, nullable = false)
     private String content;
 
     /**
      * Operator's ip address.
      */
-    @Column(name = "ip_address", columnDefinition = "varchar(127) default ''")
+    @Column(name = "ip_address", length = 127)
     private String ipAddress;
 
 
     @Override
     public void prePersist() {
         super.prePersist();
-        id = null;
 
         if (logKey == null) {
             logKey = "";

--- a/src/main/java/run/halo/app/model/entity/Menu.java
+++ b/src/main/java/run/halo/app/model/entity/Menu.java
@@ -3,6 +3,7 @@ package run.halo.app.model.entity;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
+import org.hibernate.annotations.ColumnDefault;
 
 import javax.persistence.*;
 
@@ -27,50 +28,51 @@ public class Menu extends BaseEntity {
     /**
      * Menu name.
      */
-    @Column(name = "name", columnDefinition = "varchar(50) not null")
+    @Column(name = "name", length = 50, nullable = false)
     private String name;
 
     /**
      * Menu access url.
      */
-    @Column(name = "url", columnDefinition = "varchar(1023) not null")
+    @Column(name = "url", length = 1023, nullable = false)
     private String url;
 
     /**
      * Sort.
      */
-    @Column(name = "priority", columnDefinition = "int default 0")
+    @Column(name = "priority")
+    @ColumnDefault("0")
     private Integer priority;
 
     /**
      * Page opening method
      */
-    @Column(name = "target", columnDefinition = "varchar(20) default '_self'")
+    @Column(name = "target", length = 20)
+    @ColumnDefault("'_self'")
     private String target;
 
     /**
      * Menu icon,Template support required.
      */
-    @Column(name = "icon", columnDefinition = "varchar(50) default ''")
+    @Column(name = "icon", length = 50)
     private String icon;
 
     /**
      * Parent menu.
      */
-    @Column(name = "parent_id", columnDefinition = "int default 0")
+    @Column(name = "parent_id")
+    @ColumnDefault("0")
     private Integer parentId;
 
     /**
      * Menu team name.
      */
-    @Column(name = "team", columnDefinition = "varchar(255) default ''")
+    @Column(name = "team")
     private String team;
 
     @Override
     public void prePersist() {
         super.prePersist();
-
-        id = null;
 
         if (priority == null) {
             priority = 0;

--- a/src/main/java/run/halo/app/model/entity/Option.java
+++ b/src/main/java/run/halo/app/model/entity/Option.java
@@ -4,6 +4,7 @@ import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
 import lombok.ToString;
+import org.hibernate.annotations.ColumnDefault;
 import run.halo.app.model.enums.OptionType;
 
 import javax.persistence.*;
@@ -30,19 +31,20 @@ public class Option extends BaseEntity {
     /**
      * option type
      */
-    @Column(name = "type", columnDefinition = "int default 0")
+    @Column(name = "type")
+    @ColumnDefault("0")
     private OptionType type;
 
     /**
      * option key
      */
-    @Column(name = "option_key", columnDefinition = "varchar(100) not null")
+    @Column(name = "option_key", length = 100, nullable = false)
     private String key;
 
     /**
      * option value
      */
-    @Column(name = "option_value", columnDefinition = "varchar(1023) not null")
+    @Column(name = "option_value", length = 1023, nullable = false)
     private String value;
 
     public Option(String key, String value) {
@@ -59,7 +61,6 @@ public class Option extends BaseEntity {
     @Override
     public void prePersist() {
         super.prePersist();
-        id = null;
 
         if (type == null) {
             type = OptionType.INTERNAL;

--- a/src/main/java/run/halo/app/model/entity/Photo.java
+++ b/src/main/java/run/halo/app/model/entity/Photo.java
@@ -28,50 +28,49 @@ public class Photo extends BaseEntity {
     /**
      * Picture name.
      */
-    @Column(name = "name", columnDefinition = "varchar(255) not null")
+    @Column(name = "name", nullable = false)
     private String name;
 
     /**
      * Picture description.
      */
-    @Column(name = "description", columnDefinition = "varchar(255) default ''")
+    @Column(name = "description")
     private String description;
 
     /**
      * Shooting time / creation time.
      */
-    @Column(name = "take_time", columnDefinition = "timestamp default CURRENT_TIMESTAMP")
+    @Column(name = "take_time")
     @Temporal(TemporalType.TIMESTAMP)
     private Date takeTime;
 
     /**
      * Picture location.
      */
-    @Column(name = "location", columnDefinition = "varchar(255) default ''")
+    @Column(name = "location")
     private String location;
 
     /**
      * Thumbnail
      */
-    @Column(name = "thumbnail", columnDefinition = "varchar(1023) default ''")
+    @Column(name = "thumbnail", length = 1023)
     private String thumbnail;
 
     /**
      * Picture access path.
      */
-    @Column(name = "url", columnDefinition = "varchar(1023) not null")
+    @Column(name = "url", length = 1023, nullable = false)
     private String url;
 
     /**
      * Photo team name.
      */
-    @Column(name = "team", columnDefinition = "varchar(255) default ''")
+    @Column(name = "team")
     private String team;
 
     @Override
     public void prePersist() {
         super.prePersist();
-        id = null;
 
         if (takeTime == null) {
             takeTime = this.getCreateTime();

--- a/src/main/java/run/halo/app/model/entity/PostCategory.java
+++ b/src/main/java/run/halo/app/model/entity/PostCategory.java
@@ -33,13 +33,6 @@ public class PostCategory extends BaseEntity {
     @Column(name = "post_id")
     private Integer postId;
 
-
-    @Override
-    public void prePersist() {
-        super.prePersist();
-        id = null;
-    }
-
     @Override
     public boolean equals(Object o) {
         if (this == o) {

--- a/src/main/java/run/halo/app/model/entity/PostTag.java
+++ b/src/main/java/run/halo/app/model/entity/PostTag.java
@@ -26,20 +26,14 @@ public class PostTag extends BaseEntity {
     /**
      * Post id.
      */
-    @Column(name = "post_id", columnDefinition = "int not null")
+    @Column(name = "post_id", nullable = false)
     private Integer postId;
 
     /**
      * Tag id.
      */
-    @Column(name = "tag_id", columnDefinition = "int not null")
+    @Column(name = "tag_id", nullable = false)
     private Integer tagId;
-
-    @Override
-    public void prePersist() {
-        super.prePersist();
-        id = null;
-    }
 
     @Override
     public boolean equals(Object o) {

--- a/src/main/java/run/halo/app/model/entity/Tag.java
+++ b/src/main/java/run/halo/app/model/entity/Tag.java
@@ -27,31 +27,25 @@ public class Tag extends BaseEntity {
     /**
      * Tag name.
      */
-    @Column(name = "name", columnDefinition = "varchar(255) not null")
+    @Column(name = "name", nullable = false)
     private String name;
 
     /**
      * Tag slug name.
      */
     @Deprecated
-    @Column(name = "slug_name", columnDefinition = "varchar(255) not null", unique = true)
+    @Column(name = "slug_name")
     private String slugName;
 
     /**
      * Tag slug.
      */
-    @Column(name = "slug", columnDefinition = "varchar(255)", unique = true)
+    @Column(name = "slug", unique = true)
     private String slug;
 
     /**
      * Cover thumbnail of the tag.
      */
-    @Column(name = "thumbnail", columnDefinition = "varchar(1023) default ''")
+    @Column(name = "thumbnail", length = 1023)
     private String thumbnail;
-
-    @Override
-    protected void prePersist() {
-        super.prePersist();
-        id = null;
-    }
 }

--- a/src/main/java/run/halo/app/model/entity/ThemeSetting.java
+++ b/src/main/java/run/halo/app/model/entity/ThemeSetting.java
@@ -26,25 +26,18 @@ public class ThemeSetting extends BaseEntity {
     /**
      * Setting key.
      */
-    @Column(name = "setting_key", columnDefinition = "varchar(255) not null")
+    @Column(name = "setting_key", nullable = false)
     private String key;
 
     /**
      * Setting value
      */
-    @Column(name = "setting_value", columnDefinition = "varchar(10239) not null")
+    @Column(name = "setting_value", nullable = false)
     private String value;
 
     /**
      * Theme id.
      */
-    @Column(name = "theme_id", columnDefinition = "varchar(255) not null")
+    @Column(name = "theme_id", nullable = false)
     private String themeId;
-
-    @Override
-    protected void prePersist() {
-        super.prePersist();
-
-        id = null;
-    }
 }

--- a/src/main/java/run/halo/app/model/entity/User.java
+++ b/src/main/java/run/halo/app/model/entity/User.java
@@ -29,43 +29,43 @@ public class User extends BaseEntity {
     /**
      * User name.
      */
-    @Column(name = "username", columnDefinition = "varchar(50) not null")
+    @Column(name = "username", length = 50, nullable = false)
     private String username;
 
     /**
      * User nick name,used to display on page.
      */
-    @Column(name = "nickname", columnDefinition = "varchar(255) not null")
+    @Column(name = "nickname", nullable = false)
     private String nickname;
 
     /**
      * Password.
      */
-    @Column(name = "password", columnDefinition = "varchar(255) not null")
+    @Column(name = "password", nullable = false)
     private String password;
 
     /**
      * User email.
      */
-    @Column(name = "email", columnDefinition = "varchar(127) default ''")
+    @Column(name = "email", length = 127)
     private String email;
 
     /**
      * User avatar.
      */
-    @Column(name = "avatar", columnDefinition = "varchar(1023) default ''")
+    @Column(name = "avatar", length = 1023)
     private String avatar;
 
     /**
      * User description.
      */
-    @Column(name = "description", columnDefinition = "varchar(1023) default ''")
+    @Column(name = "description", length = 1023)
     private String description;
 
     /**
      * Expire time.
      */
-    @Column(name = "expire_time", columnDefinition = "timestamp default CURRENT_TIMESTAMP")
+    @Column(name = "expire_time")
     @Temporal(TemporalType.TIMESTAMP)
     private Date expireTime;
 
@@ -73,8 +73,6 @@ public class User extends BaseEntity {
     @Override
     public void prePersist() {
         super.prePersist();
-
-        id = null;
 
         if (email == null) {
             email = "";

--- a/src/main/java/run/halo/app/model/params/BaseMetaParam.java
+++ b/src/main/java/run/halo/app/model/params/BaseMetaParam.java
@@ -18,7 +18,7 @@ import java.lang.reflect.ParameterizedType;
 @Data
 public abstract class BaseMetaParam<META> implements InputConverter<META> {
 
-    @NotBlank(message = "文章id不能为空")
+    @NotBlank(message = "文章 id 不能为空")
     private Integer postId;
 
     @NotBlank(message = "Meta key 不能为空")

--- a/src/main/java/run/halo/app/service/impl/BackupServiceImpl.java
+++ b/src/main/java/run/halo/app/service/impl/BackupServiceImpl.java
@@ -21,6 +21,7 @@ import run.halo.app.model.dto.BackupDTO;
 import run.halo.app.model.dto.post.BasePostDetailDTO;
 import run.halo.app.model.entity.Post;
 import run.halo.app.model.entity.Tag;
+import run.halo.app.model.enums.PostStatus;
 import run.halo.app.model.support.HaloConst;
 import run.halo.app.security.service.OneTimeTokenService;
 import run.halo.app.service.BackupService;
@@ -137,7 +138,7 @@ public class BackupServiceImpl implements BackupService {
 
             if (StringUtils.isNotBlank(post.getPassword())) {
                 passwords.add(one);
-            } else if (post.getDeleted()) {
+            } else if (post.getStatus() == PostStatus.DRAFT) {
                 drafts.add(one);
             } else {
                 posts.add(one);

--- a/src/main/resources/migration/V3__migrate_1.3.0-beta.1_to_1.3.0-beta.2.sql
+++ b/src/main/resources/migration/V3__migrate_1.3.0-beta.1_to_1.3.0-beta.2.sql
@@ -4,7 +4,7 @@
 update posts set `slug`=`url`;
 alter table posts modify slug varchar(255) not null;
 alter table posts modify url varchar(255) null;
-alter table posts modify summary longtext default '';
+alter table posts modify summary longtext;
 
 -- Migrate categories Table
 update categories set `slug`=`slug_name`;


### PR DESCRIPTION
1. 将所有实体属性的 columnDefinition 替换为 hibernate 的参数或者注解形式。理论上这样做可以兼容更多的数据库。
2. 删除 deleted 字段。
3. 允许在保存数据的时候传入 id，为以后数据的导入导出功能做准备。

另外有个问题：

有些表的字段默认设置为空串是否有必要。目前带来了两点问题：

1. 后台的有些组件会因为字段为空串而抛异常。
2. 主题开发过程中需要多加一个判断，如：

```
<#if post.thumbnail?? && post.thumbnail!=''>
// do something
</#if>
```

如果字段允许为空，那么：

```
<#if post.thumbnail??>
// do something
</#if>
```