### PR TITLE
Tag support color options

### DIFF
--- a/src/main/java/run/halo/app/model/dto/TagDTO.java
+++ b/src/main/java/run/halo/app/model/dto/TagDTO.java
@@ -4,6 +4,7 @@ import java.util.Date;
 import lombok.Data;
 import run.halo.app.model.dto.base.OutputConverter;
 import run.halo.app.model.entity.Tag;
+import run.halo.app.model.support.HaloConst;
 
 /**
  * Tag output dto.
@@ -20,6 +21,8 @@ public class TagDTO implements OutputConverter<TagDTO, Tag> {
     private String name;
 
     private String slug;
+
+    private String color = HaloConst.DEFAULT_TAG_COLOR;
 
     private String thumbnail;
 

--- a/src/main/java/run/halo/app/model/entity/Tag.java
+++ b/src/main/java/run/halo/app/model/entity/Tag.java
@@ -16,6 +16,7 @@ import org.hibernate.annotations.GenericGenerator;
  * Tag entity
  *
  * @author ryanwang
+ * @author guqing
  * @date 2019-03-12
  */
 @Data
@@ -49,6 +50,12 @@ public class Tag extends BaseEntity {
      */
     @Column(name = "slug", unique = true)
     private String slug;
+
+    /**
+     * Tag color.
+     */
+    @Column(name = "color", length = 20)
+    private String color;
 
     /**
      * Cover thumbnail of the tag.

--- a/src/main/java/run/halo/app/model/entity/Tag.java
+++ b/src/main/java/run/halo/app/model/entity/Tag.java
@@ -54,7 +54,7 @@ public class Tag extends BaseEntity {
     /**
      * Tag color.
      */
-    @Column(name = "color", length = 20)
+    @Column(name = "color", length = 25)
     private String color;
 
     /**

--- a/src/main/java/run/halo/app/model/params/TagParam.java
+++ b/src/main/java/run/halo/app/model/params/TagParam.java
@@ -1,5 +1,6 @@
 package run.halo.app.model.params;
 
+import io.swagger.annotations.ApiModelProperty;
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.Size;
 import lombok.Data;
@@ -28,6 +29,10 @@ public class TagParam implements InputConverter<Tag> {
     private String slug;
 
     @Size(max = 20, message = "颜色值字符长度不能超过 {max}")
+    @ApiModelProperty(value = "标签颜色，支持多种颜色模式，"
+        + "例如 Hex: #cfd3d7，颜色名称：LightGrey，RGB: rgb(207, 211, 215)，"
+        + "RGBA: rgb(207, 211, 215, 0.5)等", name = "color",
+        example = "#e23d66")
     private String color;
 
     @Size(max = 1023, message = "封面图链接的字符长度不能超过 {max}")

--- a/src/main/java/run/halo/app/model/params/TagParam.java
+++ b/src/main/java/run/halo/app/model/params/TagParam.java
@@ -28,7 +28,7 @@ public class TagParam implements InputConverter<Tag> {
     @Size(max = 255, message = "标签别名的字符长度不能超过 {max}")
     private String slug;
 
-    @Size(max = 20, message = "颜色值字符长度不能超过 {max}")
+    @Size(max = 24, message = "颜色值字符长度不能超过 {max}")
     @ApiModelProperty(value = "标签颜色，支持多种颜色模式，"
         + "例如 Hex: #cfd3d7，颜色名称：LightGrey，RGB: rgb(207, 211, 215)，"
         + "RGBA: rgb(207, 211, 215, 0.5)等", name = "color",

--- a/src/main/java/run/halo/app/model/params/TagParam.java
+++ b/src/main/java/run/halo/app/model/params/TagParam.java
@@ -6,6 +6,7 @@ import lombok.Data;
 import org.apache.commons.lang3.StringUtils;
 import run.halo.app.model.dto.base.InputConverter;
 import run.halo.app.model.entity.Tag;
+import run.halo.app.model.support.HaloConst;
 import run.halo.app.utils.SlugUtils;
 
 /**
@@ -13,6 +14,7 @@ import run.halo.app.utils.SlugUtils;
  *
  * @author johnniang
  * @author ryanwang
+ * @author guqing
  * @date 2019-03-20
  */
 @Data
@@ -24,6 +26,9 @@ public class TagParam implements InputConverter<Tag> {
 
     @Size(max = 255, message = "标签别名的字符长度不能超过 {max}")
     private String slug;
+
+    @Size(max = 20, message = "颜色值字符长度不能超过 {max}")
+    private String color;
 
     @Size(max = 1023, message = "封面图链接的字符长度不能超过 {max}")
     private String thumbnail;
@@ -37,6 +42,10 @@ public class TagParam implements InputConverter<Tag> {
             thumbnail = "";
         }
 
+        if (StringUtils.isBlank(color)) {
+            this.color = HaloConst.DEFAULT_TAG_COLOR;
+        }
+
         return InputConverter.super.convertTo();
     }
 
@@ -47,6 +56,10 @@ public class TagParam implements InputConverter<Tag> {
 
         if (null == thumbnail) {
             thumbnail = "";
+        }
+
+        if (StringUtils.isBlank(color)) {
+            this.color = HaloConst.DEFAULT_TAG_COLOR;
         }
 
         InputConverter.super.update(tag);

--- a/src/main/java/run/halo/app/model/support/HaloConst.java
+++ b/src/main/java/run/halo/app/model/support/HaloConst.java
@@ -62,7 +62,7 @@ public class HaloConst {
     /**
      * Default tag color.
      */
-    public static final String DEFAULT_TAG_COLOR = "#52c41a";
+    public static final String DEFAULT_TAG_COLOR = "#cfd3d7";
 
     /**
      * Path separator.

--- a/src/main/java/run/halo/app/model/support/HaloConst.java
+++ b/src/main/java/run/halo/app/model/support/HaloConst.java
@@ -8,6 +8,7 @@ import org.springframework.http.HttpHeaders;
  * Halo constants.
  *
  * @author ryanwang
+ * @author guqing
  * @date 2017/12/29
  */
 public class HaloConst {
@@ -59,6 +60,11 @@ public class HaloConst {
     public static final String DEFAULT_ERROR_PATH = "common/error/error";
 
     /**
+     * Default tag color.
+     */
+    public static final String DEFAULT_TAG_COLOR = "#52c41a";
+
+    /**
      * Path separator.
      */
     public static final String FILE_SEPARATOR = File.separator;
@@ -67,6 +73,7 @@ public class HaloConst {
      * Post password template name.
      */
     public static final String POST_PASSWORD_TEMPLATE = "post_password";
+
     /**
      * Suffix of freemarker template file.
      */


### PR DESCRIPTION
## What this PR does?
标签支持设置颜色，颜色字段为非必填 默认值为 `#cfd3d7`, 为了返回值客户端统一默认颜色所以`TagDTO`的color字段默认值也为`#cfd3d7`

## Why we need it?
#1559 