### PR TITLE
chore: upgrade spring boot to 2.5.12

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id "org.springframework.boot" version "2.5.11"
+    id "org.springframework.boot" version "2.5.12"
     id "io.spring.dependency-management" version "1.0.11.RELEASE"
     id "checkstyle"
     id "java"


### PR DESCRIPTION
### What this PR does?
升级 springboot 到 2.5.12
> https://docs.spring.io/spring-boot/docs/2.5.12/reference/html/

/kind dependencies
/cc @halo-dev/sig-halo 