### PR TITLE
fix: the encrypted post is in an incorrect state after being recovered from the recycle

### DIFF
--- a/src/main/java/run/halo/app/listener/post/PostRefreshStatusListener.java
+++ b/src/main/java/run/halo/app/listener/post/PostRefreshStatusListener.java
@@ -153,9 +153,9 @@ public class PostRefreshStatusListener {
         if (post.getStatus() != PostStatus.DRAFT) {
             if (StringUtils.isNotEmpty(post.getPassword())) {
                 status = PostStatus.INTIMATE;
-            } else if (isPrivate) {
+            } else if (isPrivate && !PostStatus.RECYCLE.equals(status)) {
                 status = PostStatus.INTIMATE;
-            } else {
+            } else if (!PostStatus.RECYCLE.equals(status)) {
                 status = PostStatus.PUBLISHED;
             }
         } else if (!isPrivate && StringUtils.isBlank(post.getPassword())) {

--- a/src/main/java/run/halo/app/service/impl/PostServiceImpl.java
+++ b/src/main/java/run/halo/app/service/impl/PostServiceImpl.java
@@ -207,6 +207,13 @@ public class PostServiceImpl extends BasePostServiceImpl<Post> implements PostSe
     }
 
     @Override
+    public Post updateStatus(PostStatus status, Integer postId) {
+        Post post = super.updateStatus(status, postId);
+        eventPublisher.publishEvent(new PostUpdatedEvent(this, post));
+        return post;
+    }
+
+    @Override
     public Post getBy(PostStatus status, String slug) {
         return super.getBy(status, slug);
     }


### PR DESCRIPTION
### What this PR does?
修复加密文章从回收站恢复后的状态不是加密的问题

/kind bug
/cc @halo-dev/sig-halo 