### PR TITLE
fix: update the posts encryption status synchronously after deleting the category

### DIFF
--- a/src/main/java/run/halo/app/event/category/CategoryUpdatedEvent.java
+++ b/src/main/java/run/halo/app/event/category/CategoryUpdatedEvent.java
@@ -1,5 +1,6 @@
 package run.halo.app.event.category;
 
+import java.util.Set;
 import org.springframework.context.ApplicationEvent;
 import org.springframework.lang.Nullable;
 import run.halo.app.model.entity.Category;
@@ -15,13 +16,15 @@ public class CategoryUpdatedEvent extends ApplicationEvent {
     private final Category beforeUpdated;
     private final Category category;
     private final boolean beforeIsPrivate;
+    private final Set<Integer> postIds;
 
     public CategoryUpdatedEvent(Object source, Category category,
-        Category beforeUpdated, boolean beforeIsPrivate) {
+        Category beforeUpdated, boolean beforeIsPrivate, Set<Integer> postIds) {
         super(source);
         this.category = category;
         this.beforeUpdated = beforeUpdated;
         this.beforeIsPrivate = beforeIsPrivate;
+        this.postIds = postIds;
     }
 
     @Nullable
@@ -36,5 +39,9 @@ public class CategoryUpdatedEvent extends ApplicationEvent {
 
     public boolean isBeforeIsPrivate() {
         return beforeIsPrivate;
+    }
+
+    public Set<Integer> getPostIds() {
+        return postIds;
     }
 }

--- a/src/main/java/run/halo/app/service/CategoryService.java
+++ b/src/main/java/run/halo/app/service/CategoryService.java
@@ -2,6 +2,7 @@ package run.halo.app.service;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import org.springframework.data.domain.Sort;
 import org.springframework.lang.NonNull;
 import org.springframework.lang.Nullable;
@@ -133,4 +134,13 @@ public interface CategoryService extends CrudService<Category, Integer> {
      * @return a tree of category.
      */
     List<CategoryVO> listToTree(List<Category> categories);
+
+    /**
+     * Recursively query the associated post ids according to the category id.
+     *
+     * @param categoryId category id
+     * @return a collection of post ids
+     */
+    @NonNull
+    Set<Integer> listPostIdsByCategoryIdRecursively(@NonNull Integer categoryId);
 }

--- a/src/main/java/run/halo/app/service/impl/CategoryServiceImpl.java
+++ b/src/main/java/run/halo/app/service/impl/CategoryServiceImpl.java
@@ -3,6 +3,7 @@ package run.halo.app.service.impl;
 import static run.halo.app.model.support.HaloConst.URL_SEPARATOR;
 
 import java.util.ArrayDeque;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.LinkedList;
@@ -28,6 +29,7 @@ import run.halo.app.exception.AlreadyExistsException;
 import run.halo.app.exception.NotFoundException;
 import run.halo.app.model.dto.CategoryDTO;
 import run.halo.app.model.entity.Category;
+import run.halo.app.model.entity.PostCategory;
 import run.halo.app.model.vo.CategoryVO;
 import run.halo.app.repository.CategoryRepository;
 import run.halo.app.service.CategoryService;
@@ -111,8 +113,10 @@ public class CategoryServiceImpl extends AbstractCrudService<Category, Integer>
         boolean beforeIsPrivate = isPrivate(category.getId());
 
         Category updated = super.update(category);
+
+        Set<Integer> postIds = listPostIdsByCategoryIdRecursively(category.getId());
         applicationContext.publishEvent(
-            new CategoryUpdatedEvent(this, category, beforeUpdated, beforeIsPrivate));
+            new CategoryUpdatedEvent(this, category, beforeUpdated, beforeIsPrivate, postIds));
         return updated;
     }
 
@@ -183,8 +187,11 @@ public class CategoryServiceImpl extends AbstractCrudService<Category, Integer>
     }
 
     @Override
-    @Transactional
+    @Transactional(rollbackFor = Exception.class)
     public void removeCategoryAndPostCategoryBy(Integer categoryId) {
+        final boolean beforeIsPrivate = isPrivate(categoryId);
+        Set<Integer> postIds = listPostIdsByCategoryIdRecursively(categoryId);
+        postCategoryService.listPostBy(categoryId);
         List<Category> categories = listByParentId(categoryId);
         if (null != categories && categories.size() > 0) {
             categories.forEach(category -> {
@@ -198,7 +205,8 @@ public class CategoryServiceImpl extends AbstractCrudService<Category, Integer>
         // Remove post categories
         postCategoryService.removeByCategoryId(categoryId);
 
-        applicationContext.publishEvent(new CategoryUpdatedEvent(this, null, category, false));
+        applicationContext.publishEvent(
+            new CategoryUpdatedEvent(this, null, category, beforeIsPrivate, postIds));
     }
 
     @Override
@@ -371,12 +379,26 @@ public class CategoryServiceImpl extends AbstractCrudService<Category, Integer>
                 Category categoryParam = idCategoryParamMap.get(categoryToUpdate.getId());
                 BeanUtils.updateProperties(categoryParam, categoryToUpdate);
                 Category categoryUpdated = update(categoryToUpdate);
+
+                Set<Integer> postIds = listPostIdsByCategoryIdRecursively(categoryUpdated.getId());
                 applicationContext.publishEvent(new CategoryUpdatedEvent(this,
-                    categoryUpdated, categoryBefore, beforeIsPrivate));
+                    categoryUpdated, categoryBefore, beforeIsPrivate, postIds));
                 return categoryUpdated;
             })
             .collect(Collectors.toList());
     }
 
+    @NonNull
+    @Override
+    public Set<Integer> listPostIdsByCategoryIdRecursively(@NonNull Integer categoryId) {
+        Set<Integer> categoryIds = ServiceUtils.fetchProperty(listAllByParentId(categoryId),
+            Category::getId);
+        if (CollectionUtils.isEmpty(categoryIds)) {
+            return Collections.emptySet();
+        }
+        List<PostCategory> postCategories =
+            postCategoryService.listByCategoryIdList(new ArrayList<>(categoryIds));
+        return ServiceUtils.fetchProperty(postCategories, PostCategory::getPostId);
+    }
 
 }

--- a/src/main/java/run/halo/app/service/impl/CategoryServiceImpl.java
+++ b/src/main/java/run/halo/app/service/impl/CategoryServiceImpl.java
@@ -190,8 +190,7 @@ public class CategoryServiceImpl extends AbstractCrudService<Category, Integer>
     @Transactional(rollbackFor = Exception.class)
     public void removeCategoryAndPostCategoryBy(Integer categoryId) {
         final boolean beforeIsPrivate = isPrivate(categoryId);
-        Set<Integer> postIds = listPostIdsByCategoryIdRecursively(categoryId);
-        postCategoryService.listPostBy(categoryId);
+        final Set<Integer> postIds = listPostIdsByCategoryIdRecursively(categoryId);
         List<Category> categories = listByParentId(categoryId);
         if (null != categories && categories.size() > 0) {
             categories.forEach(category -> {


### PR DESCRIPTION
### What this PR does?
删除分类后同步刷新关联文章的加密状态

### Why we need it?
解决加密分类被删除后文章私密状态没有被恢复问题

/cc @halo-dev/sig-halo
/area core