### PR TITLE
Grouping assertions

### DIFF
--- a/src/test/java/run/halo/app/conf/AntPathMatcherTest.java
+++ b/src/test/java/run/halo/app/conf/AntPathMatcherTest.java
@@ -3,7 +3,9 @@ package run.halo.app.conf;
 import org.junit.jupiter.api.Test;
 import org.springframework.util.AntPathMatcher;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
 /**
  * Ant path matcher test.

--- a/src/test/java/run/halo/app/conf/AntPathMatcherTest.java
+++ b/src/test/java/run/halo/app/conf/AntPathMatcherTest.java
@@ -1,11 +1,11 @@
 package run.halo.app.conf;
 
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
 import org.junit.jupiter.api.Test;
 import org.springframework.util.AntPathMatcher;
-
-import static org.junit.jupiter.api.Assertions.assertAll;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.assertFalse;
 
 /**
  * Ant path matcher test.

--- a/src/test/java/run/halo/app/conf/AntPathMatcherTest.java
+++ b/src/test/java/run/halo/app/conf/AntPathMatcherTest.java
@@ -1,8 +1,8 @@
 package run.halo.app.conf;
 
+import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.assertAll;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.util.AntPathMatcher;

--- a/src/test/java/run/halo/app/conf/AntPathMatcherTest.java
+++ b/src/test/java/run/halo/app/conf/AntPathMatcherTest.java
@@ -1,10 +1,9 @@
 package run.halo.app.conf;
 
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-
 import org.junit.jupiter.api.Test;
 import org.springframework.util.AntPathMatcher;
+
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * Ant path matcher test.
@@ -17,10 +16,12 @@ class AntPathMatcherTest {
 
     @Test
     void matchTest() {
-        assertFalse(pathMatcher.match("/admin/?*/**", "/admin"));
-        assertFalse(pathMatcher.match("/admin/?*/**", "/admin/"));
+        assertAll(
+            () -> assertFalse(pathMatcher.match("/admin/?*/**", "/admin")),
+            () -> assertFalse(pathMatcher.match("/admin/?*/**", "/admin/")),
 
-        assertTrue(pathMatcher.match("/admin/?*/**", "/admin/index.html"));
-        assertTrue(pathMatcher.match("/admin/?*/**", "/admin/index.html/more"));
+            () -> assertTrue(pathMatcher.match("/admin/?*/**", "/admin/index.html")),
+            () -> assertTrue(pathMatcher.match("/admin/?*/**", "/admin/index.html/more"))
+        );
     }
 }


### PR DESCRIPTION
**Problem:**
A test method with many individual assertions stops being executed on the first failed assertion, which prevents the execution of the remaining ones.

**Solution:**
By using the JUnit5 grouped assertions feature, all assertions are executed and all failures will be reported together. In this refactoring, no original assertion was changed.

**Result:**
_Before:_
```
        assertFalse(pathMatcher.match("/admin/?*/**", "/admin"));
        assertFalse(pathMatcher.match("/admin/?*/**", "/admin/"));
        assertTrue(pathMatcher.match("/admin/?*/**", "/admin/index.html"));
        assertTrue(pathMatcher.match("/admin/?*/**", "/admin/index.html/more"));
```
_After:_
```
        assertAll(
            () -> assertFalse(pathMatcher.match("/admin/?*/**", "/admin")),
            () -> assertFalse(pathMatcher.match("/admin/?*/**", "/admin/")),
            () -> assertTrue(pathMatcher.match("/admin/?*/**", "/admin/index.html")),
            () -> assertTrue(pathMatcher.match("/admin/?*/**", "/admin/index.html/more"))
        );
```
