### PR TITLE
feat: add OWNERS file for prow

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,0 +1,11 @@
+reviewers:
+- ruibaby
+- guqing
+- JohnNiang
+- lan-yonghui
+- wangzhen-fit2cloud
+
+approvers:
+- ruibaby
+- guqing
+- JohnNiang


### PR DESCRIPTION
### What this PR does?
添加 OWNERS 文件以确保 prow 可以使用 approve

/cc @halo-dev/sig-halo 