### PR TITLE
Fix the problem of no EntityManager with actual transaction available for current thread then remove method called

### DIFF
--- a/src/main/java/run/halo/app/service/impl/BaseCommentServiceImpl.java
+++ b/src/main/java/run/halo/app/service/impl/BaseCommentServiceImpl.java
@@ -27,6 +27,7 @@ import org.springframework.data.jpa.domain.Specification;
 import org.springframework.http.HttpHeaders;
 import org.springframework.lang.NonNull;
 import org.springframework.lang.Nullable;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.Assert;
 import org.springframework.util.CollectionUtils;
 import run.halo.app.event.comment.CommentNewEvent;
@@ -304,6 +305,7 @@ public abstract class BaseCommentServiceImpl<COMMENT extends BaseComment>
 
     @Override
     @NonNull
+    @Transactional(rollbackFor = Exception.class)
     public COMMENT create(@NonNull COMMENT comment) {
         Assert.notNull(comment, "Domain must not be null");
 
@@ -369,6 +371,7 @@ public abstract class BaseCommentServiceImpl<COMMENT extends BaseComment>
 
     @Override
     @NonNull
+    @Transactional(rollbackFor = Exception.class)
     public COMMENT createBy(@NonNull BaseCommentParam<COMMENT> commentParam) {
         Assert.notNull(commentParam, "Comment param must not be null");
 
@@ -402,6 +405,7 @@ public abstract class BaseCommentServiceImpl<COMMENT extends BaseComment>
 
     @Override
     @NonNull
+    @Transactional(rollbackFor = Exception.class)
     public COMMENT updateStatus(@NonNull Long commentId, @NonNull CommentStatus status) {
         Assert.notNull(commentId, "Comment id must not be null");
         Assert.notNull(status, "Comment status must not be null");
@@ -418,6 +422,7 @@ public abstract class BaseCommentServiceImpl<COMMENT extends BaseComment>
 
     @Override
     @NonNull
+    @Transactional(rollbackFor = Exception.class)
     public List<COMMENT> updateStatusByIds(@NonNull List<Long> ids, @NonNull CommentStatus status) {
         if (CollectionUtils.isEmpty(ids)) {
             return Collections.emptyList();
@@ -428,6 +433,7 @@ public abstract class BaseCommentServiceImpl<COMMENT extends BaseComment>
     }
 
     @Override
+    @Transactional(rollbackFor = Exception.class)
     public List<COMMENT> removeByPostId(@NonNull Integer postId) {
         Assert.notNull(postId, "Post id must not be null");
         return baseCommentRepository.deleteByPostId(postId);
@@ -435,6 +441,7 @@ public abstract class BaseCommentServiceImpl<COMMENT extends BaseComment>
 
     @Override
     @NonNull
+    @Transactional(rollbackFor = Exception.class)
     public COMMENT removeById(@NonNull Long id) {
         Assert.notNull(id, "Comment id must not be null");
 
@@ -455,6 +462,7 @@ public abstract class BaseCommentServiceImpl<COMMENT extends BaseComment>
 
     @Override
     @NonNull
+    @Transactional(rollbackFor = Exception.class)
     public List<COMMENT> removeByIds(@NonNull Collection<Long> ids) {
         if (CollectionUtils.isEmpty(ids)) {
             return Collections.emptyList();

--- a/src/main/java/run/halo/app/service/impl/BasePostServiceImpl.java
+++ b/src/main/java/run/halo/app/service/impl/BasePostServiceImpl.java
@@ -264,13 +264,13 @@ public abstract class BasePostServiceImpl<POST extends BasePost>
     }
 
     @Override
-    @Transactional
+    @Transactional(rollbackFor = Exception.class)
     public void increaseVisit(Integer postId) {
         increaseVisit(1L, postId);
     }
 
     @Override
-    @Transactional
+    @Transactional(rollbackFor = Exception.class)
     public void increaseLike(long likes, Integer postId) {
         Assert.isTrue(likes > 0, "Likes to increase must not be less than 1");
         Assert.notNull(postId, "Post id must not be null");
@@ -285,7 +285,7 @@ public abstract class BasePostServiceImpl<POST extends BasePost>
     }
 
     @Override
-    @Transactional
+    @Transactional(rollbackFor = Exception.class)
     public void increaseLike(Integer postId) {
         increaseLike(1L, postId);
     }
@@ -295,7 +295,7 @@ public abstract class BasePostServiceImpl<POST extends BasePost>
      * @return post with handled data
      */
     @Override
-    @Transactional
+    @Transactional(rollbackFor = Exception.class)
     public POST createOrUpdateBy(POST post) {
         Assert.notNull(post, "Post must not be null");
         PatchedContent postContent = post.getContent();
@@ -344,7 +344,7 @@ public abstract class BasePostServiceImpl<POST extends BasePost>
     }
 
     @Override
-    @Transactional
+    @Transactional(rollbackFor = Exception.class)
     public POST updateStatus(PostStatus status, Integer postId) {
         Assert.notNull(status, "Post status must not be null");
         Assert.isTrue(!ServiceUtils.isEmptyId(postId), "Post id must not be empty");
@@ -374,7 +374,7 @@ public abstract class BasePostServiceImpl<POST extends BasePost>
     }
 
     @Override
-    @Transactional
+    @Transactional(rollbackFor = Exception.class)
     public List<POST> updateStatusByIds(List<Integer> ids, PostStatus status) {
         if (CollectionUtils.isEmpty(ids)) {
             return Collections.emptyList();
@@ -403,6 +403,7 @@ public abstract class BasePostServiceImpl<POST extends BasePost>
     }
 
     @Override
+    @Transactional(rollbackFor = Exception.class)
     public POST create(POST post) {
         // Check title
         slugMustNotExist(post);
@@ -411,6 +412,7 @@ public abstract class BasePostServiceImpl<POST extends BasePost>
     }
 
     @Override
+    @Transactional(rollbackFor = Exception.class)
     public POST update(POST post) {
         // Check title
         slugMustNotExist(post);

--- a/src/main/java/run/halo/app/service/impl/PostServiceImpl.java
+++ b/src/main/java/run/halo/app/service/impl/PostServiceImpl.java
@@ -163,7 +163,7 @@ public class PostServiceImpl extends BasePostServiceImpl<Post> implements PostSe
     }
 
     @Override
-    @Transactional
+    @Transactional(rollbackFor = Exception.class)
     public PostDetailVO createBy(Post postToCreate, Set<Integer> tagIds, Set<Integer> categoryIds,
         Set<PostMeta> metas, boolean autoSave) {
         PostDetailVO createdPost = createOrUpdate(postToCreate, tagIds, categoryIds, metas);
@@ -177,6 +177,7 @@ public class PostServiceImpl extends BasePostServiceImpl<Post> implements PostSe
     }
 
     @Override
+    @Transactional(rollbackFor = Exception.class)
     public PostDetailVO createBy(Post postToCreate, Set<Integer> tagIds, Set<Integer> categoryIds,
         boolean autoSave) {
         PostDetailVO createdPost = createOrUpdate(postToCreate, tagIds, categoryIds, null);
@@ -190,7 +191,7 @@ public class PostServiceImpl extends BasePostServiceImpl<Post> implements PostSe
     }
 
     @Override
-    @Transactional
+    @Transactional(rollbackFor = Exception.class)
     public PostDetailVO updateBy(Post postToUpdate, Set<Integer> tagIds, Set<Integer> categoryIds,
         Set<PostMeta> metas, boolean autoSave) {
         // Set edit time
@@ -280,6 +281,7 @@ public class PostServiceImpl extends BasePostServiceImpl<Post> implements PostSe
     }
 
     @Override
+    @Transactional(rollbackFor = Exception.class)
     public List<Post> removeByIds(Collection<Integer> ids) {
         if (CollectionUtils.isEmpty(ids)) {
             return Collections.emptyList();
@@ -490,6 +492,7 @@ public class PostServiceImpl extends BasePostServiceImpl<Post> implements PostSe
     }
 
     @Override
+    @Transactional(rollbackFor = Exception.class)
     public Post removeById(Integer postId) {
         Assert.notNull(postId, "Post id must not be null");
 

--- a/src/main/java/run/halo/app/service/impl/SheetServiceImpl.java
+++ b/src/main/java/run/halo/app/service/impl/SheetServiceImpl.java
@@ -10,6 +10,7 @@ import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.Assert;
 import run.halo.app.event.logger.LogEvent;
 import run.halo.app.event.post.SheetVisitEvent;
@@ -83,6 +84,7 @@ public class SheetServiceImpl extends BasePostServiceImpl<Sheet>
     }
 
     @Override
+    @Transactional(rollbackFor = Exception.class)
     public Sheet createBy(Sheet sheet, boolean autoSave) {
         Sheet createdSheet = createOrUpdateBy(sheet);
         if (!autoSave) {
@@ -96,6 +98,7 @@ public class SheetServiceImpl extends BasePostServiceImpl<Sheet>
     }
 
     @Override
+    @Transactional(rollbackFor = Exception.class)
     public Sheet createBy(Sheet sheet, Set<SheetMeta> metas, boolean autoSave) {
         Sheet createdSheet = createOrUpdateBy(sheet);
 
@@ -115,6 +118,7 @@ public class SheetServiceImpl extends BasePostServiceImpl<Sheet>
     }
 
     @Override
+    @Transactional(rollbackFor = Exception.class)
     public Sheet updateBy(Sheet sheet, boolean autoSave) {
         Sheet updatedSheet = createOrUpdateBy(sheet);
         if (!autoSave) {
@@ -128,6 +132,7 @@ public class SheetServiceImpl extends BasePostServiceImpl<Sheet>
     }
 
     @Override
+    @Transactional(rollbackFor = Exception.class)
     public Sheet updateBy(Sheet sheet, Set<SheetMeta> metas, boolean autoSave) {
         Sheet updatedSheet = createOrUpdateBy(sheet);
 
@@ -260,6 +265,7 @@ public class SheetServiceImpl extends BasePostServiceImpl<Sheet>
     }
 
     @Override
+    @Transactional(rollbackFor = Exception.class)
     public Sheet removeById(Integer id) {
 
         // Remove sheet metas


### PR DESCRIPTION
### What this PR does?
修复没有事物的方法调用时报事物不可见的错误问题，特别是批量删除文章时

### Why we need it?
Fix #1714