### PR TITLE
Fix the problem of post list is incomplete due to no recursive query categories

### DIFF
--- a/src/test/java/run/halo/app/listener/PostRefreshStatusListenerTest.java
+++ b/src/test/java/run/halo/app/listener/PostRefreshStatusListenerTest.java
@@ -1,0 +1,89 @@
+package run.halo.app.listener;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Set;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.jdbc.EmbeddedDatabaseConnection;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.event.ApplicationEvents;
+import org.springframework.test.context.event.RecordApplicationEvents;
+import run.halo.app.event.category.CategoryUpdatedEvent;
+import run.halo.app.model.entity.Category;
+import run.halo.app.model.entity.Post;
+import run.halo.app.model.enums.PostStatus;
+import run.halo.app.model.vo.PostDetailVO;
+import run.halo.app.service.CategoryService;
+import run.halo.app.service.PostService;
+
+/**
+ * @author guqing
+ * @date 2022-03-28
+ */
+@SpringBootTest
+@RecordApplicationEvents
+@AutoConfigureTestDatabase(connection = EmbeddedDatabaseConnection.H2)
+public class PostRefreshStatusListenerTest {
+
+    @Autowired
+    private ApplicationEvents applicationEvents;
+
+    @Autowired
+    private CategoryService categoryService;
+
+    @Autowired
+    private PostService postService;
+
+    private Post post;
+    private Category category1;
+
+    @BeforeEach
+    public void setUp() {
+        category1 = new Category();
+        category1.setId(1);
+        category1.setName("category-1");
+        category1.setSlug("category-1");
+        category1.setPassword("123");
+        category1.setParentId(0);
+
+        Category category2 = new Category();
+        category2.setId(2);
+        category2.setName("category-2");
+        category2.setSlug("category-2");
+        category2.setParentId(1);
+
+        categoryService.create(category1);
+        categoryService.create(category2);
+
+        post = new Post();
+        post.setId(1);
+        post.setSlug("post-1");
+        post.setTitle("post-title");
+    }
+
+    @Test
+    public void clearCategoryPasswordOfTopLevelTest() {
+        // After clearing the password of the top-level category,
+        // all articles belonging to this category and sub categories should be set
+        // to draft status.
+        PostDetailVO postDetailVO =
+            postService.createBy(post, Set.of(), Set.of(2), Set.of(), false);
+        assertThat(postDetailVO).isNotNull();
+        assertThat(postDetailVO.getStatus()).isEqualTo(PostStatus.INTIMATE);
+
+        category1.setPassword(null);
+        categoryService.update(category1);
+        assertThat(applicationEvents
+            .stream(CategoryUpdatedEvent.class)
+            .filter(event -> event.getCategory().getId() == 1)
+            .count())
+            .isEqualTo(1);
+
+        Post updatedPost = postService.getById(postDetailVO.getId());
+        assertThat(updatedPost).isNotNull();
+        assertThat(updatedPost.getStatus()).isEqualTo(PostStatus.DRAFT);
+    }
+}


### PR DESCRIPTION
### What this PR does?
修复由于`根据分类id查询文章时`方法内没有查询该分类的子分类下的文章导致状态没有更新问题
场景如下：
1、创建一个分类A,进行加密
2、创建一个分类B,挂在分类A下
3、发布一个新的文章: 文章1, 挂在分类B下
> 此时 文章1 的状态为“私密”
4、将分类A的密码删除
> 此时 文章1 的状态仍然为“私密”, 期望为草稿状态(取消私密状态)

### Why we need it?
修复 #1779 但没有完全修复，该问题的第`6、重选 文章1 的分类, 重新进行发布,文章1 的状态仍然为“私密”`的问题无法在1.5.x解决，需要将`status`字段的职能拆分才可以。
> 文章的分类变更时没法去更新文章状态，因为：
> 1. 现有文章：post-1 所属加密分类则状态为私密
> 2. 用户修改文章为非私密分类并发布文章
> 3. 由于 status 混在一个字段，从原 私密 -> 非私密状态文章就会转草稿
> 4. 也就是出现了发布文章但文章状态为草稿的情况。

所以该问题无法在现有表结构基础上解决，且1.5.x不再进行大的改动，结合以上矛盾点该 Issue 将被挂起到 2.0 milestone 彻底解决。

### How to test it?
1. 创建分类 `分类1`及子分类`分类1-1`
2. 创建文章 `test1`
3. 将 `test1`所属`分类1-1`
4. 为`分类1`设置一个密码
5. 期望`test1`为加密状态
6. 取消 `分类1` 的密码
7. 期望`test1`为草稿状态

/cc @halo-dev/sig-halo 