### PR TITLE
refactor: modify the frontMatter export format to yaml syntax

### DIFF
--- a/src/main/java/run/halo/app/service/impl/PostServiceImpl.java
+++ b/src/main/java/run/halo/app/service/impl/PostServiceImpl.java
@@ -690,17 +690,18 @@ public class PostServiceImpl extends BasePostServiceImpl<Post> implements PostSe
         frontMatter.append("date: ").append(post.getCreateTime()).append("\n");
         frontMatter.append("updated: ").append(post.getUpdateTime()).append("\n");
 
-        //set fullPath
+        // set fullPath
         frontMatter.append("url: ").append(postAssembler.buildFullPath(post)).append("\n");
 
-        //set category
+        // set category
+        // classification with hierarchies has not been processed yet
         List<Category> categories = postCategoryService.listCategoriesBy(post.getId());
         StringBuilder categoryContent = new StringBuilder();
         categories.forEach(category -> categoryContent.append("- ").append(category.getName())
             .append("\n"));
         frontMatter.append("categories: ").append("\n").append(categoryContent);
 
-        //set tags
+        // set tags
         List<Tag> tags = postTagService.listTagsBy(post.getId());
         StringBuilder tagContent = new StringBuilder();
         tags.forEach(tag -> tagContent.append("- ").append(tag.getName()).append("\n"));

--- a/src/main/java/run/halo/app/service/impl/PostServiceImpl.java
+++ b/src/main/java/run/halo/app/service/impl/PostServiceImpl.java
@@ -652,6 +652,39 @@ public class PostServiceImpl extends BasePostServiceImpl<Post> implements PostSe
     private PostMarkdownVO convertToPostMarkdownVo(Post post) {
         PostMarkdownVO postMarkdownVO = new PostMarkdownVO();
 
+        // set frontMatter
+        StringBuilder frontMatter = getFrontMatterYaml(post);
+        postMarkdownVO.setFrontMatter(frontMatter.toString());
+
+        // set content
+        PatchedContent postContent = post.getContent();
+        postMarkdownVO.setOriginalContent(postContent.getOriginalContent());
+        postMarkdownVO.setTitle(post.getTitle());
+        postMarkdownVO.setSlug(post.getSlug());
+        return postMarkdownVO;
+    }
+
+    /**
+     * frontMatter has a variety of parsing methods, but the most commonly used is the yaml type.
+     * yaml is used here, and public methods can be extracted if needed for extensions.
+     * <p>
+     * Example: <br>
+     * title: default title. <br>
+     * date: 2022-04-03 19:00:00.000 <br>
+     * updated: 2022-04-03 19:00:00.000 <br>
+     * description: default description <br>
+     * categories: <br>
+     * - Java <br>
+     * - Halo <br>
+     * tags: <br>
+     * - tag <br>
+     * - doc <br>
+     * </p>
+     *
+     * @param post post not be null
+     * @return frontMatter
+     */
+    private StringBuilder getFrontMatterYaml(Post post) {
         StringBuilder frontMatter = new StringBuilder("---\n");
         frontMatter.append("title: ").append(post.getTitle()).append("\n");
         frontMatter.append("date: ").append(post.getCreateTime()).append("\n");
@@ -663,37 +696,17 @@ public class PostServiceImpl extends BasePostServiceImpl<Post> implements PostSe
         //set category
         List<Category> categories = postCategoryService.listCategoriesBy(post.getId());
         StringBuilder categoryContent = new StringBuilder();
-        for (int i = 0; i < categories.size(); i++) {
-            Category category = categories.get(i);
-            String categoryName = category.getName();
-            if (i == 0) {
-                categoryContent.append(categoryName);
-            } else {
-                categoryContent.append(" | ").append(categoryName);
-            }
-        }
-        frontMatter.append("categories: ").append(categoryContent.toString()).append("\n");
+        categories.forEach(category -> categoryContent.append("- ").append(category.getName())
+            .append("\n"));
+        frontMatter.append("categories: ").append("\n").append(categoryContent);
 
         //set tags
         List<Tag> tags = postTagService.listTagsBy(post.getId());
         StringBuilder tagContent = new StringBuilder();
-        for (int i = 0; i < tags.size(); i++) {
-            Tag tag = tags.get(i);
-            String tagName = tag.getName();
-            if (i == 0) {
-                tagContent.append(tagName);
-            } else {
-                tagContent.append(" | ").append(tagName);
-            }
-        }
-        frontMatter.append("tags: ").append(tagContent).append("\n");
+        tags.forEach(tag -> tagContent.append("- ").append(tag.getName()).append("\n"));
+        frontMatter.append("tags: ").append("\n").append(tagContent);
 
         frontMatter.append("---\n");
-        postMarkdownVO.setFrontMatter(frontMatter.toString());
-        PatchedContent postContent = post.getContent();
-        postMarkdownVO.setOriginalContent(postContent.getOriginalContent());
-        postMarkdownVO.setTitle(post.getTitle());
-        postMarkdownVO.setSlug(post.getSlug());
-        return postMarkdownVO;
+        return frontMatter;
     }
 }

--- a/src/test/java/run/halo/app/utils/MarkdownUtilsTest.java
+++ b/src/test/java/run/halo/app/utils/MarkdownUtilsTest.java
@@ -83,7 +83,7 @@ class MarkdownUtilsTest {
     }
 
     @Test
-    void getFrontMatter() {
+    void getFrontMatterYaml() {
         String markdown = "---\n"
             + "title: \"test remove\"\n"
             + "---";
@@ -94,5 +94,20 @@ class MarkdownUtilsTest {
             + "---";
         frontMatter = MarkdownUtils.getFrontMatter(markdown);
         assertEquals("\"test remove\"", frontMatter.get("title").get(0));
+
+        // halo
+        markdown = "---\n"
+            + "title: Hello Halo\n"
+            + "date: 2021-12-04 17:27:26.114\n"
+            + "updated: 2021-12-04 17:27:26.114\n"
+            + "url: /archives/hello-halo\n"
+            + "categories: \n"
+            + "- default category\n"
+            + "- multi category\n"
+            + "tags: \n"
+            + "---\n";
+        frontMatter = MarkdownUtils.getFrontMatter(markdown);
+        assertEquals("default category", frontMatter.get("categories").get(0));
+        assertEquals("multi category", frontMatter.get("categories").get(1));
     }
 }


### PR DESCRIPTION
### What this PR does?
将 markdown 导出时的 frontMatter 由原先的 ` | ` 号更改为 yaml 语法的 `- `。
用于解决导入时无法处理多个分类/标签的问题。

旧类型：
```
categories:  默认分类 | 多分类
tags:  默认标签 | 多标签
```

新类型
```
categories: 
- 默认分类
- 多分类
tags: 
- 默认标签
- 多标签
```

> 无法处理层级分类的问题，考虑到与其他博客系统的兼容性问题，层级分类将会平摊为线性分类。
- https://gohugo.io/content-management/front-matter/
- https://jekyllrb.com/docs/front-matter/
- https://hexo.io/docs/front-matter.html

### Which issue does this PR fix?
Fix #1773 