### PR TITLE
Remove prefix v of tag name when releasing a new version

### DIFF
--- a/.github/workflows/halo.yml
+++ b/.github/workflows/halo.yml
@@ -49,7 +49,9 @@ jobs:
       - name: Build with Gradle
         run: |
           # Set the version with tag name when releasing
-          sed -i "s/version=.*-SNAPSHOT$/version=${{ github.event.release.tag_name }}/1" gradle.properties
+          version=${{ github.event.release.tag_name }}
+          version=${version#v}
+          sed -i "s/version=.*-SNAPSHOT$/version=$version/1" gradle.properties
           ./gradlew clean build -x test
       - name: Archive halo jar
         uses: actions/upload-artifact@v2


### PR DESCRIPTION
### What this PR dose

Remove prefix v of tag name when releasing a new version.

### Why we need it

We don't need the prefix `v` of the version of halo. This may influence version comparing, making theme installation not working.

![image](https://user-images.githubusercontent.com/16865714/144810351-9f0ddbcb-86c2-4122-9a0d-00e2b64b315d.png)

