### PR TITLE
Set transaction isolation to read_uncommitted due to @Async

### DIFF
--- a/src/main/java/run/halo/app/listener/comment/CommentEventListener.java
+++ b/src/main/java/run/halo/app/listener/comment/CommentEventListener.java
@@ -4,11 +4,9 @@ import java.util.HashMap;
 import java.util.Map;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
-import org.springframework.context.event.EventListener;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
-import org.springframework.transaction.annotation.Isolation;
-import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.event.TransactionalEventListener;
 import run.halo.app.event.comment.CommentNewEvent;
 import run.halo.app.event.comment.CommentReplyEvent;
 import run.halo.app.exception.ServiceException;
@@ -90,13 +88,12 @@ public class CommentEventListener {
     }
 
     /**
-     * Received a new new comment event.
+     * Received a new comment event.
      *
      * @param newEvent new comment event.
      */
     @Async
-    @EventListener
-    @Transactional(isolation = Isolation.READ_UNCOMMITTED)
+    @TransactionalEventListener
     public void handleCommentNewEvent(CommentNewEvent newEvent) {
         Boolean newCommentNotice = optionService
             .getByPropertyOrDefault(CommentProperties.NEW_NOTICE, Boolean.class, false);
@@ -184,8 +181,7 @@ public class CommentEventListener {
      * @param replyEvent reply comment event.
      */
     @Async
-    @EventListener
-    @Transactional(isolation = Isolation.READ_UNCOMMITTED)
+    @TransactionalEventListener
     public void handleCommentReplyEvent(CommentReplyEvent replyEvent) {
         Boolean replyCommentNotice = optionService
             .getByPropertyOrDefault(CommentProperties.REPLY_NOTICE, Boolean.class, false);

--- a/src/main/java/run/halo/app/listener/comment/CommentEventListener.java
+++ b/src/main/java/run/halo/app/listener/comment/CommentEventListener.java
@@ -7,6 +7,8 @@ import org.apache.commons.lang3.StringUtils;
 import org.springframework.context.event.EventListener;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Isolation;
+import org.springframework.transaction.annotation.Transactional;
 import run.halo.app.event.comment.CommentNewEvent;
 import run.halo.app.event.comment.CommentReplyEvent;
 import run.halo.app.exception.ServiceException;
@@ -94,6 +96,7 @@ public class CommentEventListener {
      */
     @Async
     @EventListener
+    @Transactional(isolation = Isolation.READ_UNCOMMITTED)
     public void handleCommentNewEvent(CommentNewEvent newEvent) {
         Boolean newCommentNotice = optionService
             .getByPropertyOrDefault(CommentProperties.NEW_NOTICE, Boolean.class, false);
@@ -182,6 +185,7 @@ public class CommentEventListener {
      */
     @Async
     @EventListener
+    @Transactional(isolation = Isolation.READ_UNCOMMITTED)
     public void handleCommentReplyEvent(CommentReplyEvent replyEvent) {
         Boolean replyCommentNotice = optionService
             .getByPropertyOrDefault(CommentProperties.REPLY_NOTICE, Boolean.class, false);


### PR DESCRIPTION
### What this PR does

Set transaction isolation to read_uncommitted because the comment event handlers are executed asynchronously.

### Why we need it?

Comment events handlers are executed asynchronously.
And default transaction isolation is read_committed,
so the handlers can not see the comments created by event dispatcher

### Which issue this PR fixes

Fix #1798 

### References

- http://www.h2database.com/html/advanced.html#transaction_isolation
- https://dev.mysql.com/doc/refman/8.0/en/innodb-transaction-isolation-levels.html
- https://docs.spring.io/spring-framework/docs/current/javadoc-api/org/springframework/transaction/event/TransactionalEventListener.html

/kind bug
/area core
/milestone 1.5.x