### PR TITLE
Fix number of comment in detail of post and sheet and add it into detail of journal

### DIFF
--- a/src/main/java/run/halo/app/controller/content/api/JournalController.java
+++ b/src/main/java/run/halo/app/controller/content/api/JournalController.java
@@ -71,7 +71,7 @@ public class JournalController {
 
     @GetMapping("{journalId:\\d+}")
     @ApiOperation("Gets a journal detail")
-    public JournalDTO getBy(@PathVariable("journalId") Integer journalId) {
+    public JournalWithCmtCountDTO getBy(@PathVariable("journalId") Integer journalId) {
         Journal journal = journalService.getById(journalId);
         return journalService.convertTo(journal);
     }

--- a/src/main/java/run/halo/app/repository/base/BaseCommentRepository.java
+++ b/src/main/java/run/halo/app/repository/base/BaseCommentRepository.java
@@ -100,6 +100,15 @@ public interface BaseCommentRepository<COMMENT extends BaseComment>
     long countByPostId(@NonNull Integer postId);
 
     /**
+     * Count comments by comment status and post id.
+     *
+     * @param status status must not be null
+     * @param postId post id must not be null.
+     * @return comments count
+     */
+    long countByStatusAndPostId(@NonNull CommentStatus status, @NonNull Integer postId);
+
+    /**
      * Counts by comment status.
      *
      * @param status comment status must not be null

--- a/src/main/java/run/halo/app/service/JournalService.java
+++ b/src/main/java/run/halo/app/service/JournalService.java
@@ -68,13 +68,13 @@ public interface JournalService extends CrudService<Journal, Integer> {
     Page<Journal> pageBy(@NonNull JournalType type, @NonNull Pageable pageable);
 
     /**
-     * Converts to journal dto.
+     * Converts to journal with comment count dto.
      *
      * @param journal journal must not be null
-     * @return journal dto
+     * @return journal with comment count dto
      */
     @NonNull
-    JournalDTO convertTo(@NonNull Journal journal);
+    JournalWithCmtCountDTO convertTo(@NonNull Journal journal);
 
     /**
      * Converts to journal with comment count dto list.

--- a/src/main/java/run/halo/app/service/base/BaseCommentService.java
+++ b/src/main/java/run/halo/app/service/base/BaseCommentService.java
@@ -145,6 +145,15 @@ public interface BaseCommentService<COMMENT extends BaseComment>
     long countByPostId(@NonNull Integer postId);
 
     /**
+     * Count comments by comment status and post id.
+     *
+     * @param status status must not be null.
+     * @param postId post id must not be null.
+     * @return comments count
+     */
+    long countByStatusAndPostId(@NonNull CommentStatus status, @NonNull Integer postId);
+
+    /**
      * Counts by comment status.
      *
      * @param status comment status must not be null

--- a/src/main/java/run/halo/app/service/impl/BaseCommentServiceImpl.java
+++ b/src/main/java/run/halo/app/service/impl/BaseCommentServiceImpl.java
@@ -291,6 +291,12 @@ public abstract class BaseCommentServiceImpl<COMMENT extends BaseComment>
     }
 
     @Override
+    public long countByStatusAndPostId(@NonNull CommentStatus status, @NonNull Integer postId) {
+        Assert.notNull(postId, "Post id must not be null");
+        return baseCommentRepository.countByStatusAndPostId(status, postId);
+    }
+
+    @Override
     public long countByStatus(@NonNull CommentStatus status) {
         return baseCommentRepository.countByStatus(status);
     }

--- a/src/main/java/run/halo/app/service/impl/JournalServiceImpl.java
+++ b/src/main/java/run/halo/app/service/impl/JournalServiceImpl.java
@@ -107,10 +107,16 @@ public class JournalServiceImpl extends AbstractCrudService<Journal, Integer>
     }
 
     @Override
-    public JournalDTO convertTo(Journal journal) {
+    public JournalWithCmtCountDTO convertTo(Journal journal) {
         Assert.notNull(journal, "Journal must not be null");
 
-        return new JournalDTO().convertFrom(journal);
+        JournalWithCmtCountDTO journalWithCmtCountDto = new JournalWithCmtCountDTO()
+            .convertFrom(journal);
+
+        journalWithCmtCountDto.setCommentCount(journalCommentService.countByStatusAndPostId(
+            CommentStatus.PUBLISHED, journal.getId()));
+
+        return journalWithCmtCountDto;
     }
 
     @Override

--- a/src/main/java/run/halo/app/service/impl/PostServiceImpl.java
+++ b/src/main/java/run/halo/app/service/impl/PostServiceImpl.java
@@ -787,7 +787,8 @@ public class PostServiceImpl extends BasePostServiceImpl<Post> implements PostSe
         postDetailVO.setMetaIds(metaIds);
         postDetailVO.setMetas(postMetaService.convertTo(postMetaList));
 
-        postDetailVO.setCommentCount(postCommentService.countByPostId(post.getId()));
+        postDetailVO.setCommentCount(postCommentService.countByStatusAndPostId(
+            CommentStatus.PUBLISHED, post.getId()));
 
         postDetailVO.setFullPath(buildFullPath(post));
 

--- a/src/main/java/run/halo/app/service/impl/SheetServiceImpl.java
+++ b/src/main/java/run/halo/app/service/impl/SheetServiceImpl.java
@@ -341,7 +341,8 @@ public class SheetServiceImpl extends BasePostServiceImpl<Sheet> implements Shee
             sheetDetailVO.setSummary(generateSummary(sheet.getFormatContent()));
         }
 
-        sheetDetailVO.setCommentCount(sheetCommentService.countByPostId(sheet.getId()));
+        sheetDetailVO.setCommentCount(sheetCommentService.countByStatusAndPostId(
+            CommentStatus.PUBLISHED, sheet.getId()));
 
         sheetDetailVO.setFullPath(buildFullPath(sheet));
 


### PR DESCRIPTION
上次关于此issue的提交仅改正了列表中的评论数。现在将文章、页面的详情中评论数改正(展示的为已通过审核的评论数量)，并将日志的评论数也添加在日志详情的返回结果中。

Fix #1311 