### PR TITLE
Overwrite Jackson2Json decoder and encoder

### DIFF
--- a/src/main/java/run/halo/app/config/WebFluxConfig.java
+++ b/src/main/java/run/halo/app/config/WebFluxConfig.java
@@ -1,10 +1,14 @@
 package run.halo.app.config;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import java.util.List;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.codec.CodecConfigurer;
 import org.springframework.http.codec.HttpMessageWriter;
+import org.springframework.http.codec.ServerCodecConfigurer;
+import org.springframework.http.codec.json.Jackson2JsonDecoder;
+import org.springframework.http.codec.json.Jackson2JsonEncoder;
 import org.springframework.lang.NonNull;
 import org.springframework.web.reactive.config.EnableWebFlux;
 import org.springframework.web.reactive.config.WebFluxConfigurer;
@@ -15,6 +19,12 @@ import org.springframework.web.reactive.result.view.ViewResolver;
 @Configuration
 @EnableWebFlux
 public class WebFluxConfig implements WebFluxConfigurer {
+
+    final ObjectMapper objectMapper;
+
+    public WebFluxConfig(ObjectMapper objectMapper) {
+        this.objectMapper = objectMapper;
+    }
 
     @Bean
     ServerResponse.Context context(CodecConfigurer codec,
@@ -32,5 +42,14 @@ public class WebFluxConfig implements WebFluxConfigurer {
                 return resultHandler.getViewResolvers();
             }
         };
+    }
+
+    @Override
+    public void configureHttpMessageCodecs(ServerCodecConfigurer configurer) {
+        // we need to customize the Jackson2Json[Decoder][Encoder] here to serialize and
+        // deserialize special types, e.g.: Instant, LocalDateTime. So we use ObjectMapper
+        // created by outside.
+        configurer.defaultCodecs().jackson2JsonDecoder(new Jackson2JsonDecoder(objectMapper));
+        configurer.defaultCodecs().jackson2JsonEncoder(new Jackson2JsonEncoder(objectMapper));
     }
 }

--- a/src/main/java/run/halo/app/config/WebServerSecurityConfig.java
+++ b/src/main/java/run/halo/app/config/WebServerSecurityConfig.java
@@ -73,10 +73,14 @@ public class WebServerSecurityConfig {
     }
 
     @Bean
+    @Order(0)
     SecurityWebFilterChain webFilterChain(ServerHttpSecurity http) {
-        http.authorizeExchange(
-                exchanges -> exchanges.pathMatchers("/v3/api-docs/**", "/v3/api-docs.yaml",
-                    "/swagger-ui/**", "/swagger-ui.html", "/webjars/**").permitAll())
+        http.authorizeExchange(exchanges -> exchanges.pathMatchers(
+                "/v3/api-docs/**",
+                "/v3/api-docs.yaml",
+                "/swagger-ui/**",
+                "/swagger-ui.html",
+                "/webjars/**").permitAll())
             .authorizeExchange(exchanges -> exchanges.anyExchange().authenticated())
             .cors(withDefaults())
             .httpBasic(withDefaults())

--- a/src/main/resources/application-dev.yaml
+++ b/src/main/resources/application-dev.yaml
@@ -1,8 +1,6 @@
 server:
   port: 8090
 spring:
-  jackson:
-    date-format: yyyy-MM-dd HH:mm:ss
   output:
     ansi:
       enabled: always

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -1,11 +1,9 @@
 server:
   port: 8090
 spring:
-  jackson:
-    date-format: yyyy-MM-dd HH:mm:ss
   output:
     ansi:
-      enabled: always
+      enabled: detect
   datasource:
     type: com.zaxxer.hikari.HikariDataSource
 

--- a/src/test/java/run/halo/app/config/ServerCodecTest.java
+++ b/src/test/java/run/halo/app/config/ServerCodecTest.java
@@ -1,0 +1,94 @@
+package run.halo.app.config;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.springframework.security.test.web.reactive.server.SecurityMockServerConfigurers.csrf;
+import static org.springframework.web.reactive.function.server.RequestPredicates.accept;
+import static org.springframework.web.reactive.function.server.RequestPredicates.contentType;
+import static org.springframework.web.reactive.function.server.RouterFunctions.route;
+
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.reactive.AutoConfigureWebTestClient;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.reactive.server.WebTestClient;
+import org.springframework.web.reactive.function.server.RouterFunction;
+import org.springframework.web.reactive.function.server.ServerResponse;
+
+@SpringBootTest
+@AutoConfigureWebTestClient
+@Import(ServerCodecTest.TestConfig.class)
+class ServerCodecTest {
+
+    static final String INSTANT = "2022-06-09T10:57:30Z";
+
+    static final String LOCAL_DATE_TIME = "2022-06-10T10:57:30";
+
+    @Autowired
+    WebTestClient webClient;
+
+    @Test
+    @WithMockUser
+    void timeSerializationTest() {
+        webClient.get().uri("/fake/api/times")
+            .exchange()
+            .expectStatus().isOk()
+            .expectHeader().contentType(MediaType.APPLICATION_JSON)
+            .expectBody()
+            .jsonPath("$.instant").value(equalTo(INSTANT))
+            .jsonPath("$.localDateTime").value(equalTo(LOCAL_DATE_TIME))
+        ;
+    }
+
+    @Test
+    @WithMockUser
+    void timeDeserializationTest() {
+        webClient
+            .mutateWith(csrf())
+            .post().uri("/fake/api/time/report")
+            .contentType(MediaType.APPLICATION_JSON)
+            .accept(MediaType.APPLICATION_JSON)
+            .bodyValue(Map.of("now", Instant.parse(INSTANT)))
+            .exchange()
+            .expectStatus().isOk()
+            .expectHeader().contentType(MediaType.APPLICATION_JSON)
+            .expectBody(new ParameterizedTypeReference<Map<String, Instant>>() {
+            }).isEqualTo(Map.of("now", Instant.parse(INSTANT)))
+        ;
+    }
+
+    @TestConfiguration(proxyBeanMethods = false)
+    static class TestConfig {
+
+        @Bean
+        RouterFunction<ServerResponse> timesRouter() {
+            return route().GET("/fake/api/times", request -> {
+                var times = Map.of("instant", Instant.parse(INSTANT),
+                    "localDateTime", LocalDateTime.parse(LOCAL_DATE_TIME));
+                return ServerResponse
+                    .ok()
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .bodyValue(times);
+            }).build();
+        }
+
+        @Bean
+        RouterFunction<ServerResponse> reportTime() {
+            final var type = new ParameterizedTypeReference<Map<String, Instant>>() {
+            };
+            return route().POST("/fake/api/time/report",
+                    contentType(MediaType.APPLICATION_JSON).and(accept(MediaType.APPLICATION_JSON)),
+                    request -> ServerResponse.ok()
+                        .body(request.bodyToMono(type), type))
+                .build();
+        }
+    }
+}

--- a/src/test/resources/application.yaml
+++ b/src/test/resources/application.yaml
@@ -1,8 +1,6 @@
 server:
   port: 8090
 spring:
-  jackson:
-    date-format: yyyy-MM-dd HH:mm:ss
   output:
     ansi:
       enabled: detect


### PR DESCRIPTION
#### What type of PR is this?

/kind improvement
/area core
/kind api-change

#### What this PR does / why we need it:

By default, ServerCodecConfigurer creates some default codecs, including Jackson2Json encoder and decoder. But the ObjectMappers in both are fresh and not able to serialize and deserialize date-time types in package `java.time`.

But we have imported `spring-boot-starter-json` which is globally configuration for JSON. We could autowire an ObjectMapper to customize ServerCodecConfigurer and configure ObjectMapper uniformly.

**Attention:**

- After we do that, the date format should be followed [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) style.

#### Which issue(s) this PR fixes:

Fixes #

#### Special notes for your reviewer:

/milestone 2.0
/cc @halo-dev/sig-halo 

#### Does this PR introduce a user-facing change?

```release-note
None
```
