### PR TITLE
[Fix issue#526] Add image metadata extracter

### DIFF
--- a/src/main/java/run/halo/app/handler/file/LocalFileHandler.java
+++ b/src/main/java/run/halo/app/handler/file/LocalFileHandler.java
@@ -14,9 +14,7 @@ import run.halo.app.service.OptionService;
 import run.halo.app.utils.FilenameUtils;
 import run.halo.app.utils.HaloUtils;
 import run.halo.app.utils.ImageMetadataUtils;
-import run.halo.app.utils.ImageUtils;
 
-import java.awt.image.BufferedImage;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;

--- a/src/main/java/run/halo/app/utils/ImageMetadataUtils.java
+++ b/src/main/java/run/halo/app/utils/ImageMetadataUtils.java
@@ -1,33 +1,35 @@
 /*
- *	SimpleImageInfo.java
+ *  SimpleImageInfo.java
  *
- *	@version 0.1
- *	@author  Jaimon Mathew <http://www.jaimon.co.uk>
+ *  @version 0.1
+ *  @author  Jaimon Mathew <http://www.jaimon.co.uk>
  *
- *	A Java class to determine image width, height and MIME types for a number of image file formats without loading the whole image data.
+ *  A Java class to determine image width, height and MIME types for a number of image file formats without loading the whole image data.
  *
- *	Revision history
- *	0.1 - 29/Jan/2011 - Initial version created
+ *  Revision history
+ *  0.1 - 29/Jan/2011 - Initial version created
  *
  *  -------------------------------------------------------------------------------
 
- 	This code is licensed under the Apache License, Version 2.0 (the "License");
- 	You may not use this file except in compliance with the License.
+    This code is licensed under the Apache License, Version 2.0 (the "License");
+    You may not use this file except in compliance with the License.
 
- 	You may obtain a copy of the License at
+    You may obtain a copy of the License at
 
- 	http://www.apache.org/licenses/LICENSE-2.0
+    http://www.apache.org/licenses/LICENSE-2.0
 
-	Unless required by applicable law or agreed to in writing, software
-	distributed under the License is distributed on an "AS IS" BASIS,
-	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-	See the License for the specific language governing permissions and
-	limitations under the License.
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
 
  *  -------------------------------------------------------------------------------
  */
 
 package run.halo.app.utils;
+
+import org.springframework.lang.NonNull;
 
 import java.io.ByteArrayInputStream;
 import java.io.File;
@@ -36,7 +38,7 @@ import java.io.IOException;
 import java.io.InputStream;
 
 /**
- * Image metadata utilities.
+ * Image metadata utilities (modified original file).
  *
  * @date 28/5/20
  */
@@ -70,7 +72,12 @@ public class ImageMetadataUtils {
         }
     }
 
-    private void processStream(InputStream is) throws IOException {
+    /**
+     * Processes the stream to get image metadata.
+     * @param is input stream not null
+     * @throws IOException
+     */
+    private void processStream(@NonNull InputStream is) throws IOException {
         int c1 = is.read();
         int c2 = is.read();
         int c3 = is.read();
@@ -80,17 +87,17 @@ public class ImageMetadataUtils {
 
         if (c1 == 'G' && c2 == 'I' && c3 == 'F') { // GIF
             is.skip(3);
-            width = readInt(is,2,false);
-            height = readInt(is,2,false);
+            width = readInt(is, 2, false);
+            height = readInt(is, 2, false);
             mimeType = "image/gif";
         } else if (c1 == 0xFF && c2 == 0xD8) { // JPG
             while (c3 == 255) {
                 int marker = is.read();
-                int len = readInt(is,2,true);
+                int len = readInt(is, 2, true);
                 if (marker == 192 || marker == 193 || marker == 194) {
                     is.skip(1);
-                    height = readInt(is,2,true);
-                    width = readInt(is,2,true);
+                    height = readInt(is, 2, true);
+                    width = readInt(is, 2, true);
                     mimeType = "image/jpeg";
                     break;
                 }
@@ -99,15 +106,15 @@ public class ImageMetadataUtils {
             }
         } else if (c1 == 137 && c2 == 80 && c3 == 78) { // PNG
             is.skip(15);
-            width = readInt(is,2,true);
+            width = readInt(is, 2, true);
             is.skip(2);
-            height = readInt(is,2,true);
+            height = readInt(is, 2, true);
             mimeType = "image/png";
         } else if (c1 == 66 && c2 == 77) { // BMP
             is.skip(15);
-            width = readInt(is,2,false);
+            width = readInt(is, 2, false);
             is.skip(2);
-            height = readInt(is,2,false);
+            height = readInt(is, 2, false);
             mimeType = "image/bmp";
         } else {
             int c4 = is.read();
@@ -116,19 +123,19 @@ public class ImageMetadataUtils {
                 boolean bigEndian = c1 == 'M';
                 int ifd = 0;
                 int entries;
-                ifd = readInt(is,4,bigEndian);
+                ifd = readInt(is, 4, bigEndian);
                 is.skip(ifd - 8);
-                entries = readInt(is,2,bigEndian);
+                entries = readInt(is, 2, bigEndian);
                 for (int i = 1; i <= entries; i++) {
-                    int tag = readInt(is,2,bigEndian);
-                    int fieldType = readInt(is,2,bigEndian);
-                    long count = readInt(is,4,bigEndian);
+                    int tag = readInt(is, 2, bigEndian);
+                    int fieldType = readInt(is, 2, bigEndian);
+                    long count = readInt(is, 4, bigEndian);
                     int valOffset;
-                    if ((fieldType == 3 || fieldType == 8)) {
-                        valOffset = readInt(is,2,bigEndian);
+                    if (fieldType == 3 || fieldType == 8) {
+                        valOffset = readInt(is, 2, bigEndian);
                         is.skip(2);
                     } else {
-                        valOffset = readInt(is,4,bigEndian);
+                        valOffset = readInt(is, 4, bigEndian);
                     }
                     if (tag == 256) {
                         width = valOffset;
@@ -151,7 +158,7 @@ public class ImageMetadataUtils {
         int ret = 0;
         int sv = bigEndian ? ((noOfBytes - 1) * 8) : 0;
         int cnt = bigEndian ? -8 : 8;
-        for(int i=0;i<noOfBytes;i++) {
+        for (int i = 0; i < noOfBytes; i++) {
             ret |= is.read() << sv;
             sv += cnt;
         }

--- a/src/main/java/run/halo/app/utils/ImageMetadataUtils.java
+++ b/src/main/java/run/halo/app/utils/ImageMetadataUtils.java
@@ -1,0 +1,189 @@
+/*
+ *	SimpleImageInfo.java
+ *
+ *	@version 0.1
+ *	@author  Jaimon Mathew <http://www.jaimon.co.uk>
+ *
+ *	A Java class to determine image width, height and MIME types for a number of image file formats without loading the whole image data.
+ *
+ *	Revision history
+ *	0.1 - 29/Jan/2011 - Initial version created
+ *
+ *  -------------------------------------------------------------------------------
+
+ 	This code is licensed under the Apache License, Version 2.0 (the "License");
+ 	You may not use this file except in compliance with the License.
+
+ 	You may obtain a copy of the License at
+
+ 	http://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+
+ *  -------------------------------------------------------------------------------
+ */
+
+package run.halo.app.utils;
+
+import java.io.ByteArrayInputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+
+/**
+ * Image metadata utilities.
+ *
+ * @date 28/5/20
+ */
+public class ImageMetadataUtils {
+    private int height;
+    private int width;
+    private String mimeType;
+
+    private ImageMetadataUtils() {
+    }
+
+    public ImageMetadataUtils(File file) throws IOException {
+        InputStream is = new FileInputStream(file);
+        try {
+            processStream(is);
+        } finally {
+            is.close();
+        }
+    }
+
+    public ImageMetadataUtils(InputStream is) throws IOException {
+        processStream(is);
+    }
+
+    public ImageMetadataUtils(byte[] bytes) throws IOException {
+        InputStream is = new ByteArrayInputStream(bytes);
+        try {
+            processStream(is);
+        } finally {
+            is.close();
+        }
+    }
+
+    private void processStream(InputStream is) throws IOException {
+        int c1 = is.read();
+        int c2 = is.read();
+        int c3 = is.read();
+
+        mimeType = null;
+        width = height = -1;
+
+        if (c1 == 'G' && c2 == 'I' && c3 == 'F') { // GIF
+            is.skip(3);
+            width = readInt(is,2,false);
+            height = readInt(is,2,false);
+            mimeType = "image/gif";
+        } else if (c1 == 0xFF && c2 == 0xD8) { // JPG
+            while (c3 == 255) {
+                int marker = is.read();
+                int len = readInt(is,2,true);
+                if (marker == 192 || marker == 193 || marker == 194) {
+                    is.skip(1);
+                    height = readInt(is,2,true);
+                    width = readInt(is,2,true);
+                    mimeType = "image/jpeg";
+                    break;
+                }
+                is.skip(len - 2);
+                c3 = is.read();
+            }
+        } else if (c1 == 137 && c2 == 80 && c3 == 78) { // PNG
+            is.skip(15);
+            width = readInt(is,2,true);
+            is.skip(2);
+            height = readInt(is,2,true);
+            mimeType = "image/png";
+        } else if (c1 == 66 && c2 == 77) { // BMP
+            is.skip(15);
+            width = readInt(is,2,false);
+            is.skip(2);
+            height = readInt(is,2,false);
+            mimeType = "image/bmp";
+        } else {
+            int c4 = is.read();
+            if ((c1 == 'M' && c2 == 'M' && c3 == 0 && c4 == 42)
+                || (c1 == 'I' && c2 == 'I' && c3 == 42 && c4 == 0)) { //TIFF
+                boolean bigEndian = c1 == 'M';
+                int ifd = 0;
+                int entries;
+                ifd = readInt(is,4,bigEndian);
+                is.skip(ifd - 8);
+                entries = readInt(is,2,bigEndian);
+                for (int i = 1; i <= entries; i++) {
+                    int tag = readInt(is,2,bigEndian);
+                    int fieldType = readInt(is,2,bigEndian);
+                    long count = readInt(is,4,bigEndian);
+                    int valOffset;
+                    if ((fieldType == 3 || fieldType == 8)) {
+                        valOffset = readInt(is,2,bigEndian);
+                        is.skip(2);
+                    } else {
+                        valOffset = readInt(is,4,bigEndian);
+                    }
+                    if (tag == 256) {
+                        width = valOffset;
+                    } else if (tag == 257) {
+                        height = valOffset;
+                    }
+                    if (width != -1 && height != -1) {
+                        mimeType = "image/tiff";
+                        break;
+                    }
+                }
+            }
+        }
+        if (mimeType == null) {
+            throw new IOException("Unsupported image type");
+        }
+    }
+
+    private int readInt(InputStream is, int noOfBytes, boolean bigEndian) throws IOException {
+        int ret = 0;
+        int sv = bigEndian ? ((noOfBytes - 1) * 8) : 0;
+        int cnt = bigEndian ? -8 : 8;
+        for(int i=0;i<noOfBytes;i++) {
+            ret |= is.read() << sv;
+            sv += cnt;
+        }
+        return ret;
+    }
+
+    public int getHeight() {
+        return height;
+    }
+
+    public void setHeight(int height) {
+        this.height = height;
+    }
+
+    public int getWidth() {
+        return width;
+    }
+
+    public void setWidth(int width) {
+        this.width = width;
+    }
+
+    public String getMimeType() {
+        return mimeType;
+    }
+
+    public void setMimeType(String mimeType) {
+        this.mimeType = mimeType;
+    }
+
+    @Override
+    public String toString() {
+        return "MIME Type : " + mimeType + "\t Width : " + width + "\t Height : " + height;
+    }
+}


### PR DESCRIPTION
 Fix #526 

增加图片Metadata获取器。 
不加载图片的全部数据，只读取图片的 Metadata 来获取图片的各种信息。