### PR TITLE
fix typo: swagger api operation title typo

### DIFF
--- a/src/main/java/run/halo/app/controller/admin/api/PostController.java
+++ b/src/main/java/run/halo/app/controller/admin/api/PostController.java
@@ -173,7 +173,7 @@ public class PostController {
     }
 
     @DeleteMapping("{postId:\\d+}")
-    @ApiOperation("Deletes a photo permanently")
+    @ApiOperation("Deletes a post permanently")
     public void deletePermanently(@PathVariable("postId") Integer postId) {
         postService.removeById(postId);
     }


### PR DESCRIPTION
修复 Admin API 中 post-controller 永久删除 Post 操作名称拼写错误。

https://api.halo.run/admin-api.html#operation/deletePermanentlyUsingDELETE_6