### PR TITLE
Enable CSRF token in Set-Cookie header

### DIFF
--- a/src/main/java/run/halo/app/config/WebServerSecurityConfig.java
+++ b/src/main/java/run/halo/app/config/WebServerSecurityConfig.java
@@ -25,6 +25,7 @@ import org.springframework.security.oauth2.jwt.NimbusReactiveJwtDecoder;
 import org.springframework.security.oauth2.jwt.ReactiveJwtDecoder;
 import org.springframework.security.oauth2.jwt.SupplierReactiveJwtDecoder;
 import org.springframework.security.web.server.SecurityWebFilterChain;
+import org.springframework.security.web.server.csrf.CookieServerCsrfTokenRepository;
 import org.springframework.web.reactive.function.server.ServerResponse;
 import run.halo.app.infra.properties.JwtProperties;
 import run.halo.app.security.authentication.jwt.LoginAuthenticationFilter;
@@ -77,7 +78,10 @@ public class WebServerSecurityConfig {
                 exchanges -> exchanges.pathMatchers("/v3/api-docs/**", "/v3/api-docs.yaml",
                     "/swagger-ui/**", "/swagger-ui.html", "/webjars/**").permitAll())
             .authorizeExchange(exchanges -> exchanges.anyExchange().authenticated())
-            .cors(withDefaults()).httpBasic(withDefaults()).formLogin(withDefaults())
+            .cors(withDefaults())
+            .httpBasic(withDefaults())
+            .formLogin(withDefaults())
+            .csrf().csrfTokenRepository(new CookieServerCsrfTokenRepository()).and()
             .logout(withDefaults());
 
         return http.build();


### PR DESCRIPTION
#### What type of PR is this?

/kind improvement
/area core

#### What this PR does / why we need it:

By default, when we are redirected to login page, we will got CSRF token in response body(html) only.

After we enable CSRF token in Set-Cookie header to let front-end obtain the token conveniently. Please see the header below:

```properties
Set-Cookie: XSRF-TOKEN=5ea04bc6-5fb2-4d53-9d50-0e42356962c6; Path=/; HttpOnly
```

#### Which issue(s) this PR fixes:

Fixes #

#### Special notes for your reviewer:

/cc @halo-dev/sig-halo 
/milestone 2.0

#### Does this PR introduce a user-facing change?

```release-note
None
```
