### PR TITLE
feat: 扩展 freemarker 实现 block

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -103,6 +103,7 @@ ext {
     zxingVersion = "3.4.0"
     huaweiObsVersion = "3.19.7"
     githubApiVersion = "1.84"
+    templateInheritanceVersion = "0.4.RELEASE"
 }
 
 dependencies {
@@ -148,6 +149,7 @@ dependencies {
     implementation "com.vladsch.flexmark:flexmark-ext-yaml-front-matter:$flexmarkVersion"
     implementation "com.vladsch.flexmark:flexmark-ext-gitlab:$flexmarkVersion"
 
+    implementation "kr.pe.kwonnam.freemarker:freemarker-template-inheritance:$templateInheritanceVersion"
     implementation "net.coobird:thumbnailator:$thumbnailatorVersion"
     implementation "net.sf.image4j:image4j:$image4jVersion"
     implementation "org.flywaydb:flyway-core:$flywayVersion"

--- a/src/main/java/run/halo/app/config/HaloMvcConfiguration.java
+++ b/src/main/java/run/halo/app/config/HaloMvcConfiguration.java
@@ -10,11 +10,16 @@ import freemarker.core.TemplateClassResolver;
 import freemarker.template.TemplateException;
 import freemarker.template.TemplateExceptionHandler;
 import java.io.IOException;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Properties;
 import java.util.concurrent.TimeUnit;
 import javax.servlet.MultipartConfigElement;
 import javax.servlet.http.HttpServletRequest;
+import freemarker.template.TemplateModel;
+import kr.pe.kwonnam.freemarker.inheritance.BlockDirective;
+import kr.pe.kwonnam.freemarker.inheritance.PutDirective;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.fileupload.FileUploadBase;
 import org.apache.commons.fileupload.servlet.ServletRequestContext;
@@ -48,6 +53,7 @@ import org.springframework.web.servlet.view.freemarker.FreeMarkerConfigurer;
 import org.springframework.web.servlet.view.freemarker.FreeMarkerViewResolver;
 import run.halo.app.config.properties.HaloProperties;
 import run.halo.app.core.PageJacksonSerializer;
+import run.halo.app.core.freemarker.inheritance.ThemeExtendsDirective;
 import run.halo.app.factory.StringToEnumConverterFactory;
 import run.halo.app.model.support.HaloConst;
 import run.halo.app.security.resolver.AuthenticationArgumentResolver;
@@ -79,6 +85,16 @@ public class HaloMvcConfiguration implements WebMvcConfigurer {
         this.haloProperties = haloProperties;
     }
 
+    @Bean
+    public Map<String, TemplateModel> freemarkerLayoutDirectives() {
+        Map<String, TemplateModel> freemarkerLayoutDirectives = new HashMap<>();
+        freemarkerLayoutDirectives.put("extends", new ThemeExtendsDirective());
+        freemarkerLayoutDirectives.put("block", new BlockDirective());
+        freemarkerLayoutDirectives.put("put", new PutDirective());
+
+        return freemarkerLayoutDirectives;
+    }
+
     /**
      * Configuring freemarker template file path.
      *
@@ -107,6 +123,10 @@ public class HaloMvcConfiguration implements WebMvcConfigurer {
         if (haloProperties.isProductionEnv()) {
             configuration.setTemplateExceptionHandler(TemplateExceptionHandler.RETHROW_HANDLER);
         }
+
+        configuration.setSharedVariables(new HashMap<>(){{
+            put("layout", freemarkerLayoutDirectives());
+        }});
 
         // Set predefined freemarker configuration
         configurer.setConfiguration(configuration);

--- a/src/main/java/run/halo/app/config/HaloMvcConfiguration.java
+++ b/src/main/java/run/halo/app/config/HaloMvcConfiguration.java
@@ -9,6 +9,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import freemarker.core.TemplateClassResolver;
 import freemarker.template.TemplateException;
 import freemarker.template.TemplateExceptionHandler;
+import freemarker.template.TemplateModel;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.List;
@@ -17,7 +18,6 @@ import java.util.Properties;
 import java.util.concurrent.TimeUnit;
 import javax.servlet.MultipartConfigElement;
 import javax.servlet.http.HttpServletRequest;
-import freemarker.template.TemplateModel;
 import kr.pe.kwonnam.freemarker.inheritance.BlockDirective;
 import kr.pe.kwonnam.freemarker.inheritance.PutDirective;
 import lombok.extern.slf4j.Slf4j;
@@ -124,9 +124,10 @@ public class HaloMvcConfiguration implements WebMvcConfigurer {
             configuration.setTemplateExceptionHandler(TemplateExceptionHandler.RETHROW_HANDLER);
         }
 
-        configuration.setSharedVariables(new HashMap<>(){{
-            put("layout", freemarkerLayoutDirectives());
-        }});
+        configuration.setSharedVariables(new HashMap<>() {{
+                put("layout", freemarkerLayoutDirectives());
+            }
+        });
 
         // Set predefined freemarker configuration
         configurer.setConfiguration(configuration);

--- a/src/main/java/run/halo/app/core/freemarker/inheritance/ThemeExtendsDirective.java
+++ b/src/main/java/run/halo/app/core/freemarker/inheritance/ThemeExtendsDirective.java
@@ -1,0 +1,44 @@
+package run.halo.app.core.freemarker.inheritance;
+
+import freemarker.core.Environment;
+import freemarker.template.SimpleScalar;
+import freemarker.template.TemplateDirectiveBody;
+import freemarker.template.TemplateException;
+import freemarker.template.TemplateModel;
+import kr.pe.kwonnam.freemarker.inheritance.ExtendsDirective;
+import org.springframework.stereotype.Component;
+import java.io.IOException;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * @author LIlGG
+ * @date 2021/3/4
+ */
+@Component
+public class ThemeExtendsDirective extends ExtendsDirective {
+    private final Pattern THEME_TEMPLATE_PATH_PATTERN = Pattern.compile("^themes/.*?/");
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public void execute(Environment env, Map params, TemplateModel[] loopVars,
+        TemplateDirectiveBody body) throws TemplateException, IOException {
+        String currTemplateName = getTemplateRelativePath(env);
+        String name = ((SimpleScalar)params.get("name")).getAsString();
+
+        String includeTemplateName = env.rootBasedToAbsoluteTemplateName(env.toFullTemplateName(currTemplateName, name));
+        params.put("name", new SimpleScalar(includeTemplateName));
+
+        super.execute(env, params, loopVars, body);
+    }
+
+    private String getTemplateRelativePath(Environment env) {
+        String templateName = env.getCurrentTemplate().getName();
+
+        Matcher matcher = THEME_TEMPLATE_PATH_PATTERN.matcher(templateName);
+        return matcher.find()
+            ? matcher.group()
+            : "";
+    }
+}

--- a/src/main/java/run/halo/app/core/freemarker/inheritance/ThemeExtendsDirective.java
+++ b/src/main/java/run/halo/app/core/freemarker/inheritance/ThemeExtendsDirective.java
@@ -5,12 +5,12 @@ import freemarker.template.SimpleScalar;
 import freemarker.template.TemplateDirectiveBody;
 import freemarker.template.TemplateException;
 import freemarker.template.TemplateModel;
-import kr.pe.kwonnam.freemarker.inheritance.ExtendsDirective;
-import org.springframework.stereotype.Component;
 import java.io.IOException;
 import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import kr.pe.kwonnam.freemarker.inheritance.ExtendsDirective;
+import org.springframework.stereotype.Component;
 
 /**
  * @author LIlGG
@@ -18,16 +18,18 @@ import java.util.regex.Pattern;
  */
 @Component
 public class ThemeExtendsDirective extends ExtendsDirective {
-    private final Pattern THEME_TEMPLATE_PATH_PATTERN = Pattern.compile("^themes/.*?/");
+    private static final Pattern THEME_TEMPLATE_PATH_PATTERN = Pattern.compile("^themes/.*?/");
 
     @Override
     @SuppressWarnings("unchecked")
     public void execute(Environment env, Map params, TemplateModel[] loopVars,
         TemplateDirectiveBody body) throws TemplateException, IOException {
         String currTemplateName = getTemplateRelativePath(env);
-        String name = ((SimpleScalar)params.get("name")).getAsString();
+        String name = ((SimpleScalar) params.get("name")).getAsString();
 
-        String includeTemplateName = env.rootBasedToAbsoluteTemplateName(env.toFullTemplateName(currTemplateName, name));
+        String includeTemplateName = env.rootBasedToAbsoluteTemplateName(
+            env.toFullTemplateName(currTemplateName, name)
+        );
         params.put("name", new SimpleScalar(includeTemplateName));
 
         super.execute(env, params, loopVars, body);

--- a/src/test/java/run/halo/app/freemarker/FreeMarkerTest.java
+++ b/src/test/java/run/halo/app/freemarker/FreeMarkerTest.java
@@ -1,0 +1,107 @@
+package run.halo.app.freemarker;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import freemarker.cache.StringTemplateLoader;
+import freemarker.template.Configuration;
+import freemarker.template.Template;
+import freemarker.template.TemplateException;
+import freemarker.template.TemplateModel;
+import java.io.IOException;
+import java.io.StringWriter;
+import java.util.HashMap;
+import java.util.Map;
+import kr.pe.kwonnam.freemarker.inheritance.BlockDirective;
+import kr.pe.kwonnam.freemarker.inheritance.PutDirective;
+import org.junit.jupiter.api.Test;
+import run.halo.app.core.freemarker.inheritance.ThemeExtendsDirective;
+
+
+/**
+ * @author LIlGG
+ * @date 2021/3/5
+ */
+class FreeMarkerTest {
+
+    @Test
+    public void testBlockRender() throws IOException, TemplateException {
+        Configuration cfg = new Configuration(Configuration.VERSION_2_3_30);
+        cfg.setSharedVariables(new HashMap<>() {{
+                put("layout", freemarkerLayoutDirectives());
+            }
+        });
+        cfg.setDefaultEncoding("UTF-8");
+
+        StringTemplateLoader templateLoader = new StringTemplateLoader();
+        templateLoader.putTemplate("index.ftl",
+            "<@layout.extends name=\"layout/base.ftl\">\n" +
+                "    <@layout.put block=\"title\" type=\"replace\">\n" +
+                "        <title>自定义标题 - 替换模板内容</title>\n" +
+                "    </@layout.put>\n" +
+                "    <@layout.put block=\"header\">\n" +
+                "        <h2>第二级页头 - 默认放置在模板内容之后</h2>\n" +
+                "    </@layout.put>\n" +
+                "    <@layout.put block=\"class\">sheet test-sheet</@layout.put>\n" +
+                "    <@layout.put block=\"contents\">\n" +
+                "        <p>这是自定义页面内容</p>\n" +
+                "    </@layout.put>\n" +
+                "    <@layout.put block=\"footer\" type=\"prepend\">\n" +
+                "        <hr/>\n" +
+                "        <div class=\"footer\">页脚内容 - 放置在模板内容之前</div>\n" +
+                "    </@layout.put>\n" +
+                "</@layout.extends>");
+        templateLoader.putTemplate("layout/base.ftl",
+            "<!DOCTYPE html>\n" +
+                "<html>\n" +
+                "<head>\n" +
+                "    <@layout.block name=\"title\">\n" +
+                "        <title>标题</title>\n" +
+                "    </@layout.block>\n" +
+                "</head>\n" +
+                "<body>\n" +
+                "<@layout.block name=\"header\">\n" +
+                "    <h1>页头</h1>\n" +
+                "</@layout.block>\n" +
+                "<div class=\"content <@layout.block name='class'></@layout.block>\">\n" +
+                "    <@layout.block name=\"content\">\n" +
+                "    </@layout.block>\n" +
+                "</div>\n" +
+                "<@layout.block name=\"footer\">\n" +
+                "    <div>页脚</div>\n" +
+                "</@layout.block>\n" +
+                "</body>\n" +
+                "</html>");
+        cfg.setTemplateLoader(templateLoader);
+
+        Template template = cfg.getTemplate("index.ftl");
+        StringWriter out = new StringWriter();
+        template.process(null, out);
+
+        assertEquals(
+            "<!DOCTYPE html>\n" +
+                "<html>\n" +
+                "<head>\n" +
+                "            <title>自定义标题 - 替换模板内容</title>\n" +
+                "</head>\n" +
+                "<body>\n" +
+                "    <h1>页头</h1>\n" +
+                "        <h2>第二级页头 - 默认放置在模板内容之后</h2>\n" +
+                "<div class=\"content sheet test-sheet\">\n" +
+                "</div>\n" +
+                "        <hr/>\n" +
+                "        <div class=\"footer\">页脚内容 - 放置在模板内容之前</div>\n" +
+                "    <div>页脚</div>\n" +
+                "</body>\n" +
+                "</html>"
+        , out.toString());
+    }
+
+    private Map<String, TemplateModel> freemarkerLayoutDirectives() {
+        Map<String, TemplateModel> freemarkerLayoutDirectives = new HashMap<>();
+        freemarkerLayoutDirectives.put("extends", new ThemeExtendsDirective());
+        freemarkerLayoutDirectives.put("block", new BlockDirective());
+        freemarkerLayoutDirectives.put("put", new PutDirective());
+
+        return freemarkerLayoutDirectives;
+    }
+}

--- a/src/test/java/run/halo/app/freemarker/FreeMarkerTest.java
+++ b/src/test/java/run/halo/app/freemarker/FreeMarkerTest.java
@@ -6,102 +6,97 @@ import freemarker.cache.StringTemplateLoader;
 import freemarker.template.Configuration;
 import freemarker.template.Template;
 import freemarker.template.TemplateException;
-import freemarker.template.TemplateModel;
 import java.io.IOException;
 import java.io.StringWriter;
-import java.util.HashMap;
-import java.util.Map;
-import kr.pe.kwonnam.freemarker.inheritance.BlockDirective;
-import kr.pe.kwonnam.freemarker.inheritance.PutDirective;
 import org.junit.jupiter.api.Test;
-import run.halo.app.core.freemarker.inheritance.ThemeExtendsDirective;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.web.servlet.view.freemarker.FreeMarkerConfigurer;
 
 
 /**
  * @author LIlGG
  * @date 2021/3/5
  */
+@SpringBootTest
+@ActiveProfiles("test")
 class FreeMarkerTest {
+    @Autowired
+    FreeMarkerConfigurer freeMarkerConfigurer;
 
     @Test
     public void testBlockRender() throws IOException, TemplateException {
-        Configuration cfg = new Configuration(Configuration.VERSION_2_3_30);
-        cfg.setSharedVariables(new HashMap<>() {{
-                put("layout", freemarkerLayoutDirectives());
-            }
-        });
+        Configuration cfg = freeMarkerConfigurer.getConfiguration();
         cfg.setDefaultEncoding("UTF-8");
 
         StringTemplateLoader templateLoader = new StringTemplateLoader();
+        templateLoader.putTemplate("common/macro/common_macro.ftl", "");
+        templateLoader.putTemplate("common/macro/global_macro.ftl", "");
         templateLoader.putTemplate("index.ftl",
-            "<@layout.extends name=\"layout/base.ftl\">\n" +
-                "    <@layout.put block=\"title\" type=\"replace\">\n" +
-                "        <title>自定义标题 - 替换模板内容</title>\n" +
-                "    </@layout.put>\n" +
-                "    <@layout.put block=\"header\">\n" +
-                "        <h2>第二级页头 - 默认放置在模板内容之后</h2>\n" +
-                "    </@layout.put>\n" +
-                "    <@layout.put block=\"class\">sheet test-sheet</@layout.put>\n" +
-                "    <@layout.put block=\"contents\">\n" +
-                "        <p>这是自定义页面内容</p>\n" +
-                "    </@layout.put>\n" +
-                "    <@layout.put block=\"footer\" type=\"prepend\">\n" +
-                "        <hr/>\n" +
-                "        <div class=\"footer\">页脚内容 - 放置在模板内容之前</div>\n" +
-                "    </@layout.put>\n" +
-                "</@layout.extends>");
+            "<@layout.extends name=\"layout/base.ftl\">\n"
+                + "    <@layout.put block=\"title\" type=\"replace\">\n"
+                + "        <title>自定义标题 - 替换模板内容</title>\n"
+                + "    </@layout.put>\n"
+                + "    <@layout.put block=\"header\">\n"
+                + "        <h2>第二级页头 - 默认放置在模板内容之后</h2>\n"
+                + "    </@layout.put>\n"
+                + "    <@layout.put block=\"class\">sheet test-sheet</@layout.put>\n"
+                + "    <@layout.put block=\"contents\">\n"
+                + "        <p>这是自定义页面内容</p>\n"
+                + "    </@layout.put>\n"
+                + "    <@layout.put block=\"footer\" type=\"prepend\">\n"
+                + "        <hr/>\n"
+                + "        <div class=\"footer\">页脚内容 - 放置在模板内容之前</div>\n"
+                + "    </@layout.put>\n"
+                + "</@layout.extends>");
         templateLoader.putTemplate("layout/base.ftl",
-            "<!DOCTYPE html>\n" +
-                "<html>\n" +
-                "<head>\n" +
-                "    <@layout.block name=\"title\">\n" +
-                "        <title>标题</title>\n" +
-                "    </@layout.block>\n" +
-                "</head>\n" +
-                "<body>\n" +
-                "<@layout.block name=\"header\">\n" +
-                "    <h1>页头</h1>\n" +
-                "</@layout.block>\n" +
-                "<div class=\"content <@layout.block name='class'></@layout.block>\">\n" +
-                "    <@layout.block name=\"content\">\n" +
-                "    </@layout.block>\n" +
-                "</div>\n" +
-                "<@layout.block name=\"footer\">\n" +
-                "    <div>页脚</div>\n" +
-                "</@layout.block>\n" +
-                "</body>\n" +
-                "</html>");
+            "<!DOCTYPE html>\n"
+                + "<html>\n"
+                + "<head>\n"
+                + "    <@layout.block name=\"title\">\n"
+                + "        <title>标题</title>\n"
+                + "    </@layout.block>\n"
+                + "</head>\n"
+                + "<body>\n"
+                + "<@layout.block name=\"header\">\n"
+                + "    <h1>页头</h1>\n"
+                + "</@layout.block>\n"
+                + "<div class=\"content <@layout.block name='class'></@layout.block>\">\n"
+                + "    <@layout.block name=\"content\">\n"
+                + "    </@layout.block>\n"
+                + "</div>\n"
+                + "<@layout.block name=\"footer\">\n"
+                + "    <div>页脚</div>\n"
+                + "</@layout.block>\n"
+                + "</body>\n"
+                + "</html>");
+
         cfg.setTemplateLoader(templateLoader);
+
+        freeMarkerConfigurer.setConfiguration(cfg);
 
         Template template = cfg.getTemplate("index.ftl");
         StringWriter out = new StringWriter();
+
         template.process(null, out);
 
         assertEquals(
-            "<!DOCTYPE html>\n" +
-                "<html>\n" +
-                "<head>\n" +
-                "            <title>自定义标题 - 替换模板内容</title>\n" +
-                "</head>\n" +
-                "<body>\n" +
-                "    <h1>页头</h1>\n" +
-                "        <h2>第二级页头 - 默认放置在模板内容之后</h2>\n" +
-                "<div class=\"content sheet test-sheet\">\n" +
-                "</div>\n" +
-                "        <hr/>\n" +
-                "        <div class=\"footer\">页脚内容 - 放置在模板内容之前</div>\n" +
-                "    <div>页脚</div>\n" +
-                "</body>\n" +
-                "</html>"
-        , out.toString());
-    }
-
-    private Map<String, TemplateModel> freemarkerLayoutDirectives() {
-        Map<String, TemplateModel> freemarkerLayoutDirectives = new HashMap<>();
-        freemarkerLayoutDirectives.put("extends", new ThemeExtendsDirective());
-        freemarkerLayoutDirectives.put("block", new BlockDirective());
-        freemarkerLayoutDirectives.put("put", new PutDirective());
-
-        return freemarkerLayoutDirectives;
+            "<!DOCTYPE html>\n"
+                + "<html>\n"
+                + "<head>\n"
+                + "            <title>自定义标题 - 替换模板内容</title>\n"
+                + "</head>\n"
+                + "<body>\n"
+                + "    <h1>页头</h1>\n"
+                + "        <h2>第二级页头 - 默认放置在模板内容之后</h2>\n"
+                + "<div class=\"content sheet test-sheet\">\n"
+                + "</div>\n"
+                + "        <hr/>\n"
+                + "        <div class=\"footer\">页脚内容 - 放置在模板内容之前</div>\n"
+                + "    <div>页脚</div>\n"
+                + "</body>\n"
+                + "</html>",
+            out.toString());
     }
 }


### PR DESCRIPTION
# freemarker 扩展 block 用法

1. 在需要组件化的 ftl 模板中，按照如下方式创建块。
```html
<!-- layout.ftl -->
<!DOCTYPE html>
<html>
    <head>
        <@layout.block name="title">
            <title>标题</title>
        </@layout.block>
    </head>
    <body>
        <@layout.block name="header">
        <h1>页头</h1>
        </@layout.block>
      	<div class="content <@layout.block name='class'></@layout.block>">
            <@layout.block name="content">
            </@layout.block>
        </div>
        <@layout.block name="footer">
        <div>页脚</div>
        </@layout.block>
    </body>
</html>
```
自定义插槽标签为 `<@layout.block>` ，其属性 name 的值为块名称


2. 在需要渲染和调用模板的地方，使用如下方式传入块内容。
```html
<!-- index.ftl -->
<@layout.extends name="layout.ftl">
    <@layout.put block="title" type="replace">
        <title>自定义标题 - 替换模板内容</title>
    </@layout.put>
    <@layout.put block="header">
        <h2>第二级页头 - 默认放置在模板内容之后</h2>
    </@layout.put>
    <@layout.put block="class">sheet test-sheet</@layout.put>
    <@layout.put block="contents">
        <p>这是自定义页面内容</p>
    </@layout.put>
    <@layout.put block="footer" type="prepend">
        <hr/>
        <div class="footer">页脚内容 - 放置在模板内容之前</div>
    </@layout.put>
</@layout.extends>
```
自定义扩展标签为 `<@layout.extends>`  其属性 name 的值为组件化模板的相对路径【同 #include 的 path】
`<@layout.put>` 对应插槽标签，其属性 block 的值为块名称。type 有如下几个类型：

- append - 追加内容到块内容之后，默认
- prepend - 放置内容到块内容之前
- replace - 替换块的内容，默认块的内容将被删除
