### PR TITLE
Refactor gradle config of log4j version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,6 +33,15 @@ configurations {
     }
 }
 
+configurations.all {
+    // Aligning log4j dependency versions to 2.15.0
+    resolutionStrategy.eachDependency { DependencyResolveDetails details ->
+        if (details.requested.group == 'org.apache.logging.log4j') {
+            details.useVersion '2.15.0'
+        }
+    }
+}
+
 bootJar {
     manifest {
         attributes "Implementation-Title": "Halo Application",
@@ -96,14 +105,9 @@ ext {
     huaweiObsVersion = "3.19.7"
     templateInheritanceVersion = "0.4.RELEASE"
     jsoupVersion = "1.13.1"
-    log4jVersion = "2.15.0"
 }
 
 dependencies {
-    // Aligning log4j dependency versions to 2.15.0
-    implementation enforcedPlatform("org.apache.logging.log4j:log4j-core:$log4jVersion")
-    implementation enforcedPlatform("org.apache.logging.log4j:log4j-api:$log4jVersion")
-
     implementation "org.springframework.boot:spring-boot-starter-actuator"
     implementation "org.springframework.boot:spring-boot-starter-data-jpa"
     implementation "org.springframework.boot:spring-boot-starter-web"


### PR DESCRIPTION
### What this PR does?
由于升级springboot 2.5.7的需要，原先的配置无法适应该升级会导致build失败，因此重构配置。