### PR TITLE
Fix the redirected URL will be garbled when include Chinese

### DIFF
--- a/src/main/java/run/halo/app/controller/content/ContentContentController.java
+++ b/src/main/java/run/halo/app/controller/content/ContentContentController.java
@@ -4,6 +4,8 @@ import static run.halo.app.model.support.HaloConst.POST_PASSWORD_TEMPLATE;
 import static run.halo.app.model.support.HaloConst.SUFFIX_FTL;
 
 import java.io.UnsupportedEncodingException;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import javax.servlet.http.HttpServletRequest;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
@@ -271,6 +273,8 @@ public class ContentContentController {
         ContentAuthenticationRequest authRequest = new ContentAuthenticationRequest();
         authRequest.setPassword(password);
         Post post = postService.getBy(PostStatus.INTIMATE, slug);
+        post.setSlug(URLEncoder.encode(post.getSlug(), StandardCharsets.UTF_8));
+
         authRequest.setId(post.getId());
         authRequest.setPrincipal(EncryptTypeEnum.POST.getName());
         try {
@@ -290,6 +294,8 @@ public class ContentContentController {
         ContentAuthenticationRequest authRequest = new ContentAuthenticationRequest();
         authRequest.setPassword(password);
         Category category = categoryService.getBySlugOfNonNull(slug);
+        category.setSlug(URLEncoder.encode(category.getSlug(), StandardCharsets.UTF_8));
+
         authRequest.setId(category.getId());
         authRequest.setPrincipal(EncryptTypeEnum.CATEGORY.getName());
         try {


### PR DESCRIPTION
### What this PR does?
修复文章和分类的url带有中文时加密功能从密码页重定向到详情url由于乱码跳转不过去的问题

### Why we need it?
Fix #1784

### How to test it?
发布一篇机密文章或分类然后访问它输入密码后期望能正确跳转到文章或分类详情

/kind bug
/cc @halo-dev/sig-halo 