### PR TITLE
feat: enable swagger configuration in development.

### DIFF
--- a/src/main/java/run/halo/app/config/SwaggerConfiguration.java
+++ b/src/main/java/run/halo/app/config/SwaggerConfiguration.java
@@ -28,7 +28,6 @@ import org.springframework.lang.NonNull;
 import org.springframework.util.AntPathMatcher;
 import org.springframework.util.Assert;
 import org.springframework.util.PathMatcher;
-import run.halo.app.config.properties.HaloProperties;
 import run.halo.app.utils.SwaggerUtils;
 import springfox.documentation.builders.ApiInfoBuilder;
 import springfox.documentation.builders.PathSelectors;
@@ -66,12 +65,6 @@ import springfox.documentation.swagger.web.UiConfigurationBuilder;
     matchIfMissing = true)
 public class SwaggerConfiguration {
 
-    private final HaloProperties haloProperties;
-
-    public SwaggerConfiguration(HaloProperties haloProperties) {
-        this.haloProperties = haloProperties;
-    }
-
     @Bean
     public Docket haloDefaultApi() {
         return buildApiDocket("run.halo.app.content.api",
@@ -83,10 +76,6 @@ public class SwaggerConfiguration {
 
     @Bean
     public Docket haloAdminApi() {
-        if (haloProperties.isDocDisabled()) {
-            log.debug("Doc has been disabled");
-        }
-
         return buildApiDocket("run.halo.app.admin.api",
             "run.halo.app.controller.admin",
             "/api/admin/**")

--- a/src/main/java/run/halo/app/config/properties/HaloProperties.java
+++ b/src/main/java/run/halo/app/config/properties/HaloProperties.java
@@ -23,12 +23,6 @@ import run.halo.app.model.enums.Mode;
 public class HaloProperties {
 
     /**
-     * Doc api disabled. (Default is true)
-     */
-    @Deprecated
-    private boolean docDisabled = true;
-
-    /**
      * Production env. (Default is true)
      */
     @Deprecated

--- a/src/main/java/run/halo/app/listener/StartedListener.java
+++ b/src/main/java/run/halo/app/listener/StartedListener.java
@@ -67,6 +67,9 @@ public class StartedListener implements ApplicationListener<ApplicationStartedEv
     @Value("${spring.datasource.password}")
     private String password;
 
+    @Value("${springfox.documentation.enabled}")
+    private Boolean documentationEnabled;
+
     @Override
     public void onApplicationEvent(ApplicationStartedEvent event) {
         try {
@@ -95,9 +98,9 @@ public class StartedListener implements ApplicationListener<ApplicationStartedEv
         log.info(AnsiOutput
             .toString(AnsiColor.BRIGHT_BLUE, "Halo admin started at   ", blogUrl, "/",
                 haloProperties.getAdminPath()));
-        if (!haloProperties.isDocDisabled()) {
+        if (documentationEnabled) {
             log.debug(AnsiOutput
-                .toString(AnsiColor.BRIGHT_BLUE, "Halo api doc was enabled at  ", blogUrl,
+                .toString(AnsiColor.BRIGHT_BLUE, "Halo api documentation was enabled at  ", blogUrl,
                     "/swagger-ui.html"));
         }
         log.info(AnsiOutput.toString(AnsiColor.BRIGHT_YELLOW, "Halo has started successfully!"));

--- a/src/main/resources/application-dev.yaml
+++ b/src/main/resources/application-dev.yaml
@@ -61,6 +61,10 @@ logging:
   file:
     path: ${halo.work-dir}/newLogs
 
+springfox:
+  documentation:
+    enabled: true
+
 halo:
   auth-enabled: true
   mode: development


### PR DESCRIPTION
```
2021-03-27 13:01:07.550  INFO 73866 --- [  restartedMain] run.halo.app.listener.StartedListener    : Halo started at         http://localhost:8090
2021-03-27 13:01:07.550  INFO 73866 --- [  restartedMain] run.halo.app.listener.StartedListener    : Halo admin started at   http://localhost:8090/admin
2021-03-27 13:01:07.551 DEBUG 73866 --- [  restartedMain] run.halo.app.listener.StartedListener    : Halo api documentation was enabled at  http://localhost:8090/swagger-ui.html
```