### PR TITLE
Upgrade Spring Boot to 3.0.0-M2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'org.springframework.boot' version '3.0.0-M1'
+    id 'org.springframework.boot' version '3.0.0-M2'
     id 'io.spring.dependency-management' version '1.0.11.RELEASE'
     id "checkstyle"
     id 'java'


### PR DESCRIPTION
### What this PR does

Upgrade Spring Boot from 3.0.0-M1 to 3.0.0-M2.

Spring Boot 3.0.0-M2 has been released for a while, it's time to upgrade it. Please refer to 
- https://github.com/spring-projects/spring-boot/releases/tag/v3.0.0-M2

/area core
/cc @halo-dev/sig-halo 