### PR TITLE
refactor: remove parameter assertion

### DIFF
--- a/src/main/java/run/halo/app/cache/AbstractStringCacheStore.java
+++ b/src/main/java/run/halo/app/cache/AbstractStringCacheStore.java
@@ -8,6 +8,7 @@ import java.util.concurrent.TimeUnit;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.lang.NonNull;
 import org.springframework.util.Assert;
+import org.springframework.util.StringUtils;
 import run.halo.app.exception.ServiceException;
 import run.halo.app.utils.JsonUtils;
 
@@ -20,7 +21,9 @@ import run.halo.app.utils.JsonUtils;
 public abstract class AbstractStringCacheStore extends AbstractCacheStore<String, String> {
 
     protected Optional<CacheWrapper<String>> jsonToCacheWrapper(String json) {
-        Assert.hasText(json, "json value must not be null");
+        if (!StringUtils.hasText(json)) {
+            return Optional.empty();
+        }
         CacheWrapper<String> cacheWrapper = null;
         try {
             cacheWrapper = JsonUtils.jsonToObject(json, new TypeReference<>() {});


### PR DESCRIPTION
### What this PR does?
去掉`jsonToCacheWrapper`的参数断言

### Why we need it?
部分用户使用 leveldb 升级到1.5.0时不知道什么原因.leveldb的持久化文件 会出现一些空记录行导致恢复缓存为CacheWrapper到内存时被卡在断言处影响文章发布。

/cc @halo-dev/sig-halo 