### PR TITLE
feat: Fix Issue 702

### DIFF
--- a/src/main/java/run/halo/app/config/Config.java
+++ b/src/main/java/run/halo/app/config/Config.java
@@ -1,0 +1,33 @@
+package run.halo.app.config;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.web.servlet.FilterRegistrationBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import run.halo.app.filter.WrapRequestFilter;
+import run.halo.app.service.OptionService;
+
+@Slf4j
+@Configuration
+public class Config {
+
+    private final OptionService optionService;
+
+    public Config(OptionService optionService) {
+        this.optionService = optionService;
+    }
+
+    @Bean
+    public WrapRequestFilter wrapRequestFilter() {
+        return new WrapRequestFilter(optionService);
+    }
+
+    @Bean
+    public FilterRegistrationBean<WrapRequestFilter> wrapRequestFilterRegistrationBean() {
+        FilterRegistrationBean<WrapRequestFilter> registrationBean = new FilterRegistrationBean<>();
+        registrationBean.setFilter(wrapRequestFilter());
+        registrationBean.setName("wrapRequestFilter");
+        registrationBean.setOrder(-1000001);
+        return registrationBean;
+    }
+}

--- a/src/main/java/run/halo/app/filter/ServletContextFacadeRequestWrapper.java
+++ b/src/main/java/run/halo/app/filter/ServletContextFacadeRequestWrapper.java
@@ -1,0 +1,48 @@
+package run.halo.app.filter;
+import io.micrometer.core.instrument.util.StringUtils;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletRequestWrapper;
+
+public class ServletContextFacadeRequestWrapper extends HttpServletRequestWrapper {
+
+    private String contextPath;
+    private String servletPath;
+
+    public ServletContextFacadeRequestWrapper(HttpServletRequest request) {
+        super(request);
+    }
+
+    @Override
+    public String getContextPath() {
+        if (StringUtils.isNotBlank(contextPath)) {
+            return contextPath;
+        }
+        return super.getContextPath();
+    }
+
+    @Override
+    public String getServletPath() {
+        if (StringUtils.isNotBlank(servletPath)) {
+            return servletPath;
+        }
+        return super.getServletPath();
+    }
+
+    @Override
+    public String getRequestURI() {
+        String requestURI = super.getRequestURI();
+        if (requestURI.equals(contextPath)) {
+            return requestURI + "/";
+        }
+        return requestURI;
+    }
+
+    public void setContextPath(String contextPath) {
+        this.contextPath = contextPath;
+    }
+
+    public void setServletPath(String servletPath) {
+        this.servletPath = servletPath;
+    }
+
+}

--- a/src/main/java/run/halo/app/filter/WrapRequestFilter.java
+++ b/src/main/java/run/halo/app/filter/WrapRequestFilter.java
@@ -1,0 +1,54 @@
+package run.halo.app.filter;
+
+import org.springframework.web.filter.OncePerRequestFilter;
+import run.halo.app.model.properties.PrimaryProperties;
+import run.halo.app.service.OptionService;
+
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+public class WrapRequestFilter extends OncePerRequestFilter {
+
+    private final OptionService optionService;
+
+    public WrapRequestFilter(OptionService optionService) {
+        this.optionService = optionService;
+    }
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException, IOException, ServletException {
+        ServletContextFacadeRequestWrapper wrapper = new ServletContextFacadeRequestWrapper(request);
+        String path = getMatchingContextPathForRequest(request);
+        if (path != null) {
+            wrapper.setContextPath(request.getContextPath() + path);
+            String newPath = request.getServletPath().substring(path.length());
+            if (newPath.length() == 0) {
+                newPath = "/";
+            }
+            wrapper.setServletPath(newPath);
+        }
+        filterChain.doFilter(wrapper, response);
+    }
+
+    public String getMatchingContextPathForRequest(HttpServletRequest request) {
+        Boolean isInstalled = optionService.getByPropertyOrDefault(PrimaryProperties.IS_INSTALLED, Boolean.class, false);
+        if (!isInstalled) {
+            return null;
+        }
+        String blogBaseUrl = optionService.getBlogBaseUrl();
+        String contextPath = blogBaseUrl.substring(blogBaseUrl.indexOf("//") + 2);
+        if (contextPath.contains("/")) {
+            contextPath = contextPath.substring(contextPath.indexOf("/"));
+            if (request.getServletPath().startsWith(contextPath)) {
+                return contextPath;
+            }
+        }
+        else return null;
+
+        return "error";
+    }
+
+}


### PR DESCRIPTION
增加context path支持，可以在admin界面设置博客地址(如`http://127.0.0.1/blog`)，admin前端代码还未更改，前后端分离的情况下，通过修改api地址可以运行#702 
此外，menu中按钮的url也会同时更改。
参考代码:[Configuring a Dynamic Context Path in Spring Boot](https://www.broadleafcommerce.com/blog/configuring-a-dynamic-context-path-in-spring-boot)