### PR TITLE
Fix the problem where the activated field was not set correctly for a theme property

### DIFF
--- a/src/test/java/run/halo/app/repository/ThemeRepositoryImplTest.java
+++ b/src/test/java/run/halo/app/repository/ThemeRepositoryImplTest.java
@@ -60,13 +60,13 @@ class ThemeRepositoryImplTest {
 
         given(optionRepository.findByKey(THEME.getValue())).willReturn(Optional.empty());
         doReturn(Optional.of(expectedTheme)).when(themeRepository)
-            .fetchThemeByThemeId(HaloConst.DEFAULT_THEME_ID);
+            .fetchThemePropertyByThemeId(HaloConst.DEFAULT_THEME_ID);
 
         ThemeProperty resultTheme = themeRepository.getActivatedThemeProperty();
         assertEquals(expectedTheme, resultTheme);
 
         verify(optionRepository, times(1)).findByKey(any());
-        verify(themeRepository, times(1)).fetchThemeByThemeId(any());
+        verify(themeRepository, times(1)).fetchThemePropertyByThemeId(any());
     }
 
     @Test
@@ -77,7 +77,7 @@ class ThemeRepositoryImplTest {
 
         given(optionRepository.findByKey(THEME.getValue())).willReturn(Optional.empty());
         doReturn(Optional.of(expectedTheme)).when(themeRepository)
-            .fetchThemeByThemeId(HaloConst.DEFAULT_THEME_ID);
+            .fetchThemePropertyByThemeId(HaloConst.DEFAULT_THEME_ID);
 
         ExecutorService executorService = Executors.newFixedThreadPool(10);
         // define tasks
@@ -96,7 +96,7 @@ class ThemeRepositoryImplTest {
         });
 
         verify(optionRepository, times(1)).findByKey(any());
-        verify(themeRepository, times(1)).fetchThemeByThemeId(any());
+        verify(themeRepository, times(1)).fetchThemePropertyByThemeId(any());
     }
 
 }


### PR DESCRIPTION
### What this PR dose / Why we need it

Currently, when we get a theme property, the activated field is always false. This PR tries to fix this problem while fetching theme property from disk.

### Which issue this PR fixes?

Fix #1629 .

### Test result

```bash
╭─johnniang at x1c in / 22-01-15 - 18:11:12
╰─○ curl 'http://localhost:8090/api/admin/themes/caicai_anatole' \
  -H 'Connection: keep-alive' \
  -H 'Admin-Authorization: f2b1955c18f34************86edd270c' \
  -H 'Accept: application/json, text/plain, */*' \
  -H 'sec-ch-ua-mobile: ?0' \
  -H 'User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/97.0.4692.71 Safari/537.36 Edg/97.0.1072.62' \
  -H 'sec-ch-ua: " Not;A Brand";v="99", "Microsoft Edge";v="97", "Chromium";v="97"' \
  -H 'sec-ch-ua-platform: "Windows"' \
  -H 'Sec-Fetch-Site: same-origin' \
  -H 'Sec-Fetch-Mode: cors' \
  -H 'Sec-Fetch-Dest: empty' \
  -H 'Referer: http://localhost:8090/admin/index.html' \
  -H 'Accept-Language: en,zh-CN;q=0.9,zh;q=0.8,en-GB;q=0.7,en-US;q=0.6' \
  -H 'Cookie: JSESSIONID=node04u1egvos73wt11dfxy7yt124x0.node0' \
  --compressed | jq .
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   376    0   376    0     0  31333      0 --:--:-- --:--:-- --:--:-- 31333
{
  "status": 200,
  "message": "OK",
  "devMessage": null,
  "data": {
    "id": "caicai_anatole",
    "name": "Anatole",
    "website": "https://github.com/halo-dev/halo-theme-anatole",
    "branch": "master",
    "repo": "https://github.com/halo-dev/halo-theme-anatole",
    "updateStrategy": "RELEASE",
    "description": "A other Halo theme",
    "logo": "https://avatars1.githubusercontent.com/u/1811819?s=460&v=4",
    "version": "1.2.0",
    "require": "1.3.0",
    "author": {
      "name": "Caicai",
      "website": "https://www.caicai.me",
      "avatar": null
    },
    "themePath": "/home/johnniang/halo-dev/templates/themes/caicai_anatole",
    "folderName": "caicai_anatole",
    "hasOptions": true,
    "screenshots": "/themes/caicai_anatole/screenshot.png",
    "postMetaField": null,
    "sheetMetaField": null,
    "activated": true
  }
}
```