### PR TITLE
Automated cherry pick of #1615: chore: upgrade log4j dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -34,10 +34,10 @@ configurations {
 }
 
 configurations.all {
-    // Aligning log4j dependency versions to 2.17.0
+    // Aligning log4j dependency versions to 2.17.1
     resolutionStrategy.eachDependency { DependencyResolveDetails details ->
         if (details.requested.group == 'org.apache.logging.log4j') {
-            details.useVersion '2.17.0'
+            details.useVersion '2.17.1'
         }
     }
 }


### PR DESCRIPTION
Cherry pick of #1615 on release-1.4.

#1615: chore: upgrade log4j dependencies

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```