### PR TITLE
feat: SMTP support configuration starttls

### DIFF
--- a/src/main/java/run/halo/app/mail/AbstractMailService.java
+++ b/src/main/java/run/halo/app/mail/AbstractMailService.java
@@ -213,12 +213,7 @@ public abstract class AbstractMailService implements MailService {
                 optionService.getByPropertyOrDefault(EmailProperties.PASSWORD, String.class));
             mailProperties.setProtocol(
                 optionService.getByPropertyOrDefault(EmailProperties.PROTOCOL, String.class));
-            // check whether starttls is required to be enabled
-            String serverCheck =
-                optionService.getByPropertyOrDefault(EmailProperties.HOST, String.class);
-            if (serverCheck.contains("outlook.com") || serverCheck.contains("office365.com")
-                || serverCheck.contains("live.com") || serverCheck.contains("mail.me.com")
-                || serverCheck.contains("hotmail.com")) {
+            if (optionService.getByPropertyOrDefault(EmailProperties.STARTTLS, Boolean.class)) {
                 Map<String, String> starttls = new HashMap<>();
                 starttls.put("mail.smtp.starttls.enable", "true");
                 starttls.put("mail.smtp.auth", "true");

--- a/src/main/java/run/halo/app/mail/AbstractMailService.java
+++ b/src/main/java/run/halo/app/mail/AbstractMailService.java
@@ -2,6 +2,8 @@ package run.halo.app.mail;
 
 import java.io.UnsupportedEncodingException;
 import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.function.Consumer;
@@ -211,6 +213,17 @@ public abstract class AbstractMailService implements MailService {
                 optionService.getByPropertyOrDefault(EmailProperties.PASSWORD, String.class));
             mailProperties.setProtocol(
                 optionService.getByPropertyOrDefault(EmailProperties.PROTOCOL, String.class));
+            // check whether starttls is required to be enabled
+            String serverCheck =
+                optionService.getByPropertyOrDefault(EmailProperties.HOST, String.class);
+            if (serverCheck.contains("outlook.com") || serverCheck.contains("office365.com")
+                || serverCheck.contains("live.com") || serverCheck.contains("mail.me.com")
+                || serverCheck.contains("hotmail.com")) {
+                Map<String, String> starttls = new HashMap<>();
+                starttls.put("mail.smtp.starttls.enable", "true");
+                starttls.put("mail.smtp.auth", "true");
+                mailProperties.setProperties(starttls);
+            }
             this.cachedMailProperties = mailProperties;
         }
 

--- a/src/main/java/run/halo/app/model/properties/EmailProperties.java
+++ b/src/main/java/run/halo/app/model/properties/EmailProperties.java
@@ -19,6 +19,11 @@ public enum EmailProperties implements PropertyEnum {
     PROTOCOL("email_protocol", String.class, "smtp"),
 
     /**
+     * Is starttls enabled
+     */
+    STARTTLS("email_starttls", Boolean.class, "false"),
+
+    /**
      * SSL port
      */
     SSL_PORT("email_ssl_port", Integer.class, "465"),


### PR DESCRIPTION
Fix #1848
**What this PR does?**

- 为office365,icloud等增添starttls支持

**本地测试**

- office365和outlook成功，iCloud等暂未测试
- 切换回其他邮箱后不影响正常的使用

