### PR TITLE
Automated cherry pick of #1571: Remove prefix v of tag name when releasing a new version

### DIFF
--- a/.github/workflows/halo.yml
+++ b/.github/workflows/halo.yml
@@ -49,7 +49,9 @@ jobs:
       - name: Build with Gradle
         run: |
           # Set the version with tag name when releasing
-          sed -i "s/version=.*-SNAPSHOT$/version=${{ github.event.release.tag_name }}/1" gradle.properties
+          version=${{ github.event.release.tag_name }}
+          version=${version#v}
+          sed -i "s/version=.*-SNAPSHOT$/version=$version/1" gradle.properties
           ./gradlew clean build -x test
       - name: Archive halo jar
         uses: actions/upload-artifact@v2


### PR DESCRIPTION
Cherry pick of #1571 on release-1.4.

#1571: Remove prefix v of tag name when releasing a new version

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```