### PR TITLE
refactor: transition behavior of post state after category updated

### DIFF
--- a/src/main/java/run/halo/app/event/category/CategoryUpdatedEvent.java
+++ b/src/main/java/run/halo/app/event/category/CategoryUpdatedEvent.java
@@ -1,6 +1,7 @@
 package run.halo.app.event.category;
 
 import org.springframework.context.ApplicationEvent;
+import org.springframework.lang.Nullable;
 import run.halo.app.model.entity.Category;
 
 /**
@@ -11,14 +12,22 @@ import run.halo.app.model.entity.Category;
  */
 public class CategoryUpdatedEvent extends ApplicationEvent {
 
+    private final Category beforeUpdated;
     private final Category category;
 
-    public CategoryUpdatedEvent(Object source, Category category) {
+    public CategoryUpdatedEvent(Object source, Category category, Category beforeUpdated) {
         super(source);
         this.category = category;
+        this.beforeUpdated = beforeUpdated;
     }
 
+    @Nullable
     public Category getCategory() {
         return category;
+    }
+
+    @Nullable
+    public Category getBeforeUpdated() {
+        return beforeUpdated;
     }
 }

--- a/src/main/java/run/halo/app/event/category/CategoryUpdatedEvent.java
+++ b/src/main/java/run/halo/app/event/category/CategoryUpdatedEvent.java
@@ -14,11 +14,14 @@ public class CategoryUpdatedEvent extends ApplicationEvent {
 
     private final Category beforeUpdated;
     private final Category category;
+    private final boolean beforeIsPrivate;
 
-    public CategoryUpdatedEvent(Object source, Category category, Category beforeUpdated) {
+    public CategoryUpdatedEvent(Object source, Category category,
+        Category beforeUpdated, boolean beforeIsPrivate) {
         super(source);
         this.category = category;
         this.beforeUpdated = beforeUpdated;
+        this.beforeIsPrivate = beforeIsPrivate;
     }
 
     @Nullable
@@ -29,5 +32,9 @@ public class CategoryUpdatedEvent extends ApplicationEvent {
     @Nullable
     public Category getBeforeUpdated() {
         return beforeUpdated;
+    }
+
+    public boolean isBeforeIsPrivate() {
+        return beforeIsPrivate;
     }
 }

--- a/src/main/java/run/halo/app/listener/post/PostRefreshStatusListener.java
+++ b/src/main/java/run/halo/app/listener/post/PostRefreshStatusListener.java
@@ -71,7 +71,9 @@ public class PostRefreshStatusListener {
                 Set<Integer> encryptedCategories =
                     pickUpEncryptedFromUpdatedRecord(category.getId());
                 for (Post post : posts) {
-                    if (!isEncryptedPost(post.getId(), encryptedCategories)
+                    boolean belongsToEncryptedCategory =
+                        postBelongsToEncryptedCategory(post.getId(), encryptedCategories);
+                    if (!belongsToEncryptedCategory && StringUtils.isBlank(post.getPassword())
                         && beforeIsPrivate
                         && post.getStatus() == PostStatus.INTIMATE) {
                         post.setStatus(PostStatus.PUBLISHED);
@@ -82,7 +84,8 @@ public class PostRefreshStatusListener {
         postService.updateInBatch(posts);
     }
 
-    private boolean isEncryptedPost(Integer postId, Set<Integer> encryptedCategories) {
+    private boolean postBelongsToEncryptedCategory(Integer postId,
+        Set<Integer> encryptedCategories) {
         Set<Integer> categoryIds =
             postCategoryService.listCategoryIdsByPostId(postId);
 

--- a/src/main/java/run/halo/app/service/impl/CategoryServiceImpl.java
+++ b/src/main/java/run/halo/app/service/impl/CategoryServiceImpl.java
@@ -105,8 +105,12 @@ public class CategoryServiceImpl extends AbstractCrudService<Category, Integer>
 
     @Override
     public Category update(Category category) {
+        Category persisted = getById(category.getId());
+        Category beforeUpdated = new Category();
+        BeanUtils.updateProperties(persisted, beforeUpdated);
+
         Category updated = super.update(category);
-        applicationContext.publishEvent(new CategoryUpdatedEvent(this, category));
+        applicationContext.publishEvent(new CategoryUpdatedEvent(this, category, beforeUpdated));
         return updated;
     }
 
@@ -192,7 +196,7 @@ public class CategoryServiceImpl extends AbstractCrudService<Category, Integer>
         // Remove post categories
         postCategoryService.removeByCategoryId(categoryId);
 
-        applicationContext.publishEvent(new CategoryUpdatedEvent(this, category));
+        applicationContext.publishEvent(new CategoryUpdatedEvent(this, null, category));
     }
 
     @Override
@@ -358,10 +362,14 @@ public class CategoryServiceImpl extends AbstractCrudService<Category, Integer>
         return categoryRepository.findAllById(categoryIds)
             .stream()
             .map(categoryToUpdate -> {
+                // 将持久化状态的对象转非session管理对象否则数据会被更新
+                Category categoryBefore = BeanUtils.transformFrom(categoryToUpdate, Category.class);
+
                 Category categoryParam = idCategoryParamMap.get(categoryToUpdate.getId());
                 BeanUtils.updateProperties(categoryParam, categoryToUpdate);
                 Category categoryUpdated = update(categoryToUpdate);
-                applicationContext.publishEvent(new CategoryUpdatedEvent(this, categoryUpdated));
+                applicationContext.publishEvent(
+                    new CategoryUpdatedEvent(this, categoryUpdated, categoryBefore));
                 return categoryUpdated;
             })
             .collect(Collectors.toList());

--- a/src/main/java/run/halo/app/service/impl/CategoryServiceImpl.java
+++ b/src/main/java/run/halo/app/service/impl/CategoryServiceImpl.java
@@ -364,10 +364,11 @@ public class CategoryServiceImpl extends AbstractCrudService<Category, Integer>
             .map(categoryToUpdate -> {
                 // 将持久化状态的对象转非session管理对象否则数据会被更新
                 Category categoryBefore = BeanUtils.transformFrom(categoryToUpdate, Category.class);
-
+                System.out.println("before: " + categoryBefore);
                 Category categoryParam = idCategoryParamMap.get(categoryToUpdate.getId());
                 BeanUtils.updateProperties(categoryParam, categoryToUpdate);
                 Category categoryUpdated = update(categoryToUpdate);
+                System.out.println("after: " + categoryUpdated);
                 applicationContext.publishEvent(
                     new CategoryUpdatedEvent(this, categoryUpdated, categoryBefore));
                 return categoryUpdated;

--- a/src/main/java/run/halo/app/service/impl/PostServiceImpl.java
+++ b/src/main/java/run/halo/app/service/impl/PostServiceImpl.java
@@ -583,12 +583,6 @@ public class PostServiceImpl extends BasePostServiceImpl<Post> implements PostSe
     private PostDetailVO createOrUpdate(@NonNull Post post, Set<Integer> tagIds,
         Set<Integer> categoryIds, Set<PostMeta> metas) {
         Assert.notNull(post, "Post param must not be null");
-        // if password is not empty
-        if (post.getStatus() != PostStatus.DRAFT
-            && (StringUtils.isNotEmpty(post.getPassword()))
-        ) {
-            post.setStatus(PostStatus.INTIMATE);
-        }
 
         post = super.createOrUpdateBy(post);
 

--- a/src/main/java/run/halo/app/service/impl/PostServiceImpl.java
+++ b/src/main/java/run/halo/app/service/impl/PostServiceImpl.java
@@ -583,7 +583,6 @@ public class PostServiceImpl extends BasePostServiceImpl<Post> implements PostSe
     private PostDetailVO createOrUpdate(@NonNull Post post, Set<Integer> tagIds,
         Set<Integer> categoryIds, Set<PostMeta> metas) {
         Assert.notNull(post, "Post param must not be null");
-
         // if password is not empty
         if (post.getStatus() != PostStatus.DRAFT
             && (StringUtils.isNotEmpty(post.getPassword()))

--- a/src/test/java/run/halo/app/listener/PostRefreshStatusListenerTest.java
+++ b/src/test/java/run/halo/app/listener/PostRefreshStatusListenerTest.java
@@ -72,7 +72,6 @@ public class PostRefreshStatusListenerTest {
         PostDetailVO postDetailVO =
             postService.createBy(post, Set.of(), Set.of(2), Set.of(), false);
         assertThat(postDetailVO).isNotNull();
-        assertThat(postDetailVO.getStatus()).isEqualTo(PostStatus.INTIMATE);
 
         category1.setPassword(null);
         categoryService.update(category1);


### PR DESCRIPTION
### What this PR does?
更改分类更新后的文章状态过渡行为，由于情况复杂该PR并没有提供单元测试，目前只是在相对合理的情况下解决它有些场景不完善，等待2.0重新设计加密功能。

要考虑以下情况：

- 分类被更新： 判断密码，If 从空到非空（转私密），Else 从非空到空（公开）

- 分类被删除：判断被删除分类的密码，1.非空，检查所属该分类及其子分类的文章综合文章私密性来决定最终是私密还是公开，2.空则不用管

针对父分类的私密性对当前分类的影响分析：
- 父分类有密码：
  - 当前有密码：私密状态，密码变更 非空 -> 空，为私密
​  - 当前分类没密码：私密状态，密码状态变更也为私密
- 父分类没有密码：
  - 当前有密码：私密状态，如果当前变更为 密码 从非空 -> 空，则转为公开 
  - 当前没密码：公开状态，如果密码从 空->非空 则为私密，否则为公开

### Why we need it?
之前更新了分类会将所属分类的文章转草稿不合理，现更改它的行为

Fix #1779