### PR TITLE
feat&bug: fix issue 763

### DIFF
--- a/src/main/java/run/halo/app/service/impl/BasePostServiceImpl.java
+++ b/src/main/java/run/halo/app/service/impl/BasePostServiceImpl.java
@@ -192,9 +192,16 @@ public abstract class BasePostServiceImpl<POST extends BasePost> extends Abstrac
         Assert.isTrue(visits > 0, "Visits to increase must not be less than 1");
         Assert.notNull(postId, "Post id must not be null");
 
-        long affectedRows = basePostRepository.updateVisit(visits, postId);
+        boolean finishedIncrease;
+        if (basePostRepository.getByIdAndStatus(postId, PostStatus.DRAFT).isPresent())
+        {
+            finishedIncrease = true;
+            log.info("Post with id: [{}] is a draft and visits will not be updated", postId);
+        } else {
+            finishedIncrease = basePostRepository.updateVisit(visits, postId) == 1;
+        }
 
-        if (affectedRows != 1) {
+        if (!finishedIncrease) {
             log.error("Post with id: [{}] may not be found", postId);
             throw new BadRequestException("Failed to increase visits " + visits + " for post with id " + postId);
         }


### PR DESCRIPTION
针对 issue #763

1. 修改后文章保存草稿时进行预览不会统计访问量
2. 第二点存疑，如果第二点不统计，第一点也不会出问题。
3. 修改后，当草稿发布时，即是实际点击发布的时间 