### PR TITLE
Fixed the problem that copying the default theme at halo startup did not use themeId as the theme folder name

### DIFF
--- a/src/main/java/run/halo/app/listener/StartedListener.java
+++ b/src/main/java/run/halo/app/listener/StartedListener.java
@@ -168,7 +168,7 @@ public class StartedListener implements ApplicationListener<ApplicationStartedEv
             Path themePath = themeService.getBasePath().resolve(HaloConst.DEFAULT_THEME_ID);
 
             if (themeService.fetchThemePropertyBy(HaloConst.DEFAULT_THEME_ID).isEmpty()) {
-                FileUtils.copyFolder(source.resolve("anatole"), themePath);
+                FileUtils.copyFolder(source.resolve(HaloConst.DEFAULT_THEME_DIR_NAME), themePath);
                 log.info("Copied theme folder from [{}] to [{}]", source, themePath);
             }
         } catch (Exception e) {

--- a/src/main/java/run/halo/app/listener/StartedListener.java
+++ b/src/main/java/run/halo/app/listener/StartedListener.java
@@ -165,10 +165,10 @@ public class StartedListener implements ApplicationListener<ApplicationStartedEv
             }
 
             // Create theme folder
-            Path themePath = themeService.getBasePath();
+            Path themePath = themeService.getBasePath().resolve(HaloConst.DEFAULT_THEME_ID);
 
             if (themeService.fetchThemePropertyBy(HaloConst.DEFAULT_THEME_ID).isEmpty()) {
-                FileUtils.copyFolder(source, themePath);
+                FileUtils.copyFolder(source.resolve("anatole"), themePath);
                 log.info("Copied theme folder from [{}] to [{}]", source, themePath);
             }
         } catch (Exception e) {

--- a/src/main/java/run/halo/app/model/support/HaloConst.java
+++ b/src/main/java/run/halo/app/model/support/HaloConst.java
@@ -49,6 +49,11 @@ public class HaloConst {
     public static final String DEFAULT_THEME_ID = "caicai_anatole";
 
     /**
+     * Default theme directory name.
+     */
+    public static final String DEFAULT_THEME_DIR_NAME = "anatole";
+
+    /**
      * Default error path.
      */
     public static final String DEFAULT_ERROR_PATH = "common/error/error";


### PR DESCRIPTION
## What this PR does?
修复 Halo 启动时拷贝默认主题没有使用themeId作为主题文件夹名称的问题
See [#1548](https://github.com/halo-dev/halo/issues/1548)
合并时需要 cherry-pick 到 release-1.4

## Why we need it?
启动时拷贝默认主题应使用themeId以避免主题在线更新后文件夹名称不一致导致部分文件无法获取

## How to test it?
删除`halo work dir`下的默认主题`anatole`,然后启动`halo`查看默认主题文件夹名称是否为`caicai_anatole`
点击在线更新或上传该主题的更新包查看主题文件夹名称是否一致，同为`caicai_anatole`