### PR TITLE
修复导入markdown时多级分类无法正确识别的问题

### DIFF
--- a/src/main/java/run/halo/app/service/impl/PostServiceImpl.java
+++ b/src/main/java/run/halo/app/service/impl/PostServiceImpl.java
@@ -384,6 +384,7 @@ public class PostServiceImpl extends BasePostServiceImpl<Post> implements PostSe
                 for (String ele : elementValue) {
                     ele = StrUtil.strip(ele, "[", "]");
                     ele = StrUtil.strip(ele, "\"");
+                    ele = StrUtil.strip(ele, "\'");
                     if ("".equals(ele)) {
                         continue;
                     }
@@ -407,20 +408,28 @@ public class PostServiceImpl extends BasePostServiceImpl<Post> implements PostSe
                             post.setDisallowComment(Boolean.parseBoolean(ele));
                             break;
                         case "tags":
-                            Tag tag = tagService.getByName(ele);
-                            if (null == tag) {
-                                tag = new Tag();
-                                tag.setName(ele);
-                                tag.setSlug(SlugUtils.slug(ele));
-                                tag = tagService.create(tag);
+                            Tag tag;
+                            for (String tagName : ele.split(",")) {
+                                tagName = tagName.trim();
+                                tagName = StrUtil.strip(tagName, "\"");
+                                tagName = StrUtil.strip(tagName, "\'");
+                                tag = tagService.getByName(tagName);
+                                if (null == tag) {
+                                    tag = new Tag();
+                                    tag.setName(tagName);
+                                    tag.setSlug(SlugUtils.slug(tagName));
+                                    tag = tagService.create(tag);
+                                }
+                                tagIds.add(tag.getId());
                             }
-                            tagIds.add(tag.getId());
                             break;
                         case "categories":
                             Integer lastCategoryId = null;
                             for (String categoryName : ele.split(",")) {
-                                Category category = categoryService
-                                    .getByName(StrUtil.strip(categoryName.trim(), "\""));
+                                categoryName = categoryName.trim();
+                                categoryName = StrUtil.strip(categoryName, "\"");
+                                categoryName = StrUtil.strip(categoryName, "\'");
+                                Category category = categoryService.getByName(categoryName);
                                 if (null == category) {
                                     category = new Category();
                                     category.setName(categoryName);

--- a/src/main/java/run/halo/app/service/impl/PostServiceImpl.java
+++ b/src/main/java/run/halo/app/service/impl/PostServiceImpl.java
@@ -417,15 +417,23 @@ public class PostServiceImpl extends BasePostServiceImpl<Post> implements PostSe
                             tagIds.add(tag.getId());
                             break;
                         case "categories":
-                            Category category = categoryService.getByName(ele);
-                            if (null == category) {
-                                category = new Category();
-                                category.setName(ele);
-                                category.setSlug(SlugUtils.slug(ele));
-                                category.setDescription(ele);
-                                category = categoryService.create(category);
+                            Integer lastCategoryId = null;
+                            for (String categoryName : ele.split(",")) {
+                                Category category = categoryService
+                                    .getByName(StrUtil.strip(categoryName.trim(), "\""));
+                                if (null == category) {
+                                    category = new Category();
+                                    category.setName(categoryName);
+                                    category.setSlug(SlugUtils.slug(categoryName));
+                                    category.setDescription(categoryName);
+                                    if (lastCategoryId != null) {
+                                        category.setParentId(lastCategoryId);
+                                    }
+                                    category = categoryService.create(category);
+                                }
+                                lastCategoryId = category.getId();
+                                categoryIds.add(lastCategoryId);
                             }
-                            categoryIds.add(category.getId());
                             break;
                         default:
                             break;

--- a/src/main/java/run/halo/app/utils/MarkdownUtils.java
+++ b/src/main/java/run/halo/app/utils/MarkdownUtils.java
@@ -26,6 +26,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 import org.apache.commons.lang3.StringUtils;
 import run.halo.app.model.support.HaloConst;
 
@@ -120,6 +121,18 @@ public class MarkdownUtils {
      * @return Map
      */
     public static Map<String, List<String>> getFrontMatter(String markdown) {
+        markdown = markdown.trim();
+        Matcher matcher = FRONT_MATTER.matcher(markdown);
+        if (matcher.find()) {
+            markdown = matcher.group();
+        }
+        markdown = Arrays.stream(markdown.split("\\r?\\n")).map(row -> {
+            if (row.startsWith("- ")) {
+                return " " + row;
+            } else {
+                return row;
+            }
+        }).collect(Collectors.joining("\n"));
         AbstractYamlFrontMatterVisitor visitor = new AbstractYamlFrontMatterVisitor();
         Node document = PARSER.parse(markdown);
         visitor.visit(document);

--- a/src/test/java/run/halo/app/service/impl/PostServiceImplTest.java
+++ b/src/test/java/run/halo/app/service/impl/PostServiceImplTest.java
@@ -1,17 +1,31 @@
 package run.halo.app.service.impl;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Map;
+import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.transaction.annotation.Transactional;
+import run.halo.app.model.dto.CategoryDTO;
+import run.halo.app.model.vo.PostDetailVO;
 
+@SpringBootTest
+@ActiveProfiles("test")
 @Slf4j
 @Disabled("Due to spring boot context needed")
 class PostServiceImplTest {
 
     String standardMdContent = "---\n"
         + "title: springfox-swagger2配置成功但无法访问/swagger-ui.html\n"
+        + "categories: \n"
+        + "  - [后端,JAVA]\n"
+        + "  - [Spring]\n"
         + "tags:\n"
         + "  - spring boot\n"
         + "  - swagger\n"
@@ -26,6 +40,9 @@ class PostServiceImplTest {
 
     String nonStandardMdContent = "---\n"
         + "title: Basic concepts of JPA\n"
+        + "categories: \n"
+        + "- [后端,JAVA]\n"
+        + "- [Spring]\n"
         + "date: 2018-08-03 11:57:00\n"
         + "tags: ['spring', 'jpa', 'database', 'concept']\n"
         + "---\n"
@@ -44,7 +61,24 @@ class PostServiceImplTest {
     @Test
     @Transactional
     void markdownImportTest() {
-        postService.importMarkdown(standardMdContent, "standard");
-        postService.importMarkdown(nonStandardMdContent, "nonStandard");
+        PostDetailVO standardPost = postService.importMarkdown(standardMdContent, "standard");
+        Map<String, CategoryDTO> standardCategoryMap = standardPost.getCategories().stream()
+            .collect(Collectors.toMap(CategoryDTO::getName, post -> post));
+        assertTrue(standardCategoryMap.containsKey("后端"));
+        assertTrue(standardCategoryMap.containsKey("JAVA"));
+        assertTrue(standardCategoryMap.containsKey("Spring"));
+        assertTrue(standardCategoryMap.get("后端").getId()
+            .equals(standardCategoryMap.get("JAVA").getParentId()));
+        assertEquals(standardPost.getTags().size(), 3);
+        PostDetailVO nonStandardPost =
+            postService.importMarkdown(nonStandardMdContent, "nonStandard");
+        Map<String, CategoryDTO> nonStandardCategoryMap = nonStandardPost.getCategories().stream()
+            .collect(Collectors.toMap(CategoryDTO::getName, post -> post));
+        assertTrue(nonStandardCategoryMap.containsKey("后端"));
+        assertTrue(nonStandardCategoryMap.containsKey("JAVA"));
+        assertTrue(nonStandardCategoryMap.containsKey("Spring"));
+        assertTrue(nonStandardCategoryMap.get("后端").getId()
+            .equals(nonStandardCategoryMap.get("JAVA").getParentId()));
+        assertEquals(nonStandardPost.getTags().size(), 4);
     }
 }


### PR DESCRIPTION
hexo支持多级分类目录，如下，代表文章分类为 大数据、HBASE、运维，其中 HBASE 是 大数据 的子分类
```
categories: 
   - [大数据,HBASE]
   - [运维]
```
目前会把 “大数据,HBASE”识别为一个分类，此pull请求对该问题进行修复