### PR TITLE
fix: the content cannot be saved problem when the patch status of V1 version of post content is recycle status

### DIFF
--- a/src/main/java/run/halo/app/service/impl/ContentPatchLogServiceImpl.java
+++ b/src/main/java/run/halo/app/service/impl/ContentPatchLogServiceImpl.java
@@ -149,7 +149,7 @@ public class ContentPatchLogServiceImpl extends AbstractCrudService<ContentPatch
     private ContentPatchLog updateDraftBy(Integer postId, String formatContent,
         String originalContent) {
         ContentPatchLog draftPatchLog = findLatestDraftBy(postId);
-        if(draftPatchLog == null) {
+        if (draftPatchLog == null) {
             throw new NotFoundException("The latest draft version must not be null to update.");
         }
         // Is the draft version 1

--- a/src/main/java/run/halo/app/service/impl/ContentPatchLogServiceImpl.java
+++ b/src/main/java/run/halo/app/service/impl/ContentPatchLogServiceImpl.java
@@ -4,6 +4,7 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 import org.springframework.data.domain.Example;
+import org.springframework.lang.NonNull;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.Assert;
@@ -73,8 +74,7 @@ public class ContentPatchLogServiceImpl extends AbstractCrudService<ContentPatch
         if (latestPatchLog == null) {
             // There is no patchLog record
             version = 1;
-        } else if (PostStatus.PUBLISHED.equals(latestPatchLog.getStatus())
-            || PostStatus.INTIMATE.equals(latestPatchLog.getStatus())) {
+        } else if (shouldUpgradeVersion(latestPatchLog)) {
             // There is no draft, a draft record needs to be created
             // so the version number needs to be incremented
             version = latestPatchLog.getVersion() + 1;
@@ -116,7 +116,7 @@ public class ContentPatchLogServiceImpl extends AbstractCrudService<ContentPatch
         contentPatchLog.setStatus(PostStatus.DRAFT);
         ContentPatchLog latestPatchLog =
             contentPatchLogRepository.findFirstByPostIdOrderByVersionDesc(postId);
-        if (latestPatchLog != null) {
+        if (shouldUpgradeVersion(latestPatchLog)) {
             contentPatchLog.setVersion(latestPatchLog.getVersion() + 1);
         } else {
             contentPatchLog.setVersion(BASE_VERSION);
@@ -125,19 +125,33 @@ public class ContentPatchLogServiceImpl extends AbstractCrudService<ContentPatch
         return contentPatchLog;
     }
 
+    private boolean shouldUpgradeVersion(ContentPatchLog latestPatchLog) {
+        if (latestPatchLog == null) {
+            return false;
+        }
+        return PostStatus.PUBLISHED.equals(latestPatchLog.getStatus())
+            || PostStatus.INTIMATE.equals(latestPatchLog.getStatus());
+    }
+
     private boolean existDraftBy(Integer postId) {
         ContentPatchLog contentPatchLog = new ContentPatchLog();
         contentPatchLog.setPostId(postId);
         contentPatchLog.setStatus(PostStatus.DRAFT);
         Example<ContentPatchLog> example = Example.of(contentPatchLog);
-        return contentPatchLogRepository.exists(example);
+        boolean exists = contentPatchLogRepository.exists(example);
+        if (exists) {
+            return true;
+        }
+        contentPatchLog.setStatus(PostStatus.RECYCLE);
+        return contentPatchLogRepository.exists(Example.of(contentPatchLog));
     }
 
     private ContentPatchLog updateDraftBy(Integer postId, String formatContent,
         String originalContent) {
-        ContentPatchLog draftPatchLog =
-            contentPatchLogRepository.findFirstByPostIdAndStatusOrderByVersionDesc(postId,
-                PostStatus.DRAFT);
+        ContentPatchLog draftPatchLog = findLatestDraftBy(postId);
+        if(draftPatchLog == null) {
+            throw new NotFoundException("The latest draft version must not be null to update.");
+        }
         // Is the draft version 1
         if (Objects.equals(draftPatchLog.getVersion(), BASE_VERSION)) {
             // If it is V1, modify the content directly.
@@ -151,6 +165,18 @@ public class ContentPatchLogServiceImpl extends AbstractCrudService<ContentPatch
         draftPatchLog.setContentDiff(contentDiff.getDiff());
         draftPatchLog.setOriginalContentDiff(contentDiff.getOriginalDiff());
         contentPatchLogRepository.save(draftPatchLog);
+        return draftPatchLog;
+    }
+
+    private ContentPatchLog findLatestDraftBy(Integer postId) {
+        ContentPatchLog draftPatchLog =
+            contentPatchLogRepository.findFirstByPostIdAndStatusOrderByVersionDesc(postId,
+                PostStatus.DRAFT);
+        if (draftPatchLog == null) {
+            draftPatchLog =
+                contentPatchLogRepository.findFirstByPostIdAndStatusOrderByVersionDesc(postId,
+                    PostStatus.RECYCLE);
+        }
         return draftPatchLog;
     }
 
@@ -198,8 +224,7 @@ public class ContentPatchLogServiceImpl extends AbstractCrudService<ContentPatch
 
     @Override
     public ContentPatchLog getDraftByPostId(Integer postId) {
-        return contentPatchLogRepository.findFirstByPostIdAndStatusOrderByVersionDesc(postId,
-            PostStatus.DRAFT);
+        return findLatestDraftBy(postId);
     }
 
     @Override
@@ -219,8 +244,9 @@ public class ContentPatchLogServiceImpl extends AbstractCrudService<ContentPatch
         return applyPatch(contentPatchLog);
     }
 
+    @NonNull
     @Override
-    public ContentPatchLog getById(Integer id) {
+    public ContentPatchLog getById(@NonNull Integer id) {
         return contentPatchLogRepository.findById(id)
             .orElseThrow(() -> new NotFoundException(
                 "Post content patch log was not found or has been deleted."));


### PR DESCRIPTION
### What this PR does?
允许文章内容 v1 版本的补丁记录的status为回收站时当作草稿状态处理

### Why we need it?
由于V6__migrate_create_contents_table.sql 脚本中对`content_patch_logs`表的status是使用的文章的状态，当用户存在回收站状态的文章然后升级到1.5.0时 v1版本的 patch log 的状态就是 回收站，而原先代码的 patch 逻辑只是根据draft状态和1版本号去查询内容的 patch log 记录，用户此时恢复回收站文章就会导致文章无法保存。因此本次修改会将v1版patch log的状态为回收站时当作草稿状态处理，即：
1. 有文章 post-1 其内容的 v1 patch log状态值为 3（回收站），此时编辑文章后 ctrl + s
期望：patch log版本号不增加依旧只有v1版，内容被替换
2. 然后 发布 post-1
期望：patch log版本号不增加，内容被替换且status变为 0（发布状态）
> 当时脚本中的 status 不能写死为 1 的原因是，没有发布过的文章 patch log 只能为草稿状态，所以 status 迁移时沿用的是 post的状态

/cc @halo-dev/sig-halo 
/kind bug
/area core