### PR TITLE
Support querying multi post statuses

### DIFF
--- a/src/main/java/run/halo/app/controller/content/api/PostController.java
+++ b/src/main/java/run/halo/app/controller/content/api/PostController.java
@@ -2,9 +2,11 @@ package run.halo.app.controller.content.api;
 
 import static org.springframework.data.domain.Sort.Direction.DESC;
 
+import com.google.common.collect.ImmutableSet;
 import io.swagger.annotations.ApiOperation;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
+import java.util.Set;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -83,7 +85,7 @@ public class PostController {
         PostQuery postQuery = new PostQuery();
         postQuery.setKeyword(keyword);
         postQuery.setCategoryId(categoryId);
-        postQuery.setStatus(new PostStatus[] {PostStatus.PUBLISHED});
+        postQuery.setStatus(PostStatus.PUBLISHED);
         Page<Post> postPage = postService.pageBy(postQuery, pageable);
         return postService.convertToListVo(postPage, true);
     }

--- a/src/main/java/run/halo/app/controller/content/api/PostController.java
+++ b/src/main/java/run/halo/app/controller/content/api/PostController.java
@@ -46,6 +46,7 @@ import run.halo.app.service.PostService;
  *
  * @author johnniang
  * @author ryanwang
+ * @author guqing
  * @date 2019-04-02
  */
 @RestController("ApiContentPostController")

--- a/src/main/java/run/halo/app/controller/content/api/PostController.java
+++ b/src/main/java/run/halo/app/controller/content/api/PostController.java
@@ -85,7 +85,7 @@ public class PostController {
         PostQuery postQuery = new PostQuery();
         postQuery.setKeyword(keyword);
         postQuery.setCategoryId(categoryId);
-        postQuery.setStatus(PostStatus.PUBLISHED);
+        postQuery.setStatuses(Set.of(PostStatus.PUBLISHED));
         Page<Post> postPage = postService.pageBy(postQuery, pageable);
         return postService.convertToListVo(postPage, true);
     }

--- a/src/main/java/run/halo/app/controller/content/api/PostController.java
+++ b/src/main/java/run/halo/app/controller/content/api/PostController.java
@@ -83,7 +83,7 @@ public class PostController {
         PostQuery postQuery = new PostQuery();
         postQuery.setKeyword(keyword);
         postQuery.setCategoryId(categoryId);
-        postQuery.setStatus(PostStatus.PUBLISHED);
+        postQuery.setStatus(new PostStatus[] {PostStatus.PUBLISHED});
         Page<Post> postPage = postService.pageBy(postQuery, pageable);
         return postService.convertToListVo(postPage, true);
     }

--- a/src/main/java/run/halo/app/controller/content/api/PostController.java
+++ b/src/main/java/run/halo/app/controller/content/api/PostController.java
@@ -2,7 +2,6 @@ package run.halo.app.controller.content.api;
 
 import static org.springframework.data.domain.Sort.Direction.DESC;
 
-import com.google.common.collect.ImmutableSet;
 import io.swagger.annotations.ApiOperation;
 import java.nio.charset.StandardCharsets;
 import java.util.List;

--- a/src/main/java/run/halo/app/model/params/PostQuery.java
+++ b/src/main/java/run/halo/app/model/params/PostQuery.java
@@ -24,7 +24,7 @@ public class PostQuery {
     /**
      * Post status.
      */
-    @Deprecated(forRemoval = true, since = "2.0.0")
+    @Deprecated(forRemoval = true, since = "1.5.0")
     private PostStatus status;
 
     /**

--- a/src/main/java/run/halo/app/model/params/PostQuery.java
+++ b/src/main/java/run/halo/app/model/params/PostQuery.java
@@ -10,6 +10,7 @@ import run.halo.app.model.enums.PostStatus;
  * Post query.
  *
  * @author johnniang
+ * @author guqing
  * @date 4/10/19
  */
 @Data

--- a/src/main/java/run/halo/app/model/params/PostQuery.java
+++ b/src/main/java/run/halo/app/model/params/PostQuery.java
@@ -1,5 +1,6 @@
 package run.halo.app.model.params;
 
+import java.util.HashSet;
 import java.util.Set;
 import lombok.Data;
 import org.springframework.util.CollectionUtils;
@@ -22,22 +23,46 @@ public class PostQuery {
     /**
      * Post status.
      */
-    private Set<PostStatus> status;
+    @Deprecated(forRemoval = true, since = "2.0.0")
+    private PostStatus status;
+
+    /**
+     * Post statuses.
+     */
+    private Set<PostStatus> statuses;
 
     /**
      * Category id.
      */
     private Integer categoryId;
 
-    public void setStatus(PostStatus... status) {
-        if (!CollectionUtils.isEmpty(this.status)) {
-            throw new IllegalArgumentException("There is already a value in the statusSet, "
-                + "If you want to overwrite please use the overload method.");
-        }
-        this.status = Set.of(status);
+    /**
+     * This method is deprecated in version 1.5.0, and it is recommended to use
+     * <code>getStatuses()</code> method.
+     *
+     * @see #getStatuses()
+     * @return post status.
+     */
+    @Deprecated
+    public PostStatus getStatus() {
+        return status;
     }
 
-    public void setStatus(Set<PostStatus> status) {
-        this.status = status;
+    /**
+     * In order to be compatible with status, this method will return the combined results
+     * of status and status before status is removed.
+     *
+     * @return a combined status set of status and statues
+     */
+    public Set<PostStatus> getStatuses() {
+        Set<PostStatus> statuses = new HashSet<>();
+        // Need to be compatible with status parameter values due to historical reasons.
+        if (this.status != null) {
+            statuses.add(this.status);
+        }
+        if (!CollectionUtils.isEmpty(this.statuses)) {
+            statuses.addAll(this.statuses);
+        }
+        return statuses;
     }
 }

--- a/src/main/java/run/halo/app/model/params/PostQuery.java
+++ b/src/main/java/run/halo/app/model/params/PostQuery.java
@@ -31,8 +31,8 @@ public class PostQuery {
 
     public void setStatus(PostStatus... status) {
         if (!CollectionUtils.isEmpty(this.status)) {
-            throw new IllegalArgumentException(
-                "There is already a value in the statusSet, If you want to overwrite please use the overload method.");
+            throw new IllegalArgumentException("There is already a value in the statusSet, "
+                + "If you want to overwrite please use the overload method.");
         }
         this.status = Set.of(status);
     }

--- a/src/main/java/run/halo/app/model/params/PostQuery.java
+++ b/src/main/java/run/halo/app/model/params/PostQuery.java
@@ -51,7 +51,7 @@ public class PostQuery {
 
     /**
      * In order to be compatible with status, this method will return the combined results
-     * of status and status before status is removed.
+     * of status and statuses before status is removed.
      *
      * @return a combined status set of status and statues
      */

--- a/src/main/java/run/halo/app/model/params/PostQuery.java
+++ b/src/main/java/run/halo/app/model/params/PostQuery.java
@@ -20,7 +20,7 @@ public class PostQuery {
     /**
      * Post status.
      */
-    private PostStatus status;
+    private PostStatus[] status;
 
     /**
      * Category id.

--- a/src/main/java/run/halo/app/model/params/PostQuery.java
+++ b/src/main/java/run/halo/app/model/params/PostQuery.java
@@ -1,6 +1,8 @@
 package run.halo.app.model.params;
 
+import java.util.Set;
 import lombok.Data;
+import org.springframework.util.CollectionUtils;
 import run.halo.app.model.enums.PostStatus;
 
 /**
@@ -20,11 +22,22 @@ public class PostQuery {
     /**
      * Post status.
      */
-    private PostStatus[] status;
+    private Set<PostStatus> status;
 
     /**
      * Category id.
      */
     private Integer categoryId;
 
+    public void setStatus(PostStatus... status) {
+        if (!CollectionUtils.isEmpty(this.status)) {
+            throw new IllegalArgumentException(
+                "There is already a value in the statusSet, If you want to overwrite please use the overload method.");
+        }
+        this.status = Set.of(status);
+    }
+
+    public void setStatus(Set<PostStatus> status) {
+        this.status = status;
+    }
 }

--- a/src/main/java/run/halo/app/service/impl/PostServiceImpl.java
+++ b/src/main/java/run/halo/app/service/impl/PostServiceImpl.java
@@ -151,7 +151,7 @@ public class PostServiceImpl extends BasePostServiceImpl<Post> implements PostSe
 
         PostQuery postQuery = new PostQuery();
         postQuery.setKeyword(keyword);
-        postQuery.setStatus(PostStatus.PUBLISHED);
+        postQuery.setStatuses(Set.of(PostStatus.PUBLISHED));
 
         // Build specification and find all
         return postRepository.findAll(buildSpecByQuery(postQuery), pageable);
@@ -809,9 +809,9 @@ public class PostServiceImpl extends BasePostServiceImpl<Post> implements PostSe
         return (root, query, criteriaBuilder) -> {
             List<Predicate> predicates = new LinkedList<>();
 
-            if (!CollectionUtils.isEmpty(postQuery.getStatus())) {
+            if (!CollectionUtils.isEmpty(postQuery.getStatuses())) {
                 In<PostStatus> statusInClause = criteriaBuilder.in(root.get("status"));
-                for (PostStatus status : postQuery.getStatus()) {
+                for (PostStatus status : postQuery.getStatuses()) {
                     statusInClause.value(status);
                 }
                 predicates.add(statusInClause);

--- a/src/main/java/run/halo/app/service/impl/PostServiceImpl.java
+++ b/src/main/java/run/halo/app/service/impl/PostServiceImpl.java
@@ -809,12 +809,9 @@ public class PostServiceImpl extends BasePostServiceImpl<Post> implements PostSe
         return (root, query, criteriaBuilder) -> {
             List<Predicate> predicates = new LinkedList<>();
 
-            if (!CollectionUtils.isEmpty(postQuery.getStatuses())) {
-                In<PostStatus> statusInClause = criteriaBuilder.in(root.get("status"));
-                for (PostStatus status : postQuery.getStatuses()) {
-                    statusInClause.value(status);
-                }
-                predicates.add(statusInClause);
+            Set<PostStatus> statuses = postQuery.getStatuses();
+            if (!CollectionUtils.isEmpty(statuses)) {
+                predicates.add(root.get("status").in(statuses));
             }
 
             if (postQuery.getCategoryId() != null) {

--- a/src/main/java/run/halo/app/service/impl/PostServiceImpl.java
+++ b/src/main/java/run/halo/app/service/impl/PostServiceImpl.java
@@ -151,7 +151,7 @@ public class PostServiceImpl extends BasePostServiceImpl<Post> implements PostSe
 
         PostQuery postQuery = new PostQuery();
         postQuery.setKeyword(keyword);
-        postQuery.setStatus(new PostStatus[] {PostStatus.PUBLISHED});
+        postQuery.setStatus(PostStatus.PUBLISHED);
 
         // Build specification and find all
         return postRepository.findAll(buildSpecByQuery(postQuery), pageable);
@@ -809,7 +809,7 @@ public class PostServiceImpl extends BasePostServiceImpl<Post> implements PostSe
         return (root, query, criteriaBuilder) -> {
             List<Predicate> predicates = new LinkedList<>();
 
-            if (ArrayUtils.isNotEmpty(postQuery.getStatus())) {
+            if (!CollectionUtils.isEmpty(postQuery.getStatus())) {
                 In<PostStatus> statusInClause = criteriaBuilder.in(root.get("status"));
                 for (PostStatus status : postQuery.getStatus()) {
                     statusInClause.value(status);


### PR DESCRIPTION
## What this PR does?
文章分页列表支持多文章状态查询

## Why we need it?
[文章管理方式重构](https://github.com/halo-dev/halo-admin/issues/371) 需要文章列表多状态查询支持

## How to test it?
check 这个 PR 到本地运行，使用接口调用工具测试以下接口
```
GET http://localhost:8090/api/admin/posts?page=0&size=10&status=PUBLISHED
```
可以传递多个`status`参数例如
```
GET http://localhost:8090/api/admin/posts?page=0&size=10&status=PUBLISHED&status=DRAFT
```
然后查看接口返回结果是否只包含这写状态的文章