### PR TITLE
Add support for link group and its sort

### DIFF
--- a/src/main/java/run/halo/app/controller/admin/api/LinkController.java
+++ b/src/main/java/run/halo/app/controller/admin/api/LinkController.java
@@ -5,6 +5,8 @@ import static org.springframework.data.domain.Sort.Direction.DESC;
 
 import io.swagger.annotations.ApiOperation;
 import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
 import javax.validation.Valid;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.web.SortDefault;
@@ -17,6 +19,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import run.halo.app.model.dto.LinkDTO;
+import run.halo.app.model.dto.base.InputConverter;
 import run.halo.app.model.entity.Link;
 import run.halo.app.model.params.LinkParam;
 import run.halo.app.service.LinkService;
@@ -74,5 +77,27 @@ public class LinkController {
     @ApiOperation("Lists all link teams")
     public List<String> teams() {
         return linkService.listAllTeams();
+    }
+
+    /**
+     * Update the links in batch.
+     *
+     * <p>To realize the draggable sort approach for link priority,
+     * a links batch update API is in demand.
+     *
+     * @param linkParams the modified links params.
+     * @return the links after updated.
+     */
+    @PutMapping("/batch")
+    @ApiOperation("Updates links in batch")
+    public List<LinkDTO> updateBatchBy(@RequestBody List<@Valid LinkParam> linkParams) {
+        List<Link> links = linkParams
+            .stream()
+            .filter(linkParam -> Objects.nonNull(linkParam.getId()))
+            .map(InputConverter::convertTo)
+            .collect(Collectors.toList());
+        return linkService.updateInBatch(links).stream()
+            .map(link -> (LinkDTO) new LinkDTO().convertFrom(link))
+            .collect(Collectors.toList());
     }
 }

--- a/src/main/java/run/halo/app/controller/admin/api/LinkController.java
+++ b/src/main/java/run/halo/app/controller/admin/api/LinkController.java
@@ -62,7 +62,7 @@ public class LinkController {
     @PutMapping("{id:\\d+}")
     @ApiOperation("Updates a link")
     public LinkDTO updateBy(@PathVariable("id") Integer id,
-                            @RequestBody @Valid LinkParam linkParam) {
+        @RequestBody @Valid LinkParam linkParam) {
         Link link = linkService.updateBy(id, linkParam);
         return new LinkDTO().convertFrom(link);
     }

--- a/src/main/java/run/halo/app/model/params/LinkParam.java
+++ b/src/main/java/run/halo/app/model/params/LinkParam.java
@@ -17,6 +17,8 @@ import run.halo.app.model.entity.Link;
 @Data
 public class LinkParam implements InputConverter<Link> {
 
+    private Integer id;
+
     @NotBlank(message = "友情链接名称不能为空")
     @Size(max = 255, message = "友情链接名称的字符长度不能超过 {max}")
     private String name;

--- a/src/main/java/run/halo/app/repository/LinkRepository.java
+++ b/src/main/java/run/halo/app/repository/LinkRepository.java
@@ -17,7 +17,7 @@ public interface LinkRepository extends BaseRepository<Link, Integer> {
      *
      * @return a list of teams
      */
-    @Query(value = "select distinct a.team from Link a")
+    @Query(value = "select a.team from Link a group by a.team order by max(a.priority) DESC")
     List<String> findAllTeams();
 
     boolean existsByNameAndIdNot(String name, Integer id);

--- a/src/main/java/run/halo/app/service/impl/LinkServiceImpl.java
+++ b/src/main/java/run/halo/app/service/impl/LinkServiceImpl.java
@@ -1,6 +1,7 @@
 package run.halo.app.service.impl;
 
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
@@ -61,7 +62,7 @@ public class LinkServiceImpl extends AbstractCrudService<Link, Integer> implemen
             ServiceUtils.convertToListMap(teams, links, LinkDTO::getTeam);
 
         List<LinkTeamVO> result = new LinkedList<>();
-
+        Map<LinkTeamVO, Integer> teamPriorities = new HashMap<>();
         // Wrap link team vo list
         teamLinkListMap.forEach((team, linkList) -> {
             // Build link team vo
@@ -69,11 +70,28 @@ public class LinkServiceImpl extends AbstractCrudService<Link, Integer> implemen
             linkTeamVO.setTeam(team);
             linkTeamVO.setLinks(linkList);
 
+            teamPriorities.put(linkTeamVO, getTeamPriority(linkTeamVO));
             // Add it to result
             result.add(linkTeamVO);
         });
 
+        result.sort((a, b) -> teamPriorities.get(b) - teamPriorities.get(a));
+
         return result;
+    }
+
+
+    /**
+     * Get the priority of a link team, which is the maximum priority of its link members.
+     *
+     * @param linkTeam A team of links.
+     * @return the priority of a link team.
+     */
+    private Integer getTeamPriority(LinkTeamVO linkTeam) {
+        return linkTeam.getLinks().stream()
+            .mapToInt(LinkDTO::getPriority)
+            .max()
+            .orElse(-1);
     }
 
     @Override
@@ -166,7 +184,8 @@ public class LinkServiceImpl extends AbstractCrudService<Link, Integer> implemen
     }
 
     @Override
-    public @NonNull List<Link> listAllByRandom() {
+    public @NonNull
+    List<Link> listAllByRandom() {
         List<Link> allLink = linkRepository.findAll();
         Collections.shuffle(allLink);
         return allLink;

--- a/src/main/java/run/halo/app/service/impl/LinkServiceImpl.java
+++ b/src/main/java/run/halo/app/service/impl/LinkServiceImpl.java
@@ -184,8 +184,7 @@ public class LinkServiceImpl extends AbstractCrudService<Link, Integer> implemen
     }
 
     @Override
-    public @NonNull
-    List<Link> listAllByRandom() {
+    public @NonNull List<Link> listAllByRandom() {
         List<Link> allLink = linkRepository.findAll();
         Collections.shuffle(allLink);
         return allLink;


### PR DESCRIPTION
#### What type of PR is this?

/kind feature
/kind api-change


#### What this PR does / why we need it:

提供对友链分组的排序功能；前端还通过拖拽来提供可视化的对友链及友链分组的排序操作。

#### Which issue(s) this PR fixes:

Fixes #1905

#### Special notes for your reviewer:

出于不更改数据库表的考虑，对分组的排序没有增设新的字段如`team_priority`，而是沿用过去的link的`priority`字段，每个分组的priority设置为其组内link的最高priority。

前端不提供显式的修改priority的接口，改由前端按排序自动计算所有link的priority，再交由后端统一更新。

---

前端方面进行友链管理界面的重构，沿用了vuedraggable组件来实现拖拽，由于我对前端不是很熟练，前端方面的具体实现和PR交由 @gungnir479 负责。

---

总体效果如下
<video src="https://user-images.githubusercontent.com/65994555/169685416-e4b86306-bd96-4e5a-bbde-d40f6383d9ca.mp4"></video>

#### Does this PR introduce a user-facing change?

```release-note
重构了管理友链的界面，现在可以通过拖拽的形式可视化的管理友链及友链分组的排序
```




