### PR TITLE
Automated cherry pick of #1509: Simplify Java setup in GitHub workflow

### DIFF
--- a/.github/workflows/halo.yml
+++ b/.github/workflows/halo.yml
@@ -24,28 +24,11 @@ jobs:
         with:
           submodules: true
       - name: Set up JDK 11
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v2
         with:
+          distribution: 'temurin'
+          cache: 'gradle'
           java-version: 11
-
-      - name: Cache Gradle wrapper
-        id: cache-gradle-wrapper
-        uses: actions/cache@v2.1.3
-        with:
-          path: ~/.gradle/wrapper
-          key: ${{ runner.os }}-gradle-${{ hashFiles('gradle/wrapper/gradle-wrapper.properties') }}
-          restore-keys: |
-            ${{ runner.os }}-dependencies-
-
-      - name: Cache Dependencies
-        id: cache-dependencies
-        uses: actions/cache@v2.1.3
-        with:
-          path: ~/.gradle/caches
-          key: ${{ runner.os }}-dependencies-${{ hashFiles('**/*.gradle') }}
-          restore-keys: |
-            ${{ runner.os }}-dependencies-
-
       - name: Check And Test
         run: ./gradlew check
   build:
@@ -58,26 +41,11 @@ jobs:
         with:
           submodules: true
       - name: Set up JDK 11
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v2
         with:
+          distribution: 'temurin'
+          cache: 'gradle'
           java-version: 11
-      - name: Cache Gradle wrapper
-        id: cache-gradle-wrapper
-        uses: actions/cache@v2.1.3
-        with:
-          path: ~/.gradle/wrapper
-          key: ${{ runner.os }}-gradle-${{ hashFiles('gradle/wrapper/gradle-wrapper.properties') }}
-          restore-keys: |
-            ${{ runner.os }}-dependencies-
-      - name: Cache Dependencies
-        id: cache-dependencies
-        uses: actions/cache@v2.1.3
-        with:
-          path: ~/.gradle/caches
-          key: ${{ runner.os }}-dependencies-${{ hashFiles('**/*.gradle') }}
-          restore-keys: |
-            ${{ runner.os }}-dependencies-
-
       - name: Build with Gradle
         run: ./gradlew clean build -x test
 
@@ -142,22 +110,11 @@ jobs:
         with:
           submodules: true
       - name: Set up JDK 11
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v2
         with:
+          distribution: 'temurin'
+          cache: 'gradle'
           java-version: 11
-      - name: Download halo jar
-        uses: actions/download-artifact@v2
-        with:
-          name: halo-jar
-          path: build/libs
-      - name: Cache Gradle wrapper
-        id: cache-gradle-wrapper
-        uses: actions/cache@v2.1.3
-        with:
-          path: ~/.gradle/wrapper
-          key: ${{ runner.os }}-gradle-${{ hashFiles('gradle/wrapper/gradle-wrapper.properties') }}
-          restore-keys: |
-            ${{ runner.os }}-dependencies-
       - name: Get version of halo
         id: get_halo_version
         run: |


### PR DESCRIPTION
Cherry pick of #1509 on release-1.4.

#1509: Simplify Java setup in GitHub workflow

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```