### PR TITLE
feat: Add bearer token filter config for authentication

### DIFF
--- a/src/main/java/run/halo/app/identity/HelloController.java
+++ b/src/main/java/run/halo/app/identity/HelloController.java
@@ -1,0 +1,21 @@
+package run.halo.app.identity;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * A controller should ONLY be used during testing for this PR.
+ *
+ * @author guqing
+ * @since 2.0.0
+ */
+@RestController
+@RequestMapping("/tests")
+public class HelloController {
+
+    @GetMapping
+    public String hello() {
+        return "Now you see me.";
+    }
+}

--- a/src/main/java/run/halo/app/identity/authentication/verifier/JwtProvidedDecoderAuthenticationManagerResolver.java
+++ b/src/main/java/run/halo/app/identity/authentication/verifier/JwtProvidedDecoderAuthenticationManagerResolver.java
@@ -1,0 +1,25 @@
+package run.halo.app.identity.authentication.verifier;
+
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.AuthenticationManagerResolver;
+import org.springframework.security.oauth2.jwt.JwtDecoder;
+import org.springframework.util.Assert;
+
+/**
+ * A jwt resolver for {@link AuthenticationManager} use {@link JwtDecoder}.
+ *
+ * @author guqing
+ * @since 2.0.0
+ */
+public record JwtProvidedDecoderAuthenticationManagerResolver(JwtDecoder jwtDecoder)
+    implements AuthenticationManagerResolver<HttpServletRequest> {
+    public JwtProvidedDecoderAuthenticationManagerResolver {
+        Assert.notNull(jwtDecoder, "jwtDecoder cannot be null");
+    }
+
+    @Override
+    public AuthenticationManager resolve(HttpServletRequest request) {
+        return new JwtAuthenticationProvider(jwtDecoder)::authenticate;
+    }
+}


### PR DESCRIPTION
### What this PR does?
添加 bearer token filter 的 security 配置，完成整条 token 验证流程

### Why we need it?
拦截请求，解析并校验 token, 参见：#1864

### How to test it?
1. 拉取本 PR 到本地运行
2. 通过默认提供的用户密码获取 token
```shell
curl -X POST http://localhost:8090/api/v1/oauth2/token -H "Content-Type: application/x-www-form-urlencoded" -d 'username=user&password=123456&grant_type=password'
```
3. 先访问 `curl http://localhost:8090/api/v1/tests` 会得到 `Unauthorized` 的 response，表示请求需要认证
4. 使用 `步骤2` 中`/api/v1/oauth2/token`请求获取到的 `access_token` 替换如下 `Bearer` 后的 `your_access_token`(注意 Bearer 和 your_access_token 之间需要一个空格)
```shell
curl http://localhost:8090/api/v1/tests -H "Authorization: Bearer your_access_token"
```
便可看到如下结果
```
Now you see me.⏎
```

/kind feature
/milestone 2.0
/area core
/cc @halo-dev/sig-halo 