### PR TITLE
Add useJunitPlatform() to build.gradle

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -139,3 +139,7 @@ dependencies {
 
     developmentOnly "org.springframework.boot:spring-boot-devtools"
 }
+
+test {
+    useJUnitPlatform()
+}


### PR DESCRIPTION
This is required for the JUnit tests to run.

Source: https://docs.gradle.org/current/userguide/java_testing.html#using_junit5

Issue: https://github.com/halo-dev/halo/issues/1127