### PR TITLE
Fix the leak of version number inference when create or update content patch

### DIFF
--- a/src/main/java/run/halo/app/service/impl/ContentPatchLogServiceImpl.java
+++ b/src/main/java/run/halo/app/service/impl/ContentPatchLogServiceImpl.java
@@ -70,7 +70,8 @@ public class ContentPatchLogServiceImpl implements ContentPatchLogService {
         if (latestPatchLog == null) {
             // There is no patchLog record
             version = 1;
-        } else if (PostStatus.PUBLISHED.equals(latestPatchLog.getStatus())) {
+        } else if (PostStatus.PUBLISHED.equals(latestPatchLog.getStatus())
+            || PostStatus.INTIMATE.equals(latestPatchLog.getStatus())) {
             // There is no draft, a draft record needs to be created
             // so the version number needs to be incremented
             version = latestPatchLog.getVersion() + 1;


### PR DESCRIPTION
### What this PR does?
保存或更新文章快照时对于加密状态的文章也应该提升版本号，否则会导致私密文章快照增量不正确

### Why we need it?
目前私密状态文章处于一个特殊的模糊态，对于私密文章只能每保存一次就提升版本号（生成新快照）否则会导致在刚升级到1.5.0.alpha-1时无法保存私密文章只有发布一次才能保存的问题，后续建议将私密状态单独使用一个字段处理比如 `is_public(true/false)` 表示公开或私有