### PR TITLE
refactor: clear the deprecated attributes value of post content when prePersist and preUpdate

### DIFF
--- a/src/main/java/run/halo/app/model/entity/BasePost.java
+++ b/src/main/java/run/halo/app/model/entity/BasePost.java
@@ -243,6 +243,17 @@ public class BasePost extends BaseEntity {
         if (version == null || version < 0) {
             version = 1;
         }
+        // Clear the value of the deprecated attributes
+        this.originalContent = "";
+        this.formatContent = "";
+    }
+
+    @Override
+    protected void preUpdate() {
+        super.preUpdate();
+        // Clear the value of the deprecated attributes
+        this.originalContent = "";
+        this.formatContent = "";
     }
 
     /**


### PR DESCRIPTION
### What this PR does?
当保存或更新文章之前清空 posts entity的originalContent和formatContent字段，由于这两个字段已经过时，不需要在保存值。

### Why we need it?
当用户使用该PR所在版本，如果编辑过以前发布的文章或重新发布文章就会逐渐清空posts表的内容字段，从而提升文章列表的查询速度。
> 1.5.0 新增了contents 表用来保存文章内容替代 posts 表的 format_content 和 original_content 字段，为了过渡到1.5.0，posts 表中还保留了文章内容，所以从此版本开始已经不在需要它。

/cc @halo-dev/sig-halo
/area core 
/kind cleanup