### PR TITLE
Add post backup for contents and content_patch_logs

### DIFF
--- a/src/main/java/run/halo/app/service/ContentPatchLogService.java
+++ b/src/main/java/run/halo/app/service/ContentPatchLogService.java
@@ -1,10 +1,10 @@
 package run.halo.app.service;
 
 import java.util.List;
-import run.halo.app.exception.NotFoundException;
 import run.halo.app.model.entity.Content.ContentDiff;
 import run.halo.app.model.entity.Content.PatchedContent;
 import run.halo.app.model.entity.ContentPatchLog;
+import run.halo.app.service.base.CrudService;
 
 /**
  * Content patch log service.
@@ -12,7 +12,7 @@ import run.halo.app.model.entity.ContentPatchLog;
  * @author guqing
  * @since 2022-01-04
  */
-public interface ContentPatchLogService {
+public interface ContentPatchLogService extends CrudService<ContentPatchLog, Integer> {
 
     /**
      * Create or update content patch log by post content.
@@ -43,28 +43,12 @@ public interface ContentPatchLogService {
     ContentDiff generateDiff(Integer postId, String content, String originalContent);
 
     /**
-     * Creates or updates the {@link ContentPatchLog}.
-     *
-     * @param contentPatchLog param to create or update
-     */
-    void save(ContentPatchLog contentPatchLog);
-
-    /**
      * Gets the patch log record of the draft status of the content by post id.
      *
      * @param postId post id.
      * @return content patch log record.
      */
     ContentPatchLog getDraftByPostId(Integer postId);
-
-    /**
-     * Gets content patch log by id.
-     *
-     * @param id id
-     * @return a content patch log
-     * @throws NotFoundException if record not found.
-     */
-    ContentPatchLog getById(Integer id);
 
     /**
      * Gets content patch log by post id.

--- a/src/main/java/run/halo/app/service/impl/BackupServiceImpl.java
+++ b/src/main/java/run/halo/app/service/impl/BackupServiceImpl.java
@@ -21,6 +21,7 @@ import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -100,6 +101,7 @@ import run.halo.app.utils.DateUtils;
 import run.halo.app.utils.FileUtils;
 import run.halo.app.utils.HaloUtils;
 import run.halo.app.utils.JsonUtils;
+import run.halo.app.utils.VersionUtil;
 
 /**
  * Backup service implementation.
@@ -452,8 +454,9 @@ public class BackupServiceImpl implements BackupService {
             };
         HashMap<String, Object> data = mapper.readValue(jsonContent, typeRef);
 
-        if (!HaloConst.HALO_VERSION.equals(data.get("version"))) {
-            throw new IllegalArgumentException("导入数据版本号与当前系统版本号不匹配，不支持导入！");
+        String version = (String) Objects.requireNonNullElse(data.get("version"), "");
+        if (!VersionUtil.hasSameMajorAndMinorVersion(HaloConst.HALO_VERSION, version)) {
+            throw new IllegalArgumentException("导入数据的主次版本号与当前系统版本号不匹配，不支持导入！");
         }
 
         List<Attachment> attachments = Arrays.asList(mapper

--- a/src/main/java/run/halo/app/service/impl/ContentPatchLogServiceImpl.java
+++ b/src/main/java/run/halo/app/service/impl/ContentPatchLogServiceImpl.java
@@ -16,6 +16,7 @@ import run.halo.app.model.enums.PostStatus;
 import run.halo.app.repository.ContentPatchLogRepository;
 import run.halo.app.repository.ContentRepository;
 import run.halo.app.service.ContentPatchLogService;
+import run.halo.app.service.base.AbstractCrudService;
 import run.halo.app.utils.PatchUtils;
 
 /**
@@ -25,7 +26,8 @@ import run.halo.app.utils.PatchUtils;
  * @since 2022-01-04
  */
 @Service
-public class ContentPatchLogServiceImpl implements ContentPatchLogService {
+public class ContentPatchLogServiceImpl extends AbstractCrudService<ContentPatchLog, Integer>
+    implements ContentPatchLogService {
 
     /**
      * base version of content patch log.
@@ -38,6 +40,7 @@ public class ContentPatchLogServiceImpl implements ContentPatchLogService {
 
     public ContentPatchLogServiceImpl(ContentPatchLogRepository contentPatchLogRepository,
         ContentRepository contentRepository) {
+        super(contentPatchLogRepository);
         this.contentPatchLogRepository = contentPatchLogRepository;
         this.contentRepository = contentRepository;
     }
@@ -80,12 +83,6 @@ public class ContentPatchLogServiceImpl implements ContentPatchLogService {
             version = latestPatchLog.getVersion();
         }
         return version;
-    }
-
-    @Override
-    @Transactional(rollbackFor = Exception.class)
-    public void save(ContentPatchLog contentPatchLog) {
-        contentPatchLogRepository.save(contentPatchLog);
     }
 
     private ContentPatchLog createDraftContent(Integer postId, Integer version,

--- a/src/main/java/run/halo/app/service/impl/ContentServiceImpl.java
+++ b/src/main/java/run/halo/app/service/impl/ContentServiceImpl.java
@@ -76,7 +76,7 @@ public class ContentServiceImpl extends AbstractCrudService<Content, Integer>
         }
         contentPatchLog.setStatus(PostStatus.PUBLISHED);
         contentPatchLog.setPublishTime(new Date());
-        contentPatchLogService.save(contentPatchLog);
+        contentPatchLogService.create(contentPatchLog);
 
         Content postContent = getById(postId);
         postContent.setPatchLogId(contentPatchLog.getId());

--- a/src/main/java/run/halo/app/service/impl/PostServiceImpl.java
+++ b/src/main/java/run/halo/app/service/impl/PostServiceImpl.java
@@ -983,6 +983,8 @@ public class PostServiceImpl extends BasePostServiceImpl<Post> implements PostSe
         List<Post> allPostList = listAll();
         List<PostMarkdownVO> result = new ArrayList<>(allPostList.size());
         for (Post post : allPostList) {
+            Content postContent = getContentById(post.getId());
+            post.setContent(PatchedContent.of(postContent));
             result.add(convertToPostMarkdownVo(post));
         }
         return result;

--- a/src/main/java/run/halo/app/utils/VersionUtil.java
+++ b/src/main/java/run/halo/app/utils/VersionUtil.java
@@ -29,4 +29,17 @@ public final class VersionUtil {
         return leftVersion.compareTo(rightVersion) >= 0;
     }
 
+    /**
+     * Compare two versions to see if they have the same major and minor versions.
+     *
+     * @param left version A to compare
+     * @param right version B to compare
+     * @return {@code true} if they have the same major and minor version.
+     */
+    public static boolean hasSameMajorAndMinorVersion(String left, String right) {
+        Version leftVersion = Version.resolve(left).orElse(Version.emptyVersion());
+        Version rightVersion = Version.resolve(right).orElse(Version.emptyVersion());
+        return leftVersion.getMajor() == rightVersion.getMajor()
+            && leftVersion.getMinor() == rightVersion.getMinor();
+    }
 }

--- a/src/test/java/run/halo/app/utils/VersionUtilTest.java
+++ b/src/test/java/run/halo/app/utils/VersionUtilTest.java
@@ -1,5 +1,6 @@
 package run.halo.app.utils;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -33,4 +34,23 @@ class VersionUtilTest {
         assertTrue(VersionUtil.compareVersion(HaloConst.UNKNOWN_VERSION, randomVersion));
     }
 
+    @Test
+    void hasSameMajorAndMinorVersionTest() {
+        assertThat(
+            VersionUtil.hasSameMajorAndMinorVersion(HaloConst.UNKNOWN_VERSION, "1.4.0")).isFalse();
+
+        assertThat(VersionUtil.hasSameMajorAndMinorVersion("1.3.1", "1.5.8")).isFalse();
+
+        assertThat(VersionUtil.hasSameMajorAndMinorVersion("1.2.4.alpha-1", "1.3.5")).isFalse();
+
+        assertThat(VersionUtil.hasSameMajorAndMinorVersion("0.0.4", "0.0.1")).isTrue();
+
+        assertThat(VersionUtil.hasSameMajorAndMinorVersion("1.0.4", "1.0.5-alpha.1")).isTrue();
+
+        assertThat(VersionUtil.hasSameMajorAndMinorVersion("1.0.4", "1.0.5-rc.1")).isTrue();
+
+        assertThat(VersionUtil.hasSameMajorAndMinorVersion("2.0.0", "2.0.1")).isTrue();
+
+        assertThat(VersionUtil.hasSameMajorAndMinorVersion(null, null)).isTrue();
+    }
 }


### PR DESCRIPTION
### What this PR does?
拆分了内容表后同步修改博客json备份和markdown备份

导入数据只支持导入与系统版本号具有相同主&次版本号的json数据，有几点考虑：
1. 如果支持导入任意版本的备份，后续升级都需要做兼容还需要考虑跨版本升级，而功能不常用却投入巨大
> 要兼容跨版本升级和任意版本导入就要根据不同版本创建导入json的后置处理器，然后根据系统版本和备份版本选择执行哪些后置处理器和决策后置处理器的执行顺序，随着版本号增加，后置处理器会变多且随系统启动时一直被注册在系统中但该功能却只会在整个系统生命周期开始时被执行一次，投入与使用频率严重不成比例
2. 用户可以选择先使用与导出备份相同的版本相同的 halo 大版本jar包升级系统导入json后在升级新版本jar包，这种情况只存在夸服务器迁移并升级
3. 改动表结构才需要考虑兼容导入备份的逻辑，而改动表结构只会存在主(major)版本或次(minor)版本,因此退而求其次，允许在相同的主次版本之间随意导入json备份，减少了不必要的投入