### PR TITLE
Fix security warning of log4j 0-day

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -102,7 +102,7 @@ ext {
 dependencies {
     // Aligning log4j dependency versions to 2.15.0
     implementation enforcedPlatform("org.apache.logging.log4j:log4j-core:$log4jVersion")
-    implementation enforcedPlatform("org.apache.logging.log4j:log4j-api:2.15.0")
+    implementation enforcedPlatform("org.apache.logging.log4j:log4j-api:$log4jVersion")
 
     implementation "org.springframework.boot:spring-boot-starter-actuator"
     implementation "org.springframework.boot:spring-boot-starter-data-jpa"

--- a/build.gradle
+++ b/build.gradle
@@ -33,7 +33,6 @@ configurations {
     }
 }
 
-
 bootJar {
     manifest {
         attributes "Implementation-Title": "Halo Application",
@@ -97,9 +96,14 @@ ext {
     huaweiObsVersion = "3.19.7"
     templateInheritanceVersion = "0.4.RELEASE"
     jsoupVersion = "1.13.1"
+    log4jVersion = "2.15.0"
 }
 
 dependencies {
+    // Aligning log4j dependency versions to 2.15.0
+    implementation enforcedPlatform("org.apache.logging.log4j:log4j-core:$log4jVersion")
+    implementation enforcedPlatform("org.apache.logging.log4j:log4j-api:2.15.0")
+
     implementation "org.springframework.boot:spring-boot-starter-actuator"
     implementation "org.springframework.boot:spring-boot-starter-data-jpa"
     implementation "org.springframework.boot:spring-boot-starter-web"

--- a/build.gradle
+++ b/build.gradle
@@ -118,7 +118,8 @@ dependencies {
     implementation "com.aliyun.oss:aliyun-sdk-oss:$aliyunSdkVersion"
     implementation "com.baidubce:bce-java-sdk:$baiduSdkVersion"
     implementation "com.qcloud:cos_api:$qcloudSdkVersion"
-    implementation "com.huaweicloud:esdk-obs-java:$huaweiObsVersion"
+    // TODO Upgrade huaweicloud sdk dependence to fix log4j 0-day vulnerability
+    implementation("com.huaweicloud:esdk-obs-java:$huaweiObsVersion")
     implementation "io.minio:minio:$minioSdkVersion"
     implementation "io.springfox:springfox-boot-starter:$swaggerVersion"
     implementation "commons-fileupload:commons-fileupload:$commonsFileUploadVersion"


### PR DESCRIPTION
### What this PR does?
对齐 gradle 中 log4j 的依赖版本 到 2.15.0 以解决 log4j 0-day 安全漏洞
参考 [gradle文档](https://docs.gradle.org/7.0/userguide/dependency_version_alignment.html)

最终对其后的依赖效果如下：

```shell
$ ./gradlew dependencies | grep log4j                                                                        
+--- org.apache.logging.log4j:log4j-core:2.15.0
|    +--- org.apache.logging.log4j:log4j-api:2.15.0 (c)
|    \--- org.apache.logging.log4j:log4j-api:2.15.0
|         +--- org.apache.logging.log4j:log4j-core:2.15.0 (c)
+--- org.apache.logging.log4j:log4j-api:2.15.0 (*)
|    |    |    +--- org.apache.logging.log4j:log4j-to-slf4j:2.14.1
|    |    |    |    \--- org.apache.logging.log4j:log4j-api:2.14.1 -> 2.15.0 (*)
|    +--- org.apache.logging.log4j:log4j-core:2.8.2 -> 2.15.0 (*)
|    \--- org.apache.logging.log4j:log4j-api:2.8.2 -> 2.15.0 (*)
+--- org.apache.logging.log4j:log4j-core:2.15.0 (n)
+--- org.apache.logging.log4j:log4j-api:2.15.0 (n)
+--- org.apache.logging.log4j:log4j-core:2.15.0
|    +--- org.apache.logging.log4j:log4j-api:2.15.0 (c)
|    \--- org.apache.logging.log4j:log4j-api:2.15.0
|         +--- org.apache.logging.log4j:log4j-core:2.15.0 (c)
+--- org.apache.logging.log4j:log4j-api:2.15.0 (*)
|    |    |    +--- org.apache.logging.log4j:log4j-to-slf4j:2.14.1
|    |    |    |    \--- org.apache.logging.log4j:log4j-api:2.14.1 -> 2.15.0 (*)
|    +--- org.apache.logging.log4j:log4j-core:2.8.2 -> 2.15.0 (*)
|    \--- org.apache.logging.log4j:log4j-api:2.8.2 -> 2.15.0 (*)
+--- org.apache.logging.log4j:log4j-core:2.15.0
|    +--- org.apache.logging.log4j:log4j-api:2.15.0 (c)
|    \--- org.apache.logging.log4j:log4j-api:2.15.0
|         +--- org.apache.logging.log4j:log4j-core:2.15.0 (c)
+--- org.apache.logging.log4j:log4j-api:2.15.0 (*)
|    |    |    +--- org.apache.logging.log4j:log4j-to-slf4j:2.14.1
|    |    |    |    \--- org.apache.logging.log4j:log4j-api:2.14.1 -> 2.15.0 (*)
|    +--- org.apache.logging.log4j:log4j-core:2.8.2 -> 2.15.0 (*)
|    \--- org.apache.logging.log4j:log4j-api:2.8.2 -> 2.15.0 (*)
+--- org.apache.logging.log4j:log4j-core:2.15.0
|    +--- org.apache.logging.log4j:log4j-api:2.15.0 (c)
|    \--- org.apache.logging.log4j:log4j-api:2.15.0
|         +--- org.apache.logging.log4j:log4j-core:2.15.0 (c)
+--- org.apache.logging.log4j:log4j-api:2.15.0 (*)
|    |    |    +--- org.apache.logging.log4j:log4j-to-slf4j:2.14.1
|    |    |    |    \--- org.apache.logging.log4j:log4j-api:2.14.1 -> 2.15.0 (*)
|    +--- org.apache.logging.log4j:log4j-core:2.8.2 -> 2.15.0 (*)
|    \--- org.apache.logging.log4j:log4j-api:2.8.2 -> 2.15.0 (*)
+--- org.apache.logging.log4j:log4j-core:2.15.0
|    +--- org.apache.logging.log4j:log4j-api:2.15.0 (c)
|    \--- org.apache.logging.log4j:log4j-api:2.15.0
|         +--- org.apache.logging.log4j:log4j-core:2.15.0 (c)
+--- org.apache.logging.log4j:log4j-api:2.15.0 (*)
|    |    |    +--- org.apache.logging.log4j:log4j-to-slf4j:2.14.1
|    |    |    |    \--- org.apache.logging.log4j:log4j-api:2.14.1 -> 2.15.0 (*)
|    +--- org.apache.logging.log4j:log4j-core:2.8.2 -> 2.15.0 (*)
|    \--- org.apache.logging.log4j:log4j-api:2.8.2 -> 2.15.0 (*)

```
### Why we need it?
在广泛使用的 Java 日志库 Apache Log4j 中新发现的 0-day 漏洞很容易被利用，并使攻击者能够完全控制受影响的服务器。
该漏洞被跟踪为[CVE-2021-44228](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-44228)，被归类为严重漏洞，允许未经身份验证的远程代码执行。

### How to test it?
拉取该PR到本地运行后都点击一下看是否有功能不可用, 我已自测但还是需要拉取跑一下看看，以防止遗漏