### PR TITLE
关于百度云生成链接错误问题的修复

### DIFF
--- a/src/main/java/run/halo/app/handler/file/FilePathDescriptor.java
+++ b/src/main/java/run/halo/app/handler/file/FilePathDescriptor.java
@@ -121,9 +121,10 @@ public final class FilePathDescriptor {
 
         String getFullPath() {
             if (StringUtils.isNotBlank(this.basePath)) {
-                return getPath(this.basePath, this.subPath, this.getFullName());
+                return getPath(this.basePath, this.getFullName());
+            }else {
+                return getPath(this.subPath, this.getFullName());
             }
-            return getPath(this.subPath, this.getFullName());
         }
 
         String getRelativePath() {

--- a/src/test/java/run/halo/app/handler/file/BaiduBosFileHandlerTest.java
+++ b/src/test/java/run/halo/app/handler/file/BaiduBosFileHandlerTest.java
@@ -1,0 +1,52 @@
+package run.halo.app.handler.file;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.apache.commons.lang3.StringUtils;
+import org.junit.jupiter.api.Test;
+import run.halo.app.model.support.UploadResult;
+
+/**
+ * BaiduBosFileHandler Tester.
+ *
+ * @author <Authors name>
+ * @since <pre>4�� 24, 2022</pre>
+ * @version 1.0
+ */
+public class BaiduBosFileHandlerTest {
+
+
+    /**
+     *
+     * Method: upload(MultipartFile file)
+     *
+     */
+    @Test
+    public void testUpload() throws Exception {
+        String protocol = "https://";
+        String endPoint = "gz.bcebos.com";
+        String bucketName = "koroblog";
+        String domain1 = "https://file.korostudio.cn";
+        String source = StringUtils.join(protocol, bucketName, "." + endPoint);
+        FilePathDescriptor pathDescriptor1 = new FilePathDescriptor.Builder()
+            .setBasePath(domain1)
+            .setSubPath(source)
+            .setOriginalName("blhx-background_and_shouhou.png")
+            .build();
+        UploadResult uploadResult = new UploadResult();
+        uploadResult.setFilename(pathDescriptor1.getFullName());
+        String fullPath1 = pathDescriptor1.getFullPath();
+        assertEquals("https://file.korostudio.cn/blhx-background_and_shouhou.png",fullPath1);
+        String domain2 = "";
+        FilePathDescriptor pathDescriptor2 = new FilePathDescriptor.Builder()
+            .setBasePath(domain2)
+            .setSubPath(source)
+            .setOriginalName("blhx-background_and_shouhou.png")
+            .build();
+        String fullPath2 = pathDescriptor2.getFullPath();
+        assertEquals("https://koroblog.gz.bcebos.com/blhx-background_and_shouhou.png",fullPath2);
+    }
+
+
+}
+


### PR DESCRIPTION
该问题是上传附件时，生成的链接是错误拼接的。经过检查之后，发现他在basepath有或者没有的情况下，没有进行判断，如果basepath为空，拼接成的链接应为subPath+fileFullName，如果basepath不为空，拼接成的链接应为basePath+fileFullName，我在FilePathDescriptor中加入了这个判断。并且还写了一个junit4的测试文件BaiduBosFileHandlerTest.java，用来测试生成的链接是否正确。
