### PR TITLE
chore: Upgrade springboot to 2.5.11

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id "org.springframework.boot" version "2.5.10"
+    id "org.springframework.boot" version "2.5.11"
     id "io.spring.dependency-management" version "1.0.11.RELEASE"
     id "checkstyle"
     id "java"

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,5 +1,6 @@
 pluginManagement {
     repositories {
+        maven { url 'https://plugins.gradle.org/m2/' }
         maven { url 'https://maven.aliyun.com/repository/gradle-plugin' }
         maven { url 'https://maven.aliyun.com/repository/spring-plugin' }
         maven { url 'https://repo.spring.io/milestone' }


### PR DESCRIPTION
### What this PR does?
升级springboot到2.5.11以解决 [CVE-2022-22950: Spring Expression DoS Vulnerability](https://tanzu.vmware.com/security/cve-2022-22950)

引入了 https://plugins.gradle.org/m2/ 仓库地址，因为升级springboot到2.5.11使用原有aliyun gradle plugin 仓库会报错，该仓库不存在2.5.11
> Could not find spring-boot-buildpack-platform-2.5.11.jar (org.springframework.boot:spring-boot-buildpack-platform:2.5.11).
Searched in the following locations:
    https://maven.aliyun.com/repository/gradle-plugin/org/springframework/boot/spring-boot-buildpack-platform/2.5.11/spring-boot-buildpack-platform-2.5.11.jar

到 https://developer.aliyun.com/mvn/search 确认也确实没有

### Why we need it?
修复 https://spring.io/blog/2022/03/28/cve-report-published-for-spring-framework

/area core
/cc @halo-dev/sig-halo