### PR TITLE
chore: use providerSettings to create OAuth2TokenEndpointFilter

### DIFF
--- a/src/main/java/run/halo/app/config/WebSecurityConfig.java
+++ b/src/main/java/run/halo/app/config/WebSecurityConfig.java
@@ -44,7 +44,7 @@ import run.halo.app.infra.properties.JwtProperties;
 
 /**
  * @author guqing
- * @date 2022-04-12
+ * @since 2022-04-12
  */
 @EnableWebSecurity
 @EnableConfigurationProperties(JwtProperties.class)
@@ -69,12 +69,13 @@ public class WebSecurityConfig {
         ProviderContextFilter providerContextFilter = new ProviderContextFilter(providerSettings);
         http
             .authorizeHttpRequests((authorize) -> authorize
-                .antMatchers("/api/v1/oauth2/token").permitAll()
+                .antMatchers(providerSettings.getTokenEndpoint()).permitAll()
                 .antMatchers("/api/**", "/apis/**").authenticated()
             )
             .csrf(AbstractHttpConfigurer::disable)
             .httpBasic(Customizer.withDefaults())
-            .addFilterBefore(new OAuth2TokenEndpointFilter(authenticationManager()),
+            .addFilterBefore(new OAuth2TokenEndpointFilter(authenticationManager(),
+                    providerSettings.getTokenEndpoint()),
                 FilterSecurityInterceptor.class)
             .addFilterAfter(providerContextFilter, SecurityContextPersistenceFilter.class)
             .sessionManagement(


### PR DESCRIPTION
### What this PR does?
通过`providerSettings#getTokenEndpoint()`创建 OAuth2TokenEndpointFilter 作为其 tokenEndpointMatcher,默认值为`/api/v1/oauth2/token`也就是 password 认证模式和 refresh token 的 uri

### Why we need it?
统一配置，可以在创建 providerSettings 时定制认证 endpoint

### What to do next
针对已经颁发的 token 提供验证功能，client request 携带 token 后验证是否正确，如果不正确则不允许访问内部资源

/cc @halo-dev/sig-halo 