### PR TITLE
Add some apis for group obtain theme configurations and setting items

### DIFF
--- a/src/main/java/run/halo/app/controller/admin/api/ThemeController.java
+++ b/src/main/java/run/halo/app/controller/admin/api/ThemeController.java
@@ -3,6 +3,7 @@ package run.halo.app.controller.admin.api;
 import io.swagger.annotations.ApiOperation;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -18,17 +19,20 @@ import org.springframework.web.multipart.MultipartFile;
 import run.halo.app.annotation.DisableOnCondition;
 import run.halo.app.cache.lock.CacheLock;
 import run.halo.app.handler.theme.config.support.Group;
+import run.halo.app.handler.theme.config.support.Item;
 import run.halo.app.handler.theme.config.support.ThemeProperty;
 import run.halo.app.model.params.ThemeContentParam;
 import run.halo.app.model.support.BaseResponse;
 import run.halo.app.model.support.ThemeFile;
 import run.halo.app.service.ThemeService;
 import run.halo.app.service.ThemeSettingService;
+import run.halo.app.utils.ServiceUtils;
 
 /**
  * Theme controller.
  *
  * @author ryanwang
+ * @author guqing
  * @date 2019-03-20
  */
 @RestController
@@ -137,6 +141,19 @@ public class ThemeController {
         return themeService.fetchConfig(themeId);
     }
 
+    @GetMapping("{themeId:.+}/configurations/groups/{group}")
+    @ApiOperation("Fetches theme configuration by theme id and group name")
+    public Set<Item> fetchConfigByGroup(@PathVariable("themeId") String themeId,
+        @PathVariable String group) {
+        return themeService.fetchConfigItemsBy(themeId, group);
+    }
+
+    @GetMapping("{themeId:.+}/configurations/groups")
+    @ApiOperation("Fetches theme configuration group names by theme id")
+    public Set<String> fetchConfigGroups(@PathVariable("themeId") String themeId) {
+        return ServiceUtils.fetchProperty(themeService.fetchConfig(themeId), Group::getName);
+    }
+
     @GetMapping("activation/settings")
     @ApiOperation("Lists activated theme settings")
     public Map<String, Object> listSettingsBy() {
@@ -147,6 +164,13 @@ public class ThemeController {
     @ApiOperation("Lists theme settings by theme id")
     public Map<String, Object> listSettingsBy(@PathVariable("themeId") String themeId) {
         return themeSettingService.listAsMapBy(themeId);
+    }
+
+    @GetMapping("{themeId:.+}/groups/{group}/settings")
+    @ApiOperation("Lists theme settings by theme id and group name")
+    public Map<String, Object> listSettingsBy(@PathVariable("themeId") String themeId,
+        @PathVariable String group) {
+        return themeSettingService.listAsMapBy(themeId, group);
     }
 
     @PostMapping("activation/settings")

--- a/src/main/java/run/halo/app/service/ThemeService.java
+++ b/src/main/java/run/halo/app/service/ThemeService.java
@@ -3,10 +3,12 @@ package run.halo.app.service;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import org.springframework.lang.NonNull;
 import org.springframework.lang.Nullable;
 import org.springframework.web.multipart.MultipartFile;
 import run.halo.app.handler.theme.config.support.Group;
+import run.halo.app.handler.theme.config.support.Item;
 import run.halo.app.handler.theme.config.support.ThemeProperty;
 import run.halo.app.model.support.ThemeFile;
 
@@ -14,6 +16,7 @@ import run.halo.app.model.support.ThemeFile;
  * Theme service interface.
  *
  * @author ryanwang
+ * @author guqing
  * @date 2019-03-26
  */
 public interface ThemeService {
@@ -67,7 +70,7 @@ public interface ThemeService {
     Optional<ThemeProperty> fetchThemePropertyBy(@Nullable String themeId);
 
     /**
-     * Gets all themes
+     * Gets all themes.
      *
      * @return set of themes
      */
@@ -95,7 +98,7 @@ public interface ThemeService {
     List<String> listCustomTemplates(@NonNull String themeId, @NonNull String prefix);
 
     /**
-     * Judging whether template exists under the specified theme
+     * Judging whether template exists under the specified theme.
      *
      * @param template template must not be blank
      * @return boolean
@@ -103,7 +106,7 @@ public interface ThemeService {
     boolean templateExists(@Nullable String template);
 
     /**
-     * Checks whether theme exists under template path
+     * Checks whether theme exists under template path.
      *
      * @param themeId theme id
      * @return boolean
@@ -168,6 +171,15 @@ public interface ThemeService {
      */
     @NonNull
     List<Group> fetchConfig(@NonNull String themeId);
+
+    /**
+     * Fetch config items by <code>themeId</code> and <code>group</code>.
+     *
+     * @param themeId theme id must not be blank
+     * @param group group name must not be blank
+     * @return config items
+     */
+    Set<Item> fetchConfigItemsBy(@NonNull String themeId, String group);
 
     /**
      * Renders a theme page.

--- a/src/main/java/run/halo/app/service/ThemeSettingService.java
+++ b/src/main/java/run/halo/app/service/ThemeSettingService.java
@@ -2,9 +2,11 @@ package run.halo.app.service;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import org.springframework.lang.NonNull;
 import org.springframework.lang.Nullable;
 import org.springframework.transaction.annotation.Transactional;
+import run.halo.app.handler.theme.config.support.Item;
 import run.halo.app.model.entity.ThemeSetting;
 import run.halo.app.service.base.CrudService;
 
@@ -54,6 +56,16 @@ public interface ThemeSettingService extends CrudService<ThemeSetting, Integer> 
      */
     @NonNull
     Map<String, Object> listAsMapBy(@NonNull String themeId);
+
+    /**
+     * Lists theme settings as map by <code>themeId</code> and <code>group</code> name.
+     *
+     * @param themeId theme id must not be blank.
+     * @param group theme group name must not be blank.
+     * @return theme setting map(key: item name, value: item)
+     */
+    @NonNull
+    Map<String, Object> listAsMapBy(String themeId, String group);
 
     /**
      * Delete unused theme setting.

--- a/src/main/java/run/halo/app/service/impl/ThemeServiceImpl.java
+++ b/src/main/java/run/halo/app/service/impl/ThemeServiceImpl.java
@@ -6,8 +6,10 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Collections;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import lombok.extern.slf4j.Slf4j;
@@ -33,7 +35,7 @@ import run.halo.app.exception.ThemePropertyMissingException;
 import run.halo.app.exception.ThemeUpdateException;
 import run.halo.app.handler.theme.config.ThemeConfigResolver;
 import run.halo.app.handler.theme.config.support.Group;
-import run.halo.app.handler.theme.config.support.Option;
+import run.halo.app.handler.theme.config.support.Item;
 import run.halo.app.handler.theme.config.support.ThemeProperty;
 import run.halo.app.model.support.HaloConst;
 import run.halo.app.model.support.ThemeFile;
@@ -54,6 +56,7 @@ import run.halo.app.utils.FileUtils;
  * Theme service implementation.
  *
  * @author ryanwang
+ * @author guqing
  * @date 2019-03-26
  */
 @Slf4j
@@ -294,6 +297,16 @@ public class ThemeServiceImpl implements ThemeService {
         } catch (IOException e) {
             throw new ServiceException("读取主题配置文件失败", e);
         }
+    }
+
+    @Override
+    public Set<Item> fetchConfigItemsBy(@NonNull String themeId, @NonNull String group) {
+        return fetchConfig(themeId).stream()
+            .filter(g -> StringUtils.equals(g.getName(), group))
+            .findFirst()
+            .map(Group::getItems)
+            .map(items -> (Set<Item>) new LinkedHashSet<>(items))
+            .orElseGet(Collections::emptySet);
     }
 
     @Override

--- a/src/main/java/run/halo/app/service/impl/ThemeSettingServiceImpl.java
+++ b/src/main/java/run/halo/app/service/impl/ThemeSettingServiceImpl.java
@@ -10,6 +10,7 @@ import java.util.Optional;
 import java.util.Set;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
+import org.jetbrains.annotations.NotNull;
 import org.springframework.data.domain.Example;
 import org.springframework.lang.NonNull;
 import org.springframework.stereotype.Service;
@@ -121,6 +122,7 @@ public class ThemeSettingServiceImpl extends AbstractCrudService<ThemeSetting, I
         }
     }
 
+    @NonNull
     @Override
     public List<ThemeSetting> listBy(String themeId) {
         assertThemeIdHasText(themeId);
@@ -128,10 +130,29 @@ public class ThemeSettingServiceImpl extends AbstractCrudService<ThemeSetting, I
         return themeSettingRepository.findAllByThemeId(themeId);
     }
 
+    @NonNull
     @Override
-    public Map<String, Object> listAsMapBy(String themeId) {
+    public Map<String, Object> listAsMapBy(@NonNull String themeId) {
         // Convert to item map(key: item name, value: item)
         Map<String, Item> itemMap = getConfigItemMap(themeId);
+
+        return listAsMapBy(themeId, itemMap);
+    }
+
+    @NonNull
+    @Override
+    public Map<String, Object> listAsMapBy(String themeId, String group) {
+        // Convert to item map(key: item name, value: item)
+        Set<Item> items = themeService.fetchConfigItemsBy(themeId, group);
+        Map<String, Item> itemMap = ServiceUtils.convertToMap(items, Item::getName);
+
+        return listAsMapBy(themeId, itemMap);
+    }
+
+    @NotNull
+    private Map<String, Object> listAsMapBy(String themeId, Map<String, Item> itemMap) {
+        Assert.notNull(themeId, "The themeId must not be null.");
+        Assert.notNull(itemMap, "The itemMap must not be null.");
 
         // Get theme setting
         List<ThemeSetting> themeSettings = listBy(themeId);
@@ -170,7 +191,6 @@ public class ThemeSettingServiceImpl extends AbstractCrudService<ThemeSetting, I
 
             result.put(name, convertedDefaultValue);
         });
-
         return result;
     }
 


### PR DESCRIPTION
### What this PR does?
- 支持分组获取主题设置表单配置项和值
- 支持根据主题id查询主题所有分组名称
合并后 SDK需要在`admin-api`的`ThemeClient`中添加这三个接口对应的方法

### Why we need it?
如果设置项过多，可能会导致渲染卡顿，因为目前是将所有设置项表单都渲染出来。如果能通过分组名按需调用设置项， 则可以有效改善此问题
相关Issue [主题设置项列表根据 group 获取](https://github.com/halo-dev/halo-admin/issues/227)

### How to test it?
安装一个halo并测试三个接口的功能是否符合期望值，以默认主题`caicai_anatole` 为例调用三接口期望值如下:
1. `/api/admin/themes/caicai_anatole/configurations/groups/sns`
```json
{
    "status": 200,
    "message": "OK",
    "devMessage": null,
    "data": [
        {
            "name": "rss",
            "label": "RSS",
            "type": "RADIO",
            "dataType": "BOOL",
            "defaultValue": true,
            "placeholder": "",
            "description": "",
            "options": [
                {
                    "label": "开启",
                    "value": true
                },
                {
                    "label": "关闭",
                    "value": false
                }
            ]
        },
        {
            "name": "twitter",
            "label": "Twitter",
            "type": "TEXT",
            "dataType": "STRING",
            "defaultValue": null,
            "placeholder": "只需填入 Twitter 用户名即可",
            "description": "",
            "options": []
        },
        {
            "name": "facebook",
            "label": "Facebook",
            "type": "TEXT",
            "dataType": "STRING",
            "defaultValue": null,
            "placeholder": "只需填入 Facebook 用户名即可",
            "description": "",
            "options": []
        },
        {
            "name": "instagram",
            "label": "Instagram",
            "type": "TEXT",
            "dataType": "STRING",
            "defaultValue": null,
            "placeholder": "只需填入 Instagram 用户名即可",
            "description": "",
            "options": []
        },
        {
            "name": "dribbble",
            "label": "Dribbble",
            "type": "TEXT",
            "dataType": "STRING",
            "defaultValue": null,
            "placeholder": "只需填入 Dribbble 用户名即可",
            "description": "",
            "options": []
        },
        {
            "name": "weibo",
            "label": "微博",
            "type": "TEXT",
            "dataType": "STRING",
            "defaultValue": null,
            "placeholder": "只需填入微博 Id 即可",
            "description": "",
            "options": []
        },
        {
            "name": "email",
            "label": "Email",
            "type": "TEXT",
            "dataType": "STRING",
            "defaultValue": null,
            "placeholder": "只需填入邮箱地址即可",
            "description": "",
            "options": []
        },
        {
            "name": "github",
            "label": "Github",
            "type": "TEXT",
            "dataType": "STRING",
            "defaultValue": null,
            "placeholder": "只需填入 Github 用户名即可",
            "description": "",
            "options": []
        },
        {
            "name": "qq",
            "label": "QQ",
            "type": "TEXT",
            "dataType": "STRING",
            "defaultValue": null,
            "placeholder": "只需填入 QQ 号即可",
            "description": "",
            "options": []
        },
        {
            "name": "telegram",
            "label": "Telegram",
            "type": "TEXT",
            "dataType": "STRING",
            "defaultValue": null,
            "placeholder": "只需填入 Telegram Id 即可",
            "description": "",
            "options": []
        }
    ]
}
```
2. `/api/admin/themes/caicai_anatole/groups/sns/settings`
```json
{
    "status": 200,
    "message": "OK",
    "devMessage": null,
    "data": {
        "rss": true
    }
}
```
3. `/api/admin/themes/caicai_anatole/configurations/groups`
```json
{
    "status": 200,
    "message": "OK",
    "devMessage": null,
    "data": [
        "sns",
        "style"
    ]
}
```