### PR TITLE
fix: posts in the recycle are not excluded when calculating posts under tag

### DIFF
--- a/src/main/java/run/halo/app/repository/PostTagRepository.java
+++ b/src/main/java/run/halo/app/repository/PostTagRepository.java
@@ -114,7 +114,8 @@ public interface PostTagRepository extends BaseRepository<PostTag, Integer> {
      * @return a list of tag post count projection
      */
     @Query("select new run.halo.app.model.projection.TagPostPostCountProjection(count(pt.postId),"
-        + " pt.tagId) from PostTag pt group by pt.tagId")
+        + " pt.tagId) from PostTag pt inner join Post p on p.id=pt.postId and"
+        + " p.status<>2 group by pt.tagId")
     @NonNull
     List<TagPostPostCountProjection> findPostCount();
 }


### PR DESCRIPTION
### What this PR does?
修复根据标签统计文章数量时没有过滤掉回收站中的文章问题

/kind bug
/cc @halo-dev/sig-halo 