### PR TITLE
feat: add issues triage action config

### DIFF
--- a/.github/commands.json
+++ b/.github/commands.json
@@ -54,7 +54,7 @@
   },
   {
     "type": "comment",
-    "name": "notebook",
+    "name": "rntg",
     "assign": [
       "ruibaby",
       "JohnNiang",

--- a/.github/commands.json
+++ b/.github/commands.json
@@ -79,7 +79,8 @@
       "JohnNiang",
       "guqing",
       "LIlGG",
-      "halo-dev-bot"
+      "halo-dev-bot",
+      "guqing-bot"
     ],
     "action": "updateLabels",
     "addLabel": "confirmed",

--- a/.github/commands.json
+++ b/.github/commands.json
@@ -16,31 +16,31 @@
     "type": "label",
     "name": "*question",
     "action": "close",
-    "comment": "请到 [Halo Forum](https://bbs.halo.run/) 提问. 我们在那边有一个很好的社区. 他们已经回答了数千个问题，并且很乐意回答您的问题. 也可以到[Halo 官网](https://halo.run) 查看文档指南."
+    "comment": "请到 [Halo Forum](https://bbs.halo.run/) 提问. 我们在那边有一个很好的社区。 他们已经回答了数千个问题，并且很乐意回答您的问题。 也可以到[Halo 官网](https://halo.run) 查看文档指南。"
   },
   {
     "type": "label",
     "name": "*dev-question",
     "action": "close",
-    "comment": "请到 [Halo Forum](https://bbs.halo.run/t/ask-for-help)提问，这是您提出问题并获得支持的好地方. "
+    "comment": "请到 [Halo Forum](https://bbs.halo.run/t/ask-for-help)提问，这是您提出问题并获得支持的好地方。 "
   },
   {
     "type": "label",
     "name": "*not-reproducible",
     "action": "close",
-    "comment": "我们关闭了这个问题，因为我们无法通过您描述的步骤重现问题. 在最新版本的 Halo 代码中，我们已经修复了您的问题. 如果没有，请要求我们重新打开问题并为我们提供更多细节. 我们的 [贡献指南](https://docs.halo.run/zh/contribution/issue) 或许可以帮到您."
+    "comment": "我们关闭了这个问题，因为我们无法通过您描述的步骤重现问题。 在最新版本的 Halo 代码中，我们已经修复了您的问题。 如果没有，请要求我们重新打开问题并为我们提供更多细节。 我们的 [贡献指南](https://docs.halo.run/zh/contribution/issue) 或许可以帮到您。"
   },
   {
     "type": "label",
     "name": "*out-of-scope",
     "action": "close",
-    "comment": "我们关闭了这个问题，因为我们不打算在可预见的未来解决它。 您可以在 [此处](https://github.com/halo-dev/halo/milestones) 找到有关我们决策过程的更多详细信息. 如果你不同意并觉得这个问题至关重要：我们很乐意倾听并重新考虑.\n\n感谢您的理解, happy coding!"
+    "comment": "我们关闭了这个问题，因为我们不打算在可预见的未来解决它。 您可以在 [此处](https://github.com/halo-dev/halo/milestones) 找到有关我们决策过程的更多详细信息。如果你不同意并觉得这个问题至关重要：我们很乐意倾听并重新考虑.\n\n感谢您的理解！"
   },
   {
     "type": "label",
     "name": "*as-designed",
     "action": "close",
-    "comment": "所描述的行为是预期工作的方式。 如果您不同意，请解释预期的内容以及更详细的内容. "
+    "comment": "所描述的行为是预期工作的方式。 如果您不同意，请解释预期的内容以及更详细的内容。"
   },
   {
     "type": "label",
@@ -69,7 +69,7 @@
     "type": "label",
     "name": "*duplicate",
     "action": "close",
-    "comment": "感谢您创建了这个issue！ 我们认为它与我们已经拥有的另一个相同。 因此，我们将此一个归还为重复(duplicate)并关闭了它。 您可以在 [这里](${duplicateQuery}) 搜索现有问题. "
+    "comment": "感谢您创建了这个issue！ 我们认为它与我们已经拥有的另一个相同。 因此，我们将此一个归还为重复(duplicate)并关闭了它。 您可以在 [这里](${duplicateQuery}) 搜索现有问题。"
   },
   {
     "type": "comment",
@@ -79,8 +79,7 @@
       "JohnNiang",
       "guqing",
       "LIlGG",
-      "halo-dev-bot",
-      "guqing-bot"
+      "halo-dev-bot"
     ],
     "action": "updateLabels",
     "addLabel": "confirmed",
@@ -118,7 +117,7 @@
     "name": "needs more info",
     "action": "updateLabels",
     "addLabel": "needs more info",
-    "comment": "感谢您创建了这个issue! 请提供更多的描述或错误日志以帮助我们理解您的问题。"
+    "comment": "感谢您创建了这个issue！ 请提供更多的描述或错误日志以帮助我们理解您的问题。"
   },
   {
     "type": "label",
@@ -131,7 +130,7 @@
     "type": "label",
     "name": "*off-topic",
     "action": "close",
-    "comment": "感谢您创建了这个问题。我们认为此问题与本项目的目标毫无关联，因此我们关闭了它. 您可以阅读我们的[问题报告](https://docs.halo.run/zh/contribution/issue)指南."
+    "comment": "感谢您创建了这个问题。我们认为此问题与本项目的目标毫无关联，因此我们关闭了它。您可以阅读我们的[问题报告](https://docs.halo.run/zh/contribution/issue)指南。"
   },
   {
     "type": "comment",
@@ -145,7 +144,7 @@
     ],
     "action": "comment",
     "addLabel": "needs more info",
-    "comment": "感谢您报告了这个issue! 遗憾的是, 我们很难了解你看到的问题. 请提供一段屏幕录制来准确地展示不符合预期的情况. 虽然`GitHub`支持很多标准格式，但尽量首选`.gif` 文件，因为它们在GitHub是内联展示. 你可以使用基于浏览器的gif录制工具 https://gifcap.dev 来帮助您.\n\n如果这个issue依赖键盘输入, 您可以通过启用`screencast`模式来录制 (`Developer: Toggle Screencast Mode` in the command palette)."
+    "comment": "感谢您报告了这个issue！遗憾的是，我们很难了解你看到的问题。 请提供一段屏幕录制来准确地展示不符合预期的情况。虽然`GitHub`支持很多标准格式，但尽量首选`.gif` 文件，因为它们在GitHub是内联展示。你可以使用基于浏览器的gif录制工具 https://gifcap.dev 来帮助您。\n\n如果这个issue依赖键盘输入，您可以通过启用`screencast`模式来录制 (`Developer: Toggle Screencast Mode` in the command palette)。"
   },
   {
     "type": "comment",

--- a/.github/commands.json
+++ b/.github/commands.json
@@ -1,0 +1,192 @@
+[
+  {
+    "type": "comment",
+    "name": "question",
+    "allowUsers": [
+      "ruibaby",
+      "JohnNiang",
+      "guqing",
+      "LIlGG",
+      "halo-dev-bot"
+    ],
+    "action": "updateLabels",
+    "addLabel": "question"
+  },
+  {
+    "type": "label",
+    "name": "question",
+    "action": "close",
+    "comment": "请到 [Halo Forum](https://bbs.halo.run/) 提问. 我们在那边有一个很好的社区. 他们已经回答了数千个问题，并且很乐意回答您的问题. 也可以到[Halo 官网](https://halo.run) 查看文档指南.\n\nHappy Coding!"
+  },
+  {
+    "type": "label",
+    "name": "*dev-question",
+    "action": "close",
+    "comment": "请到 [Halo Forum](https://bbs.halo.run/t/ask-for-help)提问，这是您提出问题并获得支持的好地方. \n\nHappy Coding!"
+  },
+  {
+    "type": "label",
+    "name": "*not-reproducible",
+    "action": "close",
+    "comment": "我们关闭了这个问题，因为我们无法通过您描述的步骤重现问题. 在最近版本的Halo代码中，我们已经修复了您的问题. 如果没有，请要求我们重新打开问题并为我们提供更多细节. 我们的 [贡献指南](https://docs.halo.run/zh/contribution/issue) 或许可以帮到您.\n\nHappy Coding!"
+  },
+  {
+    "type": "label",
+    "name": "*out-of-scope",
+    "action": "close",
+    "comment": "我们关闭了这个问题，因为我们不打算在可预见的未来解决它。 您可以在 [此处](https://github.com/halo-dev/halo/milestones) 找到有关我们决策过程的更多详细信息. 如果你不同意并觉得这个问题至关重要：我们很乐意倾听并重新考虑.\n\n感谢您的理解, happy coding!"
+  },
+  {
+    "type": "label",
+    "name": "*as-designed",
+    "action": "close",
+    "comment": "所描述的行为是预期工作的方式。 如果您不同意，请解释预期的内容以及更详细的内容. \n\nHappy Coding!"
+  },
+  {
+    "type": "label",
+    "name": "notebook",
+    "assign": [
+      "ruibaby",
+      "JohnNiang",
+      "guqing",
+      "LIlGG",
+      "halo-dev-bot"
+    ]
+  },
+  {
+    "type": "comment",
+    "name": "duplicate",
+    "allowUsers": [
+      "ruibaby",
+      "JohnNiang",
+      "guqing",
+      "LIlGG",
+      "halo-dev-bot"
+    ],
+    "action": "updateLabels",
+    "addLabel": "*duplicate"
+  },
+  {
+    "type": "label",
+    "name": "*duplicate",
+    "action": "close",
+    "comment": "感谢您创建了这个issue！ 我们认为它与我们已经拥有的另一个相同。 因此，我们将此一个归还为重复(duplicate)并关闭了它。 您可以在 [这里](${duplicateQuery}) 搜索现有问题. \n\nHappy Coding!"
+  },
+  {
+    "type": "comment",
+    "name": "confirm",
+    "allowUsers": [
+      "ruibaby",
+      "JohnNiang",
+      "guqing",
+      "LIlGG",
+      "halo-dev-bot"
+    ],
+    "action": "updateLabels",
+    "addLabel": "confirmed",
+    "removeLabel": "confirmation-pending"
+  },
+  {
+    "type": "comment",
+    "name": "confirmationPending",
+    "allowUsers": [
+      "ruibaby",
+      "JohnNiang",
+      "guqing",
+      "LIlGG",
+      "halo-dev-bot"
+    ],
+    "action": "updateLabels",
+    "addLabel": "confirmation-pending",
+    "removeLabel": "confirmed"
+  },
+  {
+    "type": "comment",
+    "name": "needsMoreInfo",
+    "allowUsers": [
+      "ruibaby",
+      "JohnNiang",
+      "guqing",
+      "LIlGG",
+      "halo-dev-bot"
+    ],
+    "action": "updateLabels",
+    "addLabel": "needs more info"
+  },
+  {
+    "type": "label",
+    "name": "needs more info",
+    "action": "updateLabels",
+    "addLabel": "needs more info",
+    "comment": "感谢您创建了这个issue! 请提供更多的描述或错误日志以帮助我们理解您的问题。\n\nHappy Coding!"
+  },
+  {
+    "type": "label",
+    "name": "needs version info",
+    "action": "updateLabels",
+    "addLabel": "needs more info",
+    "comment": "感谢您创建了这个问题！我们认为它缺少一些基本信息，例如版本号，或者以其他方式不遵循我们的[问题报告](https://docs.halo.run/zh/contribution/issue)指南。请花点时间查看这些并更新issue。\n\nHappy Coding!"
+  },
+  {
+    "type": "label",
+    "name": "*off-topic",
+    "action": "close",
+    "comment": "感谢您创建了这个问题。我们认为此问题与本项目的目标毫无关联，因此我们关闭了它. 您可以阅读我们的[问题报告](https://docs.halo.run/zh/contribution/issue)指南.\n\nHappy Coding!"
+  },
+  {
+    "type": "comment",
+    "name": "gifPlease",
+    "allowUsers": [
+      "ruibaby",
+      "JohnNiang",
+      "guqing",
+      "LIlGG",
+      "halo-dev-bot"
+    ],
+    "action": "comment",
+    "addLabel": "needs more info",
+    "comment": "感谢您报告了这个issue! 遗憾的是, 我们很难了解你看到的问题. 请提供一段屏幕录制来准确地展示不符合预期的情况. 虽然`GitHub`支持很多标准格式，但尽量首选`.gif` 文件，因为它们在GitHub是内联展示. 你可以使用基于浏览器的gif录制工具 https://gifcap.dev 来帮助您.\n\n如果这个issue依赖键盘输入, 您可以通过启用`screencast`模式来录制 (`Developer: Toggle Screencast Mode` in the command palette).\n\nHappy coding!"
+  },
+  {
+    "type": "comment",
+    "name": "bug",
+    "allowUsers": [
+      "ruibaby",
+      "JohnNiang",
+      "guqing",
+      "LIlGG",
+      "halo-dev-bot"
+    ],
+    "action": "updateLabels",
+    "addLabel": "bug"
+  },
+  {
+    "type": "comment",
+    "name": "lgtm",
+    "allowUsers": [
+      "ruibaby",
+      "JohnNiang",
+      "guqing",
+      "LIlGG",
+      "halo-dev-bot"
+    ],
+    "action": "updateLabels",
+    "addLabel": "lgtm"
+  },
+  {
+    "type": "comment",
+    "name": "label",
+    "allowUsers": []
+  },
+  {
+    "type": "comment",
+    "name": "assign",
+    "allowUsers": [
+      "ruibaby",
+      "JohnNiang",
+      "guqing",
+      "LIlGG",
+      "halo-dev-bot"
+    ]
+  }
+]

--- a/.github/commands.json
+++ b/.github/commands.json
@@ -49,8 +49,7 @@
       "ruibaby",
       "JohnNiang",
       "guqing",
-      "LIlGG",
-      "halo-dev-bot"
+      "LIlGG"
     ]
   },
   {

--- a/.github/commands.json
+++ b/.github/commands.json
@@ -54,6 +54,16 @@
   },
   {
     "type": "comment",
+    "name": "notebook",
+    "assign": [
+      "ruibaby",
+      "JohnNiang",
+      "guqing",
+      "LIlGG"
+    ]
+  },
+  {
+    "type": "comment",
     "name": "duplicate",
     "allowUsers": [
       "ruibaby",

--- a/.github/commands.json
+++ b/.github/commands.json
@@ -1,7 +1,7 @@
 [
   {
     "type": "comment",
-    "name": "question",
+    "name": "*question",
     "allowUsers": [
       "ruibaby",
       "JohnNiang",
@@ -10,11 +10,11 @@
       "halo-dev-bot"
     ],
     "action": "updateLabels",
-    "addLabel": "question"
+    "addLabel": "*question"
   },
   {
     "type": "label",
-    "name": "question",
+    "name": "*question",
     "action": "close",
     "comment": "请到 [Halo Forum](https://bbs.halo.run/) 提问. 我们在那边有一个很好的社区. 他们已经回答了数千个问题，并且很乐意回答您的问题. 也可以到[Halo 官网](https://halo.run) 查看文档指南."
   },

--- a/.github/commands.json
+++ b/.github/commands.json
@@ -16,19 +16,19 @@
     "type": "label",
     "name": "question",
     "action": "close",
-    "comment": "请到 [Halo Forum](https://bbs.halo.run/) 提问. 我们在那边有一个很好的社区. 他们已经回答了数千个问题，并且很乐意回答您的问题. 也可以到[Halo 官网](https://halo.run) 查看文档指南.\n\nHappy Coding!"
+    "comment": "请到 [Halo Forum](https://bbs.halo.run/) 提问. 我们在那边有一个很好的社区. 他们已经回答了数千个问题，并且很乐意回答您的问题. 也可以到[Halo 官网](https://halo.run) 查看文档指南."
   },
   {
     "type": "label",
     "name": "*dev-question",
     "action": "close",
-    "comment": "请到 [Halo Forum](https://bbs.halo.run/t/ask-for-help)提问，这是您提出问题并获得支持的好地方. \n\nHappy Coding!"
+    "comment": "请到 [Halo Forum](https://bbs.halo.run/t/ask-for-help)提问，这是您提出问题并获得支持的好地方. "
   },
   {
     "type": "label",
     "name": "*not-reproducible",
     "action": "close",
-    "comment": "我们关闭了这个问题，因为我们无法通过您描述的步骤重现问题. 在最近版本的Halo代码中，我们已经修复了您的问题. 如果没有，请要求我们重新打开问题并为我们提供更多细节. 我们的 [贡献指南](https://docs.halo.run/zh/contribution/issue) 或许可以帮到您.\n\nHappy Coding!"
+    "comment": "我们关闭了这个问题，因为我们无法通过您描述的步骤重现问题. 在最新版本的 Halo 代码中，我们已经修复了您的问题. 如果没有，请要求我们重新打开问题并为我们提供更多细节. 我们的 [贡献指南](https://docs.halo.run/zh/contribution/issue) 或许可以帮到您."
   },
   {
     "type": "label",
@@ -40,7 +40,7 @@
     "type": "label",
     "name": "*as-designed",
     "action": "close",
-    "comment": "所描述的行为是预期工作的方式。 如果您不同意，请解释预期的内容以及更详细的内容. \n\nHappy Coding!"
+    "comment": "所描述的行为是预期工作的方式。 如果您不同意，请解释预期的内容以及更详细的内容. "
   },
   {
     "type": "label",
@@ -70,7 +70,7 @@
     "type": "label",
     "name": "*duplicate",
     "action": "close",
-    "comment": "感谢您创建了这个issue！ 我们认为它与我们已经拥有的另一个相同。 因此，我们将此一个归还为重复(duplicate)并关闭了它。 您可以在 [这里](${duplicateQuery}) 搜索现有问题. \n\nHappy Coding!"
+    "comment": "感谢您创建了这个issue！ 我们认为它与我们已经拥有的另一个相同。 因此，我们将此一个归还为重复(duplicate)并关闭了它。 您可以在 [这里](${duplicateQuery}) 搜索现有问题. "
   },
   {
     "type": "comment",
@@ -118,20 +118,20 @@
     "name": "needs more info",
     "action": "updateLabels",
     "addLabel": "needs more info",
-    "comment": "感谢您创建了这个issue! 请提供更多的描述或错误日志以帮助我们理解您的问题。\n\nHappy Coding!"
+    "comment": "感谢您创建了这个issue! 请提供更多的描述或错误日志以帮助我们理解您的问题。"
   },
   {
     "type": "label",
     "name": "needs version info",
     "action": "updateLabels",
     "addLabel": "needs more info",
-    "comment": "感谢您创建了这个问题！我们认为它缺少一些基本信息，例如版本号，或者以其他方式不遵循我们的[问题报告](https://docs.halo.run/zh/contribution/issue)指南。请花点时间查看这些并更新issue。\n\nHappy Coding!"
+    "comment": "感谢您创建了这个问题！我们认为它缺少一些基本信息，例如版本号，或者以其他方式不遵循我们的[问题报告](https://docs.halo.run/zh/contribution/issue)指南。请花点时间查看这些并更新issue。"
   },
   {
     "type": "label",
     "name": "*off-topic",
     "action": "close",
-    "comment": "感谢您创建了这个问题。我们认为此问题与本项目的目标毫无关联，因此我们关闭了它. 您可以阅读我们的[问题报告](https://docs.halo.run/zh/contribution/issue)指南.\n\nHappy Coding!"
+    "comment": "感谢您创建了这个问题。我们认为此问题与本项目的目标毫无关联，因此我们关闭了它. 您可以阅读我们的[问题报告](https://docs.halo.run/zh/contribution/issue)指南."
   },
   {
     "type": "comment",
@@ -145,7 +145,7 @@
     ],
     "action": "comment",
     "addLabel": "needs more info",
-    "comment": "感谢您报告了这个issue! 遗憾的是, 我们很难了解你看到的问题. 请提供一段屏幕录制来准确地展示不符合预期的情况. 虽然`GitHub`支持很多标准格式，但尽量首选`.gif` 文件，因为它们在GitHub是内联展示. 你可以使用基于浏览器的gif录制工具 https://gifcap.dev 来帮助您.\n\n如果这个issue依赖键盘输入, 您可以通过启用`screencast`模式来录制 (`Developer: Toggle Screencast Mode` in the command palette).\n\nHappy coding!"
+    "comment": "感谢您报告了这个issue! 遗憾的是, 我们很难了解你看到的问题. 请提供一段屏幕录制来准确地展示不符合预期的情况. 虽然`GitHub`支持很多标准格式，但尽量首选`.gif` 文件，因为它们在GitHub是内联展示. 你可以使用基于浏览器的gif录制工具 https://gifcap.dev 来帮助您.\n\n如果这个issue依赖键盘输入, 您可以通过启用`screencast`模式来录制 (`Developer: Toggle Screencast Mode` in the command palette)."
   },
   {
     "type": "comment",

--- a/.github/commands.yml
+++ b/.github/commands.yml
@@ -1,0 +1,19 @@
+{
+  perform: true,
+  commands:
+    [
+      {
+        type: "comment",
+        name: "findDuplicates",
+        allowUsers: [
+            "ruibaby",
+            "JohnNiang",
+            "guqing",
+            "LIlGG",
+            "halo-dev-bot"
+        ],
+        action: "comment",
+        comment: "Potential duplicates:\n${potentialDuplicates}",
+      },
+    ],
+}

--- a/.github/subscribers.json
+++ b/.github/subscribers.json
@@ -1,0 +1,9 @@
+{
+  "notebook": [
+    "ruibaby",
+    "JohnNiang",
+    "guqing",
+    "LIlGG",
+    "halo-dev-bot"
+  ]
+}

--- a/.github/workflows/needs-more-info-closer.yml
+++ b/.github/workflows/needs-more-info-closer.yml
@@ -1,0 +1,29 @@
+name: Needs More Info Closer
+on:
+  schedule:
+    - cron: 20 11 * * * # 4:20am Redmond
+  repository_dispatch:
+    types: [trigger-needs-more-info]
+
+jobs:
+  main:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Actions
+        uses: actions/checkout@v2
+        with:
+          repository: "microsoft/vscode-github-triage-actions"
+          path: ./actions
+          ref: stable
+      - name: Install Actions
+        run: npm install --production --prefix ./actions
+      - name: Run Needs More Info Closer
+        uses: ./actions/needs-more-info-closer
+        with:
+          token: ${{secrets.ISSUE_TRIAGE_BOT_PAT}}
+          label: needs more info
+          closeDays: 7
+          additionalTeam: "ruibaby|JohnNiang|guqing|LIlGG|halo-dev-bot"
+          closeComment: "此问题已自动关闭，因为它需要更多信息且最近没有活跃.\n\nHappy Coding!"
+          pingDays: 80
+          pingComment: "Hey @${assignee}, 这个问题可能需要进一步关注.\n\n@${author}, 如果问题不再存在，您可以帮助我们关闭此问题, 或者添加更多信息."

--- a/.github/workflows/needs-more-info-closer.yml
+++ b/.github/workflows/needs-more-info-closer.yml
@@ -24,6 +24,6 @@ jobs:
           label: needs more info
           closeDays: 7
           additionalTeam: "ruibaby|JohnNiang|guqing|LIlGG|halo-dev-bot"
-          closeComment: "此问题已自动关闭，因为它需要更多信息且最近没有活跃.\n\nHappy Coding!"
+          closeComment: "此问题已自动关闭，因为它需要更多信息且最近没有活跃."
           pingDays: 80
           pingComment: "Hey @${assignee}, 这个问题可能需要进一步关注.\n\n@${author}, 如果问题不再存在，您可以帮助我们关闭此问题, 或者添加更多信息."

--- a/.github/workflows/needs-more-info-closer.yml
+++ b/.github/workflows/needs-more-info-closer.yml
@@ -24,6 +24,6 @@ jobs:
           label: needs more info
           closeDays: 7
           additionalTeam: "ruibaby|JohnNiang|guqing|LIlGG|halo-dev-bot"
-          closeComment: "此问题已自动关闭，因为它需要更多信息且最近没有活跃."
+          closeComment: "此问题已自动关闭，因为它需要更多信息且最近没有活跃。"
           pingDays: 80
-          pingComment: "Hey @${assignee}, 这个问题可能需要进一步关注.\n\n@${author}, 如果问题不再存在，您可以帮助我们关闭此问题, 或者添加更多信息."
+          pingComment: "Hey @${assignee}， 这个问题可能需要进一步关注。\n\n@${author}， 如果问题不再存在，您可以帮助我们关闭此问题，或者添加更多信息。"

--- a/.github/workflows/on-comment.yml
+++ b/.github/workflows/on-comment.yml
@@ -1,0 +1,23 @@
+name: On Comment
+on:
+  issue_comment:
+    types: [created]
+
+# also make changes in ./on-label.yml
+jobs:
+  main:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Actions
+        uses: actions/checkout@v2
+        with:
+          repository: "microsoft/vscode-github-triage-actions"
+          path: ./actions
+          ref: stable
+      - name: Install Actions
+        run: npm install --production --prefix ./actions
+      - name: Run Commands
+        uses: ./actions/commands
+        with:
+          token: ${{secrets.ISSUE_TRIAGE_BOT_PAT}}
+          config-path: commands

--- a/.github/workflows/on-label.yml
+++ b/.github/workflows/on-label.yml
@@ -22,7 +22,7 @@ jobs:
         uses: ./actions/author-verified
         with:
           token: ${{secrets.ISSUE_TRIAGE_BOT_PAT}}
-          requestVerificationComment: "该问题已在最新版本中修复!\n\n@${author}, 请在今天或者稍晚确认你的使用的版本是否包含该提交： ${commit}，如果这件事已按预期得到解决，您可以通过评论 `/verified` 来帮助我们标记此问题.\n\n如果该问题仍然没有得到解决, 可以在评论中留下你希望得到的预期结果.\n\nHappy Coding!"
+          requestVerificationComment: "该问题已在最新版本中修复!\n\n@${author}, 请在今天或者稍晚确认你的使用的版本是否包含该提交： ${commit}，如果这件事已按预期得到解决，您可以通过评论 `/verified` 来帮助我们标记此问题.\n\n如果该问题仍然没有得到解决, 可以在评论中留下你希望得到的预期结果."
           verifiedLabel: verified
           authorVerificationRequestedLabel: author-verification-requested
 

--- a/.github/workflows/on-label.yml
+++ b/.github/workflows/on-label.yml
@@ -22,7 +22,7 @@ jobs:
         uses: ./actions/author-verified
         with:
           token: ${{secrets.ISSUE_TRIAGE_BOT_PAT}}
-          requestVerificationComment: "该问题已在最新版本中修复!\n\n@${author}, 请在今天或者稍晚确认你的使用的版本是否包含该提交： ${commit}，如果这件事已按预期得到解决，您可以通过评论 `/verified` 来帮助我们标记此问题.\n\n如果该问题仍然没有得到解决, 可以在评论中留下你希望得到的预期结果."
+          requestVerificationComment: "该问题已在最新版本中修复!\n\n@${author}，请在今天或者稍晚确认你的使用的版本是否包含该提交： ${commit}，如果这件事已按预期得到解决，您可以通过评论 `/verified` 来帮助我们标记此问题。\n\n如果该问题仍然没有得到解决， 可以在评论中留下你希望得到的预期结果。"
           verifiedLabel: verified
           authorVerificationRequestedLabel: author-verification-requested
 

--- a/.github/workflows/on-label.yml
+++ b/.github/workflows/on-label.yml
@@ -1,0 +1,42 @@
+name: On Label
+on:
+  issues:
+    types: [labeled]
+
+jobs:
+  main:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Actions
+        uses: actions/checkout@v2
+        with:
+          repository: "microsoft/vscode-github-triage-actions"
+          ref: stable
+          path: ./actions
+      - name: Install Actions
+        run: npm install --production --prefix ./actions
+
+      # source of truth in ./author-verified.yml
+      - name: Run Author Verified
+        if: contains(github.event.issue.labels.*.name, 'author-verification-requested')
+        uses: ./actions/author-verified
+        with:
+          token: ${{secrets.ISSUE_TRIAGE_BOT_PAT}}
+          requestVerificationComment: "该问题已在最新版本中修复!\n\n@${author}, 请在今天或者稍晚确认你的使用的版本是否包含该提交： ${commit}，如果这件事已按预期得到解决，您可以通过评论 `/verified` 来帮助我们标记此问题.\n\n如果该问题仍然没有得到解决, 可以在评论中留下你希望得到的预期结果.\n\nHappy Coding!"
+          verifiedLabel: verified
+          authorVerificationRequestedLabel: author-verification-requested
+
+
+      # also make changes in ./on-comment.yml
+      - name: Run Commands
+        uses: ./actions/commands
+        with:
+          token: ${{secrets.ISSUE_TRIAGE_BOT_PAT}}
+          config-path: commands
+
+      # only here.
+      - name: Run Subscribers
+        uses: ./actions/topic-subscribe
+        with:
+          token: ${{secrets.ISSUE_TRIAGE_BOT_PAT}}
+          config-path: subscribers


### PR DESCRIPTION
通过评论和添加标签来管理issues
还需要手动添加一下几个label来更好的管理issues:
- *dev-question: 表明是开发问题，需要到论坛寻求帮助，打上此标签的issue会被自动关闭
- *not-reproducible: 表明无法通过issue的描述的步骤重现问题，打上此标签的issue会被自动关闭
- *out-of-scope：表明这个问题，我们不打算在可预见的未来解决它，打上此标签的issue会被自动关闭
- *as-designed： 设计如此不是缺陷，打上此标签的issue会被自动关闭
- *duplicate： 表明是重复问题，会被自动关闭
- *off-topic: 表明该问题与本项目毫无关联，会自动关闭
- *question: 表明是需要到社区提问的问题，会自动关闭
- confirmed：表明问题已得到halo成员确认，需要进行修复或者开发
- confirmationPending： 表明问题在确认中
- needs more info：表明问题缺少必要的描述信息，难以理解
- needs version info： 缺少版本信息
- lgtm： 表明该问题或pr已经审核通过等待合并或进一步处理

提供以下指令来来协助管理issue:
- /*question: 添加*question标签并自动关闭issue
- /duplicate: 添加*duplicate标签并自动关闭
- /confirmationPending: 为issue分配confirmation-pending标签表示等待确认
- /confirm: 为issue分配confirmed标签,表示问题已经得到确认
- /needsMoreInfo：分配needs more info标签
- /gifPlease: 需要提供屏幕录制来帮助成员理解问题
- /bug: 分配bug标签
- /lgtm: 分配lgtm标签
- /rntg: 分配给core team所有人
- /assign guqing: 表示请求guqing审查
- /assign -guqing: 表示从审查者中将guqing移除
- /label enchancement: 表示为issue分配enchancement标签
- /label -enchancement: 表示从issue移除enchancement标签