### PR TITLE
Fix the exception of content not found when empty sheet deleted

### DIFF
--- a/src/main/java/run/halo/app/service/assembler/BasePostAssembler.java
+++ b/src/main/java/run/halo/app/service/assembler/BasePostAssembler.java
@@ -179,8 +179,12 @@ public class BasePostAssembler<POST extends BasePost> {
 
         PatchedContent patchedContent = post.getContentOfNullable();
         if (patchedContent == null) {
-            Content postContent = contentService.getById(post.getId());
-            postVo.setSummary(generateSummary(postContent.getContent()));
+            Content postContent = contentService.getByIdOfNullable(post.getId());
+            if (postContent != null) {
+                postVo.setSummary(generateSummary(postContent.getContent()));
+            } else {
+                postVo.setSummary(StringUtils.EMPTY);
+            }
         } else {
             postVo.setSummary(generateSummary(patchedContent.getContent()));
         }

--- a/src/main/java/run/halo/app/service/impl/PostServiceImpl.java
+++ b/src/main/java/run/halo/app/service/impl/PostServiceImpl.java
@@ -518,6 +518,7 @@ public class PostServiceImpl extends BasePostServiceImpl<Post> implements PostSe
         log.debug("Removed post content: [{}]", postContent);
 
         Post deletedPost = super.removeById(postId);
+        deletedPost.setContent(PatchedContent.of(postContent));
 
         // Log it
         eventPublisher.publishEvent(new LogEvent(this, postId.toString(), LogType.POST_DELETED,

--- a/src/main/java/run/halo/app/service/impl/SheetServiceImpl.java
+++ b/src/main/java/run/halo/app/service/impl/SheetServiceImpl.java
@@ -275,6 +275,7 @@ public class SheetServiceImpl extends BasePostServiceImpl<Sheet>
         log.debug("Removed sheet content: [{}]", sheetContent);
 
         Sheet sheet = super.removeById(id);
+        sheet.setContent(PatchedContent.of(sheetContent));
 
         // Log it
         eventPublisher.publishEvent(


### PR DESCRIPTION
### What this PR does?
修复文章内容删除后给前端返回被删除数据时，调用过生成摘要方法的时候getById报内容找不到异常的问题

### Why we need it?
Fix #1713