### PR TITLE
fix: locale for unit test of json extension converter

### DIFF
--- a/src/test/java/run/halo/app/extension/JsonExtensionConverterTest.java
+++ b/src/test/java/run/halo/app/extension/JsonExtensionConverterTest.java
@@ -6,6 +6,8 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.IOException;
+import java.util.Locale;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import run.halo.app.extension.exception.ExtensionConvertException;
@@ -18,13 +20,23 @@ class JsonExtensionConverterTest {
 
     ObjectMapper objectMapper;
 
+    Locale localeDefault;
+
     @BeforeEach
     void setUp() {
+        localeDefault = Locale.getDefault();
+        Locale.setDefault(Locale.ENGLISH);
+
         DefaultSchemeManager schemeManager = new DefaultSchemeManager(null);
         converter = new JSONExtensionConverter(schemeManager);
         objectMapper = JSONExtensionConverter.OBJECT_MAPPER;
 
         schemeManager.register(FakeExtension.class);
+    }
+
+    @AfterEach
+    void cleanUp() {
+        Locale.setDefault(localeDefault);
     }
 
     @Test


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. 如果这是你的第一次，请阅读我们的贡献指南：<https://github.com/halo-dev/halo/blob/master/CONTRIBUTING.md>。
1. If this is your first time, please read our contributor guidelines: <https://github.com/halo-dev/halo/blob/master/CONTRIBUTING.md>.
2. 请根据你解决问题的类型为 Pull Request 添加合适的标签。
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request.
3. 请确保你已经添加并运行了适当的测试。
3. Ensure you have added or ran the appropriate tests for your PR.
-->

#### What type of PR is this?
/kind improvement
/area core 
/milestone 2.0
<!--
添加其中一个类别：
Add one of the following kinds:

/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind optimization

适当添加其中一个或多个类别（可选）：
Optionally add one or more of the following kinds if applicable:

/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
由于 com.networknt.schema 做了多语言导致单元测试断言时语言环境不同而无法测试成功
![telegram-cloud-photo-size-5-6161322794944671728-y](https://user-images.githubusercontent.com/38999863/174544457-f57b2663-2a39-488b-9ffb-6a4780f639bb.jpg)

#### Which issue(s) this PR fixes:

<!--
PR 合并时自动关闭 issue。
Automatically closes linked issue when PR is merged.

用法：`Fixes #<issue 号>`，或者 `Fixes (粘贴 issue 完整链接)`
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
/cc @halo-dev/sig-halo 
#### Does this PR introduce a user-facing change?

<!--
如果当前 Pull Request 的修改不会造成用户侧的任何变更，在 `release-note` 代码块儿中填写 `NONE`。
否则请填写用户侧能够理解的 Release Note。如果当前 Pull Request 包含破坏性更新（Break Change），
Release Note 需要以 `action required` 开头。
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->

```release-note
None
```
