### PR TITLE
Set the final version with tag name when releasing

### DIFF
--- a/.github/workflows/halo.yml
+++ b/.github/workflows/halo.yml
@@ -47,8 +47,10 @@ jobs:
           cache: 'gradle'
           java-version: 11
       - name: Build with Gradle
-        run: ./gradlew clean build -x test
-
+        run: |
+          # Set the version with tag name when releasing
+          sed -i "s/version=.*-SNAPSHOT$/version=${{ github.event.release.tag_name }}/1" gradle.properties
+          ./gradlew clean build -x test
       - name: Archive halo jar
         uses: actions/upload-artifact@v2
         with:

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,6 @@ plugins {
 }
 
 group = "run.halo.app"
-version = "1.4.13"
 description = "Halo, An excellent open source blog publishing application."
 sourceCompatibility = JavaVersion.VERSION_11
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,1 @@
+version=1.4.13-SNAPSHOT


### PR DESCRIPTION
### What this PR dose?

- Set the final version with tag name when releasing, and 
- Change default version of halo to `1.4.13-SNAPSHOT`.

### Why we need it?

It's more convenient to release a new version of halo. We just need to change the snapshot version in the master branch or other release branches.

### TODOs

- [ ] Bump snapshot version automatically.

/kind enhancement