### PR TITLE
Update application-dev.yaml

### DIFF
--- a/src/main/resources/application-dev.yaml
+++ b/src/main/resources/application-dev.yaml
@@ -17,7 +17,7 @@ spring:
 
     # H2 database configuration.
     driver-class-name: org.h2.Driver
-    url: jdbc:h2:file:~/halo-dev/db/halo
+    url: jdbc:h2:file:~/halo-dev/db/halo;AUTO_SERVER=TRUE
     username: admin
     password: 123456
 


### PR DESCRIPTION
According to [H2 doc](http://www.h2database.com/html/features.html#auto_mixed_mode), appending `;AUTO_SERVER=TRUE` to the database URL will allow multiple thread to access database. This will be nicer for developer who fellows the default setup.