### PR TITLE
feat: Enhance the function of post management (#733)

### DIFF
--- a/src/main/java/run/halo/app/controller/admin/api/PostController.java
+++ b/src/main/java/run/halo/app/controller/admin/api/PostController.java
@@ -139,6 +139,20 @@ public class PostController {
         return postService.updateStatusByIds(ids, status);
     }
 
+    @PutMapping("disallow_comment/{disallow_comment}")
+    @ApiOperation("Updates post disallowComment in batch")
+    public List<Post> updateDisallowCommentInBatch(@PathVariable(name = "disallow_comment") Boolean disallowComment,
+                                                   @RequestBody List<Integer> ids) {
+        return postService.updateDisallowCommentByIds(ids, disallowComment);
+    }
+
+    @PutMapping("top_priority/{top_priority}")
+    @ApiOperation("Updates post topPriority in batch")
+    public List<Post> updateTopPriorityInBatch(@PathVariable(name = "top_priority") Integer topPriority,
+                                               @RequestBody List<Integer> ids) {
+        return postService.updateTopPriorityByIds(ids, topPriority);
+    }
+
     @PutMapping("{postId:\\d+}/status/draft/content")
     @ApiOperation("Updates draft")
     public BasePostDetailDTO updateDraftBy(

--- a/src/main/java/run/halo/app/controller/admin/api/PostController.java
+++ b/src/main/java/run/halo/app/controller/admin/api/PostController.java
@@ -5,6 +5,7 @@ import io.swagger.annotations.ApiOperation;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
+import org.springframework.util.CollectionUtils;
 import org.springframework.web.bind.annotation.*;
 import run.halo.app.cache.AbstractStringCacheStore;
 import run.halo.app.model.dto.post.BasePostDetailDTO;
@@ -16,6 +17,7 @@ import run.halo.app.model.enums.PostStatus;
 import run.halo.app.model.params.PostContentParam;
 import run.halo.app.model.params.PostParam;
 import run.halo.app.model.params.PostQuery;
+import run.halo.app.model.params.PostSettingParam;
 import run.halo.app.model.vo.PostDetailVO;
 import run.halo.app.service.OptionService;
 import run.halo.app.service.PostService;
@@ -24,8 +26,10 @@ import javax.validation.Valid;
 import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
+import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
 
 import static org.springframework.data.domain.Sort.Direction.DESC;
 
@@ -95,6 +99,18 @@ public class PostController {
         return postService.convertToDetailVo(post);
     }
 
+    @PostMapping("posts")
+    @ApiOperation("Gets posts by ids")
+    public List<PostDetailVO> getByIds(@RequestBody List<Integer> ids) {
+        if (CollectionUtils.isEmpty(ids)) {
+            return Collections.emptyList();
+        }
+        return ids.stream().map(id -> {
+            Post post = postService.getById(id);
+            return postService.convertToDetailVo(post);
+        }).collect(Collectors.toList());
+    }
+
     @PutMapping("{postId:\\d+}/likes")
     @ApiOperation("Likes a post")
     public void likes(@PathVariable("postId") Integer postId) {
@@ -151,6 +167,12 @@ public class PostController {
     public List<Post> updateTopPriorityInBatch(@PathVariable(name = "top_priority") Integer topPriority,
                                                @RequestBody List<Integer> ids) {
         return postService.updateTopPriorityByIds(ids, topPriority);
+    }
+
+    @PutMapping("setting")
+    @ApiOperation("Updates post setting in batch")
+    public List<Post> updateSettingInBatch(@RequestBody PostSettingParam postSettingParam) {
+        return postService.updateSettingByIds(postSettingParam.getIds(), postSettingParam);
     }
 
     @PutMapping("{postId:\\d+}/status/draft/content")

--- a/src/main/java/run/halo/app/controller/admin/api/PostController.java
+++ b/src/main/java/run/halo/app/controller/admin/api/PostController.java
@@ -99,9 +99,9 @@ public class PostController {
         return postService.convertToDetailVo(post);
     }
 
-    @PostMapping("posts")
+    @GetMapping("posts")
     @ApiOperation("Gets posts by ids")
-    public List<PostDetailVO> getByIds(@RequestBody List<Integer> ids) {
+    public List<PostDetailVO> getByIds(@RequestParam(name = "ids", required = true) List<Integer> ids) {
         if (CollectionUtils.isEmpty(ids)) {
             return Collections.emptyList();
         }

--- a/src/main/java/run/halo/app/model/params/PostSettingParam.java
+++ b/src/main/java/run/halo/app/model/params/PostSettingParam.java
@@ -1,0 +1,35 @@
+package run.halo.app.model.params;
+
+import lombok.Data;
+import run.halo.app.model.dto.base.InputConverter;
+import run.halo.app.model.entity.Post;
+
+import javax.validation.constraints.Min;
+import javax.validation.constraints.Size;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Post param.
+ *
+ * @author Holldean
+ * @date 2020-05-05
+ */
+@Data
+public class PostSettingParam implements InputConverter<Post> {
+
+    private List<Integer> ids;
+
+    private Boolean disallowComment = false;
+
+    @Size(max = 255, message = "文章密码的字符长度不能超过 {max}")
+    private String password;
+
+    @Min(value = 0, message = "Post top priority must not be less than {value}")
+    private Integer topPriority = 0;
+
+    private Set<Integer> tagIds;
+
+    private Set<Integer> categoryIds;
+
+}

--- a/src/main/java/run/halo/app/repository/base/BasePostRepository.java
+++ b/src/main/java/run/halo/app/repository/base/BasePostRepository.java
@@ -189,6 +189,28 @@ public interface BasePostRepository<POST extends BasePost> extends BaseRepositor
     int updateStatus(@Param("status") @NonNull PostStatus status, @Param("postId") @NonNull Integer postId);
 
     /**
+     * Updates post disallowComment by post id.
+     *
+     * @param disallowComment post disallowComment must not be null.
+     * @param postId          post id must not be null.
+     * @return updated rows.
+     */
+    @Modifying
+    @Query("update BasePost p set p.disallowComment = :disallowComment where p.id = :postId")
+    int updateDisallowComment(@Param("disallowComment") @NonNull Boolean disallowComment, @Param("postId") @NonNull Integer postId);
+
+    /**
+     * Updates post topPriority by post id.
+     *
+     * @param topPriority post topPriority must not be null.
+     * @param postId      post id must not be null.
+     * @return updated rows.
+     */
+    @Modifying
+    @Query("update BasePost p set p.topPriority = :topPriority where p.id = :postId")
+    int updateTopPriority(@Param("topPriority") @NonNull Integer topPriority, @Param("postId") @NonNull Integer postId);
+
+    /**
      * Updates post format content by post id.
      *
      * @param formatContent format content must not be null.

--- a/src/main/java/run/halo/app/service/PostService.java
+++ b/src/main/java/run/halo/app/service/PostService.java
@@ -8,6 +8,7 @@ import run.halo.app.model.entity.Post;
 import run.halo.app.model.entity.PostMeta;
 import run.halo.app.model.enums.PostStatus;
 import run.halo.app.model.params.PostQuery;
+import run.halo.app.model.params.PostSettingParam;
 import run.halo.app.model.vo.*;
 import run.halo.app.service.base.BasePostService;
 
@@ -83,6 +84,27 @@ public interface PostService extends BasePostService<Post> {
      */
     @NonNull
     PostDetailVO updateBy(@NonNull Post postToUpdate, Set<Integer> tagIds, Set<Integer> categoryIds, Set<PostMeta> metas, boolean autoSave);
+
+    /**
+     * Updates post by post setting param.
+     *
+     * @param postToUpdate post to update must not be null
+     * @param tagIds       tag id set
+     * @param categoryIds  category id set
+     * @return updated post
+     */
+    @NonNull
+    Post updateSettingBy(@NonNull Post postToUpdate, Set<Integer> tagIds, Set<Integer> categoryIds);
+
+    /**
+     * Updates posts by post ids and post setting param.
+     *
+     * @param ids              post of ids to update must not be null
+     * @param postSettingParam post setting param must not be null
+     * @return updated posts
+     */
+    @NonNull
+    List<Post> updateSettingByIds(List<Integer> ids, PostSettingParam postSettingParam);
 
     /**
      * Gets post by post status and slug.

--- a/src/main/java/run/halo/app/service/base/BasePostService.java
+++ b/src/main/java/run/halo/app/service/base/BasePostService.java
@@ -300,6 +300,46 @@ public interface BasePostService<POST extends BasePost> extends CrudService<POST
     List<POST> updateStatusByIds(@NonNull List<Integer> ids, @NonNull PostStatus status);
 
     /**
+     * Updates post disallowComment.
+     *
+     * @param disallowComment post disallowComment must not be null
+     * @param postId          post id must not be null
+     * @return updated post
+     */
+    @NonNull
+    POST updateDisallowComment(@NonNull Boolean disallowComment, @NonNull Integer postId);
+
+    /**
+     * Updates post disallowComment by ids.
+     *
+     * @param ids             post ids must not be null
+     * @param disallowComment post disallowComment must not be null
+     * @return updated posts
+     */
+    @NonNull
+    List<POST> updateDisallowCommentByIds(@NonNull List<Integer> ids, @NonNull Boolean disallowComment);
+
+    /**
+     * Updates post topPriority.
+     *
+     * @param topPriority post topPriority must not be null
+     * @param postId      post id must not be null
+     * @return updated post
+     */
+    @NonNull
+    POST updateTopPriority(@NonNull Integer topPriority, @NonNull Integer postId);
+
+    /**
+     * Updates post topPriority by ids.
+     *
+     * @param ids         post ids must not be null
+     * @param topPriority post topPriority must not be null
+     * @return updated posts
+     */
+    @NonNull
+    List<POST> updateTopPriorityByIds(@NonNull List<Integer> ids, @NonNull Integer topPriority);
+
+    /**
      * Replace post blog url in batch.
      *
      * @param oldUrl old blog url.

--- a/src/main/java/run/halo/app/service/impl/BasePostServiceImpl.java
+++ b/src/main/java/run/halo/app/service/impl/BasePostServiceImpl.java
@@ -406,6 +406,72 @@ public abstract class BasePostServiceImpl<POST extends BasePost> extends Abstrac
     }
 
     @Override
+    @Transactional
+    public POST updateDisallowComment(Boolean disallowComment, Integer postId) {
+        Assert.notNull(disallowComment, "Post disallowComment must not be null");
+        Assert.isTrue(!ServiceUtils.isEmptyId(postId), "Post id must not be empty");
+
+        // Get post
+        POST post = getById(postId);
+
+        if (!disallowComment.equals(post.getDisallowComment())) {
+            // Update post
+            int updatedRows = basePostRepository.updateDisallowComment(disallowComment, postId);
+            if (updatedRows != 1) {
+                throw new ServiceException("Failed to update post disallowComment of post with id " + postId);
+            }
+
+            post.setDisallowComment(disallowComment);
+        }
+
+        return post;
+    }
+
+    @Override
+    @Transactional
+    public List<POST> updateDisallowCommentByIds(List<Integer> ids, Boolean disallowComment) {
+        if (CollectionUtils.isEmpty(ids)) {
+            return Collections.emptyList();
+        }
+        return ids.stream().map(id -> {
+            return updateDisallowComment(disallowComment, id);
+        }).collect(Collectors.toList());
+    }
+
+    @Override
+    @Transactional
+    public POST updateTopPriority(Integer topPriority, Integer postId) {
+        Assert.notNull(topPriority, "Post topPriority must not be null");
+        Assert.isTrue(!ServiceUtils.isEmptyId(postId), "Post id must not be empty");
+
+        // Get post
+        POST post = getById(postId);
+
+        if (!topPriority.equals(post.getTopPriority())) {
+            // Update post
+            int updatedRows = basePostRepository.updateTopPriority(topPriority, postId);
+            if (updatedRows != 1) {
+                throw new ServiceException("Failed to update post topPriority of post with id " + postId);
+            }
+
+            post.setTopPriority(topPriority);
+        }
+
+        return post;
+    }
+
+    @Override
+    @Transactional
+    public List<POST> updateTopPriorityByIds(List<Integer> ids, Integer topPriority) {
+        if (CollectionUtils.isEmpty(ids)) {
+            return Collections.emptyList();
+        }
+        return ids.stream().map(id -> {
+            return updateTopPriority(topPriority, id);
+        }).collect(Collectors.toList());
+    }
+
+    @Override
     public List<BasePostDetailDTO> replaceUrl(String oldUrl, String newUrl) {
         List<POST> posts = listAll();
         List<POST> replaced = new ArrayList<>();

--- a/src/main/java/run/halo/app/service/impl/PostServiceImpl.java
+++ b/src/main/java/run/halo/app/service/impl/PostServiceImpl.java
@@ -166,12 +166,14 @@ public class PostServiceImpl extends BasePostServiceImpl<Post> implements PostSe
     }
 
     @Override
+    @Transactional
     public Post updateSettingBy(Post postToUpdate, Set<Integer> tagIds, Set<Integer> categoryIds) {
         update(postToUpdate, tagIds, categoryIds);
         return postToUpdate;
     }
 
     @Override
+    @Transactional
     public List<Post> updateSettingByIds(List<Integer> ids, PostSettingParam postSettingParam) {
         if (CollectionUtils.isEmpty(ids)) {
             return Collections.emptyList();


### PR DESCRIPTION
前端加入评论、置顶、分类、标签、加密的批量操作的入口[halo-admin/pull/157](https://github.com/halo-dev/halo-admin/pull/157)，后端新增三个API #733
1. getByIds: 批量获取post的信息
2. updateDisallowCommentInBatch: 批量开启或关闭post的评论功能
3. updateTopPriorityInBatch: 批量设置post置顶
4. updateSettingInBatch: 批量设置post的评论、置顶、分类、标签、加密的设置，传入的某个值如果为null则使用原先的设置（该API仅针对状态为已发布或私密的post）
