### PR TITLE
feat: Allow configuration for token and refresh token time-to-live

### DIFF
--- a/src/main/java/run/halo/app/identity/authentication/JwtDaoAuthenticationProvider.java
+++ b/src/main/java/run/halo/app/identity/authentication/JwtDaoAuthenticationProvider.java
@@ -26,10 +26,6 @@ public class JwtDaoAuthenticationProvider extends DaoAuthenticationProvider {
         "https://datatracker.ietf.org/doc/html/rfc6749#section-5.2";
     private final OAuth2TokenGenerator<? extends OAuth2Token> tokenGenerator;
     private final OAuth2AuthorizationService authorizationService;
-    /**
-     * TODO from token settings
-     */
-    private static final boolean isReuseRefreshTokens = false;
 
     public JwtDaoAuthenticationProvider(
         OAuth2TokenGenerator<? extends OAuth2Token> tokenGenerator,
@@ -89,9 +85,12 @@ public class JwtDaoAuthenticationProvider extends DaoAuthenticationProvider {
             authorizationBuilder.accessToken(accessToken);
         }
 
+        ProviderSettings providerSettings =
+            ProviderContextHolder.getProviderContext().providerSettings();
+
         // ----- Refresh token -----
         OAuth2RefreshToken currentRefreshToken = refreshToken.getToken();
-        if (!isReuseRefreshTokens) {
+        if (!providerSettings.isReuseRefreshTokens()) {
             tokenContext = tokenContextBuilder.tokenType(OAuth2TokenType.REFRESH_TOKEN).build();
             OAuth2Token generatedRefreshToken = this.tokenGenerator.generate(tokenContext);
             if (generatedRefreshToken == null) {

--- a/src/main/java/run/halo/app/identity/authentication/OAuth2TokenContext.java
+++ b/src/main/java/run/halo/app/identity/authentication/OAuth2TokenContext.java
@@ -10,7 +10,7 @@ import org.springframework.util.Assert;
 
 /**
  * @author guqing
- * @date 2022-04-14
+ * @since 2.0.0
  */
 public interface OAuth2TokenContext extends Context {
 

--- a/src/main/java/run/halo/app/identity/authentication/ProviderSettings.java
+++ b/src/main/java/run/halo/app/identity/authentication/ProviderSettings.java
@@ -1,5 +1,6 @@
 package run.halo.app.identity.authentication;
 
+import java.time.Duration;
 import java.util.Map;
 import org.springframework.util.Assert;
 import run.halo.app.infra.config.AbstractSettings;
@@ -9,7 +10,7 @@ import run.halo.app.infra.config.ConfigurationSettingNames;
  * A facility for provider configuration settings.
  *
  * @author guqing
- * @date 2022-04-14
+ * @since 2.0.0
  */
 public final class ProviderSettings extends AbstractSettings {
     private ProviderSettings(Map<String, Object> settings) {
@@ -54,15 +55,44 @@ public final class ProviderSettings extends AbstractSettings {
     }
 
     /**
+     * Returns the time-to-live for an access token. The default is 5 minutes.
+     *
+     * @return the time-to-live for an access token
+     */
+    public Duration getAccessTokenTimeToLive() {
+        return getSetting(ConfigurationSettingNames.Token.ACCESS_TOKEN_TIME_TO_LIVE);
+    }
+
+    /**
+     * Returns {@code true} if refresh tokens are reused when returning the access token response,
+     * or {@code false} if a new refresh token is issued. The default is {@code true}.
+     */
+    public boolean isReuseRefreshTokens() {
+        return getSetting(ConfigurationSettingNames.Token.REUSE_REFRESH_TOKENS);
+    }
+
+    /**
+     * Returns the time-to-live for a refresh token. The default is 60 minutes.
+     *
+     * @return the time-to-live for a refresh token
+     */
+    public Duration getRefreshTokenTimeToLive() {
+        return getSetting(ConfigurationSettingNames.Token.REFRESH_TOKEN_TIME_TO_LIVE);
+    }
+
+    /**
      * Constructs a new {@link Builder} with the default settings.
      *
      * @return the {@link Builder}
      */
     public static Builder builder() {
         return new Builder()
-            .authorizationEndpoint("/oauth2/authorize")
-            .tokenEndpoint("/oauth2/token")
-            .jwkSetEndpoint("/oauth2/jwks");
+            .authorizationEndpoint("/api/v1/oauth2/authorize")
+            .tokenEndpoint("/api/v1/oauth2/token")
+            .jwkSetEndpoint("/api/v1/oauth2/jwks")
+            .accessTokenTimeToLive(Duration.ofMinutes(5L))
+            .refreshTokenTimeToLive(Duration.ofMinutes(60))
+            .reuseRefreshTokens(false);
     }
 
     /**
@@ -124,6 +154,48 @@ public final class ProviderSettings extends AbstractSettings {
          */
         public Builder jwkSetEndpoint(String jwkSetEndpoint) {
             return setting(ConfigurationSettingNames.Provider.JWK_SET_ENDPOINT, jwkSetEndpoint);
+        }
+
+        /**
+         * Set the time-to-live for an access token. Must be greater than {@code Duration.ZERO}.
+         *
+         * @param accessTokenTimeToLive the time-to-live for an access token
+         * @return the {@link Builder} for further configuration
+         */
+        public Builder accessTokenTimeToLive(Duration accessTokenTimeToLive) {
+            Assert.notNull(accessTokenTimeToLive, "accessTokenTimeToLive cannot be null");
+            Assert.isTrue(accessTokenTimeToLive.getSeconds() > 0,
+                "accessTokenTimeToLive must be greater than Duration.ZERO");
+            return setting(ConfigurationSettingNames.Token.ACCESS_TOKEN_TIME_TO_LIVE,
+                accessTokenTimeToLive);
+        }
+
+        /**
+         * Set to {@code true} if refresh tokens are reused when returning the access token
+         * response,
+         * or {@code false} if a new refresh token is issued.
+         *
+         * @param reuseRefreshTokens {@code true} to reuse refresh tokens, {@code false} to issue
+         * new refresh tokens
+         * @return the {@link Builder} for further configuration
+         */
+        public Builder reuseRefreshTokens(boolean reuseRefreshTokens) {
+            return setting(ConfigurationSettingNames.Token.REUSE_REFRESH_TOKENS,
+                reuseRefreshTokens);
+        }
+
+        /**
+         * Set the time-to-live for a refresh token. Must be greater than {@code Duration.ZERO}.
+         *
+         * @param refreshTokenTimeToLive the time-to-live for a refresh token
+         * @return the {@link Builder} for further configuration
+         */
+        public Builder refreshTokenTimeToLive(Duration refreshTokenTimeToLive) {
+            Assert.notNull(refreshTokenTimeToLive, "refreshTokenTimeToLive cannot be null");
+            Assert.isTrue(refreshTokenTimeToLive.getSeconds() > 0,
+                "refreshTokenTimeToLive must be greater than Duration.ZERO");
+            return setting(ConfigurationSettingNames.Token.REFRESH_TOKEN_TIME_TO_LIVE,
+                refreshTokenTimeToLive);
         }
 
         /**

--- a/src/main/java/run/halo/app/infra/config/AbstractSettings.java
+++ b/src/main/java/run/halo/app/infra/config/AbstractSettings.java
@@ -12,7 +12,7 @@ import org.springframework.util.Assert;
  * Base implementation for configuration settings.
  *
  * @author guqing
- * @date 2022-04-14
+ * @since 2.0.0
  */
 public abstract class AbstractSettings implements Serializable {
     private final Map<String, Object> settings;

--- a/src/main/java/run/halo/app/infra/config/ConfigurationSettingNames.java
+++ b/src/main/java/run/halo/app/infra/config/ConfigurationSettingNames.java
@@ -60,14 +60,6 @@ public class ConfigurationSettingNames {
             TOKEN_SETTINGS_NAMESPACE.concat("access-token-time-to-live");
 
         /**
-         * Set the {@link OAuth2TokenFormat token format} for an access token.
-         *
-         * @since 0.2.3
-         */
-        public static final String ACCESS_TOKEN_FORMAT =
-            TOKEN_SETTINGS_NAMESPACE.concat("access-token-format");
-
-        /**
          * Set to {@code true} if refresh tokens are reused when returning the access token
          * response,
          * or {@code false} if a new refresh token is issued.

--- a/src/test/java/run/halo/app/authentication/JwtGeneratorTest.java
+++ b/src/test/java/run/halo/app/authentication/JwtGeneratorTest.java
@@ -6,7 +6,6 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
 import java.time.Instant;
-import java.time.temporal.ChronoUnit;
 import java.util.Set;
 import java.util.stream.Collectors;
 import org.junit.jupiter.api.BeforeEach;
@@ -100,7 +99,15 @@ public class JwtGeneratorTest {
             tokenContext.getPrincipal().getName());
 
         Instant issuedAt = Instant.now();
-        Instant expiresAt = issuedAt.plus(30, ChronoUnit.MINUTES);
+
+        ProviderSettings providerSettings = tokenContext.getProviderContext().providerSettings();
+        Instant expiresAt;
+        if (OAuth2TokenType.ACCESS_TOKEN.equals(tokenContext.getTokenType())) {
+            expiresAt = issuedAt.plus(providerSettings.getAccessTokenTimeToLive());
+        } else {
+            expiresAt = issuedAt.plus(providerSettings.getAccessTokenTimeToLive());
+        }
+
         assertThat(jwtClaimsSet.getIssuedAt()).isBetween(issuedAt.minusSeconds(1),
             issuedAt.plusSeconds(1));
         assertThat(jwtClaimsSet.getExpiresAt()).isBetween(expiresAt.minusSeconds(1),

--- a/src/test/java/run/halo/app/authentication/ProviderSettingsTest.java
+++ b/src/test/java/run/halo/app/authentication/ProviderSettingsTest.java
@@ -3,6 +3,7 @@ package run.halo.app.authentication;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
 
+import java.time.Duration;
 import org.junit.jupiter.api.Test;
 import run.halo.app.identity.authentication.ProviderSettings;
 
@@ -19,9 +20,13 @@ public class ProviderSettingsTest {
         ProviderSettings providerSettings = ProviderSettings.builder().build();
 
         assertThat(providerSettings.getIssuer()).isNull();
-        assertThat(providerSettings.getAuthorizationEndpoint()).isEqualTo("/oauth2/authorize");
-        assertThat(providerSettings.getTokenEndpoint()).isEqualTo("/oauth2/token");
-        assertThat(providerSettings.getJwkSetEndpoint()).isEqualTo("/oauth2/jwks");
+        assertThat(providerSettings.getAuthorizationEndpoint()).isEqualTo(
+            "/api/v1/oauth2/authorize");
+        assertThat(providerSettings.getTokenEndpoint()).isEqualTo("/api/v1/oauth2/token");
+        assertThat(providerSettings.getJwkSetEndpoint()).isEqualTo("/api/v1/oauth2/jwks");
+        assertThat(providerSettings.isReuseRefreshTokens()).isEqualTo(false);
+        assertThat(providerSettings.getAccessTokenTimeToLive()).isEqualTo(Duration.ofMinutes(5));
+        assertThat(providerSettings.getRefreshTokenTimeToLive()).isEqualTo(Duration.ofMinutes(60));
     }
 
     @Test
@@ -30,18 +35,27 @@ public class ProviderSettingsTest {
         String tokenEndpoint = "/oauth2/v1/token";
         String jwkSetEndpoint = "/oauth2/v1/jwks";
         String issuer = "https://example.com:9000";
+        boolean isReuseRefreshTokens = true;
+        Duration accessTokenTimeToLive = Duration.ofMinutes(30);
+        Duration refreshTokenTimeToLive = Duration.ofMinutes(120);
 
         ProviderSettings providerSettings = ProviderSettings.builder()
             .issuer(issuer)
             .authorizationEndpoint(authorizationEndpoint)
             .tokenEndpoint(tokenEndpoint)
             .jwkSetEndpoint(jwkSetEndpoint)
+            .reuseRefreshTokens(isReuseRefreshTokens)
+            .accessTokenTimeToLive(accessTokenTimeToLive)
+            .refreshTokenTimeToLive(refreshTokenTimeToLive)
             .build();
 
         assertThat(providerSettings.getIssuer()).isEqualTo(issuer);
         assertThat(providerSettings.getAuthorizationEndpoint()).isEqualTo(authorizationEndpoint);
         assertThat(providerSettings.getTokenEndpoint()).isEqualTo(tokenEndpoint);
         assertThat(providerSettings.getJwkSetEndpoint()).isEqualTo(jwkSetEndpoint);
+        assertThat(providerSettings.isReuseRefreshTokens()).isEqualTo(isReuseRefreshTokens);
+        assertThat(providerSettings.getAccessTokenTimeToLive()).isEqualTo(accessTokenTimeToLive);
+        assertThat(providerSettings.getRefreshTokenTimeToLive()).isEqualTo(refreshTokenTimeToLive);
     }
 
     @Test
@@ -51,7 +65,7 @@ public class ProviderSettingsTest {
             .settings(settings -> settings.put("name2", "value2"))
             .build();
 
-        assertThat(providerSettings.getSettings()).hasSize(5);
+        assertThat(providerSettings.getSettings()).hasSize(8);
         assertThat(providerSettings.<String>getSetting("name1")).isEqualTo("value1");
         assertThat(providerSettings.<String>getSetting("name2")).isEqualTo("value2");
     }
@@ -82,5 +96,33 @@ public class ProviderSettingsTest {
         assertThatIllegalArgumentException()
             .isThrownBy(() -> ProviderSettings.builder().jwkSetEndpoint(null))
             .withMessage("value cannot be null");
+    }
+
+    @Test
+    public void refreshTokenTimeToLiveWhenNullThenThrowIllegalArgumentException() {
+        assertThatIllegalArgumentException()
+            .isThrownBy(() -> ProviderSettings.builder().refreshTokenTimeToLive(null))
+            .withMessage("refreshTokenTimeToLive cannot be null");
+    }
+
+    @Test
+    public void refreshTokenTimeToLiveWhenLessThanZeroThenThrowIllegalArgumentException() {
+        assertThatIllegalArgumentException()
+            .isThrownBy(() -> ProviderSettings.builder().refreshTokenTimeToLive(Duration.ZERO))
+            .withMessage("refreshTokenTimeToLive must be greater than Duration.ZERO");
+    }
+
+    @Test
+    public void accessTokenTimeToLiveToLiveWhenNullThenThrowIllegalArgumentException() {
+        assertThatIllegalArgumentException()
+            .isThrownBy(() -> ProviderSettings.builder().accessTokenTimeToLive(null))
+            .withMessage("accessTokenTimeToLive cannot be null");
+    }
+
+    @Test
+    public void accessTokenTimeToLiveToLiveWhenLessThanZeroThenThrowIllegalArgumentException() {
+        assertThatIllegalArgumentException()
+            .isThrownBy(() -> ProviderSettings.builder().accessTokenTimeToLive(Duration.ZERO))
+            .withMessage("accessTokenTimeToLive must be greater than Duration.ZERO");
     }
 }


### PR DESCRIPTION
### What this PR does?
支持通过配置来定制 token 和 refresh token 的生存时间

参考文档：https://datatracker.ietf.org/doc/html/rfc6749#section-4.2.2

### Why we need it?
为了确保安全，生成 jwt access token 会伴随有过期时间，过期后在通过携带 refresh token 到接口换取新的 access token，那么access token和 refresh token的生存时间就需要允许通过配置来个性化修改，通常 access token的生存时间要比 refresh token短。

### How to test it?
1. 拉取本 PR后运行
```shell
curl -X POST http://localhost:8090/api/v1/oauth2/login -H "Content-Type: application/x-www-form-urlencoded" -d 'username=user&password=123456'
```
2. 会收到类似如下结果
```json
{
    "access_token": "eyJhbGciOiJSUzI1NiJ9.eyJzdWIiOiJ1c2VyIiwibmJmIjoxNjUwMjY2MTI3LCJzY29wZSI6WyJST0xFX1VTRVIiXSwiaXNzIjoiaHR0cDpcL1wvbG9jYWxob3N0OjgwOTAiLCJleHAiOjE2NTAyNjY0MjcsImlhdCI6MTY1MDI2NjEyNywianRpIjoiMjg2Yjc4ODU1MDcxNGQ3M2I1NjgzMjFjYjQ3OWM2NTMifQ.K_5d66DshBClReSKpdMoxQmg_4gMYL0Te8_s2fS5Jbwmur9Lvck2ORzyVDfyi3fTicCLVWeOzJmSBMOTIEAZy91kVfAdZlPb8VLRu9VoK5oiWmX58t-yBpzDDy8t0Qmrd_YNMJkOCAXNhnHjpes7A26q8C659LgvRpd5B2pWsluJX97xHaPWAPmy9X3OlInpBFlwg5bPj85cUoohfhiDV2y342Xx-Irn-YC36Ualz20JazjFL6QaWsxoFS-yrJqOIY-g3rkCzdfWOBILt1GHL9JxTyawEOIkMnzgS31dmi1rFstbpWlniBw_g3-66FqrOVony4dsVi1AvIUJDUbpEA",
    "refresh_token": "eyJhbGciOiJSUzI1NiJ9.eyJzdWIiOiJ1c2VyIiwibmJmIjoxNjUwMjY2MTI3LCJpc3MiOiJodHRwOlwvXC9sb2NhbGhvc3Q6ODA5MCIsImV4cCI6MTY1MDI2OTcyNywiaWF0IjoxNjUwMjY2MTI3LCJqdGkiOiI3YzQxZTc1YmYyODE0YWI3ODkzMGFlMzZiNDMwZjY3NCJ9.umGsALlQ7xAliJY3slJCfGZ3rcfKDT4je1HmaElw91Tibf6BA1iSYQQczvTeLpQgTJ11_Us6ldpwD9M9Z1vESu87jHa0zKtkV7mUuKOWIRYBL3I_bzjdgNSeAuI0ayFJBcpsd3TwMW-ioLqYUtGcXjuA12twSHYyycSk5oN9ZO_T70y5MYSGwShxn8wDjfNuLGYwyUs-tbYD0ey2K5vcgAJ8A_o4HzHS3iJFmo9B1PyIYFSL4EFaU8sDna4eFxC2CJfkz1W6tAFEnIVgJysctbtaggh9wwQTgrW8z7tLzdPKEjoSIhEvpduPiEMi8B1bM6vh9uBn8rILo1kFJigkjA",
    "scope": "ROLE_USER",
    "token_type": "Bearer",
    "expires_in": 299
}
```
默认 expires_in (access_token的过期时间)为 5 分钟
可以到 https://jwt.io 填入 access_token 看到类似如下结果：
```json
HEADER:ALGORITHM & TOKEN TYPE
{
  "alg": "RS256"
}

PAYLOAD:DATA
{
  "sub": "user",
  "nbf": 1650266127,
  "scope": [ // refresh token 没有 scope 属性
    "ROLE_USER"
  ],
  "iss": "http://localhost:8090",
  "exp": 1650266427, // Mon Apr 18 2022 15:20:27 GMT+0800 (中国标准时间)
  "iat": 1650266127, // Mon Apr 18 2022 15:15:27 GMT+0800 (中国标准时间)
  "jti": "286b788550714d73b568321cb479c653"
}
```
填入 refresh_token (生存时间1小时)到 https://jwt.io
```json
HEADER:ALGORITHM & TOKEN TYPE
{
  "alg": "RS256"
}

PAYLOAD:DATA
{
  "sub": "user",
  "nbf": 1650266127,
  "iss": "http://localhost:8090",
  "exp": 1650269727, // Mon Apr 18 2022 16:15:27 GMT+0800 (中国标准时间)
  "iat": 1650266127, // Mon Apr 18 2022 15:15:27 GMT+0800 (中国标准时间)
  "jti": "7c41e75bf2814ab78930ae36b430f674"
}
```
### What to do next
提供 OAuth2AuthorizationService 的默认实现 InMemeryOAuth2AuthorizationService 用来在存储持久化 oauth2 token 和 查询

/kind feature
/milestone 2.0
/area core
/cc @halo-dev/sig-halo