### PR TITLE
feat: add shared application context for plugin

### DIFF
--- a/src/main/java/run/halo/app/plugin/PluginApplicationContext.java
+++ b/src/main/java/run/halo/app/plugin/PluginApplicationContext.java
@@ -1,17 +1,6 @@
 package run.halo.app.plugin;
 
-import java.lang.reflect.Field;
-import java.util.Set;
-import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
-import org.springframework.context.ApplicationEvent;
-import org.springframework.context.PayloadApplicationEvent;
-import org.springframework.context.event.ApplicationEventMulticaster;
-import org.springframework.context.support.AbstractApplicationContext;
 import org.springframework.context.support.GenericApplicationContext;
-import org.springframework.core.ResolvableType;
-import org.springframework.lang.NonNull;
-import org.springframework.lang.Nullable;
-import org.springframework.util.Assert;
 
 /**
  * The generic IOC container for plugins.
@@ -24,56 +13,6 @@ import org.springframework.util.Assert;
 public class PluginApplicationContext extends GenericApplicationContext {
 
     private String pluginId;
-
-    /**
-     * <p>覆盖父类方法中判断context parent不为空时使用parent context广播事件的逻辑。
-     * 如果主应用桥接事件到插件中且设置了parent会导致发布事件时死循环.</p>
-     *
-     * @param event the event to publish (may be an {@link ApplicationEvent} or a payload object
-     * to be turned into a {@link PayloadApplicationEvent})
-     * @param eventType the resolved event type, if known
-     */
-    @Override
-    protected void publishEvent(@NonNull Object event, @Nullable ResolvableType eventType) {
-        Assert.notNull(event, "Event must not be null");
-
-        // Decorate event as an ApplicationEvent if necessary
-        ApplicationEvent applicationEvent;
-        if (event instanceof ApplicationEvent) {
-            applicationEvent = (ApplicationEvent) event;
-        } else {
-            applicationEvent = new PayloadApplicationEvent<>(this, event);
-            if (eventType == null) {
-                eventType = ((PayloadApplicationEvent<?>) applicationEvent).getResolvableType();
-            }
-        }
-
-        // Multicast right now if possible - or lazily once the multicaster is initialized
-        Set<ApplicationEvent> earlyApplicationEvents = getEarlyApplicationEvents();
-        if (earlyApplicationEvents != null) {
-            earlyApplicationEvents.add(applicationEvent);
-        } else {
-            getApplicationEventMulticaster().multicastEvent(applicationEvent, eventType);
-        }
-    }
-
-    private ApplicationEventMulticaster getApplicationEventMulticaster() {
-        ConfigurableListableBeanFactory beanFactory = getBeanFactory();
-        return beanFactory.getBean(APPLICATION_EVENT_MULTICASTER_BEAN_NAME,
-            ApplicationEventMulticaster.class);
-    }
-
-    @SuppressWarnings("unchecked")
-    protected Set<ApplicationEvent> getEarlyApplicationEvents() {
-        try {
-            Field earlyApplicationEventsField =
-                AbstractApplicationContext.class.getDeclaredField("earlyApplicationEvents");
-            return (Set<ApplicationEvent>) earlyApplicationEventsField.get(this);
-        } catch (NoSuchFieldException | IllegalAccessException e) {
-            // ignore this exception
-            return null;
-        }
-    }
 
     public String getPluginId() {
         return pluginId;

--- a/src/main/java/run/halo/app/plugin/PluginApplicationInitializer.java
+++ b/src/main/java/run/halo/app/plugin/PluginApplicationInitializer.java
@@ -24,9 +24,12 @@ public class PluginApplicationInitializer {
     protected final HaloPluginManager haloPluginManager;
 
     private final ExtensionContextRegistry contextRegistry = ExtensionContextRegistry.getInstance();
+    private final SharedApplicationContextHolder sharedApplicationContextHolder;
 
     public PluginApplicationInitializer(HaloPluginManager springPluginManager) {
         this.haloPluginManager = springPluginManager;
+        sharedApplicationContextHolder = springPluginManager.getRootApplicationContext()
+            .getBean(SharedApplicationContextHolder.class);
     }
 
     public ApplicationContext getRootApplicationContext() {
@@ -40,7 +43,11 @@ public class PluginApplicationInitializer {
         StopWatch stopWatch = new StopWatch("initialize-plugin-context");
         stopWatch.start("Create PluginApplicationContext");
         PluginApplicationContext pluginApplicationContext = new PluginApplicationContext();
-        pluginApplicationContext.setParent(getRootApplicationContext());
+
+        if (sharedApplicationContextHolder != null) {
+            pluginApplicationContext.setParent(sharedApplicationContextHolder.getInstance());
+        }
+
         pluginApplicationContext.setClassLoader(pluginClassLoader);
         // populate plugin to plugin application context
         pluginApplicationContext.setPluginId(pluginId);

--- a/src/main/java/run/halo/app/plugin/PluginCompositeRouterFunction.java
+++ b/src/main/java/run/halo/app/plugin/PluginCompositeRouterFunction.java
@@ -98,9 +98,6 @@ public class PluginCompositeRouterFunction implements RouterFunction<ServerRespo
     @SuppressWarnings("unchecked")
     private List<RouterFunction<ServerResponse>> routerFunctions(
         PluginApplicationContext applicationContext) {
-        // TODO: Since the parent of the ApplicationContext of the plugin is RootApplicationContext
-        //  obtaining the RouterFunction here will obtain the existing in the parent
-        //  resulting in a loop when there is no matching route
         List<RouterFunction<ServerResponse>> functions =
             applicationContext.getBeanProvider(RouterFunction.class)
                 .orderedStream()

--- a/src/main/java/run/halo/app/plugin/SharedApplicationContext.java
+++ b/src/main/java/run/halo/app/plugin/SharedApplicationContext.java
@@ -1,0 +1,15 @@
+package run.halo.app.plugin;
+
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.support.GenericApplicationContext;
+
+/**
+ * <p>An {@link ApplicationContext} implementation shared by plugins.</p>
+ * <p>Beans in the Core that need to be shared with plugins will be injected into this
+ * {@link SharedApplicationContext}.</p>
+ *
+ * @author guqing
+ * @since 2.0.0
+ */
+public class SharedApplicationContext extends GenericApplicationContext {
+}

--- a/src/main/java/run/halo/app/plugin/SharedApplicationContextHolder.java
+++ b/src/main/java/run/halo/app/plugin/SharedApplicationContextHolder.java
@@ -1,0 +1,64 @@
+package run.halo.app.plugin;
+
+import org.springframework.beans.factory.support.DefaultListableBeanFactory;
+import org.springframework.context.ApplicationContext;
+import org.springframework.stereotype.Component;
+import run.halo.app.extension.DefaultSchemeManager;
+import run.halo.app.extension.ExtensionClient;
+
+/**
+ * <p>This {@link SharedApplicationContextHolder} class is used to hold a singleton instance of
+ * {@link SharedApplicationContext}.</p>
+ * <p>If sharedApplicationContext cache is null when calling the {@link #getInstance()} method,
+ * then it will call {@link #createSharedApplicationContext()} to create and cache it. Otherwise,
+ * it will be obtained directly.</p>
+ * <p>It is thread safe.</p>
+ *
+ * @author guqing
+ * @since 2.0.0
+ */
+@Component
+public class SharedApplicationContextHolder {
+
+    private final ApplicationContext rootApplicationContext;
+    private volatile SharedApplicationContext sharedApplicationContext;
+
+    public SharedApplicationContextHolder(ApplicationContext applicationContext) {
+        this.rootApplicationContext = applicationContext;
+    }
+
+    /**
+     * Get singleton instance of {@link SharedApplicationContext}.
+     *
+     * @return a singleton instance of {@link SharedApplicationContext}.
+     */
+    public SharedApplicationContext getInstance() {
+        if (this.sharedApplicationContext == null) {
+            synchronized (SharedApplicationContextHolder.class) {
+                if (this.sharedApplicationContext == null) {
+                    this.sharedApplicationContext = createSharedApplicationContext();
+                }
+            }
+        }
+        return this.sharedApplicationContext;
+    }
+
+    SharedApplicationContext createSharedApplicationContext() {
+        // TODO Optimize creation timing
+        SharedApplicationContext sharedApplicationContext = new SharedApplicationContext();
+        sharedApplicationContext.refresh();
+
+        DefaultListableBeanFactory beanFactory =
+            (DefaultListableBeanFactory) sharedApplicationContext.getBeanFactory();
+
+        // register shared object here
+        ExtensionClient extensionClient = rootApplicationContext.getBean(ExtensionClient.class);
+        beanFactory.registerSingleton("extensionClient", extensionClient);
+        DefaultSchemeManager defaultSchemeManager =
+            rootApplicationContext.getBean(DefaultSchemeManager.class);
+        beanFactory.registerSingleton("schemeManager", defaultSchemeManager);
+        // TODO add more shared instance here
+
+        return sharedApplicationContext;
+    }
+}

--- a/src/test/java/run/halo/app/plugin/SharedApplicationContextHolderTest.java
+++ b/src/test/java/run/halo/app/plugin/SharedApplicationContextHolderTest.java
@@ -1,0 +1,37 @@
+package run.halo.app.plugin;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.context.SpringBootTest;
+
+/**
+ * Tests for {@link SharedApplicationContextHolder}.
+ *
+ * @author guqing
+ * @since 2.0.0
+ */
+@SpringBootTest
+@AutoConfigureTestDatabase
+class SharedApplicationContextHolderTest {
+
+    @Autowired
+    SharedApplicationContextHolder sharedApplicationContextHolder;
+
+    @Test
+    void getInstance() {
+        SharedApplicationContext instance1 = sharedApplicationContextHolder.getInstance();
+        SharedApplicationContext instance2 = sharedApplicationContextHolder.getInstance();
+        assertThat(instance1).isNotNull();
+        assertThat(instance1).isEqualTo(instance2);
+    }
+
+    @Test
+    void createSharedApplicationContext() {
+        SharedApplicationContext sharedApplicationContext =
+            sharedApplicationContextHolder.createSharedApplicationContext();
+        assertThat(sharedApplicationContext).isNotNull();
+    }
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. 如果这是你的第一次，请阅读我们的贡献指南：<https://github.com/halo-dev/halo/blob/master/CONTRIBUTING.md>。
1. If this is your first time, please read our contributor guidelines: <https://github.com/halo-dev/halo/blob/master/CONTRIBUTING.md>.
2. 请根据你解决问题的类型为 Pull Request 添加合适的标签。
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request.
3. 请确保你已经添加并运行了适当的测试。
3. Ensure you have added or ran the appropriate tests for your PR.
-->

#### What type of PR is this?
/kind feature
/area core
/milestone 2.0
<!--
添加其中一个类别：
Add one of the following kinds:

/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind optimization

适当添加其中一个或多个类别（可选）：
Optionally add one or more of the following kinds if applicable:

/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
新增 SharedApplicationContext 做为所有 PluginApplicationContext 的 parent. 当 Core 需要共享实例给插件使用时会注入到 SharedApplicationCoantext 中，它是一个单类，所有插件都公用它。
该方案直接解决了直接使用 Core 作为 PluginApplicationContext 的 parent 的一些问题：
1. 插件获取 Bean 时会获取到 Core 不想共享给插件使用的 Bean，容易出现一些循环问题例如插件获取 RouterFunction 时获取到了 Core 中存在的导致形成环时路由不匹配时出现 Stack Overflow
2. Core 中事件被触发时广播到 PluginApplicationContext 此时 spring 的默认处理是会调用 parent ApplicationContext 发布事件则会导致事件循环
#### Which issue(s) this PR fixes:

<!--
PR 合并时自动关闭 issue。
Automatically closes linked issue when PR is merged.

用法：`Fixes #<issue 号>`，或者 `Fixes (粘贴 issue 完整链接)`
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
/cc @halo-dev/sig-halo 
#### Does this PR introduce a user-facing change?

<!--
如果当前 Pull Request 的修改不会造成用户侧的任何变更，在 `release-note` 代码块儿中填写 `NONE`。
否则请填写用户侧能够理解的 Release Note。如果当前 Pull Request 包含破坏性更新（Break Change），
Release Note 需要以 `action required` 开头。
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->

```release-note
None
```
