### PR TITLE
Refresh post summary when its original content changed.

### DIFF
--- a/src/main/java/run/halo/app/controller/admin/api/PostController.java
+++ b/src/main/java/run/halo/app/controller/admin/api/PostController.java
@@ -2,6 +2,7 @@ package run.halo.app.controller.admin.api;
 
 import cn.hutool.core.util.IdUtil;
 import io.swagger.annotations.ApiOperation;
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
@@ -117,6 +118,10 @@ public class PostController {
             @RequestParam(value = "autoSave", required = false, defaultValue = "false") Boolean autoSave) {
         // Get the post info
         Post postToUpdate = postService.getById(postId);
+        // Clean up old summary when original content changed
+        if (!postToUpdate.getOriginalContent().equals(postParam.getOriginalContent())) {
+            postToUpdate.setSummary(StringUtils.EMPTY);
+        }
 
         postParam.update(postToUpdate);
         return postService.updateBy(postToUpdate, postParam.getTagIds(), postParam.getCategoryIds(), postParam.getPostMetas(), autoSave);


### PR DESCRIPTION
## 背景
[文章修改后，摘要信息不能自动更新](https://github.com/halo-dev/halo/issues/1137)

## 改动
- [x] 更新文章后，如果是文章内容进行了修改，则在文章更新之前，先把旧的文章摘要信息清除掉，再进行后续更新逻辑。