### PR TITLE
feat: Support visitor map (Issue #551)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -140,4 +140,6 @@ dependencies {
     testImplementation "org.springframework.boot:spring-boot-starter-test"
 
     developmentOnly "org.springframework.boot:spring-boot-devtools"
+
+    compile group: 'org.lionsoul', name: 'ip2region', version: '1.7.2'
 }

--- a/src/main/java/run/halo/app/config/WebMvcAutoConfiguration.java
+++ b/src/main/java/run/halo/app/config/WebMvcAutoConfiguration.java
@@ -105,10 +105,6 @@ public class WebMvcAutoConfiguration extends WebMvcConfigurationSupport {
         registry.addResourceHandler("/themes/**")
             .addResourceLocations(workDir + "templates/themes/");
 
-        // register /database/** resource handler.
-        registry.addResourceHandler("/database/**")
-            .addResourceLocations(workDir + "database/");
-
         String uploadUrlPattern = ensureBoth(haloProperties.getUploadUrlPrefix(), URL_SEPARATOR) + "**";
         String adminPathPattern = ensureSuffix(haloProperties.getAdminPath(), URL_SEPARATOR) + "**";
 

--- a/src/main/java/run/halo/app/config/WebMvcAutoConfiguration.java
+++ b/src/main/java/run/halo/app/config/WebMvcAutoConfiguration.java
@@ -105,6 +105,10 @@ public class WebMvcAutoConfiguration extends WebMvcConfigurationSupport {
         registry.addResourceHandler("/themes/**")
             .addResourceLocations(workDir + "templates/themes/");
 
+        // register /database/** resource handler.
+        registry.addResourceHandler("/database/**")
+            .addResourceLocations(workDir + "database/");
+
         String uploadUrlPattern = ensureBoth(haloProperties.getUploadUrlPrefix(), URL_SEPARATOR) + "**";
         String adminPathPattern = ensureSuffix(haloProperties.getAdminPath(), URL_SEPARATOR) + "**";
 

--- a/src/main/java/run/halo/app/controller/admin/api/VisitorLogController.java
+++ b/src/main/java/run/halo/app/controller/admin/api/VisitorLogController.java
@@ -1,0 +1,58 @@
+package run.halo.app.controller.admin.api;
+
+import io.swagger.annotations.ApiOperation;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.web.bind.annotation.*;
+import run.halo.app.model.dto.VisitorLogDTO;
+import run.halo.app.model.entity.VisitorLog;
+import run.halo.app.model.projection.VisitorLogDayCountProjection;
+import run.halo.app.model.projection.VisitorLogMonthCountProjection;
+import run.halo.app.model.vo.VisitorLogRegionVo;
+import run.halo.app.service.VisitorLogService;
+
+import java.util.List;
+
+import static org.springframework.data.domain.Sort.Direction.DESC;
+
+/**
+ * VisitorLog controller.
+ *
+ * @author Holldean
+ * @date 2020-05-14
+ */
+@RestController
+@RequestMapping("/api/admin/visits")
+public class VisitorLogController {
+
+    private VisitorLogService visitorLogService;
+
+    public VisitorLogController(VisitorLogService visitorLogService) { this.visitorLogService = visitorLogService; }
+
+    @GetMapping
+    @ApiOperation("Lists visitor logs")
+    public Page<VisitorLogDTO> pageBy(@PageableDefault(sort = "updateTime", direction = DESC) Pageable pageable) {
+        Page<VisitorLog> visitorLogPage = visitorLogService.listAll(pageable);
+        return visitorLogPage.map(visitorLog -> new VisitorLogDTO().convertFrom(visitorLog));
+    }
+
+    @GetMapping("region")
+    @ApiOperation("Count visits for map in a year")
+    public VisitorLogRegionVo countVisitsByRegion() {
+        return visitorLogService.getVisitCountByRegion(360);
+    }
+
+    @GetMapping("day")
+    @ApiOperation("Count visits by day")
+    public List<VisitorLogDayCountProjection> countVisitsByDay(@RequestParam(name = "days") Integer days) {
+        return visitorLogService.getVisitCountByDay(days);
+    }
+
+    @GetMapping("month")
+    @ApiOperation("Count visits by month")
+    public List<VisitorLogMonthCountProjection> countVisitsByMonth(Integer months) {
+        return visitorLogService.getVisitCountByMonth(months);
+    }
+
+}

--- a/src/main/java/run/halo/app/controller/admin/api/VisitorLogController.java
+++ b/src/main/java/run/halo/app/controller/admin/api/VisitorLogController.java
@@ -38,9 +38,9 @@ public class VisitorLogController {
     }
 
     @GetMapping("region")
-    @ApiOperation("Count visits for map in a year")
-    public VisitorLogRegionVo countVisitsByRegion() {
-        return visitorLogService.getVisitCountByRegion(360);
+    @ApiOperation("Count visits for map")
+    public VisitorLogRegionVo countVisitsByRegion(@RequestParam(name = "days") Integer days) {
+        return visitorLogService.getVisitCountByRegion(days);
     }
 
     @GetMapping("day")

--- a/src/main/java/run/halo/app/controller/content/ContentContentController.java
+++ b/src/main/java/run/halo/app/controller/content/ContentContentController.java
@@ -2,12 +2,14 @@ package run.halo.app.controller.content;
 
 import cn.hutool.core.util.IdUtil;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.*;
 import run.halo.app.cache.AbstractStringCacheStore;
 import run.halo.app.cache.lock.CacheLock;
 import run.halo.app.controller.content.model.*;
+import run.halo.app.event.logger.VisitorLogEvent;
 import run.halo.app.exception.NotFoundException;
 import run.halo.app.model.dto.post.BasePostMinimalDTO;
 import run.halo.app.model.entity.Post;
@@ -23,7 +25,6 @@ import run.halo.app.utils.ServletUtils;
 import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
-import java.util.Date;
 import java.util.concurrent.TimeUnit;
 
 /**
@@ -59,6 +60,8 @@ public class ContentContentController {
 
     private final VisitorLogService visitorLogService;
 
+    private final ApplicationEventPublisher eventPublisher;
+
     public ContentContentController(PostModel postModel,
                                     SheetModel sheetModel,
                                     CategoryModel categoryModel,
@@ -70,7 +73,8 @@ public class ContentContentController {
                                     PostService postService,
                                     SheetService sheetService,
                                     AbstractStringCacheStore cacheStore,
-                                    VisitorLogService visitorLogService) {
+                                    VisitorLogService visitorLogService,
+                                    ApplicationEventPublisher eventPublisher) {
         this.postModel = postModel;
         this.sheetModel = sheetModel;
         this.categoryModel = categoryModel;
@@ -83,6 +87,7 @@ public class ContentContentController {
         this.sheetService = sheetService;
         this.cacheStore = cacheStore;
         this.visitorLogService = visitorLogService;
+        this.eventPublisher = eventPublisher;
     }
 
     @GetMapping("{prefix}")
@@ -229,6 +234,6 @@ public class ContentContentController {
 
     private void saveVisitorLog() {
         String ipAddress = ServletUtils.getRequestIp();
-        visitorLogService.createOrUpdate(ipAddress);
+        eventPublisher.publishEvent(new VisitorLogEvent(this, ipAddress));
     }
 }

--- a/src/main/java/run/halo/app/controller/content/ContentContentController.java
+++ b/src/main/java/run/halo/app/controller/content/ContentContentController.java
@@ -229,6 +229,6 @@ public class ContentContentController {
 
     private void saveVisitorLog() {
         String ipAddress = ServletUtils.getRequestIp();
-        visitorLogService.createOrUpdate(new Date(), ipAddress);
+        visitorLogService.createOrUpdate(ipAddress);
     }
 }

--- a/src/main/java/run/halo/app/controller/content/ContentIndexController.java
+++ b/src/main/java/run/halo/app/controller/content/ContentIndexController.java
@@ -1,6 +1,7 @@
 package run.halo.app.controller.content;
 
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -11,7 +12,10 @@ import run.halo.app.model.entity.Post;
 import run.halo.app.model.enums.PostPermalinkType;
 import run.halo.app.service.OptionService;
 import run.halo.app.service.PostService;
+import run.halo.app.service.VisitorLogService;
+import run.halo.app.utils.ServletUtils;
 
+import java.util.Date;
 import java.util.Objects;
 
 /**
@@ -31,12 +35,16 @@ public class ContentIndexController {
 
     private final PostModel postModel;
 
+    private final VisitorLogService visitorLogService;
+
     public ContentIndexController(PostService postService,
                                   OptionService optionService,
-                                  PostModel postModel) {
+                                  PostModel postModel,
+                                  VisitorLogService visitorLogService) {
         this.postService = postService;
         this.optionService = optionService;
         this.postModel = postModel;
+        this.visitorLogService = visitorLogService;
     }
 
 
@@ -49,7 +57,6 @@ public class ContentIndexController {
      */
     @GetMapping
     public String index(Integer p, String token, Model model) {
-
         PostPermalinkType permalinkType = optionService.getPostPermalinkType();
 
         if (PostPermalinkType.ID.equals(permalinkType) && !Objects.isNull(p)) {
@@ -70,6 +77,8 @@ public class ContentIndexController {
     @GetMapping(value = "page/{page}")
     public String index(Model model,
                         @PathVariable(value = "page") Integer page) {
+        String ipAddress = ServletUtils.getRequestIp();
+        visitorLogService.createOrUpdate(new Date(), ipAddress);
         return postModel.list(page, model);
     }
 }

--- a/src/main/java/run/halo/app/controller/content/ContentIndexController.java
+++ b/src/main/java/run/halo/app/controller/content/ContentIndexController.java
@@ -1,7 +1,6 @@
 package run.halo.app.controller.content;
 
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -78,7 +77,7 @@ public class ContentIndexController {
     public String index(Model model,
                         @PathVariable(value = "page") Integer page) {
         String ipAddress = ServletUtils.getRequestIp();
-        visitorLogService.createOrUpdate(new Date(), ipAddress);
+        visitorLogService.createOrUpdate(ipAddress);
         return postModel.list(page, model);
     }
 }

--- a/src/main/java/run/halo/app/controller/content/ContentIndexController.java
+++ b/src/main/java/run/halo/app/controller/content/ContentIndexController.java
@@ -1,20 +1,20 @@
 package run.halo.app.controller.content;
 
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import run.halo.app.controller.content.model.PostModel;
+import run.halo.app.event.logger.VisitorLogEvent;
 import run.halo.app.model.entity.Post;
 import run.halo.app.model.enums.PostPermalinkType;
 import run.halo.app.service.OptionService;
 import run.halo.app.service.PostService;
-import run.halo.app.service.VisitorLogService;
 import run.halo.app.utils.ServletUtils;
 
-import java.util.Date;
 import java.util.Objects;
 
 /**
@@ -34,16 +34,16 @@ public class ContentIndexController {
 
     private final PostModel postModel;
 
-    private final VisitorLogService visitorLogService;
+    private final ApplicationEventPublisher eventPublisher;
 
     public ContentIndexController(PostService postService,
                                   OptionService optionService,
                                   PostModel postModel,
-                                  VisitorLogService visitorLogService) {
+                                  ApplicationEventPublisher eventPublisher) {
         this.postService = postService;
         this.optionService = optionService;
         this.postModel = postModel;
-        this.visitorLogService = visitorLogService;
+        this.eventPublisher = eventPublisher;
     }
 
 
@@ -77,7 +77,7 @@ public class ContentIndexController {
     public String index(Model model,
                         @PathVariable(value = "page") Integer page) {
         String ipAddress = ServletUtils.getRequestIp();
-        visitorLogService.createOrUpdate(ipAddress);
+        eventPublisher.publishEvent(new VisitorLogEvent(this, ipAddress));
         return postModel.list(page, model);
     }
 }

--- a/src/main/java/run/halo/app/event/logger/VisitorLogEvent.java
+++ b/src/main/java/run/halo/app/event/logger/VisitorLogEvent.java
@@ -1,0 +1,28 @@
+package run.halo.app.event.logger;
+
+import org.springframework.context.ApplicationEvent;
+
+/**
+ * @author Holldean
+ * @date 2020-05-17
+ */
+public class VisitorLogEvent extends ApplicationEvent {
+
+    private final String ipAddress;
+
+    /**
+     * Create a new ApplicationEvent.
+     *
+     * @param source   the object on which the event initially occurred (never {@code null})
+     * @param ipAddress visitor's ip address
+     */
+    public VisitorLogEvent(Object source, String ipAddress) {
+        super(source);
+
+        this.ipAddress = ipAddress;
+    }
+
+    public String getIpAddress() {
+        return ipAddress;
+    }
+}

--- a/src/main/java/run/halo/app/listener/logger/VisitorLogEventListener.java
+++ b/src/main/java/run/halo/app/listener/logger/VisitorLogEventListener.java
@@ -1,0 +1,30 @@
+package run.halo.app.listener.logger;
+
+import org.springframework.context.event.EventListener;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import run.halo.app.event.logger.VisitorLogEvent;
+import run.halo.app.service.VisitorLogService;
+
+/**
+ * VisitorLog event listener.
+ *
+ * @author Holldean
+ * @date 2020-05-17
+ */
+@Component
+public class VisitorLogEventListener {
+
+    private final VisitorLogService visitorLogService;
+
+    public VisitorLogEventListener(VisitorLogService visitorLogService) {
+        this.visitorLogService = visitorLogService;
+    }
+
+    @EventListener
+    @Async
+    public void onApplicationEvent(VisitorLogEvent event) {
+        // Create or update visitor log
+        visitorLogService.createOrUpdate(event.getIpAddress());
+    }
+}

--- a/src/main/java/run/halo/app/model/dto/StatisticDTO.java
+++ b/src/main/java/run/halo/app/model/dto/StatisticDTO.java
@@ -3,9 +3,6 @@ package run.halo.app.model.dto;
 import lombok.Data;
 import run.halo.app.model.projection.VisitorLogDayCountProjection;
 import run.halo.app.model.projection.VisitorLogMonthCountProjection;
-import run.halo.app.model.projection.VisitorLogRegionCountProjection;
-
-import java.util.List;
 
 /**
  * Statistic DTO.

--- a/src/main/java/run/halo/app/model/dto/StatisticDTO.java
+++ b/src/main/java/run/halo/app/model/dto/StatisticDTO.java
@@ -1,6 +1,11 @@
 package run.halo.app.model.dto;
 
 import lombok.Data;
+import run.halo.app.model.projection.VisitorLogDayCountProjection;
+import run.halo.app.model.projection.VisitorLogMonthCountProjection;
+import run.halo.app.model.projection.VisitorLogRegionCountProjection;
+
+import java.util.List;
 
 /**
  * Statistic DTO.
@@ -34,4 +39,8 @@ public class StatisticDTO {
     private Long visitCount;
 
     private Long likeCount;
+
+    private VisitorLogDayCountProjection visitCountToday;
+
+    private VisitorLogMonthCountProjection visitCountCurrentMonth;
 }

--- a/src/main/java/run/halo/app/model/dto/VisitorLogDTO.java
+++ b/src/main/java/run/halo/app/model/dto/VisitorLogDTO.java
@@ -1,0 +1,36 @@
+package run.halo.app.model.dto;
+
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+import run.halo.app.model.dto.base.OutputConverter;
+import run.halo.app.model.entity.VisitorLog;
+
+import java.util.Date;
+
+/**
+ * @author Holldean
+ * @date 2020-5-15
+ */
+@Data
+@ToString
+@EqualsAndHashCode
+public class VisitorLogDTO implements OutputConverter<VisitorLogDTO, VisitorLog> {
+
+    private Date updateTime;
+
+    private Date accessDate;
+
+    private String ipAddress;
+
+    private String country;
+
+    private String province;
+
+    private String city;
+
+    private String ISP;
+
+    private Integer count;
+
+}

--- a/src/main/java/run/halo/app/model/dto/VisitorLogDTO.java
+++ b/src/main/java/run/halo/app/model/dto/VisitorLogDTO.java
@@ -29,7 +29,7 @@ public class VisitorLogDTO implements OutputConverter<VisitorLogDTO, VisitorLog>
 
     private String city;
 
-    private String ISP;
+    private String isp;
 
     private Integer count;
 

--- a/src/main/java/run/halo/app/model/entity/VisitorLog.java
+++ b/src/main/java/run/halo/app/model/entity/VisitorLog.java
@@ -1,0 +1,82 @@
+package run.halo.app.model.entity;
+
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+import org.hibernate.annotations.ColumnDefault;
+import run.halo.app.model.entity.id.VisitorLogId;
+
+import javax.persistence.*;
+import java.util.Date;
+
+/**
+ * Log entity.
+ *
+ * @author johnniang
+ */
+@Data
+@Entity
+@Table(name = "visitor_logs", indexes = {@Index(name = "visitor_log_create_time", columnList = "create_time")})
+@IdClass(VisitorLogId.class)
+@ToString
+@EqualsAndHashCode(callSuper = true)
+public class VisitorLog extends BaseEntity {
+
+    /**
+     * Visitor's access date.
+     * Primary key.
+     */
+    @Id
+    @Column(name = "access_date")
+    @Temporal(TemporalType.DATE)
+    private Date accessDate;
+
+    /**
+     * Visitor's ip address.
+     * Primary Key.
+     */
+    @Id
+    @Column(name = "ip_address", length = 127)
+    private String ipAddress;
+
+    /**
+     * Visitor IP's country.
+     */
+    @Column(name = "country", length = 64)
+    private String country;
+
+    /**
+     * Visitor IP's province.
+     */
+    @Column(name = "province", length = 64)
+    private String province;
+
+    /**
+     * Visitor IP's city.
+     */
+    @Column(name = "city", length = 64)
+    private String city;
+
+    /**
+     * Visitor IP's ISP.
+     */
+    @Column(name = "isp", length = 64)
+    private String ISP;
+
+    /**
+     * Visitor's visits count.
+     */
+    @Column(name = "count")
+    @ColumnDefault("1")
+    private Integer count;
+
+    public VisitorLog() {
+    }
+
+    public VisitorLog(Date accessDate, String ipAddress) {
+        super();
+        this.accessDate = accessDate;
+        this.ipAddress = ipAddress;
+        this.count = 1;
+    }
+}

--- a/src/main/java/run/halo/app/model/entity/VisitorLog.java
+++ b/src/main/java/run/halo/app/model/entity/VisitorLog.java
@@ -86,7 +86,7 @@ public class VisitorLog extends BaseEntity {
     }
 
     @PrePersist
-    protected void prePersist() {
+    protected void preCheck() {
         Date now = DateUtils.now();
         if (accessDate == null) {
             accessDate = now;

--- a/src/main/java/run/halo/app/model/entity/VisitorLog.java
+++ b/src/main/java/run/halo/app/model/entity/VisitorLog.java
@@ -62,7 +62,7 @@ public class VisitorLog extends BaseEntity {
      * Visitor IP's ISP.
      */
     @Column(name = "isp", length = 64)
-    private String ISP;
+    private String isp;
 
     /**
      * Visitor's visits count.

--- a/src/main/java/run/halo/app/model/entity/VisitorLog.java
+++ b/src/main/java/run/halo/app/model/entity/VisitorLog.java
@@ -5,14 +5,15 @@ import lombok.EqualsAndHashCode;
 import lombok.ToString;
 import org.hibernate.annotations.ColumnDefault;
 import run.halo.app.model.entity.id.VisitorLogId;
+import run.halo.app.utils.DateUtils;
 
 import javax.persistence.*;
 import java.util.Date;
 
 /**
- * Log entity.
+ * VisitorLog entity.
  *
- * @author johnniang
+ * @author Holldean
  */
 @Data
 @Entity
@@ -73,10 +74,22 @@ public class VisitorLog extends BaseEntity {
     public VisitorLog() {
     }
 
+    public VisitorLog(String ipAddress) {
+        this(null, ipAddress);
+    }
+
     public VisitorLog(Date accessDate, String ipAddress) {
         super();
         this.accessDate = accessDate;
         this.ipAddress = ipAddress;
         this.count = 1;
+    }
+
+    @PrePersist
+    protected void prePersist() {
+        Date now = DateUtils.now();
+        if (accessDate == null) {
+            accessDate = now;
+        }
     }
 }

--- a/src/main/java/run/halo/app/model/entity/id/VisitorLogId.java
+++ b/src/main/java/run/halo/app/model/entity/id/VisitorLogId.java
@@ -15,5 +15,4 @@ public class VisitorLogId implements Serializable {
         this.accessDate = accessDate;
         this.ipAddress = ipAddress;
     }
-
 }

--- a/src/main/java/run/halo/app/model/entity/id/VisitorLogId.java
+++ b/src/main/java/run/halo/app/model/entity/id/VisitorLogId.java
@@ -1,0 +1,19 @@
+package run.halo.app.model.entity.id;
+
+import java.io.Serializable;
+import java.util.Date;
+
+public class VisitorLogId implements Serializable {
+
+    private Date accessDate;
+
+    private String ipAddress;
+
+    public VisitorLogId() {}
+
+    public VisitorLogId(Date accessDate, String ipAddress) {
+        this.accessDate = accessDate;
+        this.ipAddress = ipAddress;
+    }
+
+}

--- a/src/main/java/run/halo/app/model/entity/id/VisitorLogId.java
+++ b/src/main/java/run/halo/app/model/entity/id/VisitorLogId.java
@@ -2,6 +2,7 @@ package run.halo.app.model.entity.id;
 
 import java.io.Serializable;
 import java.util.Date;
+import java.util.Objects;
 
 public class VisitorLogId implements Serializable {
 
@@ -14,5 +15,19 @@ public class VisitorLogId implements Serializable {
     public VisitorLogId(Date accessDate, String ipAddress) {
         this.accessDate = accessDate;
         this.ipAddress = ipAddress;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        VisitorLogId visitorLogId = (VisitorLogId) o;
+        return accessDate.equals(visitorLogId.accessDate) &&
+            ipAddress.equals(visitorLogId.ipAddress);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(accessDate, ipAddress);
     }
 }

--- a/src/main/java/run/halo/app/model/projection/VisitorLogDayCountProjection.java
+++ b/src/main/java/run/halo/app/model/projection/VisitorLogDayCountProjection.java
@@ -1,0 +1,23 @@
+package run.halo.app.model.projection;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.Date;
+
+/**
+ * Visitor's ip log post count by day.
+ *
+ * @author Holldean
+ * @date 2020-5-13
+ */
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class VisitorLogDayCountProjection {
+
+    private Date date;
+
+    private Long count;
+}

--- a/src/main/java/run/halo/app/model/projection/VisitorLogMonthCountProjection.java
+++ b/src/main/java/run/halo/app/model/projection/VisitorLogMonthCountProjection.java
@@ -4,8 +4,6 @@ import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
-import java.util.Date;
-
 /**
  * Visitor's ip log post count by month.
  *

--- a/src/main/java/run/halo/app/model/projection/VisitorLogMonthCountProjection.java
+++ b/src/main/java/run/halo/app/model/projection/VisitorLogMonthCountProjection.java
@@ -1,0 +1,23 @@
+package run.halo.app.model.projection;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.Date;
+
+/**
+ * Visitor's ip log post count by month.
+ *
+ * @author Holldean
+ * @date 2020-5-16
+ */
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class VisitorLogMonthCountProjection {
+
+    private Integer month;
+
+    private Long count;
+}

--- a/src/main/java/run/halo/app/model/projection/VisitorLogRegionCountProjection.java
+++ b/src/main/java/run/halo/app/model/projection/VisitorLogRegionCountProjection.java
@@ -4,8 +4,6 @@ import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
-import java.util.Date;
-
 /**
  * Visitor's ip log post count by region.
  *

--- a/src/main/java/run/halo/app/model/projection/VisitorLogRegionCountProjection.java
+++ b/src/main/java/run/halo/app/model/projection/VisitorLogRegionCountProjection.java
@@ -1,0 +1,24 @@
+package run.halo.app.model.projection;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.Date;
+
+/**
+ * Visitor's ip log post count by region.
+ *
+ * @author Holldean
+ * @date 2020-5-13
+ */
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class VisitorLogRegionCountProjection {
+
+    private String region;
+
+    private Long count;
+
+}

--- a/src/main/java/run/halo/app/model/support/HaloConst.java
+++ b/src/main/java/run/halo/app/model/support/HaloConst.java
@@ -147,5 +147,5 @@ public class HaloConst {
     /**
      * ip2region database path.
      */
-    public static String IP2REGION_DATABASE_PATH = "/database/ip2region.db";
+    public static String IP2REGION_DATABASE_PATH = "database/ip2region.db";
 }

--- a/src/main/java/run/halo/app/model/support/HaloConst.java
+++ b/src/main/java/run/halo/app/model/support/HaloConst.java
@@ -144,4 +144,8 @@ public class HaloConst {
      */
     public static String HALO_VERSION = null;
 
+    /**
+     * ip2region database path.
+     */
+    public static String IP2REGION_DATABASE_PATH = "/database/ip2region.db";
 }

--- a/src/main/java/run/halo/app/model/vo/VisitorLogRegionVo.java
+++ b/src/main/java/run/halo/app/model/vo/VisitorLogRegionVo.java
@@ -1,0 +1,30 @@
+package run.halo.app.model.vo;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import run.halo.app.model.entity.Post;
+import run.halo.app.model.projection.VisitorLogDayCountProjection;
+import run.halo.app.model.projection.VisitorLogRegionCountProjection;
+
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * VisitorLog Vo.
+ *
+ * @author Holldean
+ * @date 2020/5/14
+ */
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class VisitorLogRegionVo {
+
+    private List<VisitorLogRegionCountProjection> countByCountry;
+
+    private List<VisitorLogRegionCountProjection> countByProvince;
+
+}

--- a/src/main/java/run/halo/app/model/vo/VisitorLogRegionVo.java
+++ b/src/main/java/run/halo/app/model/vo/VisitorLogRegionVo.java
@@ -4,18 +4,15 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
-import run.halo.app.model.entity.Post;
-import run.halo.app.model.projection.VisitorLogDayCountProjection;
 import run.halo.app.model.projection.VisitorLogRegionCountProjection;
 
 import java.util.List;
-import java.util.Optional;
 
 /**
  * VisitorLog Vo.
  *
  * @author Holldean
- * @date 2020/5/14
+ * @date 2020-5-14
  */
 @Data
 @NoArgsConstructor

--- a/src/main/java/run/halo/app/repository/VisitorLogRepository.java
+++ b/src/main/java/run/halo/app/repository/VisitorLogRepository.java
@@ -14,7 +14,7 @@ import java.util.Date;
 import java.util.List;
 
 /**
- * VisitorLog repository
+ * VisitorLog repository.
  *
  * @author Holldean
  * @date 2020-05-13

--- a/src/main/java/run/halo/app/repository/VisitorLogRepository.java
+++ b/src/main/java/run/halo/app/repository/VisitorLogRepository.java
@@ -1,0 +1,81 @@
+package run.halo.app.repository;
+
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+import run.halo.app.model.entity.VisitorLog;
+import run.halo.app.model.entity.id.VisitorLogId;
+import run.halo.app.model.projection.VisitorLogDayCountProjection;
+import run.halo.app.model.projection.VisitorLogMonthCountProjection;
+import run.halo.app.model.projection.VisitorLogRegionCountProjection;
+import run.halo.app.repository.base.BaseRepository;
+
+import java.util.Date;
+import java.util.List;
+
+/**
+ * VisitorLog repository
+ *
+ * @author Holldean
+ * @date 2020-05-13
+ */
+@Repository
+public interface VisitorLogRepository extends BaseRepository<VisitorLog, VisitorLogId> {
+
+    /**
+     * Find a VisitorLog by accessDate and ipAddress.
+     *
+     * @param accessDate visitor's access date.
+     * @param ipAddress visitor's ip address.
+     * @return visitor ip log.
+     */
+    VisitorLog findByAccessDateAndIpAddress(Date accessDate, String ipAddress);
+
+    /**
+     * Find all VisitorLog after the start date.
+     *
+     * @param startDate the start date.
+     * @return list of visitor ip log.
+     */
+    List<VisitorLog> findByAccessDateAfter(Date startDate);
+
+    /**
+     * Count VisitorLog group by date after the start date.
+     *
+     * @param startDate the start date.
+     * @return list of date and count pair.
+     */
+    @Query("select new run.halo.app.model.projection.VisitorLogDayCountProjection(v.accessDate, count(distinct v.ipAddress)) from VisitorLog v " +
+           "where v.accessDate >= :startDate group by v.accessDate order by v.accessDate")
+    List<VisitorLogDayCountProjection> countByAccessDateAfterGroupByDay(@Param(value = "startDate") Date startDate);
+
+    /**
+     * Count VisitorLog group by country after the start date.
+     *
+     * @param startDate the start date.
+     * @return list of country and count pair.
+     */
+    @Query("select new run.halo.app.model.projection.VisitorLogRegionCountProjection(v.country, count(v.ipAddress)) from VisitorLog v " +
+           "where v.accessDate >= :startDate group by v.country order by v.country")
+    List<VisitorLogRegionCountProjection> countByAccessDateAfterGroupByCountry(@Param(value = "startDate") Date startDate);
+
+    /**
+     * Count VisitorLog group by province after the start date.
+     *
+     * @param startDate the start date.
+     * @return list of province and count pair.
+     */
+    @Query("select new run.halo.app.model.projection.VisitorLogRegionCountProjection(v.province, count(v.ipAddress)) from VisitorLog v " +
+           "where v.accessDate >= :startDate and v.country = '中国' group by v.province order by v.province")
+    List<VisitorLogRegionCountProjection> countByAccessDateAfterGroupByChineseProvince(@Param(value = "startDate") Date startDate);
+
+    /**
+     * Count VisitorLog group by month.
+     *
+     * @param startDate the start date.
+     * @return list of month and count pair.
+     */
+    @Query("select new run.halo.app.model.projection.VisitorLogMonthCountProjection(FUNCTION('MONTH', v.accessDate), count(v.ipAddress)) from VisitorLog v " +
+           "where v.accessDate >= :startDate group by FUNCTION('YEAR', v.accessDate), FUNCTION('MONTH', v.accessDate) order by FUNCTION('YEAR', v.accessDate), FUNCTION('MONTH', v.accessDate)")
+    List<VisitorLogMonthCountProjection> countByAccessDateAfterGroupByMonth(@Param(value = "startDate") Date startDate);
+}

--- a/src/main/java/run/halo/app/service/VisitorLogService.java
+++ b/src/main/java/run/halo/app/service/VisitorLogService.java
@@ -29,7 +29,7 @@ public interface VisitorLogService extends CrudService<VisitorLog, VisitorLogId>
     VisitorLog getBy(@NonNull Date accessDate, @NonNull String ipAddress);
 
     /**
-     * Gets ip count of a region from days before until now.
+     * Gets visit count of a region from days before until now.
      *
      * @param days the number of days from now to the start date.
      * @return list of data and count pair.
@@ -37,7 +37,7 @@ public interface VisitorLogService extends CrudService<VisitorLog, VisitorLogId>
     VisitorLogRegionVo getVisitCountByRegion(@NonNull Integer days);
 
     /**
-     * Gets ip count of a day from days before until now.
+     * Gets visit count of a day from days before until now.
      *
      * @param days the number of days from now to the start date.
      * @return list of data and count pair.
@@ -45,7 +45,7 @@ public interface VisitorLogService extends CrudService<VisitorLog, VisitorLogId>
     List<VisitorLogDayCountProjection> getVisitCountByDay(@NonNull Integer days);
 
     /**
-     * Gets ip count of a month.
+     * Gets visit count of a month.
      *
      * @param months the number of months from now.
      * @return list of month and count pair.
@@ -55,9 +55,8 @@ public interface VisitorLogService extends CrudService<VisitorLog, VisitorLogId>
     /**
      * Create VisitorLog or increase VisitorLog's count by one.
      *
-     * @param accessDate visitor's access date.
      * @param ipAddress  visitor's ip address.
      */
-    void createOrUpdate(@NonNull Date accessDate, @NonNull String ipAddress);
+    void createOrUpdate(String ipAddress);
 
 }

--- a/src/main/java/run/halo/app/service/VisitorLogService.java
+++ b/src/main/java/run/halo/app/service/VisitorLogService.java
@@ -1,0 +1,63 @@
+package run.halo.app.service;
+
+import org.springframework.lang.NonNull;
+import run.halo.app.model.entity.VisitorLog;
+import run.halo.app.model.entity.id.VisitorLogId;
+import run.halo.app.model.projection.VisitorLogDayCountProjection;
+import run.halo.app.model.projection.VisitorLogMonthCountProjection;
+import run.halo.app.model.vo.VisitorLogRegionVo;
+import run.halo.app.service.base.CrudService;
+
+import java.util.Date;
+import java.util.List;
+
+/**
+ * VisitorLog service interface.
+ *
+ * @author Holldean
+ * @date 2020-05-13
+ */
+public interface VisitorLogService extends CrudService<VisitorLog, VisitorLogId> {
+
+    /**
+     * Gets VisitorLog by access date and ip address.
+     *
+     * @param accessDate visitor's access date.
+     * @param ipAddress  visitor's ip address.
+     * @return visitor ip log.
+     */
+    VisitorLog getBy(@NonNull Date accessDate, @NonNull String ipAddress);
+
+    /**
+     * Gets ip count of a region from days before until now.
+     *
+     * @param days the number of days from now to the start date.
+     * @return list of data and count pair.
+     */
+    VisitorLogRegionVo getVisitCountByRegion(@NonNull Integer days);
+
+    /**
+     * Gets ip count of a day from days before until now.
+     *
+     * @param days the number of days from now to the start date.
+     * @return list of data and count pair.
+     */
+    List<VisitorLogDayCountProjection> getVisitCountByDay(@NonNull Integer days);
+
+    /**
+     * Gets ip count of a month.
+     *
+     * @param months the number of months from now.
+     * @return list of month and count pair.
+     */
+    List<VisitorLogMonthCountProjection> getVisitCountByMonth(@NonNull Integer months);
+
+    /**
+     * Create VisitorLog or increase VisitorLog's count by one.
+     *
+     * @param accessDate visitor's access date.
+     * @param ipAddress  visitor's ip address.
+     */
+    void createOrUpdate(@NonNull Date accessDate, @NonNull String ipAddress);
+
+}

--- a/src/main/java/run/halo/app/service/impl/StatisticServiceImpl.java
+++ b/src/main/java/run/halo/app/service/impl/StatisticServiceImpl.java
@@ -13,9 +13,7 @@ import run.halo.app.model.projection.VisitorLogMonthCountProjection;
 import run.halo.app.service.*;
 import run.halo.app.utils.DateUtils;
 
-import java.util.Calendar;
 import java.util.Date;
-import java.util.GregorianCalendar;
 import java.util.List;
 
 /**

--- a/src/main/java/run/halo/app/service/impl/StatisticServiceImpl.java
+++ b/src/main/java/run/halo/app/service/impl/StatisticServiceImpl.java
@@ -10,8 +10,8 @@ import run.halo.app.model.enums.CommentStatus;
 import run.halo.app.model.enums.PostStatus;
 import run.halo.app.model.projection.VisitorLogDayCountProjection;
 import run.halo.app.model.projection.VisitorLogMonthCountProjection;
-import run.halo.app.model.vo.VisitorLogRegionVo;
 import run.halo.app.service.*;
+import run.halo.app.utils.DateUtils;
 
 import java.util.Calendar;
 import java.util.Date;
@@ -102,24 +102,19 @@ public class StatisticServiceImpl implements StatisticService {
         statisticDTO.setLikeCount(postService.countLike() + sheetService.countLike());
 
         List<VisitorLogDayCountProjection> countToday = visitorLogService.getVisitCountByDay(0);
+        Date today = DateUtils.getStartTimeOfDay(DateUtils.now());
         if (!countToday.isEmpty()) {
             statisticDTO.setVisitCountToday(countToday.get(0));
         } else {
-            Calendar calendar = new GregorianCalendar();
-            calendar.set(Calendar.HOUR_OF_DAY, 0);
-            calendar.set(Calendar.MINUTE, 0);
-            calendar.set(Calendar.SECOND, 0);
-            calendar.set(Calendar.MILLISECOND, 0);
-            statisticDTO.setVisitCountToday(new VisitorLogDayCountProjection(calendar.getTime(), (Long) 0L));
+            statisticDTO.setVisitCountToday(new VisitorLogDayCountProjection(today, (Long) 0L));
         }
 
         List<VisitorLogMonthCountProjection>  countCurrentMonth = visitorLogService.getVisitCountByMonth(0);
         if (!countCurrentMonth.isEmpty()) {
             statisticDTO.setVisitCountCurrentMonth(countCurrentMonth.get(0));
         } else {
-            Calendar calendar = new GregorianCalendar();
             VisitorLogMonthCountProjection v = new VisitorLogMonthCountProjection();
-            v.setMonth(calendar.get(Calendar.MONTH) + 1);
+            v.setMonth(DateUtils.getMonth(today));
             v.setCount((Long) 0L);
             statisticDTO.setVisitCountCurrentMonth(v);
         }

--- a/src/main/java/run/halo/app/service/impl/VisitorLogServiceImpl.java
+++ b/src/main/java/run/halo/app/service/impl/VisitorLogServiceImpl.java
@@ -1,7 +1,6 @@
 package run.halo.app.service.impl;
 
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import run.halo.app.model.entity.VisitorLog;
 import run.halo.app.model.entity.id.VisitorLogId;
@@ -60,22 +59,22 @@ public class VisitorLogServiceImpl extends AbstractCrudService<VisitorLog, Visit
 
     @Override
     public void createOrUpdate(String ipAddress) {
-        VisitorLog VisitorLog = getBy(DateUtils.now(), ipAddress);
-        if (VisitorLog == null) {
-            VisitorLog = new VisitorLog(ipAddress);
+        VisitorLog visitorLog = getBy(DateUtils.now(), ipAddress);
+        if (visitorLog == null) {
+            visitorLog = new VisitorLog(ipAddress);
             try {
                 IpUtils.IpRegion region = IpUtils.getRegion(ipAddress);
-                VisitorLog.setCountry(region.getCountry());
-                VisitorLog.setProvince(region.getProvince());
-                VisitorLog.setCity(region.getCity());
-                VisitorLog.setISP(region.getISP());
+                visitorLog.setCountry(region.getCountry());
+                visitorLog.setProvince(region.getProvince());
+                visitorLog.setCity(region.getCity());
+                visitorLog.setIsp(region.getIsp());
             } catch (IOException e) {
                 e.printStackTrace();
             }
         } else {
-            VisitorLog.setCount(VisitorLog.getCount() + 1);
+            visitorLog.setCount(visitorLog.getCount() + 1);
         }
-        visitorLogRepository.save(VisitorLog);
+        visitorLogRepository.save(visitorLog);
     }
 
 }

--- a/src/main/java/run/halo/app/service/impl/VisitorLogServiceImpl.java
+++ b/src/main/java/run/halo/app/service/impl/VisitorLogServiceImpl.java
@@ -1,0 +1,107 @@
+package run.halo.app.service.impl;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.stereotype.Service;
+import run.halo.app.model.entity.VisitorLog;
+import run.halo.app.model.entity.id.VisitorLogId;
+import run.halo.app.model.projection.VisitorLogDayCountProjection;
+import run.halo.app.model.projection.VisitorLogMonthCountProjection;
+import run.halo.app.model.vo.VisitorLogRegionVo;
+import run.halo.app.repository.VisitorLogRepository;
+import run.halo.app.service.*;
+import run.halo.app.service.base.AbstractCrudService;
+import run.halo.app.utils.IpUtils;
+
+import java.io.IOException;
+import java.util.*;
+
+/**
+ * Admin service implementation.
+ *
+ * @author johnniang
+ * @author ryanwang
+ * @date 2019-04-29
+ */
+@Slf4j
+@Service
+public class VisitorLogServiceImpl extends AbstractCrudService<VisitorLog, VisitorLogId> implements VisitorLogService {
+
+    private VisitorLogRepository visitorLogRepository;
+
+    protected VisitorLogServiceImpl(VisitorLogRepository visitorLogRepository) {
+        super(visitorLogRepository);
+        this.visitorLogRepository = visitorLogRepository;
+    }
+
+    @Override
+    public VisitorLog getBy(Date accessDate, String ipAddress) {
+        return visitorLogRepository.findByAccessDateAndIpAddress(accessDate, ipAddress);
+    }
+
+    @Override
+    public VisitorLogRegionVo getVisitCountByRegion(Integer days) {
+        Date startDate = getStartDate(days);
+        VisitorLogRegionVo visitorLogRegionVo = new VisitorLogRegionVo();
+        visitorLogRegionVo.setCountByCountry(visitorLogRepository.countByAccessDateAfterGroupByCountry(startDate));
+        visitorLogRegionVo.setCountByProvince(visitorLogRepository.countByAccessDateAfterGroupByChineseProvince(startDate));
+        return visitorLogRegionVo;
+    }
+
+    @Override
+    public List<VisitorLogDayCountProjection> getVisitCountByDay(Integer days) {
+        System.out.println(getStartDate(days));
+        return visitorLogRepository.countByAccessDateAfterGroupByDay(getStartDate(days));
+    }
+
+    @Override
+    public List<VisitorLogMonthCountProjection> getVisitCountByMonth(Integer months) {
+        return visitorLogRepository.countByAccessDateAfterGroupByMonth(getFistDayOfMonth(months));
+    }
+
+    @Override
+    public void createOrUpdate(Date accessDate, String ipAddress) {
+        VisitorLog VisitorLog = getBy(accessDate, ipAddress);
+        if (VisitorLog == null) {
+            VisitorLog = new VisitorLog(accessDate, ipAddress);
+            try {
+                IpUtils.IpRegion region = IpUtils.getRegion(ipAddress);
+                VisitorLog.setCountry(region.getCountry());
+                VisitorLog.setProvince(region.getProvince());
+                VisitorLog.setCity(region.getCity());
+                VisitorLog.setISP(region.getISP());
+            } catch (IOException e) {
+                e.printStackTrace();
+            }
+        } else {
+            VisitorLog.setCount(VisitorLog.getCount() + 1);
+        }
+        visitorLogRepository.save(VisitorLog);
+    }
+
+    private Date getStartDate(Integer days) {
+        Calendar calendar = Calendar.getInstance();
+        calendar.setTime(new Date());
+        // reset time
+        calendar.set(Calendar.HOUR_OF_DAY, 0);
+        calendar.set(Calendar.MINUTE, 0);
+        calendar.set(Calendar.SECOND, 0);
+        calendar.set(Calendar.MILLISECOND, 0);
+        // get start date
+        calendar.add(Calendar.DAY_OF_MONTH, -days);
+        return calendar.getTime();
+    }
+
+    private Date getFistDayOfMonth(Integer months) {
+        Calendar calendar = Calendar.getInstance();
+        // reset time
+        calendar.set(Calendar.HOUR_OF_DAY, 0);
+        calendar.set(Calendar.MINUTE, 0);
+        calendar.set(Calendar.SECOND, 0);
+        calendar.set(Calendar.MILLISECOND, 0);
+        // get first day of that month
+        calendar.add(Calendar.MONTH, -months);
+        calendar.set(Calendar.DAY_OF_MONTH, 1);
+        return calendar.getTime();
+    }
+}

--- a/src/main/java/run/halo/app/utils/DateUtils.java
+++ b/src/main/java/run/halo/app/utils/DateUtils.java
@@ -5,6 +5,7 @@ import org.springframework.util.Assert;
 
 import java.util.Calendar;
 import java.util.Date;
+import java.util.GregorianCalendar;
 import java.util.concurrent.TimeUnit;
 
 /**
@@ -87,5 +88,38 @@ public class DateUtils {
                 result = date;
         }
         return result;
+    }
+
+    public static Date getStartTimeOfDay(Date date) {
+        Calendar calendar = new GregorianCalendar();
+        calendar.setTime(date);
+        calendar.set(Calendar.HOUR_OF_DAY, 0);
+        calendar.set(Calendar.MINUTE, 0);
+        calendar.set(Calendar.SECOND, 0);
+        calendar.set(Calendar.MILLISECOND, 0);
+        return calendar.getTime();
+    }
+
+    public static int getMonth(Date date) {
+        Calendar calendar = new GregorianCalendar();
+        calendar.setTime(date);
+        return calendar.get(Calendar.MONTH) + 1;
+    }
+
+
+    public static Date getDayAgo(int days) {
+        Calendar calendar = new GregorianCalendar();
+        calendar.setTime(now());
+        // get few days ago
+        calendar.add(Calendar.DAY_OF_MONTH, -days);
+        return getStartTimeOfDay(calendar.getTime());
+    }
+
+    public static Date getFistDayOfMonth(Integer months) {
+        Calendar calendar = Calendar.getInstance();
+        // get first day of that month
+        calendar.add(Calendar.MONTH, -months);
+        calendar.set(Calendar.DAY_OF_MONTH, 1);
+        return getStartTimeOfDay(calendar.getTime());
     }
 }

--- a/src/main/java/run/halo/app/utils/DateUtils.java
+++ b/src/main/java/run/halo/app/utils/DateUtils.java
@@ -90,7 +90,13 @@ public class DateUtils {
         return result;
     }
 
-    public static Date getStartTimeOfDay(Date date) {
+    /**
+     * Get the start time of a day.
+     *
+     * @param  date date instance must not be null
+     * @return date object of the start time
+     */
+    public static Date getStartTimeOfDay(@NonNull Date date) {
         Calendar calendar = new GregorianCalendar();
         calendar.setTime(date);
         calendar.set(Calendar.HOUR_OF_DAY, 0);
@@ -100,13 +106,24 @@ public class DateUtils {
         return calendar.getTime();
     }
 
-    public static int getMonth(Date date) {
+    /**
+     * Get the number of date.
+     *
+     * @param  date date instance must not be null
+     * @return the number of month, this number already plus one
+     */
+    public static int getMonth(@NonNull Date date) {
         Calendar calendar = new GregorianCalendar();
         calendar.setTime(date);
         return calendar.get(Calendar.MONTH) + 1;
     }
 
-
+    /**
+     * Get the date of few days ago.
+     *
+     * @param  days the number of days
+     * @return date object of that day
+     */
     public static Date getDayAgo(int days) {
         Calendar calendar = new GregorianCalendar();
         calendar.setTime(now());
@@ -115,7 +132,13 @@ public class DateUtils {
         return getStartTimeOfDay(calendar.getTime());
     }
 
-    public static Date getFistDayOfMonth(Integer months) {
+    /**
+     * Get the first day of the month few months ago.
+     *
+     * @param  months the number of months
+     * @return date object of that day
+     */
+    public static Date getFistDayOfMonth(int months) {
         Calendar calendar = Calendar.getInstance();
         // get first day of that month
         calendar.add(Calendar.MONTH, -months);

--- a/src/main/java/run/halo/app/utils/IpUtils.java
+++ b/src/main/java/run/halo/app/utils/IpUtils.java
@@ -6,6 +6,7 @@ import org.lionsoul.ip2region.DbConfig;
 import org.lionsoul.ip2region.DbMakerConfigException;
 import org.lionsoul.ip2region.DbSearcher;
 import org.springframework.core.io.ClassPathResource;
+import org.springframework.lang.NonNull;
 import org.springframework.util.FileCopyUtils;
 import run.halo.app.model.support.HaloConst;
 
@@ -29,7 +30,13 @@ public class IpUtils {
         }
     }
 
-    public static IpRegion getRegion(String ipAddress) throws IOException {
+    /**
+     * Search the region in ip2region database of the ip address.
+     *
+     * @param  ipAddress ip address string
+     * @return IpRegion object describing the region
+     */
+    public static IpRegion getRegion(@NonNull String ipAddress) throws IOException {
         DataBlock dataBlock = DB_SEARCHER.memorySearch(ipAddress);
         String[] details = dataBlock.toString().split("\\|");
         return new IpRegion(dataBlock.getCityId(), details[1], details[3], details[4], details[5]);

--- a/src/main/java/run/halo/app/utils/IpUtils.java
+++ b/src/main/java/run/halo/app/utils/IpUtils.java
@@ -1,12 +1,11 @@
 package run.halo.app.utils;
 
 import lombok.Data;
-import lombok.extern.slf4j.Slf4j;
 import org.lionsoul.ip2region.DataBlock;
 import org.lionsoul.ip2region.DbConfig;
 import org.lionsoul.ip2region.DbMakerConfigException;
 import org.lionsoul.ip2region.DbSearcher;
-import org.springframework.beans.factory.annotation.Autowired;
+import run.halo.app.model.support.HaloConst;
 
 import java.io.FileNotFoundException;
 import java.io.IOException;
@@ -15,10 +14,9 @@ import java.io.IOException;
  * @author Holldean
  * @date 2020-5-12
  */
-@Slf4j
 public class IpUtils {
 
-    private static final String dbPath = IpUtils.class.getResource("/database/ip2region.db").getPath();
+    private static final String dbPath = IpUtils.class.getResource(HaloConst.IP2REGION_DATABASE_PATH).getPath();
 
     private static DbSearcher dbSearcher;
 

--- a/src/main/java/run/halo/app/utils/IpUtils.java
+++ b/src/main/java/run/halo/app/utils/IpUtils.java
@@ -1,0 +1,98 @@
+package run.halo.app.utils;
+
+import lombok.Data;
+import lombok.extern.slf4j.Slf4j;
+import org.lionsoul.ip2region.DataBlock;
+import org.lionsoul.ip2region.DbConfig;
+import org.lionsoul.ip2region.DbMakerConfigException;
+import org.lionsoul.ip2region.DbSearcher;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.io.FileNotFoundException;
+import java.io.IOException;
+
+/**
+ * @author Holldean
+ * @date 2020-5-12
+ */
+@Slf4j
+public class IpUtils {
+
+    private static final String dbPath = IpUtils.class.getResource("/database/ip2region.db").getPath();
+
+    private static DbSearcher dbSearcher;
+
+    static {
+        try {
+            dbSearcher = new DbSearcher(new DbConfig(), dbPath);
+        } catch (DbMakerConfigException | FileNotFoundException e) {
+            e.printStackTrace();
+        }
+    }
+
+    public static IpRegion getRegion(String ipAddress) throws IOException {
+        DataBlock dataBlock = dbSearcher.memorySearch(ipAddress);
+        String[] details = dataBlock.toString().split("\\|");
+        return new IpRegion(dataBlock.getCityId(), details[1], details[3], details[4], details[5]);
+    }
+
+    public static String processProvinceName(String province) {
+        if (province.endsWith("维吾尔自治区")) {
+            return province.substring(0, province.length() - 6);
+        } else if (province.endsWith("回族自治区") || province.endsWith("特别行政区")) {
+            return province.substring(0, province.length() - 5);
+        } else if (province.endsWith("自治区")) {
+            return province.substring(0, province.length() - 3);
+        } else if (province.endsWith("省") || province.endsWith("市")) {
+            return province.substring(0, province.length() - 1);
+        } else {
+            return province;
+        }
+    }
+
+    @Data
+    public static class IpRegion {
+        private final Integer cityId;
+        private final String country;
+        private final String province;
+        private final String city;
+        private final String ISP;
+
+        public IpRegion(Integer cityId, String country, String province, String city, String ISP) {
+            if (cityId == 0) {
+                this.cityId = null;
+            } else {
+                this.cityId = cityId;
+            }
+
+            if (country.equals("0")) {
+                this.country = "";
+            } else {
+                this.country = country;
+            }
+
+            if (province.equals("0")) {
+                this.province = "";
+            } else {
+                this.province = processProvinceName(province);
+            }
+
+            if (city.equals("0") || city.equals("内网IP")) {
+                this.city = "";
+            } else {
+                this.city = city;
+            }
+
+            if (ISP.equals("0")) {
+                this.ISP = "";
+            } else {
+                this.ISP = ISP;
+            }
+        }
+
+        @Override
+        public String toString() {
+            return this.country + this.province + this.city + this.ISP;
+        }
+    }
+}

--- a/src/main/java/run/halo/app/utils/IpUtils.java
+++ b/src/main/java/run/halo/app/utils/IpUtils.java
@@ -35,20 +35,6 @@ public class IpUtils {
         return new IpRegion(dataBlock.getCityId(), details[1], details[3], details[4], details[5]);
     }
 
-    public static String processProvinceName(String province) {
-        if (province.endsWith("维吾尔自治区")) {
-            return province.substring(0, province.length() - 6);
-        } else if (province.endsWith("回族自治区") || province.endsWith("特别行政区")) {
-            return province.substring(0, province.length() - 5);
-        } else if (province.endsWith("自治区")) {
-            return province.substring(0, province.length() - 3);
-        } else if (province.endsWith("省") || province.endsWith("市")) {
-            return province.substring(0, province.length() - 1);
-        } else {
-            return province;
-        }
-    }
-
     @Data
     public static class IpRegion {
         private final Integer cityId;
@@ -73,7 +59,7 @@ public class IpUtils {
             if (province.equals("0")) {
                 this.province = "";
             } else {
-                this.province = processProvinceName(province);
+                this.province = province;
             }
 
             if (city.equals("0") || city.equals("内网IP")) {

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -16,7 +16,7 @@ spring:
 
     # H2 database configuration.
     driver-class-name: org.h2.Driver
-    url: jdbc:h2:file:~/.halo/db/halo
+    url: jdbc:h2:file:~/.halo/db/halo;AUTO_SERVER=TRUE
     username: admin
     password: 123456
 
@@ -46,7 +46,7 @@ management:
         include: ['httptrace', 'metrics','env','logfile','health']
 logging:
   level:
-    run.halo.app: INFO
+    run.halo.app: DEBUG
   file:
     path: \${user.home}/.halo/logs
 

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -16,7 +16,7 @@ spring:
 
     # H2 database configuration.
     driver-class-name: org.h2.Driver
-    url: jdbc:h2:file:~/.halo/db/halo;AUTO_SERVER=TRUE
+    url: jdbc:h2:file:~/.halo/db/halo
     username: admin
     password: 123456
 
@@ -46,7 +46,7 @@ management:
         include: ['httptrace', 'metrics','env','logfile','health']
 logging:
   level:
-    run.halo.app: DEBUG
+    run.halo.app: INFO
   file:
     path: \${user.home}/.halo/logs
 

--- a/src/test/java/run/halo/app/repository/VisitorLogRepositoryTest.java
+++ b/src/test/java/run/halo/app/repository/VisitorLogRepositoryTest.java
@@ -209,4 +209,5 @@ public class VisitorLogRepositoryTest {
         Assert.assertEquals((Integer) (calendar.get(Calendar.MONTH) + 1), result.get(0).getMonth());
         calendar.setTime(today);
         Assert.assertEquals((Integer) (calendar.get(Calendar.MONTH) + 1), result.get(1).getMonth());
-    }}
+    }
+}

--- a/src/test/java/run/halo/app/repository/VisitorLogRepositoryTest.java
+++ b/src/test/java/run/halo/app/repository/VisitorLogRepositoryTest.java
@@ -1,0 +1,212 @@
+package run.halo.app.repository;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.test.context.junit4.SpringRunner;
+import run.halo.app.model.entity.VisitorLog;
+import run.halo.app.model.projection.VisitorLogDayCountProjection;
+import run.halo.app.model.projection.VisitorLogMonthCountProjection;
+import run.halo.app.model.projection.VisitorLogRegionCountProjection;
+
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.Calendar;
+import java.util.Date;
+import java.util.List;
+
+@RunWith(SpringRunner.class)
+@DataJpaTest
+public class VisitorLogRepositoryTest {
+
+    @Autowired
+    private VisitorLogRepository visitorLogRepository;
+
+    @Test
+    public void findByAccessDateAndIpAddressTest() {
+        // insert a ip log into database
+        Date current = new Date();
+        visitorLogRepository.save(new VisitorLog(current, "HELLO IP"));
+
+        // test findByAccessDateAndIpAddress
+        Assert.assertNotNull(visitorLogRepository.findByAccessDateAndIpAddress(current, "HELLO IP"));
+        Assert.assertNull(visitorLogRepository.findByAccessDateAndIpAddress(current, "HELLO"));
+    }
+
+    @Test
+    public void findByAccessDateAfter() {
+        Calendar calendar = Calendar.getInstance();
+        // get date in the last month
+        calendar.setTime(new Date());
+        calendar.add(Calendar.MONTH, -1);
+        Date lastMonth = calendar.getTime();
+
+        // get date in the last month plus one day
+        calendar.add(Calendar.DAY_OF_MONTH, 1);
+        Date lastMonthPlusAnHour = calendar.getTime();
+
+        // get date in the last month minus one day
+        calendar.add(Calendar.DAY_OF_MONTH, -2);
+        Date lastMonthMinusAnHour = calendar.getTime();
+
+        // insert two ip logs into database
+        visitorLogRepository.save(new VisitorLog(lastMonthPlusAnHour, "HELLO IP1"));
+        visitorLogRepository.save(new VisitorLog(lastMonthMinusAnHour, "HELLO IP2"));
+
+        // test findByAccessDateAndIpAddress
+        List<VisitorLog> result = visitorLogRepository.findByAccessDateAfter(lastMonth);
+
+        Assert.assertNotNull(result);
+        Assert.assertEquals(1, result.size());
+        Assert.assertEquals(lastMonthPlusAnHour, result.get(0).getAccessDate());
+    }
+
+    @Test
+    public void countByAccessDateAfterGroupByDayTest() throws ParseException {
+        Calendar calendar = Calendar.getInstance();
+        // get date in the last month
+        calendar.setTime(new Date());
+        calendar.add(Calendar.MONTH, -1);
+        Date lastMonth = calendar.getTime();
+
+        // get date of yesterday
+        calendar.setTime(new Date());
+        calendar.add(Calendar.DAY_OF_MONTH, -1);
+        Date yesterday = calendar.getTime();
+
+        // get date of today
+        calendar.setTime(new Date());
+        Date today = calendar.getTime();
+
+        // insert three ip logs into database
+        visitorLogRepository.save(new VisitorLog(yesterday, "192.168.1.1"));
+        visitorLogRepository.save(new VisitorLog(yesterday, "192.168.1.2"));
+        visitorLogRepository.save(new VisitorLog(today, "192.168.1.1"));
+
+        // test findByAccessDateAndIpAddress
+        List<VisitorLogDayCountProjection> result = visitorLogRepository.countByAccessDateAfterGroupByDay(lastMonth);
+        SimpleDateFormat formater = new SimpleDateFormat("yyyy-MM-dd");
+
+        Assert.assertEquals(formater.format(yesterday), result.get(0).getDate().toString());
+        Assert.assertEquals((Long) 2L, result.get(0).getCount());
+        Assert.assertEquals(formater.format(today), result.get(1).getDate().toString());
+        Assert.assertEquals((Long) 1L, result.get(1).getCount());
+    }
+
+    @Test
+    public void countByAccessDateAfterGroupByCountryTest() throws ParseException {
+        Calendar calendar = Calendar.getInstance();
+        // get date in the last month
+        calendar.setTime(new Date());
+        calendar.add(Calendar.MONTH, -1);
+        Date lastMonth = calendar.getTime();
+
+        // get date of yesterday
+        calendar.setTime(new Date());
+        calendar.add(Calendar.DAY_OF_MONTH, -1);
+        Date yesterday = calendar.getTime();
+
+        // get date of today
+        calendar.setTime(new Date());
+        Date today = calendar.getTime();
+
+        // insert three ip logs into database
+        VisitorLog logOne = new VisitorLog(yesterday, "192.168.1.1");
+        logOne.setCountry("中国");
+        VisitorLog logTwo = new VisitorLog(yesterday, "192.168.1.2");
+        logTwo.setCountry("美国");
+        VisitorLog logThree = new VisitorLog(today, "192.168.1.1");
+        logThree.setCountry("中国");
+        visitorLogRepository.save(logOne);
+        visitorLogRepository.save(logTwo);
+        visitorLogRepository.save(logThree);
+
+        // test countByAccessDateAfterGroupByCountry
+        List<VisitorLogRegionCountProjection> result = visitorLogRepository.countByAccessDateAfterGroupByCountry(lastMonth);
+
+        Assert.assertEquals("中国", result.get(0).getRegion());
+        Assert.assertEquals((Long) 2L, result.get(0).getCount());
+        Assert.assertEquals("美国", result.get(1).getRegion());
+        Assert.assertEquals((Long) 1L, result.get(1).getCount());
+    }
+
+    @Test
+    public void countByAccessDateAfterGroupByChineseProvinceTest() throws ParseException {
+        Calendar calendar = Calendar.getInstance();
+        // get date in the last month
+        calendar.setTime(new Date());
+        calendar.add(Calendar.MONTH, -1);
+        Date lastMonth = calendar.getTime();
+
+        // get date of yesterday
+        calendar.setTime(new Date());
+        calendar.add(Calendar.DAY_OF_MONTH, -1);
+        Date yesterday = calendar.getTime();
+
+        // get date of today
+        calendar.setTime(new Date());
+        Date today = calendar.getTime();
+
+        // insert four ip logs into database
+        VisitorLog logOne = new VisitorLog(yesterday, "192.168.1.1");
+        logOne.setCountry("中国");
+        logOne.setProvince("北京");
+        VisitorLog logTwo = new VisitorLog(yesterday, "192.168.1.2");
+        logTwo.setCountry("中国");
+        logTwo.setProvince("北京");
+        VisitorLog logThree = new VisitorLog(today, "192.168.1.1");
+        logThree.setCountry("中国");
+        logThree.setProvince("上海");
+        VisitorLog logFour = new VisitorLog(today, "192.168.1.3");
+        logFour.setCountry("美国");
+        visitorLogRepository.save(logOne);
+        visitorLogRepository.save(logTwo);
+        visitorLogRepository.save(logThree);
+        visitorLogRepository.save(logFour);
+
+        // test countByAccessDateAfterGroupByCountry
+        List<VisitorLogRegionCountProjection> result = visitorLogRepository.countByAccessDateAfterGroupByChineseProvince(lastMonth);
+
+        Assert.assertEquals("上海", result.get(0).getRegion());
+        Assert.assertEquals((Long) 1L, result.get(0).getCount());
+        Assert.assertEquals("北京", result.get(1).getRegion());
+        Assert.assertEquals((Long) 2L, result.get(1).getCount());
+    }
+
+    @Test
+    public void countByAccessDateAfterGroupByMonthTest() {
+        Calendar calendar = Calendar.getInstance();
+        // get date in the last year
+        calendar.setTime(new Date());
+        calendar.add(Calendar.YEAR, -1);
+        Date lastYear = calendar.getTime();
+
+        // get date of last month
+        calendar.setTime(new Date());
+        calendar.add(Calendar.MONTH, -1);
+        Date lastMonth = calendar.getTime();
+
+        // get date of today
+        calendar.setTime(new Date());
+        Date today = calendar.getTime();
+
+        // insert three ip logs into database
+        VisitorLog logOne = new VisitorLog(lastMonth, "192.168.1.1");
+        VisitorLog logTwo = new VisitorLog(today, "192.168.1.2");
+        VisitorLog logThree = new VisitorLog(today, "192.168.1.1");
+        visitorLogRepository.save(logOne);
+        visitorLogRepository.save(logTwo);
+        visitorLogRepository.save(logThree);
+
+        List<VisitorLogMonthCountProjection> result = visitorLogRepository.countByAccessDateAfterGroupByMonth(lastYear);
+
+        Assert.assertEquals(2, result.size());
+        Assert.assertEquals((Long) 1L, result.get(0).getCount());
+        Assert.assertEquals((Long) 2L, result.get(1).getCount());
+        calendar.setTime(lastMonth);
+        Assert.assertEquals((Integer) (calendar.get(Calendar.MONTH) + 1), result.get(0).getMonth());
+        calendar.setTime(today);
+        Assert.assertEquals((Integer) (calendar.get(Calendar.MONTH) + 1), result.get(1).getMonth());
+    }}

--- a/src/test/java/run/halo/app/utils/IpUtilsTest.java
+++ b/src/test/java/run/halo/app/utils/IpUtilsTest.java
@@ -11,10 +11,10 @@ public class IpUtilsTest {
     public void getRegionTest() throws IOException {
         IpUtils.IpRegion ipRegionOne = IpUtils.getRegion("101.105.35.57");
         Assert.assertEquals("中国", ipRegionOne.getCountry());
-        Assert.assertEquals("广东", ipRegionOne.getProvince());
+        Assert.assertEquals("广东省", ipRegionOne.getProvince());
         Assert.assertEquals("深圳市", ipRegionOne.getCity());
         Assert.assertEquals("鹏博士", ipRegionOne.getIsp());
-        Assert.assertEquals("中国广东深圳市鹏博士", ipRegionOne.toString());
+        Assert.assertEquals("中国广东省深圳市鹏博士", ipRegionOne.toString());
 
         IpUtils.IpRegion ipRegionTwo = IpUtils.getRegion("199.43.0.47");
         Assert.assertEquals("美国", ipRegionTwo.getCountry());
@@ -24,20 +24,10 @@ public class IpUtilsTest {
         Assert.assertEquals("美国弗吉尼亚阿什本", ipRegionTwo.toString());
 
         IpUtils.IpRegion ipRegionThree = IpUtils.getRegion("192.168.1.1");
+        Assert.assertEquals("", ipRegionThree.getCountry());
         Assert.assertEquals("", ipRegionThree.getCity());
         Assert.assertEquals("内网IP", ipRegionThree.getIsp());
         Assert.assertEquals("内网IP", ipRegionThree.toString());
     }
 
-    @Test
-    public void processProvinceNameTest() {
-        Assert.assertEquals("广东", IpUtils.processProvinceName("广东省"));
-        Assert.assertEquals("内蒙古", IpUtils.processProvinceName("内蒙古自治区"));
-        Assert.assertEquals("宁夏", IpUtils.processProvinceName("宁夏回族自治区"));
-        Assert.assertEquals("新疆", IpUtils.processProvinceName("新疆维吾尔自治区"));
-        Assert.assertEquals("北京", IpUtils.processProvinceName("北京市"));
-        Assert.assertEquals("香港", IpUtils.processProvinceName("香港特别行政区"));
-        Assert.assertEquals("香港", IpUtils.processProvinceName("香港特别行政区"));
-        Assert.assertEquals("浙江", IpUtils.processProvinceName("浙江"));
-    }
 }

--- a/src/test/java/run/halo/app/utils/IpUtilsTest.java
+++ b/src/test/java/run/halo/app/utils/IpUtilsTest.java
@@ -1,0 +1,44 @@
+package run.halo.app.utils;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.io.IOException;
+
+public class IpUtilsTest {
+
+    @Test
+    public void getRegionTest() throws IOException {
+        IpUtils.IpRegion ipRegionOne = IpUtils.getRegion("101.105.35.57");
+        Assert.assertEquals("中国", ipRegionOne.getCountry());
+        Assert.assertEquals("广东", ipRegionOne.getProvince());
+        Assert.assertEquals("深圳市", ipRegionOne.getCity());
+        Assert.assertEquals("鹏博士", ipRegionOne.getISP());
+        Assert.assertEquals("中国广东深圳市鹏博士", ipRegionOne.toString());
+
+        IpUtils.IpRegion ipRegionTwo = IpUtils.getRegion("199.43.0.47");
+        Assert.assertEquals("美国", ipRegionTwo.getCountry());
+        Assert.assertEquals("弗吉尼亚", ipRegionTwo.getProvince());
+        Assert.assertEquals("阿什本", ipRegionTwo.getCity());
+        Assert.assertEquals("", ipRegionTwo.getISP());
+        Assert.assertEquals("美国弗吉尼亚阿什本", ipRegionTwo.toString());
+
+        IpUtils.IpRegion ipRegionThree = IpUtils.getRegion("192.168.1.1");
+        Assert.assertEquals("", ipRegionThree.getCity());
+        Assert.assertEquals("内网IP", ipRegionThree.getISP());
+        Assert.assertEquals("内网IP", ipRegionThree.toString());
+    }
+
+    @Test
+    public void processProvinceNameTest() {
+        Assert.assertEquals("广东" , IpUtils.processProvinceName("广东省"));
+        Assert.assertEquals("内蒙古" , IpUtils.processProvinceName("内蒙古自治区"));
+        Assert.assertEquals("宁夏" , IpUtils.processProvinceName("宁夏回族自治区"));
+        Assert.assertEquals("新疆" , IpUtils.processProvinceName("新疆维吾尔自治区"));
+        Assert.assertEquals("北京" , IpUtils.processProvinceName("北京市"));
+        Assert.assertEquals("香港" , IpUtils.processProvinceName("香港特别行政区"));
+        Assert.assertEquals("香港" , IpUtils.processProvinceName("香港特别行政区"));
+        Assert.assertEquals("浙江" , IpUtils.processProvinceName("浙江"));
+    }
+}

--- a/src/test/java/run/halo/app/utils/IpUtilsTest.java
+++ b/src/test/java/run/halo/app/utils/IpUtilsTest.java
@@ -2,7 +2,6 @@ package run.halo.app.utils;
 
 import org.junit.Assert;
 import org.junit.Test;
-import org.springframework.beans.factory.annotation.Autowired;
 
 import java.io.IOException;
 

--- a/src/test/java/run/halo/app/utils/IpUtilsTest.java
+++ b/src/test/java/run/halo/app/utils/IpUtilsTest.java
@@ -13,31 +13,31 @@ public class IpUtilsTest {
         Assert.assertEquals("中国", ipRegionOne.getCountry());
         Assert.assertEquals("广东", ipRegionOne.getProvince());
         Assert.assertEquals("深圳市", ipRegionOne.getCity());
-        Assert.assertEquals("鹏博士", ipRegionOne.getISP());
+        Assert.assertEquals("鹏博士", ipRegionOne.getIsp());
         Assert.assertEquals("中国广东深圳市鹏博士", ipRegionOne.toString());
 
         IpUtils.IpRegion ipRegionTwo = IpUtils.getRegion("199.43.0.47");
         Assert.assertEquals("美国", ipRegionTwo.getCountry());
         Assert.assertEquals("弗吉尼亚", ipRegionTwo.getProvince());
         Assert.assertEquals("阿什本", ipRegionTwo.getCity());
-        Assert.assertEquals("", ipRegionTwo.getISP());
+        Assert.assertEquals("", ipRegionTwo.getIsp());
         Assert.assertEquals("美国弗吉尼亚阿什本", ipRegionTwo.toString());
 
         IpUtils.IpRegion ipRegionThree = IpUtils.getRegion("192.168.1.1");
         Assert.assertEquals("", ipRegionThree.getCity());
-        Assert.assertEquals("内网IP", ipRegionThree.getISP());
+        Assert.assertEquals("内网IP", ipRegionThree.getIsp());
         Assert.assertEquals("内网IP", ipRegionThree.toString());
     }
 
     @Test
     public void processProvinceNameTest() {
-        Assert.assertEquals("广东" , IpUtils.processProvinceName("广东省"));
-        Assert.assertEquals("内蒙古" , IpUtils.processProvinceName("内蒙古自治区"));
-        Assert.assertEquals("宁夏" , IpUtils.processProvinceName("宁夏回族自治区"));
-        Assert.assertEquals("新疆" , IpUtils.processProvinceName("新疆维吾尔自治区"));
-        Assert.assertEquals("北京" , IpUtils.processProvinceName("北京市"));
-        Assert.assertEquals("香港" , IpUtils.processProvinceName("香港特别行政区"));
-        Assert.assertEquals("香港" , IpUtils.processProvinceName("香港特别行政区"));
-        Assert.assertEquals("浙江" , IpUtils.processProvinceName("浙江"));
+        Assert.assertEquals("广东", IpUtils.processProvinceName("广东省"));
+        Assert.assertEquals("内蒙古", IpUtils.processProvinceName("内蒙古自治区"));
+        Assert.assertEquals("宁夏", IpUtils.processProvinceName("宁夏回族自治区"));
+        Assert.assertEquals("新疆", IpUtils.processProvinceName("新疆维吾尔自治区"));
+        Assert.assertEquals("北京", IpUtils.processProvinceName("北京市"));
+        Assert.assertEquals("香港", IpUtils.processProvinceName("香港特别行政区"));
+        Assert.assertEquals("香港", IpUtils.processProvinceName("香港特别行政区"));
+        Assert.assertEquals("浙江", IpUtils.processProvinceName("浙江"));
     }
 }


### PR DESCRIPTION
## 改动

- `VisitorLog`储存访客的IP及IP定位的信息

- 基于[lionsoul2014/ip2region](https://github.com/lionsoul2014/ip2region)IP数据库，IpUtils中提供IP定位的接口（实测定位效果不错）

- `VisitorLogEvent`异步处理IP定位并储存`VisitorLog`的任务

- `VisitorLogRepository`的几个接口以及`IpUtils`均添加测试样例

- 在`ContentContentController`和`ContentIndexController`几个访问博客页面的方法中发布访客访问事件，每个IP的一次或多次访问均记当天访问量一次，count记录IP当天访问页面的次数

- 已打包在Centos 7上测试成功

-------
### 关于ip2region
数据库文件放在resources/database下面，路径名在`HaloConst.IP2REGION_DATABASE_PATH`中
搜索方法使用的是`memorySearch`，支持[并发使用](https://github.com/lionsoul2014/ip2region#ip2region-%E5%B9%B6%E5%8F%91%E4%BD%BF%E7%94%A8)

Issue #551 