### PR TITLE
Automated cherry pick of #1604: fix: Log4j Security Vulnerabilities

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -34,10 +34,10 @@ configurations {
 }
 
 configurations.all {
-    // Aligning log4j dependency versions to 2.15.0
+    // Aligning log4j dependency versions to 2.17.0
     resolutionStrategy.eachDependency { DependencyResolveDetails details ->
         if (details.requested.group == 'org.apache.logging.log4j') {
-            details.useVersion '2.15.0'
+            details.useVersion '2.17.0'
         }
     }
 }


### PR DESCRIPTION
Cherry pick of #1604 on release-1.4.

#1604: fix: Log4j Security Vulnerabilities

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```