### PR TITLE
Fix the problem jsonToCacheWrapper crashes when cache value is not JSON format

### DIFF
--- a/src/main/java/run/halo/app/cache/AbstractStringCacheStore.java
+++ b/src/main/java/run/halo/app/cache/AbstractStringCacheStore.java
@@ -1,6 +1,7 @@
 package run.halo.app.cache;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
 import java.io.IOException;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
@@ -22,8 +23,8 @@ public abstract class AbstractStringCacheStore extends AbstractCacheStore<String
         Assert.hasText(json, "json value must not be null");
         CacheWrapper<String> cacheWrapper = null;
         try {
-            cacheWrapper = JsonUtils.jsonToObject(json, CacheWrapper.class);
-        } catch (IOException e) {
+            cacheWrapper = JsonUtils.jsonToObject(json, new TypeReference<>() {});
+        } catch (Exception e) {
             log.debug("Failed to convert json to wrapper value bytes: [{}]", json, e);
         }
         return Optional.ofNullable(cacheWrapper);

--- a/src/test/java/run/halo/app/cache/LevelCacheStoreTest.java
+++ b/src/test/java/run/halo/app/cache/LevelCacheStoreTest.java
@@ -1,0 +1,54 @@
+package run.halo.app.cache;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static run.halo.app.model.support.HaloConst.FILE_SEPARATOR;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.Optional;
+import org.iq80.leveldb.DB;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+import run.halo.app.config.properties.HaloProperties;
+import run.halo.app.utils.FileUtils;
+
+/**
+ * @author guqing
+ * @date 2022-03-02
+ */
+public class LevelCacheStoreTest {
+    LevelCacheStore cacheStore;
+    HaloProperties haloProperties = new HaloProperties();
+
+    @BeforeEach
+    void setUp() throws IOException {
+        String testDir = FileUtils.createTempDirectory().toString();
+        System.out.println(testDir);
+        haloProperties.setWorkDir(testDir + FILE_SEPARATOR);
+        cacheStore = new LevelCacheStore(haloProperties);
+        cacheStore.init();
+    }
+
+    @Test
+    public void corruptCacheStructureTest() {
+        cacheStore.put("A", "B");
+
+        // Simulate corrupt cache structure
+        DB levelDb = (DB) ReflectionTestUtils.getField(cacheStore, "LEVEL_DB");
+        levelDb.put("B".getBytes(StandardCharsets.UTF_8), "NOT_JSON".getBytes(StandardCharsets.UTF_8));
+
+        Optional<CacheWrapper> bOpt = cacheStore.getAny("B", CacheWrapper.class);
+        assertThat(bOpt).isNotNull();
+        assertThat(bOpt.isEmpty()).isTrue();
+
+        assertThat(cacheStore.toMap().toString()).isEqualTo("{A=B, B=null}");
+    }
+
+    @AfterEach
+    public void cleanUp() {
+        cacheStore.delete("A");
+        cacheStore.delete("B");
+    }
+}

--- a/src/test/java/run/halo/app/cache/LevelCacheStoreTest.java
+++ b/src/test/java/run/halo/app/cache/LevelCacheStoreTest.java
@@ -37,7 +37,8 @@ public class LevelCacheStoreTest {
 
         // Simulate corrupt cache structure
         DB levelDb = (DB) ReflectionTestUtils.getField(cacheStore, "LEVEL_DB");
-        levelDb.put("B".getBytes(StandardCharsets.UTF_8), "NOT_JSON".getBytes(StandardCharsets.UTF_8));
+        levelDb.put("B".getBytes(StandardCharsets.UTF_8),
+            "NOT_JSON".getBytes(StandardCharsets.UTF_8));
 
         Optional<CacheWrapper> bOpt = cacheStore.getAny("B", CacheWrapper.class);
         assertThat(bOpt).isNotNull();


### PR DESCRIPTION
### What this PR does?
对`jsonToCacheWrapper(String json)`方法捕获的异常放宽为`Exception`,也就是一旦转换出错就不放入缓存，否则出现未处理异常时会导致功能无法使用

### Why we need it?
Fix #1681, #1683
但没有完全解决 #1683 问题，所以不应该关联关闭它