### PR TITLE
[Fix #319] 去除同一IP地址对同一篇文章访问时总访问量的增加

### DIFF
--- a/src/main/java/run/halo/app/controller/content/ContentContentController.java
+++ b/src/main/java/run/halo/app/controller/content/ContentContentController.java
@@ -17,6 +17,7 @@ import run.halo.app.model.enums.PostStatus;
 import run.halo.app.service.OptionService;
 import run.halo.app.service.PostService;
 import run.halo.app.service.SheetService;
+import run.halo.app.utils.ServletUtils;
 
 import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
@@ -119,13 +120,14 @@ public class ContentContentController {
                           @RequestParam(value = "token", required = false) String token,
                           Model model) {
         PostPermalinkType postPermalinkType = optionService.getPostPermalinkType();
+        String requestIp = ServletUtils.getRequestIp();
 
         if (postPermalinkType.equals(PostPermalinkType.DEFAULT) && optionService.getArchivesPrefix().equals(prefix)) {
             Post post = postService.getBySlug(slug);
-            return postModel.content(post, token, model);
+            return postModel.content(requestIp, post, token, model);
         } else if (optionService.getSheetPrefix().equals(prefix)) {
             Sheet sheet = sheetService.getBySlug(slug);
-            return sheetModel.content(sheet, token, model);
+            return sheetModel.content(requestIp, sheet, token, model);
         } else if (optionService.getCategoriesPrefix().equals(prefix)) {
             return categoryModel.listPost(model, slug, 1);
         } else if (optionService.getTagsPrefix().equals(prefix)) {
@@ -156,9 +158,11 @@ public class ContentContentController {
                           @RequestParam(value = "token", required = false) String token,
                           Model model) {
         PostPermalinkType postPermalinkType = optionService.getPostPermalinkType();
+        String requestIp = ServletUtils.getRequestIp();
+
         if (postPermalinkType.equals(PostPermalinkType.DATE)) {
             Post post = postService.getBy(year, month, slug);
-            return postModel.content(post, token, model);
+            return postModel.content(requestIp, post, token, model);
         } else {
             throw new NotFoundException("Not Found");
         }
@@ -172,9 +176,11 @@ public class ContentContentController {
                           @RequestParam(value = "token", required = false) String token,
                           Model model) {
         PostPermalinkType postPermalinkType = optionService.getPostPermalinkType();
+        String requestIp = ServletUtils.getRequestIp();
+
         if (postPermalinkType.equals(PostPermalinkType.DAY)) {
             Post post = postService.getBy(year, month, day, slug);
-            return postModel.content(post, token, model);
+            return postModel.content(requestIp, post, token, model);
         } else {
             throw new NotFoundException("Not Found");
         }

--- a/src/main/java/run/halo/app/controller/content/ContentContentController.java
+++ b/src/main/java/run/halo/app/controller/content/ContentContentController.java
@@ -17,7 +17,6 @@ import run.halo.app.model.enums.PostStatus;
 import run.halo.app.service.OptionService;
 import run.halo.app.service.PostService;
 import run.halo.app.service.SheetService;
-import run.halo.app.utils.ServletUtils;
 
 import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
@@ -120,14 +119,13 @@ public class ContentContentController {
                           @RequestParam(value = "token", required = false) String token,
                           Model model) {
         PostPermalinkType postPermalinkType = optionService.getPostPermalinkType();
-        String requestIp = ServletUtils.getRequestIp();
 
         if (postPermalinkType.equals(PostPermalinkType.DEFAULT) && optionService.getArchivesPrefix().equals(prefix)) {
             Post post = postService.getBySlug(slug);
-            return postModel.content(requestIp, post, token, model);
+            return postModel.content(post, token, model);
         } else if (optionService.getSheetPrefix().equals(prefix)) {
             Sheet sheet = sheetService.getBySlug(slug);
-            return sheetModel.content(requestIp, sheet, token, model);
+            return sheetModel.content(sheet, token, model);
         } else if (optionService.getCategoriesPrefix().equals(prefix)) {
             return categoryModel.listPost(model, slug, 1);
         } else if (optionService.getTagsPrefix().equals(prefix)) {
@@ -158,11 +156,10 @@ public class ContentContentController {
                           @RequestParam(value = "token", required = false) String token,
                           Model model) {
         PostPermalinkType postPermalinkType = optionService.getPostPermalinkType();
-        String requestIp = ServletUtils.getRequestIp();
 
         if (postPermalinkType.equals(PostPermalinkType.DATE)) {
             Post post = postService.getBy(year, month, slug);
-            return postModel.content(requestIp, post, token, model);
+            return postModel.content(post, token, model);
         } else {
             throw new NotFoundException("Not Found");
         }
@@ -176,11 +173,10 @@ public class ContentContentController {
                           @RequestParam(value = "token", required = false) String token,
                           Model model) {
         PostPermalinkType postPermalinkType = optionService.getPostPermalinkType();
-        String requestIp = ServletUtils.getRequestIp();
 
         if (postPermalinkType.equals(PostPermalinkType.DAY)) {
             Post post = postService.getBy(year, month, day, slug);
-            return postModel.content(requestIp, post, token, model);
+            return postModel.content(post, token, model);
         } else {
             throw new NotFoundException("Not Found");
         }

--- a/src/main/java/run/halo/app/controller/content/ContentIndexController.java
+++ b/src/main/java/run/halo/app/controller/content/ContentIndexController.java
@@ -54,7 +54,7 @@ public class ContentIndexController {
 
         if (PostPermalinkType.ID.equals(permalinkType) && !Objects.isNull(p)) {
             Post post = postService.getById(p);
-            return postModel.content(post, token, model);
+            return postModel.content(null, post, token, model);
         }
 
         return this.index(model, 1);

--- a/src/main/java/run/halo/app/controller/content/ContentIndexController.java
+++ b/src/main/java/run/halo/app/controller/content/ContentIndexController.java
@@ -54,7 +54,7 @@ public class ContentIndexController {
 
         if (PostPermalinkType.ID.equals(permalinkType) && !Objects.isNull(p)) {
             Post post = postService.getById(p);
-            return postModel.content(null, post, token, model);
+            return postModel.content(post, token, model);
         }
 
         return this.index(model, 1);

--- a/src/main/java/run/halo/app/controller/content/model/PostModel.java
+++ b/src/main/java/run/halo/app/controller/content/model/PostModel.java
@@ -9,10 +9,7 @@ import org.springframework.stereotype.Component;
 import org.springframework.ui.Model;
 import run.halo.app.cache.AbstractStringCacheStore;
 import run.halo.app.exception.ForbiddenException;
-import run.halo.app.model.entity.Category;
-import run.halo.app.model.entity.Post;
-import run.halo.app.model.entity.PostMeta;
-import run.halo.app.model.entity.Tag;
+import run.halo.app.model.entity.*;
 import run.halo.app.model.enums.PostEditorType;
 import run.halo.app.model.enums.PostStatus;
 import run.halo.app.model.support.HaloConst;
@@ -20,6 +17,7 @@ import run.halo.app.model.vo.AdjacentPostVO;
 import run.halo.app.model.vo.ArchiveYearVO;
 import run.halo.app.model.vo.PostListVO;
 import run.halo.app.service.*;
+import run.halo.app.service.impl.PostVisitIpServiceImpl;
 import run.halo.app.utils.MarkdownUtils;
 import run.halo.app.utils.ServletUtils;
 
@@ -61,7 +59,8 @@ public class PostModel {
                      PostTagService postTagService,
                      TagService tagService,
                      OptionService optionService,
-                     AbstractStringCacheStore cacheStore) {
+                     AbstractStringCacheStore cacheStore,
+                     PostVisitIpServiceImpl postVisitIpService) {
         this.postService = postService;
         this.themeService = themeService;
         this.postCategoryService = postCategoryService;

--- a/src/main/java/run/halo/app/controller/content/model/PostModel.java
+++ b/src/main/java/run/halo/app/controller/content/model/PostModel.java
@@ -72,7 +72,7 @@ public class PostModel {
         this.cacheStore = cacheStore;
     }
 
-    public String content(Post post, String token, Model model) {
+    public String content(String requestIp, Post post, String token, Model model) {
 
         if (post.getStatus().equals(PostStatus.INTIMATE) && StringUtils.isEmpty(token)) {
             model.addAttribute("slug", post.getSlug());
@@ -94,7 +94,7 @@ public class PostModel {
             }
         }
 
-        postService.publishVisitEvent(post.getId());
+        postService.publishVisitEvent(requestIp, post.getId());
 
         AdjacentPostVO adjacentPostVO = postService.getAdjacentPosts(post);
         adjacentPostVO.getOptionalPrevPost().ifPresent(prevPost -> model.addAttribute("prevPost", postService.convertToDetailVo(prevPost)));

--- a/src/main/java/run/halo/app/controller/content/model/PostModel.java
+++ b/src/main/java/run/halo/app/controller/content/model/PostModel.java
@@ -72,6 +72,15 @@ public class PostModel {
         this.cacheStore = cacheStore;
     }
 
+    /**
+     * Post content.
+     *
+     * @param requestIp request ip address
+     * @param post post
+     * @param token token
+     * @param model model
+     * @return template name
+     */
     public String content(String requestIp, Post post, String token, Model model) {
 
         if (post.getStatus().equals(PostStatus.INTIMATE) && StringUtils.isEmpty(token)) {

--- a/src/main/java/run/halo/app/controller/content/model/PostModel.java
+++ b/src/main/java/run/halo/app/controller/content/model/PostModel.java
@@ -21,6 +21,7 @@ import run.halo.app.model.vo.ArchiveYearVO;
 import run.halo.app.model.vo.PostListVO;
 import run.halo.app.service.*;
 import run.halo.app.utils.MarkdownUtils;
+import run.halo.app.utils.ServletUtils;
 
 import java.util.List;
 import java.util.stream.Collectors;
@@ -73,7 +74,7 @@ public class PostModel {
     }
 
     /**
-     * Post content (without ip address).
+     * Post content.
      *
      * @param post post
      * @param token token
@@ -81,19 +82,6 @@ public class PostModel {
      * @return template name
      */
     public String content(Post post, String token, Model model) {
-        return content(null, post, token, model);
-    }
-
-    /**
-     * Post content (with ip address).
-     *
-     * @param requestIp request ip address
-     * @param post post
-     * @param token token
-     * @param model model
-     * @return template name
-     */
-    public String content(String requestIp, Post post, String token, Model model) {
 
         if (post.getStatus().equals(PostStatus.INTIMATE) && StringUtils.isEmpty(token)) {
             model.addAttribute("slug", post.getSlug());
@@ -115,7 +103,7 @@ public class PostModel {
             }
         }
 
-        postService.publishVisitEvent(requestIp, post.getId());
+        postService.publishVisitEvent(ServletUtils.getRequestIp(), post.getId());
 
         AdjacentPostVO adjacentPostVO = postService.getAdjacentPosts(post);
         adjacentPostVO.getOptionalPrevPost().ifPresent(prevPost -> model.addAttribute("prevPost", postService.convertToDetailVo(prevPost)));

--- a/src/main/java/run/halo/app/controller/content/model/PostModel.java
+++ b/src/main/java/run/halo/app/controller/content/model/PostModel.java
@@ -73,7 +73,19 @@ public class PostModel {
     }
 
     /**
-     * Post content.
+     * Post content (without ip address).
+     *
+     * @param post post
+     * @param token token
+     * @param model model
+     * @return template name
+     */
+    public String content(Post post, String token, Model model) {
+        return content(null, post, token, model);
+    }
+
+    /**
+     * Post content (with ip address).
      *
      * @param requestIp request ip address
      * @param post post

--- a/src/main/java/run/halo/app/controller/content/model/SheetModel.java
+++ b/src/main/java/run/halo/app/controller/content/model/SheetModel.java
@@ -53,12 +53,13 @@ public class SheetModel {
     /**
      * Sheet content.
      *
+     * @param requestIp request ip address
      * @param sheet sheet
      * @param token token
      * @param model model
      * @return template name
      */
-    public String content(Sheet sheet, String token, Model model) {
+    public String content(String requestIp, Sheet sheet, String token, Model model) {
 
         if (StringUtils.isEmpty(token)) {
             sheet = sheetService.getBy(PostStatus.PUBLISHED, sheet.getSlug());
@@ -76,7 +77,7 @@ public class SheetModel {
             }
         }
 
-        sheetService.publishVisitEvent(sheet.getId());
+        sheetService.publishVisitEvent(requestIp, sheet.getId());
 
         SheetDetailVO sheetDetailVO = sheetService.convertToDetailVo(sheet);
 

--- a/src/main/java/run/halo/app/controller/content/model/SheetModel.java
+++ b/src/main/java/run/halo/app/controller/content/model/SheetModel.java
@@ -51,7 +51,19 @@ public class SheetModel {
     }
 
     /**
-     * Sheet content.
+     * Sheet content (without ip address).
+     *
+     * @param sheet sheet
+     * @param token token
+     * @param model model
+     * @return template name
+     */
+    public String content(Sheet sheet, String token, Model model) {
+        return content(null, sheet, token, model);
+    }
+
+    /**
+     * Sheet content (with ip address)
      *
      * @param requestIp request ip address
      * @param sheet sheet

--- a/src/main/java/run/halo/app/controller/content/model/SheetModel.java
+++ b/src/main/java/run/halo/app/controller/content/model/SheetModel.java
@@ -16,6 +16,7 @@ import run.halo.app.service.SheetMetaService;
 import run.halo.app.service.SheetService;
 import run.halo.app.service.ThemeService;
 import run.halo.app.utils.MarkdownUtils;
+import run.halo.app.utils.ServletUtils;
 
 import java.util.List;
 
@@ -51,7 +52,7 @@ public class SheetModel {
     }
 
     /**
-     * Sheet content (without ip address).
+     * Sheet content.
      *
      * @param sheet sheet
      * @param token token
@@ -59,19 +60,6 @@ public class SheetModel {
      * @return template name
      */
     public String content(Sheet sheet, String token, Model model) {
-        return content(null, sheet, token, model);
-    }
-
-    /**
-     * Sheet content (with ip address)
-     *
-     * @param requestIp request ip address
-     * @param sheet sheet
-     * @param token token
-     * @param model model
-     * @return template name
-     */
-    public String content(String requestIp, Sheet sheet, String token, Model model) {
 
         if (StringUtils.isEmpty(token)) {
             sheet = sheetService.getBy(PostStatus.PUBLISHED, sheet.getSlug());
@@ -89,7 +77,7 @@ public class SheetModel {
             }
         }
 
-        sheetService.publishVisitEvent(requestIp, sheet.getId());
+        sheetService.publishVisitEvent(ServletUtils.getRequestIp(), sheet.getId());
 
         SheetDetailVO sheetDetailVO = sheetService.convertToDetailVo(sheet);
 

--- a/src/main/java/run/halo/app/event/post/AbstractVisitEvent.java
+++ b/src/main/java/run/halo/app/event/post/AbstractVisitEvent.java
@@ -2,6 +2,7 @@ package run.halo.app.event.post;
 
 import org.springframework.context.ApplicationEvent;
 import org.springframework.lang.NonNull;
+import org.springframework.lang.Nullable;
 import org.springframework.util.Assert;
 
 /**
@@ -17,13 +18,13 @@ public abstract class AbstractVisitEvent extends ApplicationEvent {
     private final String requestIp;
 
     /**
-     * Create a new ApplicationEvent.
+     * Create a new ApplicationEvent (with ip).
      *
      * @param source the object on which the event initially occurred (never {@code null})
      * @param requestIp the ip address of visitor, could be null (index)
-     * @param id     id
+     * @param id     id of post/sheet
      */
-    public AbstractVisitEvent(@NonNull Object source, String requestIp, @NonNull Integer id) {
+    public AbstractVisitEvent(@NonNull Object source, @Nullable String requestIp, @NonNull Integer id) {
         super(source);
 
         Assert.notNull(id, "Id must not be null");
@@ -32,6 +33,12 @@ public abstract class AbstractVisitEvent extends ApplicationEvent {
         this.requestIp = requestIp;
     }
 
+    /**
+     * Create a new ApplicationEvent (without ip).
+     *
+     * @param source the object on which the event initially occurred (never {@code null})
+     * @param id     id of post/sheet
+     */
     public AbstractVisitEvent(@NonNull Object source, @NonNull Integer id) {
         super(source);
 
@@ -46,6 +53,7 @@ public abstract class AbstractVisitEvent extends ApplicationEvent {
         return id;
     }
 
+    @Nullable
     public String getIp() {
         return requestIp;
     }

--- a/src/main/java/run/halo/app/event/post/AbstractVisitEvent.java
+++ b/src/main/java/run/halo/app/event/post/AbstractVisitEvent.java
@@ -14,21 +14,30 @@ public abstract class AbstractVisitEvent extends ApplicationEvent {
 
     private final Integer id;
 
+    private final String requestIp;
+
     /**
      * Create a new ApplicationEvent.
      *
      * @param source the object on which the event initially occurred (never {@code null})
+     * @param requestIp the ip address of visitor, could be null (index)
      * @param id     id
      */
-    public AbstractVisitEvent(@NonNull Object source, @NonNull Integer id) {
+    public AbstractVisitEvent(@NonNull Object source, String requestIp, @NonNull Integer id) {
         super(source);
 
         Assert.notNull(id, "Id must not be null");
         this.id = id;
+
+        this.requestIp = requestIp;
     }
 
     @NonNull
     public Integer getId() {
         return id;
+    }
+
+    public String getIp() {
+        return requestIp;
     }
 }

--- a/src/main/java/run/halo/app/event/post/AbstractVisitEvent.java
+++ b/src/main/java/run/halo/app/event/post/AbstractVisitEvent.java
@@ -32,6 +32,15 @@ public abstract class AbstractVisitEvent extends ApplicationEvent {
         this.requestIp = requestIp;
     }
 
+    public AbstractVisitEvent(@NonNull Object source, @NonNull Integer id) {
+        super(source);
+
+        Assert.notNull(id, "Id must not be null");
+        this.id = id;
+
+        this.requestIp = null;
+    }
+
     @NonNull
     public Integer getId() {
         return id;

--- a/src/main/java/run/halo/app/event/post/PostVisitEvent.java
+++ b/src/main/java/run/halo/app/event/post/PostVisitEvent.java
@@ -19,8 +19,13 @@ public class PostVisitEvent extends AbstractVisitEvent {
      * @param requestIp the ip of visitor
      * @param postId post id must not be null
      */
-    public PostVisitEvent(Object source, @NonNull String requestIp, @NonNull Integer postId) {
+    public PostVisitEvent(Object source, String requestIp, @NonNull Integer postId) {
         super(source, requestIp, postId);
+        Assert.isTrue(!ServiceUtils.isEmptyId(postId), "Post id must not be empty");
+    }
+
+    public PostVisitEvent(Object source, @NonNull Integer postId) {
+        super(source, postId);
         Assert.isTrue(!ServiceUtils.isEmptyId(postId), "Post id must not be empty");
     }
 }

--- a/src/main/java/run/halo/app/event/post/PostVisitEvent.java
+++ b/src/main/java/run/halo/app/event/post/PostVisitEvent.java
@@ -16,10 +16,11 @@ public class PostVisitEvent extends AbstractVisitEvent {
      * Create a new ApplicationEvent.
      *
      * @param source the object on which the event initially occurred (never {@code null})
+     * @param requestIp the ip of visitor
      * @param postId post id must not be null
      */
-    public PostVisitEvent(Object source, @NonNull Integer postId) {
-        super(source, postId);
+    public PostVisitEvent(Object source, @NonNull String requestIp, @NonNull Integer postId) {
+        super(source, requestIp, postId);
         Assert.isTrue(!ServiceUtils.isEmptyId(postId), "Post id must not be empty");
     }
 }

--- a/src/main/java/run/halo/app/event/post/SheetVisitEvent.java
+++ b/src/main/java/run/halo/app/event/post/SheetVisitEvent.java
@@ -12,9 +12,10 @@ public class SheetVisitEvent extends AbstractVisitEvent {
      * Create a new ApplicationEvent.
      *
      * @param source  the object on which the event initially occurred (never {@code null})
+     * @param requestIp the ip of visitor
      * @param sheetId sheet id must not be null
      */
-    public SheetVisitEvent(Object source, Integer sheetId) {
-        super(source, sheetId);
+    public SheetVisitEvent(Object source, String requestIp, Integer sheetId) {
+        super(source, requestIp, sheetId);
     }
 }

--- a/src/main/java/run/halo/app/event/post/SheetVisitEvent.java
+++ b/src/main/java/run/halo/app/event/post/SheetVisitEvent.java
@@ -18,4 +18,8 @@ public class SheetVisitEvent extends AbstractVisitEvent {
     public SheetVisitEvent(Object source, String requestIp, Integer sheetId) {
         super(source, requestIp, sheetId);
     }
+
+    public SheetVisitEvent(Object source, Integer sheetId) {
+        super(source, sheetId);
+    }
 }

--- a/src/main/java/run/halo/app/handler/migrate/support/wordpress/Item.java
+++ b/src/main/java/run/halo/app/handler/migrate/support/wordpress/Item.java
@@ -3,7 +3,6 @@ package run.halo.app.handler.migrate.support.wordpress;
 import com.alibaba.fastjson.annotation.JSONField;
 import lombok.Data;
 import run.halo.app.handler.migrate.utils.PropertyMappingTo;
-import run.halo.app.model.entity.BasePost;
 
 import java.util.List;
 

--- a/src/main/java/run/halo/app/listener/post/AbstractVisitEventListener.java
+++ b/src/main/java/run/halo/app/listener/post/AbstractVisitEventListener.java
@@ -114,6 +114,12 @@ public abstract class AbstractVisitEventListener {
 
         private IpRecorder ipRecorder;
 
+        private PostVisitTask(Integer id) {
+            this.id = id;
+            this.ip = null;
+            this.ipRecorder = null;
+        }
+
         private PostVisitTask(Integer id, String ip, IpRecorder ipRecorder) {
             this.id = id;
             this.ip = ip;
@@ -129,8 +135,8 @@ public abstract class AbstractVisitEventListener {
 
                     log.debug("Took a new visit for post id: [{}], from ip address [{}]", postId, ip);
 
-                    // If the ip is not null and hasn't appeared before, increase the visit
-                    if (ip != null && !ipRecorder.checkIp(this.ip)) {
+                    // If the ip and ipRecorder are not null and this ip hasn't appeared before, increase the visit
+                    if (ip != null && ipRecorder != null && !ipRecorder.checkIp(this.ip)) {
                         basePostService.increaseVisit(postId);
 
                         log.debug("Increased visits for post id: [{}], from ip address [{}]", postId, ip);

--- a/src/main/java/run/halo/app/listener/post/AbstractVisitEventListener.java
+++ b/src/main/java/run/halo/app/listener/post/AbstractVisitEventListener.java
@@ -159,6 +159,11 @@ public abstract class AbstractVisitEventListener {
             this.ipMap = new ConcurrentHashMap<>(initCapacity << 1);
         }
 
+        /**
+         * Check if the ip address has already visited before
+         * @param ip ip address
+         * @return whether the ip visited before
+         */
         protected boolean checkIp(String ip) {
             if (this.ipMap.get(ip) == null) {
                 ipMap.put(ip, true);

--- a/src/main/java/run/halo/app/listener/post/AbstractVisitEventListener.java
+++ b/src/main/java/run/halo/app/listener/post/AbstractVisitEventListener.java
@@ -5,10 +5,10 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.util.Assert;
 import run.halo.app.event.post.AbstractVisitEvent;
 import run.halo.app.service.base.BasePostService;
+import run.halo.app.utils.PairUtils;
 
 import java.util.Map;
 import java.util.concurrent.*;
-import com.sun.tools.javac.util.Pair;
 
 /**
  * Abstract visit event listener.
@@ -21,7 +21,7 @@ public abstract class AbstractVisitEventListener {
 
     private final Map<Integer, BlockingQueue<Integer>> visitQueueMap;
 
-    private final Map<Pair<Integer, String>, PostVisitTask> visitTaskMap;
+    private final Map<PairUtils<Integer, String>, PostVisitTask> visitTaskMap;
 
     private final Map<Integer, IpRecorder> visitIpMap;
 
@@ -64,7 +64,7 @@ public abstract class AbstractVisitEventListener {
         // Get request ip address
         String ip = event.getIp();
 
-        Pair<Integer, String> pair = new Pair<>(id, ip);
+        PairUtils<Integer, String> pair = new PairUtils<>(id, ip);
         log.debug("Received a visit event, post id: [{}], request ip address: [{}]", id, ip);
 
         // Get post visit queue
@@ -79,9 +79,9 @@ public abstract class AbstractVisitEventListener {
     }
 
 
-    private PostVisitTask createPostVisitTask(Pair<Integer, String> pair) {
-        int postId = pair.fst;
-        String requestIp = pair.snd;
+    private PostVisitTask createPostVisitTask(PairUtils<Integer, String> pair) {
+        int postId = pair.getFirst();
+        String requestIp = pair.getLast();
 
         // Create new post visit task
         PostVisitTask postVisitTask = new PostVisitTask(postId, requestIp, this.visitIpMap.get(postId));

--- a/src/main/java/run/halo/app/listener/post/PostVisitEventListener.java
+++ b/src/main/java/run/halo/app/listener/post/PostVisitEventListener.java
@@ -38,7 +38,7 @@ public class PostVisitEventListener extends AbstractVisitEventListener {
      * @return whether ip has appeared previously
      */
     @Override
-    boolean checkIpRecord(Integer postId, String requestIp) {
+    public boolean checkIpRecord(Integer postId, String requestIp) {
         boolean appeared = postVisitIpService.checkIpRecordByPostIdAndIp(postId, requestIp);
         if (!appeared) {
             PostVisitIp visitIp = new PostVisitIp();

--- a/src/main/java/run/halo/app/listener/post/PostVisitEventListener.java
+++ b/src/main/java/run/halo/app/listener/post/PostVisitEventListener.java
@@ -4,7 +4,9 @@ import org.springframework.context.event.EventListener;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
 import run.halo.app.event.post.PostVisitEvent;
+import run.halo.app.model.entity.PostVisitIp;
 import run.halo.app.service.PostService;
+import run.halo.app.service.PostVisitIpService;
 
 /**
  * Visit event listener.
@@ -15,13 +17,37 @@ import run.halo.app.service.PostService;
 @Component
 public class PostVisitEventListener extends AbstractVisitEventListener {
 
-    public PostVisitEventListener(PostService postService) {
+    private final PostVisitIpService postVisitIpService;
+
+    public PostVisitEventListener(PostService postService, PostVisitIpService postVisitIpService, PostVisitIpService postVisitIpService1) {
         super(postService);
+        this.postVisitIpService = postVisitIpService1;
     }
 
     @Async
     @EventListener
     public void onPostVisitEvent(PostVisitEvent event) throws InterruptedException {
         handleVisitEvent(event);
+    }
+
+    /**
+     * Check ip record by post id and request ip.
+     *
+     * @param postId    post id
+     * @param requestIp request ip
+     * @return whether ip has appeared previously
+     */
+    @Override
+    boolean checkIpRecord(Integer postId, String requestIp) {
+        boolean appeared = postVisitIpService.checkIpRecordByPostIdAndIp(postId, requestIp);
+        if (!appeared) {
+            PostVisitIp visitIp = new PostVisitIp();
+            visitIp.setPostId(postId);
+            visitIp.setIpAddress(requestIp);
+            postVisitIpService.createBy(visitIp);
+            return false;
+        } else {
+            return true;
+        }
     }
 }

--- a/src/main/java/run/halo/app/listener/post/SheetVisitEventListener.java
+++ b/src/main/java/run/halo/app/listener/post/SheetVisitEventListener.java
@@ -4,7 +4,9 @@ import org.springframework.context.event.EventListener;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
 import run.halo.app.event.post.SheetVisitEvent;
+import run.halo.app.model.entity.SheetVisitIp;
 import run.halo.app.service.SheetService;
+import run.halo.app.service.SheetVisitIpService;
 
 /**
  * Sheet visit event listener.
@@ -15,8 +17,11 @@ import run.halo.app.service.SheetService;
 @Component
 public class SheetVisitEventListener extends AbstractVisitEventListener {
 
-    protected SheetVisitEventListener(SheetService sheetService) {
+    private final SheetVisitIpService sheetVisitIpService;
+
+    protected SheetVisitEventListener(SheetService sheetService, SheetVisitIpService sheetVisitIpService) {
         super(sheetService);
+        this.sheetVisitIpService = sheetVisitIpService;
     }
 
     @Async
@@ -25,4 +30,24 @@ public class SheetVisitEventListener extends AbstractVisitEventListener {
         handleVisitEvent(event);
     }
 
+    /**
+     * Check ip record by sheet id and request ip.
+     *
+     * @param sheetId    sheet id
+     * @param requestIp request ip
+     * @return whether ip has appeared previously
+     */
+    @Override
+    boolean checkIpRecord(Integer sheetId, String requestIp) {
+        boolean appeared = sheetVisitIpService.checkIpRecordByPostIdAndIp(sheetId, requestIp);
+        if (!appeared) {
+            SheetVisitIp visitIp = new SheetVisitIp();
+            visitIp.setPostId(sheetId);
+            visitIp.setIpAddress(requestIp);
+            sheetVisitIpService.createBy(visitIp);
+            return false;
+        } else {
+            return true;
+        }
+    }
 }

--- a/src/main/java/run/halo/app/listener/post/SheetVisitEventListener.java
+++ b/src/main/java/run/halo/app/listener/post/SheetVisitEventListener.java
@@ -38,7 +38,7 @@ public class SheetVisitEventListener extends AbstractVisitEventListener {
      * @return whether ip has appeared previously
      */
     @Override
-    boolean checkIpRecord(Integer sheetId, String requestIp) {
+    public boolean checkIpRecord(Integer sheetId, String requestIp) {
         boolean appeared = sheetVisitIpService.checkIpRecordByPostIdAndIp(sheetId, requestIp);
         if (!appeared) {
             SheetVisitIp visitIp = new SheetVisitIp();

--- a/src/main/java/run/halo/app/model/dto/BaseVisitIpDTO.java
+++ b/src/main/java/run/halo/app/model/dto/BaseVisitIpDTO.java
@@ -1,0 +1,27 @@
+package run.halo.app.model.dto;
+
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+import run.halo.app.model.dto.base.OutputConverter;
+import run.halo.app.model.entity.BaseVisitIp;
+
+import java.util.Date;
+
+/**
+ * Base visit ip address dto.
+ *
+ * @author KristenLawrence
+ * @date 2020-05-07
+ */
+@Data
+@ToString
+@EqualsAndHashCode
+public class BaseVisitIpDTO implements OutputConverter<BaseVisitIpDTO, BaseVisitIp> {
+
+    private Integer id;
+
+    private String requestIp;
+
+    private Date requestTime;
+}

--- a/src/main/java/run/halo/app/model/entity/BaseVisitIp.java
+++ b/src/main/java/run/halo/app/model/entity/BaseVisitIp.java
@@ -1,0 +1,40 @@
+package run.halo.app.model.entity;
+
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+import org.hibernate.annotations.GenericGenerator;
+
+import javax.persistence.*;
+
+/**
+ * Base visit ip address entity.
+ *
+ * @author KristenLawrence
+ * @date 2020-05-07
+ */
+@Data
+@Entity(name = "BaseVisitIp")
+@Table(name = "visit_ip", indexes = {@Index(name = "base_visit_ip_post_id", columnList = "post_id")})
+//@DiscriminatorColumn(name = "type", discriminatorType = DiscriminatorType.INTEGER, columnDefinition = "int default 0")
+@ToString(callSuper = true)
+@EqualsAndHashCode(callSuper = true)
+public class BaseVisitIp extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY, generator = "custom-id")
+    @GenericGenerator(name = "custom-id", strategy = "run.halo.app.model.entity.support.CustomIdGenerator")
+    private Long id;
+
+    /**
+     * Post/Sheet id.
+     */
+    @Column(name = "post_id", nullable = false)
+    private Integer postId;
+
+    /**
+     * Visitor's ip address.
+     */
+    @Column(name = "ip_address", length = 127, nullable = false)
+    private String ipAddress;
+}

--- a/src/main/java/run/halo/app/model/entity/PostVisitIp.java
+++ b/src/main/java/run/halo/app/model/entity/PostVisitIp.java
@@ -1,0 +1,19 @@
+package run.halo.app.model.entity;
+
+import lombok.EqualsAndHashCode;
+
+import javax.persistence.DiscriminatorValue;
+import javax.persistence.Entity;
+
+/**
+ * Post Visit ip address.
+ *
+ * @author KristenLawrence
+ * @date 2020-05-07
+ */
+@Entity(name = "PostVisitIp")
+@DiscriminatorValue("0")
+@EqualsAndHashCode(callSuper = true)
+public class PostVisitIp extends BaseVisitIp {
+
+}

--- a/src/main/java/run/halo/app/model/entity/SheetVisitIp.java
+++ b/src/main/java/run/halo/app/model/entity/SheetVisitIp.java
@@ -1,0 +1,19 @@
+package run.halo.app.model.entity;
+
+import lombok.EqualsAndHashCode;
+
+import javax.persistence.DiscriminatorValue;
+import javax.persistence.Entity;
+
+/**
+ * Sheet Visit ip address.
+ *
+ * @author KristenLawrence
+ * @date 2020-05-07
+ */
+@Entity(name = "SheetVisitIp")
+@DiscriminatorValue("1")
+@EqualsAndHashCode(callSuper = true)
+public class SheetVisitIp extends BaseVisitIp {
+
+}

--- a/src/main/java/run/halo/app/repository/PostVisitIpRepository.java
+++ b/src/main/java/run/halo/app/repository/PostVisitIpRepository.java
@@ -1,0 +1,39 @@
+package run.halo.app.repository;
+
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.lang.NonNull;
+import run.halo.app.model.entity.PostVisitIp;
+import run.halo.app.repository.base.BaseVisitIpRepository;
+
+import java.util.List;
+
+/**
+ * Post visit ip address repository.
+ *
+ * @author KristenLawrence
+ * @date 2020-05-07
+ */
+public interface PostVisitIpRepository extends BaseVisitIpRepository<PostVisitIp>, JpaSpecificationExecutor<PostVisitIp> {
+
+    /**
+     * Finds all visitIp by post id.
+     *
+     * @param postId post id must not be null
+     * @return a list of visitIp ordered by visit time
+     */
+    @NonNull
+    @Query("select visit from PostVisitIp visit where visit.postId = :postId order by visit.createTime desc")
+    List<PostVisitIp> findAllByPostId(@Param("postId") @NonNull Integer postId);
+
+    /**
+     * Finds all visitIp by post id and request ip.
+     *
+     * @param postId post id must not be null
+     * @param requestIp request ip must not be null
+     * @return a list of visitIp (with 1 or 0 item)
+     */
+    @Query("select visit from PostVisitIp visit where visit.postId = :postId and visit.ipAddress = :requestIp")
+    List<PostVisitIp> findByPostIdAndIp(@Param("postId") @NonNull Integer postId, @Param("requestIp") @NonNull String requestIp);
+}

--- a/src/main/java/run/halo/app/repository/SheetVisitIpRepository.java
+++ b/src/main/java/run/halo/app/repository/SheetVisitIpRepository.java
@@ -1,0 +1,39 @@
+package run.halo.app.repository;
+
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.lang.NonNull;
+import run.halo.app.model.entity.SheetVisitIp;
+import run.halo.app.repository.base.BaseVisitIpRepository;
+
+import java.util.List;
+
+/**
+ * Sheet visit ip address repository.
+ *
+ * @author KristenLawrence
+ * @date 2020-05-07
+ */
+public interface SheetVisitIpRepository extends BaseVisitIpRepository<SheetVisitIp>, JpaSpecificationExecutor<SheetVisitIp> {
+
+    /**
+     * Finds all visitIp by sheet id.
+     *
+     * @param postId post id must not be null
+     * @return a list of visitIp ordered by visit time
+     */
+    @NonNull
+    @Query("select visit from SheetVisitIp visit where visit.postId = :postId order by visit.createTime desc")
+    List<SheetVisitIp> findAllByPostId(@Param("postId") @NonNull Integer postId);
+
+    /**
+     * Finds all visitIp by sheet id and request ip.
+     *
+     * @param postId post id must not be null
+     * @param requestIp request ip must not be null
+     * @return a list of visitIp (with 1 or 0 item)
+     */
+    @Query("select visit from SheetVisitIp visit where visit.postId = :postId and visit.ipAddress = :requestIp")
+    List<SheetVisitIp> findByPostIdAndIp(@Param("postId") @NonNull Integer postId, @Param("requestIp") @NonNull String requestIp);
+}

--- a/src/main/java/run/halo/app/repository/base/BaseVisitIpRepository.java
+++ b/src/main/java/run/halo/app/repository/base/BaseVisitIpRepository.java
@@ -1,0 +1,35 @@
+package run.halo.app.repository.base;
+
+import org.springframework.data.repository.NoRepositoryBean;
+import org.springframework.lang.NonNull;
+import run.halo.app.model.entity.BaseVisitIp;
+
+import java.util.List;
+
+/**
+ * Base visit ip address repository.
+ *
+ * @author KristenLawrence
+ * @date 2020-05-07
+ */
+@NoRepositoryBean
+public interface BaseVisitIpRepository<VISITIP extends BaseVisitIp> extends BaseRepository<VISITIP, Long> {
+
+    /**
+     * Finds all visitIp by post id.
+     *
+     * @param postId post id must not be null
+     * @return a list of visitIp (ip address and visit time)
+     */
+    @NonNull
+    List<VISITIP> findAllByPostId(@NonNull Integer postId);
+
+    /**
+     * Finds all visitIp by post id and request ip.
+     *
+     * @param postId post id must not be null
+     * @param requestIp request ip must not be null
+     * @return a list of visitIp (with 1 or 0 item)
+     */
+    List<VISITIP> findByPostIdAndIp(@NonNull Integer postId, @NonNull String requestIp);
+}

--- a/src/main/java/run/halo/app/service/PostService.java
+++ b/src/main/java/run/halo/app/service/PostService.java
@@ -250,9 +250,10 @@ public interface PostService extends BasePostService<Post> {
     /**
      * Publish a post visit event.
      *
+     * @param requestIp requestIp could be null (index)
      * @param postId postId must not be null
      */
-    void publishVisitEvent(@NonNull Integer postId);
+    void publishVisitEvent(String requestIp, @NonNull Integer postId);
 
     /**
      * Gets pre && next post.

--- a/src/main/java/run/halo/app/service/PostService.java
+++ b/src/main/java/run/halo/app/service/PostService.java
@@ -248,7 +248,14 @@ public interface PostService extends BasePostService<Post> {
     Page<PostDetailVO> convertToDetailVo(@NonNull Page<Post> postPage);
 
     /**
-     * Publish a post visit event.
+     * Publish a post visit event (without ip address).
+     *
+     * @param postId postId must not be null
+     */
+    void publishVisitEvent(@NonNull Integer postId);
+
+    /**
+     * Publish a post visit event (with ip address).
      *
      * @param requestIp requestIp could be null (index)
      * @param postId postId must not be null

--- a/src/main/java/run/halo/app/service/PostVisitIpService.java
+++ b/src/main/java/run/halo/app/service/PostVisitIpService.java
@@ -1,0 +1,13 @@
+package run.halo.app.service;
+
+import run.halo.app.model.entity.PostVisitIp;
+import run.halo.app.service.base.BasePostVisitIpService;
+
+/**
+ * Post visit ip address service.
+ *
+ * @author KristenLawrence
+ * @date 2020-05-08
+ */
+public interface PostVisitIpService extends BasePostVisitIpService<PostVisitIp> {
+}

--- a/src/main/java/run/halo/app/service/SheetService.java
+++ b/src/main/java/run/halo/app/service/SheetService.java
@@ -126,10 +126,17 @@ public interface SheetService extends BasePostService<Sheet> {
     SheetDetailVO convertToDetailVo(@NonNull Sheet sheet);
 
     /**
-     * Publish a sheet visit event.
+     * Publish a sheet visit event (without ip address).
      *
-     * @param requestIp requestIp must not be null
      * @param sheetId sheetId must not be null
      */
-    void publishVisitEvent(@NonNull String requestIp, @NonNull Integer sheetId);
+    void publishVisitEvent(@NonNull Integer sheetId);
+
+    /**
+     * Publish a sheet visit event (with ip address).
+     *
+     * @param requestIp requestIp could be null
+     * @param sheetId sheetId must not be null
+     */
+    void publishVisitEvent(String requestIp, @NonNull Integer sheetId);
 }

--- a/src/main/java/run/halo/app/service/SheetService.java
+++ b/src/main/java/run/halo/app/service/SheetService.java
@@ -128,7 +128,8 @@ public interface SheetService extends BasePostService<Sheet> {
     /**
      * Publish a sheet visit event.
      *
+     * @param requestIp requestIp must not be null
      * @param sheetId sheetId must not be null
      */
-    void publishVisitEvent(@NonNull Integer sheetId);
+    void publishVisitEvent(@NonNull String requestIp, @NonNull Integer sheetId);
 }

--- a/src/main/java/run/halo/app/service/SheetVisitIpService.java
+++ b/src/main/java/run/halo/app/service/SheetVisitIpService.java
@@ -1,0 +1,13 @@
+package run.halo.app.service;
+
+import run.halo.app.model.entity.SheetVisitIp;
+import run.halo.app.service.base.BasePostVisitIpService;
+
+/**
+ * Sheet visit ip address service.
+ *
+ * @author KristenLawrence
+ * @date 2020-05-08
+ */
+public interface SheetVisitIpService extends BasePostVisitIpService<SheetVisitIp> {
+}

--- a/src/main/java/run/halo/app/service/base/BasePostVisitIpService.java
+++ b/src/main/java/run/halo/app/service/base/BasePostVisitIpService.java
@@ -1,0 +1,41 @@
+package run.halo.app.service.base;
+
+import org.springframework.lang.NonNull;
+import run.halo.app.model.entity.BaseVisitIp;
+
+import java.util.List;
+
+/**
+ * Base visit ip address service interface.
+ *
+ * @author KristenLawrence
+ * @date 2020-05-07
+ */
+public interface BasePostVisitIpService<VISITIP extends BaseVisitIp> extends CrudService<VISITIP, Long> {
+
+    /**
+     * Create by visitIp.
+     *
+     * @param visitIp visitIp must not be null
+     * @return created visitIp
+     */
+    @NonNull
+    VISITIP createBy(@NonNull VISITIP visitIp);
+
+    /**
+     * Gets all of the ip records of a post.
+     *
+     * @param postId post id must not ne null
+     * @return a list of ip records
+     */
+    List<VISITIP> getIpRecordsByPostId(@NonNull Integer postId);
+
+    /**
+     * Check ip record's existence by post id and ip address.
+     *
+     * @param postId post id must not ne null
+     * @param requestIp request ip must not be null
+     * @return whether ip record exits (true: exit, false: not exist)
+     */
+    boolean checkIpRecordByPostIdAndIp(@NonNull Integer postId, @NonNull String requestIp);
+}

--- a/src/main/java/run/halo/app/service/impl/BasePostVisitIpServiceImpl.java
+++ b/src/main/java/run/halo/app/service/impl/BasePostVisitIpServiceImpl.java
@@ -1,7 +1,6 @@
 package run.halo.app.service.impl;
 
 import lombok.extern.slf4j.Slf4j;
-import org.jetbrains.annotations.NotNull;
 import org.springframework.lang.NonNull;
 import org.springframework.util.Assert;
 import run.halo.app.model.entity.BaseVisitIp;

--- a/src/main/java/run/halo/app/service/impl/BasePostVisitIpServiceImpl.java
+++ b/src/main/java/run/halo/app/service/impl/BasePostVisitIpServiceImpl.java
@@ -30,14 +30,12 @@ public abstract class BasePostVisitIpServiceImpl<VISITIP extends BaseVisitIp> ex
 
     @Override
     @Transactional
-    @NotNull
     public VISITIP create(@NonNull VISITIP visitIp) {
         return super.create(visitIp);
     }
 
     @Override
     @Transactional
-    @NotNull
     public VISITIP createBy(VISITIP visitIp) {
         Assert.notNull(visitIp, "BasePostVisitIp to create must not be null");
         return create(visitIp);

--- a/src/main/java/run/halo/app/service/impl/BasePostVisitIpServiceImpl.java
+++ b/src/main/java/run/halo/app/service/impl/BasePostVisitIpServiceImpl.java
@@ -1,0 +1,58 @@
+package run.halo.app.service.impl;
+
+import lombok.extern.slf4j.Slf4j;
+import org.jetbrains.annotations.NotNull;
+import org.springframework.lang.NonNull;
+import org.springframework.util.Assert;
+import run.halo.app.model.entity.BaseVisitIp;
+import run.halo.app.repository.base.BaseVisitIpRepository;
+import run.halo.app.service.base.AbstractCrudService;
+import run.halo.app.service.base.BasePostVisitIpService;
+
+import javax.transaction.Transactional;
+import java.util.List;
+
+/**
+ * Base post visit ip address service implementation.
+ *
+ * @author KristenLawrence
+ * @date 2020-05-07
+ */
+@Slf4j
+public abstract class BasePostVisitIpServiceImpl<VISITIP extends BaseVisitIp> extends AbstractCrudService<VISITIP, Long> implements BasePostVisitIpService<VISITIP> {
+
+    private final BaseVisitIpRepository<VISITIP> baseVisitIpRepository;
+
+    protected BasePostVisitIpServiceImpl(BaseVisitIpRepository<VISITIP> baseVisitIpRepository) {
+        super(baseVisitIpRepository);
+        this.baseVisitIpRepository = baseVisitIpRepository;
+    }
+
+    @Override
+    @Transactional
+    @NotNull
+    public VISITIP create(@NonNull VISITIP visitIp) {
+        return super.create(visitIp);
+    }
+
+    @Override
+    @Transactional
+    @NotNull
+    public VISITIP createBy(VISITIP visitIp) {
+        Assert.notNull(visitIp, "BasePostVisitIp to create must not be null");
+        return create(visitIp);
+    }
+
+    public List<VISITIP> getIpRecordsByPostId(@NonNull Integer postId) {
+        return baseVisitIpRepository.findAllByPostId(postId);
+    }
+
+    public boolean checkIpRecordByPostIdAndIp(@NonNull Integer postId, @NonNull String requestIp) {
+        List<VISITIP> ipList = baseVisitIpRepository.findByPostIdAndIp(postId, requestIp);
+
+        log.debug("Check if ip [{}] Previously requested for article [{}], result: [{}]", requestIp, postId, ipList.isEmpty());
+        log.debug("Current ip database for post [{}]: {}", postId, baseVisitIpRepository.findAllByPostId(postId));
+
+        return !ipList.isEmpty();
+    }
+}

--- a/src/main/java/run/halo/app/service/impl/PostServiceImpl.java
+++ b/src/main/java/run/halo/app/service/impl/PostServiceImpl.java
@@ -786,8 +786,8 @@ public class PostServiceImpl extends BasePostServiceImpl<Post> implements PostSe
     }
 
     @Override
-    public void publishVisitEvent(Integer postId) {
-        eventPublisher.publishEvent(new PostVisitEvent(this, postId));
+    public void publishVisitEvent(String requestIp, Integer postId) {
+        eventPublisher.publishEvent(new PostVisitEvent(this, requestIp, postId));
     }
 
     @Override

--- a/src/main/java/run/halo/app/service/impl/PostServiceImpl.java
+++ b/src/main/java/run/halo/app/service/impl/PostServiceImpl.java
@@ -786,6 +786,11 @@ public class PostServiceImpl extends BasePostServiceImpl<Post> implements PostSe
     }
 
     @Override
+    public void publishVisitEvent(Integer postId) {
+        eventPublisher.publishEvent(new PostVisitEvent(this, null, postId));
+    }
+
+    @Override
     public void publishVisitEvent(String requestIp, Integer postId) {
         eventPublisher.publishEvent(new PostVisitEvent(this, requestIp, postId));
     }

--- a/src/main/java/run/halo/app/service/impl/PostVisitIpServiceImpl.java
+++ b/src/main/java/run/halo/app/service/impl/PostVisitIpServiceImpl.java
@@ -1,0 +1,20 @@
+package run.halo.app.service.impl;
+
+import org.springframework.stereotype.Service;
+import run.halo.app.model.entity.PostVisitIp;
+import run.halo.app.repository.PostVisitIpRepository;
+import run.halo.app.service.PostVisitIpService;
+
+/**
+ * Post visit ip address service implementation.
+ *
+ * @author KristenLawrence
+ * @date 2020-05-07
+ */
+@Service
+public class PostVisitIpServiceImpl extends BasePostVisitIpServiceImpl<PostVisitIp> implements PostVisitIpService {
+
+    protected PostVisitIpServiceImpl(PostVisitIpRepository postVisitIpRepository) {
+        super(postVisitIpRepository);
+    }
+}

--- a/src/main/java/run/halo/app/service/impl/SheetServiceImpl.java
+++ b/src/main/java/run/halo/app/service/impl/SheetServiceImpl.java
@@ -266,6 +266,11 @@ public class SheetServiceImpl extends BasePostServiceImpl<Sheet> implements Shee
     }
 
     @Override
+    public void publishVisitEvent(Integer sheetId) {
+        eventPublisher.publishEvent(new SheetVisitEvent(this, null, sheetId));
+    }
+
+    @Override
     public void publishVisitEvent(String requestIp, Integer sheetId) {
         eventPublisher.publishEvent(new SheetVisitEvent(this, requestIp, sheetId));
     }

--- a/src/main/java/run/halo/app/service/impl/SheetServiceImpl.java
+++ b/src/main/java/run/halo/app/service/impl/SheetServiceImpl.java
@@ -266,8 +266,8 @@ public class SheetServiceImpl extends BasePostServiceImpl<Sheet> implements Shee
     }
 
     @Override
-    public void publishVisitEvent(Integer sheetId) {
-        eventPublisher.publishEvent(new SheetVisitEvent(this, sheetId));
+    public void publishVisitEvent(String requestIp, Integer sheetId) {
+        eventPublisher.publishEvent(new SheetVisitEvent(this, requestIp, sheetId));
     }
 
     @Override

--- a/src/main/java/run/halo/app/service/impl/SheetVisitIpServiceImpl.java
+++ b/src/main/java/run/halo/app/service/impl/SheetVisitIpServiceImpl.java
@@ -1,0 +1,21 @@
+package run.halo.app.service.impl;
+
+import org.springframework.stereotype.Service;
+import run.halo.app.model.entity.SheetVisitIp;
+import run.halo.app.repository.SheetVisitIpRepository;
+import run.halo.app.service.SheetVisitIpService;
+
+/**
+ * Sheet visit ip address service implementation.
+ *
+ * @author KristenLawrence
+ * @date 2020-05-07
+ */
+@Service
+public class SheetVisitIpServiceImpl extends BasePostVisitIpServiceImpl<SheetVisitIp> implements SheetVisitIpService {
+
+    protected SheetVisitIpServiceImpl(SheetVisitIpRepository sheetVisitIpRepository) {
+        super(sheetVisitIpRepository);
+    }
+
+}

--- a/src/main/java/run/halo/app/utils/Pair.java
+++ b/src/main/java/run/halo/app/utils/Pair.java
@@ -1,23 +1,25 @@
 package run.halo.app.utils;
 
+import java.util.Objects;
+
 /**
- * Pair utilities.
+ * Pair class.
  *
  * @author KristenLawrence
  * @date 20-5-3
  */
-public class PairUtils<V, K> {
+public class Pair<V, K> {
 
     private V first;
 
     private K last;
 
-    public PairUtils() {
+    public Pair() {
         this.first = null;
         this.last  = null;
     }
 
-    public PairUtils(V first, K last) {
+    public Pair(V first, K last) {
         this.first = first;
         this.last = last;
     }
@@ -39,18 +41,16 @@ public class PairUtils<V, K> {
     }
 
     @Override
-    public int hashCode() {
-        return first.hashCode() + last.hashCode();
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        Pair<?, ?> pair = (Pair<?, ?>) o;
+        return Objects.equals(first, pair.first) &&
+            Objects.equals(last, pair.last);
     }
-    
+
     @Override
-    public boolean equals(Object object) {
-        if (!(object instanceof PairUtils)) {
-            return false;
-        }
-        
-        PairUtils<V, K> pair = (PairUtils<V,K>) object;
-        
-        return pair.first.equals(first) && pair.last.equals(last);
+    public int hashCode() {
+        return Objects.hash(first, last);
     }
 }

--- a/src/main/java/run/halo/app/utils/PairUtils.java
+++ b/src/main/java/run/halo/app/utils/PairUtils.java
@@ -1,14 +1,11 @@
 package run.halo.app.utils;
 
-import lombok.extern.slf4j.Slf4j;
-
 /**
  * Pair utilities.
  *
  * @author KristenLawrence
  * @date 20-5-3
  */
-@Slf4j
 public class PairUtils<V, K> {
 
     private V first;

--- a/src/main/java/run/halo/app/utils/PairUtils.java
+++ b/src/main/java/run/halo/app/utils/PairUtils.java
@@ -1,0 +1,56 @@
+package run.halo.app.utils;
+
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * Pair utilities.
+ *
+ * @author KristenLawrence
+ * @date 20-5-3
+ */
+@Slf4j
+public class PairUtils<V, K> {
+
+    private V first;
+
+    private K last;
+
+    public PairUtils() {}
+
+    public PairUtils(V first, K last) {
+        this.first = first;
+        this.last = last;
+    }
+
+    public V getFirst() {
+        return this.first;
+    }
+
+    public void setFirst(V first) {
+        this.first = first;
+    }
+
+    public K getLast() {
+        return this.last;
+    }
+
+    public void setLast(K last) {
+        this.last = last;
+    }
+
+    @Override
+    public int hashCode() {
+        return first.hashCode() + last.hashCode();
+    }
+    
+    @Override
+    public boolean equals(Object object) {
+        if (!(object instanceof PairUtils)) {
+            return false;
+        }
+        
+        PairUtils<V, K> pair = (PairUtils<V,K>) object;
+        
+        return pair.first.equals(first) && pair.last.equals(last);
+    }
+}

--- a/src/main/java/run/halo/app/utils/PairUtils.java
+++ b/src/main/java/run/halo/app/utils/PairUtils.java
@@ -15,7 +15,10 @@ public class PairUtils<V, K> {
 
     private K last;
 
-    public PairUtils() {}
+    public PairUtils() {
+        this.first = null;
+        this.last  = null;
+    }
 
     public PairUtils(V first, K last) {
         this.first = first;

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -25,11 +25,11 @@ spring:
       settings:
         web-allow-others: false
       path: /h2-console
-      enabled: true
+      enabled: false
   jpa:
     hibernate:
       ddl-auto: update
-    show-sql: true
+    show-sql: false
     open-in-view: false
   flyway:
     enabled: false
@@ -46,7 +46,7 @@ management:
         include: ['httptrace', 'metrics','env','logfile','health']
 logging:
   level:
-    run.halo.app: DEBUG
+    run.halo.app: INFO
   file:
     path: \${user.home}/.halo/logs
 

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -37,7 +37,7 @@ spring:
     multipart:
       max-file-size: 10240MB
       max-request-size: 10240MB
-      location: \${java.io.tmpdir}
+      location: ${java.io.tmpdir}
 management:
   endpoints:
     web:
@@ -48,7 +48,7 @@ logging:
   level:
     run.halo.app: INFO
   file:
-    path: \${user.home}/.halo/logs
+    path: ${user.home}/.halo/logs
 
 halo:
   download-timeout: 5m

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -52,6 +52,3 @@ logging:
 
 halo:
   download-timeout: 5m
-
-application:
-  version: ${version}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -25,11 +25,11 @@ spring:
       settings:
         web-allow-others: false
       path: /h2-console
-      enabled: false
+      enabled: true
   jpa:
     hibernate:
       ddl-auto: update
-    show-sql: false
+    show-sql: true
     open-in-view: false
   flyway:
     enabled: false
@@ -46,7 +46,7 @@ management:
         include: ['httptrace', 'metrics','env','logfile','health']
 logging:
   level:
-    run.halo.app: INFO
+    run.halo.app: DEBUG
   file:
     path: \${user.home}/.halo/logs
 

--- a/src/test/java/run/halo/app/service/impl/VisitIpServiceImplTest.java
+++ b/src/test/java/run/halo/app/service/impl/VisitIpServiceImplTest.java
@@ -1,0 +1,53 @@
+package run.halo.app.service.impl;
+
+import lombok.extern.slf4j.Slf4j;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.junit4.SpringRunner;
+import run.halo.app.listener.post.PostVisitEventListener;
+
+@RunWith(SpringRunner.class)
+@SpringBootTest
+@ActiveProfiles("test")
+@Slf4j
+public class VisitIpServiceImplTest {
+
+    @Autowired
+    private PostVisitIpServiceImpl postVisitIpService;
+
+    @Autowired
+    private PostVisitEventListener postVisitEventListener;
+
+    public void recordsAmountTest(int postId, String requestIp, int amount) {
+        Assert.assertEquals(amount, postVisitIpService.getIpRecordsByPostId(postId).size());
+    }
+
+    public void ipRecordsTest(int postId) {
+        log.debug("Current ip records of post id [{}] are: [{}]", postId, postVisitIpService.getIpRecordsByPostId(postId));
+    }
+
+    @Test
+    public void visitWithSameIpTest() {
+        int postId = 123;
+        String requestIp = "127.0.0.1";
+
+        ipRecordsTest(postId);
+        recordsAmountTest(postId, requestIp, 0);
+        Assert.assertFalse(postVisitEventListener.checkIpRecord(123, "127.0.0.1"));
+
+        ipRecordsTest(postId);
+        Assert.assertTrue(postVisitIpService.checkIpRecordByPostIdAndIp(postId, requestIp));
+        recordsAmountTest(postId, requestIp, 1);
+
+        ipRecordsTest(postId);
+        Assert.assertTrue(postVisitIpService.checkIpRecordByPostIdAndIp(postId, requestIp));
+        recordsAmountTest(postId, requestIp, 1);
+
+        ipRecordsTest(postId);
+    }
+
+}

--- a/src/test/java/run/halo/app/utils/PairTest.java
+++ b/src/test/java/run/halo/app/utils/PairTest.java
@@ -13,7 +13,7 @@ public class PairTest {
 
     @Test
     public void getSetTest() {
-        PairUtils<Integer, String> pair = new PairUtils<>(100, "127.0.0.1");
+        Pair<Integer, String> pair = new Pair<>(100, "127.0.0.1");
 
         pair.setFirst(200);
         Assert.assertEquals(200, (int) pair.getFirst());
@@ -24,11 +24,19 @@ public class PairTest {
 
     @Test
     public void equalTest() {
-        PairUtils<Integer, String> pair1 = new PairUtils<>(100, "127.0.0.1");
-        PairUtils<Integer, String> pair2 = new PairUtils<>(100, "127.0.0.1");
+        Pair<Integer, String> pair1 = new Pair<>(100, "127.0.0.1");
+        Pair<Integer, String> pair2 = new Pair<>(100, "127.0.0.1");
 
         Assert.assertEquals(pair1.hashCode(), pair2.hashCode());
+        Assert.assertEquals(pair1, pair2);
+    }
 
+    @Test
+    public void nullTest() {
+        Pair<String, String> pair1 = new Pair<>(null, null);
+        Pair<String, String> pair2 = new Pair<>(null, null);
+
+        Assert.assertEquals(pair1.hashCode(), pair2.hashCode());
         Assert.assertEquals(pair1, pair2);
     }
 }

--- a/src/test/java/run/halo/app/utils/PairTest.java
+++ b/src/test/java/run/halo/app/utils/PairTest.java
@@ -1,0 +1,34 @@
+package run.halo.app.utils;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * Pair test.
+ *
+ * @author KristenLawrence
+ * @date 20-5-3
+ */
+public class PairTest {
+
+    @Test
+    public void getSetTest() {
+        PairUtils<Integer, String> pair = new PairUtils<>(100, "127.0.0.1");
+
+        pair.setFirst(200);
+        Assert.assertEquals(200, (int) pair.getFirst());
+
+        pair.setLast("10.0.0.1");
+        Assert.assertEquals("10.0.0.1", pair.getLast());
+    }
+
+    @Test
+    public void equalTest() {
+        PairUtils<Integer, String> pair1 = new PairUtils<>(100, "127.0.0.1");
+        PairUtils<Integer, String> pair2 = new PairUtils<>(100, "127.0.0.1");
+
+        Assert.assertEquals(pair1.hashCode(), pair2.hashCode());
+
+        Assert.assertEquals(pair1, pair2);
+    }
+}


### PR DESCRIPTION
修复issue [#319 ](https://github.com/halo-dev/halo/issues/319) 中提出的问题。

具体如下：
1. 相同IP对于同一文章的访问量不会重复累计。
2. 在`AbstractVisitEventListener`使用如下数据结构储存每篇文章所有访问对应的IP地址，可在后端查看最近访问IP：
`private final Map<Integer, IpRecorder> visitIpMap`
目前还未实现前端显示。