### PR TITLE
Fix issue #763

### DIFF
--- a/src/main/java/run/halo/app/controller/content/model/PostModel.java
+++ b/src/main/java/run/halo/app/controller/content/model/PostModel.java
@@ -79,6 +79,7 @@ public class PostModel {
             return "common/template/post_password";
         }
 
+        boolean isDraft = false;
         if (StringUtils.isEmpty(token)) {
             post = postService.getBy(PostStatus.PUBLISHED, post.getSlug());
         } else {
@@ -92,11 +93,12 @@ public class PostModel {
             } else {
                 post.setFormatContent(post.getOriginalContent());
             }
-            // visit decrease 1
-            // postService.increaseVisit(-1L, post.getId());
+            isDraft = true;
         }
 
-        postService.publishVisitEvent(post.getId());
+        if (!isDraft) {
+            postService.publishVisitEvent(post.getId());
+        }
 
         AdjacentPostVO adjacentPostVO = postService.getAdjacentPosts(post);
         adjacentPostVO.getOptionalPrevPost().ifPresent(prevPost -> model.addAttribute("prevPost", postService.convertToDetailVo(prevPost)));

--- a/src/main/java/run/halo/app/controller/content/model/PostModel.java
+++ b/src/main/java/run/halo/app/controller/content/model/PostModel.java
@@ -92,6 +92,8 @@ public class PostModel {
             } else {
                 post.setFormatContent(post.getOriginalContent());
             }
+            // visit decrease 1
+            postService.increaseVisit(-1L, post.getId());
         }
 
         postService.publishVisitEvent(post.getId());

--- a/src/main/java/run/halo/app/controller/content/model/PostModel.java
+++ b/src/main/java/run/halo/app/controller/content/model/PostModel.java
@@ -93,7 +93,7 @@ public class PostModel {
                 post.setFormatContent(post.getOriginalContent());
             }
             // visit decrease 1
-            postService.increaseVisit(-1L, post.getId());
+            // postService.increaseVisit(-1L, post.getId());
         }
 
         postService.publishVisitEvent(post.getId());

--- a/src/main/java/run/halo/app/model/params/PostParam.java
+++ b/src/main/java/run/halo/app/model/params/PostParam.java
@@ -8,11 +8,13 @@ import run.halo.app.model.entity.Post;
 import run.halo.app.model.entity.PostMeta;
 import run.halo.app.model.enums.PostEditorType;
 import run.halo.app.model.enums.PostStatus;
+import run.halo.app.utils.DateTimeUtils;
 import run.halo.app.utils.SlugUtils;
 
 import javax.validation.constraints.Min;
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.Size;
+import java.time.LocalDateTime;
 import java.util.Date;
 import java.util.HashSet;
 import java.util.Set;
@@ -95,6 +97,15 @@ public class PostParam implements InputConverter<Post> {
         if (null == editorType) {
             editorType = PostEditorType.MARKDOWN;
         }
+
+        LocalDateTime now = LocalDateTime.now();
+        Date nowDate = new Date(DateTimeUtils.toEpochMilli(now));
+        // 这里我注意到可以编辑发布的时间到未来的日期，但是好像并不支持“未来发布”
+        // if(nowDate.after(this.createTime)){
+        //    this.createTime=nowDate;
+        // }
+        // 如果实际上支持“未来发布”，那么应当注释掉下面这一行
+        this.createTime = nowDate;
 
         InputConverter.super.update(post);
     }

--- a/src/main/java/run/halo/app/model/params/PostParam.java
+++ b/src/main/java/run/halo/app/model/params/PostParam.java
@@ -100,12 +100,16 @@ public class PostParam implements InputConverter<Post> {
 
         LocalDateTime now = LocalDateTime.now();
         Date nowDate = new Date(DateTimeUtils.toEpochMilli(now));
-        // 这里我注意到可以编辑发布的时间到未来的日期，但是好像并不支持“未来发布”
-        // if(nowDate.after(this.createTime)){
-        //    this.createTime=nowDate;
-        // }
-        // 如果实际上支持“未来发布”，那么应当注释掉下面这一行
-        this.createTime = nowDate;
+
+        // 如果发表的时间晚于当前，修改为当前
+        if (post.getCreateTime().after(nowDate)) {
+            setCreateTime(nowDate);
+        }
+
+        // 如果原来是草稿，应该把创建时间修改为当前时间
+        if (post.getStatus().equals(PostStatus.DRAFT)) {
+            setCreateTime(nowDate);
+        }
 
         InputConverter.super.update(post);
     }

--- a/src/main/java/run/halo/app/service/impl/BasePostServiceImpl.java
+++ b/src/main/java/run/halo/app/service/impl/BasePostServiceImpl.java
@@ -189,8 +189,7 @@ public abstract class BasePostServiceImpl<POST extends BasePost> extends Abstrac
     @Override
     @Transactional
     public void increaseVisit(long visits, Integer postId) {
-        // allow -1 to decrease for visiting to drafts
-        Assert.isTrue(visits > 0 || visits == -1L, "Visits to increase must not be less than 1");
+        Assert.isTrue(visits > 0, "Visits to increase must not be less than 1");
         Assert.notNull(postId, "Post id must not be null");
         long affectedRows = basePostRepository.updateVisit(visits, postId);
 

--- a/src/main/java/run/halo/app/service/impl/BasePostServiceImpl.java
+++ b/src/main/java/run/halo/app/service/impl/BasePostServiceImpl.java
@@ -189,9 +189,9 @@ public abstract class BasePostServiceImpl<POST extends BasePost> extends Abstrac
     @Override
     @Transactional
     public void increaseVisit(long visits, Integer postId) {
-        Assert.isTrue(visits > 0, "Visits to increase must not be less than 1");
+        // allow -1 to decrease for visiting to drafts
+        Assert.isTrue(visits > 0 || visits == -1L, "Visits to increase must not be less than 1");
         Assert.notNull(postId, "Post id must not be null");
-
         long affectedRows = basePostRepository.updateVisit(visits, postId);
 
         if (affectedRows != 1) {


### PR DESCRIPTION
- 不统计草稿的访问，解决方案是对于草稿每次将访问数-1，不过似乎和pull #818 冲突，暂时被注释掉了
- 不统计自己的访问量似乎不太好做，访问文章除了对于草稿会多个token，其它都是匿名的。看起来可能得改前端？
- 在update里面加了一行对时间的判断，来使得发布时间一直等于最后一次点击发布的时间
