### PR TITLE
Fix the problem of encrypted category displayed in query posts according to category

### DIFF
--- a/src/main/java/run/halo/app/core/freemarker/tag/PostTagDirective.java
+++ b/src/main/java/run/halo/app/core/freemarker/tag/PostTagDirective.java
@@ -1,6 +1,5 @@
 package run.halo.app.core.freemarker.tag;
 
-import com.google.common.collect.Sets;
 import freemarker.core.Environment;
 import freemarker.template.Configuration;
 import freemarker.template.DefaultObjectWrapperBuilder;
@@ -84,15 +83,12 @@ public class PostTagDirective implements TemplateDirectiveModel {
                     Integer categoryId = Integer.parseInt(params.get("categoryId").toString());
                     env.setVariable("posts", builder.build()
                         .wrap(postRenderAssembler.convertToListVo(
-                            postCategoryService.listPostBy(categoryId,
-                                Sets.immutableEnumSet(PostStatus.PUBLISHED,
-                                    PostStatus.INTIMATE)))));
+                            postCategoryService.listPostBy(categoryId, PostStatus.PUBLISHED))));
                     break;
                 case "listByCategorySlug":
                     String categorySlug = params.get("categorySlug").toString();
                     List<Post> posts =
-                        postCategoryService.listPostBy(categorySlug,
-                            Sets.immutableEnumSet(PostStatus.PUBLISHED, PostStatus.INTIMATE));
+                        postCategoryService.listPostBy(categorySlug, PostStatus.PUBLISHED);
                     env.setVariable("posts",
                         builder.build().wrap(postRenderAssembler.convertToListVo(posts)));
                     break;


### PR DESCRIPTION
### What this PR does?
根据分类 id 和 slug 查询文章的自定义标签处过滤掉加密分类

### Why we need it?
根据分类 id 和 slug 查询文章列表的自定义标签不应该显示加密的文章
Fix #1807

/cc @halo-dev/sig-halo 
/kind bug
/area core