### PR TITLE
fix: post modified in the recycle will be restored

### DIFF
--- a/src/main/java/run/halo/app/listener/post/PostRefreshStatusListener.java
+++ b/src/main/java/run/halo/app/listener/post/PostRefreshStatusListener.java
@@ -155,7 +155,7 @@ public class PostRefreshStatusListener {
                 status = PostStatus.INTIMATE;
             } else if (isPrivate) {
                 status = PostStatus.INTIMATE;
-            } else {
+            } else if (!PostStatus.RECYCLE.equals(status)) {
                 status = PostStatus.PUBLISHED;
             }
         } else if (!isPrivate && StringUtils.isBlank(post.getPassword())) {


### PR DESCRIPTION
### What this PR does?
修复重新设置回收站中的文章，文章会被从回收站还原的问题
<img width="1020" alt="image" src="https://user-images.githubusercontent.com/38999863/161920129-1c96a88f-ba31-4165-ac27-311734481cbb.png">

/kind bug
/cc @halo-dev/sig-halo