### PR TITLE
Pass IOException into exception stack instead of ignoring it

### DIFF
--- a/src/main/java/run/halo/app/handler/file/LocalFileHandler.java
+++ b/src/main/java/run/halo/app/handler/file/LocalFileHandler.java
@@ -152,7 +152,8 @@ public class LocalFileHandler implements FileHandler {
                 file.getOriginalFilename(), uploadFilePath.getFullPath());
             return uploadResult;
         } catch (IOException e) {
-            throw new FileOperationException("上传附件失败", e).setErrorData(uploadFilePath.getFullPath());
+            throw new FileOperationException("上传附件失败", e)
+                .setErrorData(uploadFilePath.getFullPath());
         }
     }
 

--- a/src/main/java/run/halo/app/handler/file/LocalFileHandler.java
+++ b/src/main/java/run/halo/app/handler/file/LocalFileHandler.java
@@ -152,7 +152,7 @@ public class LocalFileHandler implements FileHandler {
                 file.getOriginalFilename(), uploadFilePath.getFullPath());
             return uploadResult;
         } catch (IOException e) {
-            throw new FileOperationException("上传附件失败").setErrorData(uploadFilePath.getFullPath());
+            throw new FileOperationException("上传附件失败", e).setErrorData(uploadFilePath.getFullPath());
         }
     }
 


### PR DESCRIPTION
### What this PR does

Pass IOException into exception stack instead of ignoring it.

### Why we need it?

由于忽略了 IOException，导致无法排查到真实错误原因，例如：
- https://github.com/halo-dev/halo/issues/1912
- https://github.com/halo-dev/halo/issues/1897

/kind bug
/area core
/milestone 1.5.x