### PR TITLE
chore: issue template add hints on how to get logs

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.en.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.en.yml
@@ -61,7 +61,7 @@ body:
     id: logs
     attributes:
       label: "Relevant log output"
-      description: "Please copy and paste any relevant log output. This will be automatically formatted into code, so no need for backticks."
+      description: "Please copy and paste any relevant log output. This will be automatically formatted into code, so no need for backticks. The way to get the logs can be found at https://docs.halo.run/user-guide/faq#如何查看运行日志"
       render: shell
   - type: textarea
     id: additional-information

--- a/.github/ISSUE_TEMPLATE/bug_report.zh.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.zh.yml
@@ -62,7 +62,7 @@ body:
     id: logs
     attributes:
       label: "相关日志输出"
-      description: "请复制并粘贴任何相关的日志输出。 这将自动格式化为代码，因此无需反引号。"
+      description: "请复制并粘贴任何相关的日志输出。 这将自动格式化为代码，因此无需反引号。获取日志的方法可参考：https://docs.halo.run/user-guide/faq#如何查看运行日志"
       render: shell
   - type: textarea
     id: additional-information


### PR DESCRIPTION
Issues 模板添加获取日志方式的链接。

see https://github.com/ruibaby/halo/issues/new?assignees=&labels=bug&template=bug_report.zh.yml
see https://github.com/ruibaby/halo/issues/new?assignees=&labels=bug&template=bug_report.en.yml

Signed-off-by: Ryan Wang <i@ryanc.cc>