### PR TITLE
Journal supports receiving front-end rendering results

### DIFF
--- a/src/main/java/run/halo/app/model/params/JournalParam.java
+++ b/src/main/java/run/halo/app/model/params/JournalParam.java
@@ -1,10 +1,12 @@
 package run.halo.app.model.params;
 
+import java.util.Objects;
 import javax.validation.constraints.NotBlank;
 import lombok.Data;
 import run.halo.app.model.dto.base.InputConverter;
 import run.halo.app.model.entity.Journal;
 import run.halo.app.model.enums.JournalType;
+import run.halo.app.utils.MarkdownUtils;
 
 /**
  * Journal param.
@@ -19,5 +21,34 @@ public class JournalParam implements InputConverter<Journal> {
     @NotBlank(message = "内容不能为空")
     private String sourceContent;
 
+    private String content;
+
     private JournalType type = JournalType.PUBLIC;
+
+    /**
+     * if {@code true}, it means is that do not let the back-end render the original content
+     * because the content has been rendered, and you only need to store the original content.
+     */
+    private Boolean keepRaw = false;
+
+    @Override
+    public Journal convertTo() {
+        Journal journal = InputConverter.super.convertTo();
+        populateContent(journal);
+        return journal;
+    }
+
+    @Override
+    public void update(Journal domain) {
+        InputConverter.super.update(domain);
+        populateContent(domain);
+    }
+
+    private void populateContent(Journal journal) {
+        if (Objects.equals(keepRaw, false)) {
+            journal.setContent(MarkdownUtils.renderHtml(sourceContent));
+        } else {
+            journal.setContent(content);
+        }
+    }
 }

--- a/src/main/java/run/halo/app/service/impl/JournalServiceImpl.java
+++ b/src/main/java/run/halo/app/service/impl/JournalServiceImpl.java
@@ -19,7 +19,6 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.Assert;
 import org.springframework.util.CollectionUtils;
 import run.halo.app.exception.BadRequestException;
-import run.halo.app.model.dto.JournalDTO;
 import run.halo.app.model.dto.JournalWithCmtCountDTO;
 import run.halo.app.model.entity.Journal;
 import run.halo.app.model.entity.JournalComment;
@@ -31,7 +30,6 @@ import run.halo.app.repository.JournalRepository;
 import run.halo.app.service.JournalCommentService;
 import run.halo.app.service.JournalService;
 import run.halo.app.service.base.AbstractCrudService;
-import run.halo.app.utils.MarkdownUtils;
 import run.halo.app.utils.ServiceUtils;
 
 /**
@@ -62,7 +60,6 @@ public class JournalServiceImpl extends AbstractCrudService<Journal, Integer>
         Assert.notNull(journalParam, "Journal param must not be null");
 
         Journal journal = journalParam.convertTo();
-        journal.setContent(MarkdownUtils.renderHtml(journal.getSourceContent()));
 
         return create(journal);
     }
@@ -70,9 +67,6 @@ public class JournalServiceImpl extends AbstractCrudService<Journal, Integer>
     @Override
     public Journal updateBy(Journal journal) {
         Assert.notNull(journal, "Journal must not be null");
-
-        journal.setContent(MarkdownUtils.renderHtml(journal.getSourceContent()));
-
         return update(journal);
     }
 


### PR DESCRIPTION
### What this PR does?
日志支持接收前端渲染结果
- 保存和更新接口增加了`keepRaw`字段默认值为false表示后端使用`sourceContent`渲染`content`
- 如果传递`keepRaw=true`则表示使用前端渲染的内容不再使用`sourceContent`渲染
需要同步修改`SDK`

### Why we need it?
Fix #1738