### PR TITLE
feat: Add Principal attribute to authorizationBuilder when password authenticate successfully

### DIFF
--- a/src/main/java/run/halo/app/identity/authentication/OAuth2PasswordAuthenticationProvider.java
+++ b/src/main/java/run/halo/app/identity/authentication/OAuth2PasswordAuthenticationProvider.java
@@ -1,5 +1,6 @@
 package run.halo.app.identity.authentication;
 
+import java.security.Principal;
 import java.util.Collections;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -78,7 +79,8 @@ public class OAuth2PasswordAuthenticationProvider extends DaoAuthenticationProvi
         OAuth2Authorization.Builder authorizationBuilder = new OAuth2Authorization.Builder()
             .principalName(authentication.getName())
             .authorizationGrantType(AuthorizationGrantType.PASSWORD)
-            .attribute(OAuth2Authorization.AUTHORIZED_SCOPE_ATTRIBUTE_NAME, scopes);
+            .attribute(OAuth2Authorization.AUTHORIZED_SCOPE_ATTRIBUTE_NAME, scopes)
+            .attribute(Principal.class.getName(), authentication);
 
         // ----- Access token -----
         OAuth2TokenContext tokenContext =


### PR DESCRIPTION
### What this PR does?
认证成功创建 token 时添加 Principal 属性到 OAuth2Authorization 对象中通过 authorizationService 持久化
在刷新 token 时便于通过其恢复 principal

### How to test it?
1. 拉取本PR到本地启动
2. 通过密码认证获取 refresh_token
```shell
curl -X POST http://localhost:8090/api/v1/oauth2/token -H "Content-Type: application/x-www-form-urlencoded" -d 'username=user&password=123456&grant_type=password'
```
3. 使用获取到的 refresh_token 刷新一个新 token 对象(替换下面的 `your_refresh_token` 为 `步骤2` 获取到的 `refresh_token`值)
```shell
curl -X POST http://localhost:8090/api/v1/oauth2/token -H "Content-Type: application/x-www-form-urlencoded" -d 'refresh_token=your_refresh_token&grant_type=refresh_token'
```
此时会得到一个新的token对象
如果继续使用 `步骤3` 的请求会得到
```
{
    "error": "invalid_grant"
}
```
原因是： 一个 refresh_token 只能使用一次，用过以后就不能在使用了，这也是为什么需要 OAuth2AuthorizationService 的原因之一

/kind feature
/milestone 2.0
/cc @halo-dev/sig-halo 