### PR TITLE
Disable standard streams of test logging

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -143,6 +143,5 @@ dependencies {
 }
 
 test {
-    useJUnitPlatform()
-    testLogging.showStandardStreams = true
+    useJUnitPlatform
 }

--- a/build.gradle
+++ b/build.gradle
@@ -143,5 +143,5 @@ dependencies {
 }
 
 test {
-    useJUnitPlatform
+    useJUnitPlatform()
 }


### PR DESCRIPTION
### What this PR does

As mentioned in title.

### Why do we need it?

Too many logging outputs will disturb us to see which test case failed. You can see https://github.com/halo-dev/halo/runs/5401606115?check_suite_focus=true#step:4:4633.

/cc @halo-dev/sig-halo 