### PR TITLE
Update the path patterns of static files while refreshing

### DIFF
--- a/src/main/java/run/halo/app/service/impl/StaticStorageServiceImpl.java
+++ b/src/main/java/run/halo/app/service/impl/StaticStorageServiceImpl.java
@@ -53,7 +53,12 @@ public class StaticStorageServiceImpl
 
     @Override
     public List<StaticFile> listStaticFolder() {
-        return listStaticFileTree(staticDir);
+
+        List<StaticFile> staticFiles = listStaticFileTree(staticDir);
+
+        onChange(); // To update the mapping of local files.
+
+        return staticFiles;
     }
 
     @Nullable


### PR DESCRIPTION
### What this PR does?
fix #1880 
在刷新时把static目录下用户新增的文件（未通过后台添加的）加入blackPatterns中。使其可以正常访问。