### PR TITLE
Configure CORS for API endpoints

### DIFF
--- a/src/main/java/run/halo/app/config/WebServerSecurityConfig.java
+++ b/src/main/java/run/halo/app/config/WebServerSecurityConfig.java
@@ -7,9 +7,12 @@ import com.nimbusds.jose.JWSAlgorithm;
 import com.nimbusds.jose.jwk.JWKSet;
 import com.nimbusds.jose.jwk.RSAKey;
 import com.nimbusds.jose.jwk.source.ImmutableJWKSet;
+import java.util.Arrays;
+import java.util.List;
 import org.springframework.context.annotation.Bean;
 import org.springframework.core.Ordered;
 import org.springframework.core.annotation.Order;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.codec.ServerCodecConfigurer;
 import org.springframework.security.config.annotation.web.reactive.EnableWebFluxSecurity;
 import org.springframework.security.config.web.server.SecurityWebFiltersOrder;
@@ -24,6 +27,9 @@ import org.springframework.security.oauth2.jwt.ReactiveJwtDecoder;
 import org.springframework.security.oauth2.jwt.SupplierReactiveJwtDecoder;
 import org.springframework.security.web.server.SecurityWebFilterChain;
 import org.springframework.security.web.server.csrf.CookieServerCsrfTokenRepository;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.reactive.CorsConfigurationSource;
+import org.springframework.web.cors.reactive.UrlBasedCorsConfigurationSource;
 import org.springframework.web.reactive.function.server.ServerResponse;
 import run.halo.app.core.extension.service.RoleService;
 import run.halo.app.core.extension.service.UserService;
@@ -55,6 +61,7 @@ public class WebServerSecurityConfig {
         UserService userService,
         RoleService roleService) {
         http.csrf().disable()
+            .cors(corsSpec -> corsSpec.configurationSource(apiCorsConfigurationSource()))
             .securityMatcher(pathMatchers("/api/**", "/apis/**"))
             .authorizeExchange(exchanges ->
                 exchanges.anyExchange().access(new RequestInfoAuthorizationManager(roleService)))
@@ -92,6 +99,18 @@ public class WebServerSecurityConfig {
             .logout(withDefaults());
 
         return http.build();
+    }
+
+    CorsConfigurationSource apiCorsConfigurationSource() {
+        CorsConfiguration configuration = new CorsConfiguration();
+        configuration.setAllowedOriginPatterns(List.of("*"));
+        configuration.setAllowedHeaders(
+            List.of(HttpHeaders.AUTHORIZATION, HttpHeaders.CONTENT_TYPE, HttpHeaders.ACCEPT));
+        configuration.setAllowedMethods(Arrays.asList("GET", "POST", "PUT", "DELETE", "PATCH"));
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/api/**", configuration);
+        source.registerCorsConfiguration("/apis/**", configuration);
+        return source;
     }
 
     @Bean

--- a/src/test/java/run/halo/app/config/CorsTest.java
+++ b/src/test/java/run/halo/app/config/CorsTest.java
@@ -1,0 +1,93 @@
+package run.halo.app.config;
+
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.reactive.AutoConfigureWebTestClient;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.reactive.server.WebTestClient;
+
+@SpringBootTest
+@AutoConfigureWebTestClient
+class CorsTest {
+
+    @Autowired
+    WebTestClient webClient;
+
+    @Nested
+    class RequestCorsEnabledApi {
+
+        @Test
+        @WithMockUser
+        void shouldNotResponseAllowOriginHeaderWithSameOrigin() {
+            webClient.get().uri("http://localhost:3000/apis/cors-enabled")
+                .header(HttpHeaders.ORIGIN, "http://localhost:3000")
+                .header(HttpHeaders.AUTHORIZATION, "fake-authorization")
+                .header("FakeHeader", "fake-header-value")
+                .accept(MediaType.APPLICATION_JSON)
+                .exchange()
+                .expectHeader()
+                .doesNotExist(HttpHeaders.ACCESS_CONTROL_ALLOW_ORIGIN);
+        }
+
+        @Test
+        @WithMockUser
+        void shouldResponseAllowOriginHeaderWithDifferentOrigin() {
+            webClient.get().uri("http://localhost:3000/apis/cors-enabled")
+                .header(HttpHeaders.ORIGIN, "https://another.website")
+                .header(HttpHeaders.AUTHORIZATION, "fake-authorization")
+                // .header("ForbiddenHeader", "fake value")
+                .accept(MediaType.APPLICATION_JSON)
+                .exchange()
+                .expectHeader()
+                .exists(HttpHeaders.ACCESS_CONTROL_ALLOW_ORIGIN);
+        }
+
+        @Test
+        @WithMockUser
+        void shouldResponseAllowOriginHeaderWithForbiddenHeader() {
+            webClient.get().uri("http://localhost:3000/apis/cors-enabled")
+                .header(HttpHeaders.ORIGIN, "https://another.website")
+                .header(HttpHeaders.AUTHORIZATION, "fake-authorization")
+                .header("FakeHeader", "fake-header-value")
+                // .header("ForbiddenHeader", "fake value")
+                .accept(MediaType.APPLICATION_JSON)
+                .exchange()
+                .expectHeader()
+                .exists(HttpHeaders.ACCESS_CONTROL_ALLOW_ORIGIN);
+        }
+    }
+
+    @Nested
+    class RequestCorsDisabledApi {
+
+        @Test
+        @WithMockUser
+        void shouldNotResponseAllowOriginHeaderWithDifferentOrigin() {
+            webClient.get().uri("http://localhost:3000/cors-disabled")
+                .header(HttpHeaders.ORIGIN, "https://another.website")
+                .header(HttpHeaders.AUTHORIZATION, "fake-authorization")
+                .accept(MediaType.APPLICATION_JSON)
+                .exchange()
+                .expectHeader()
+                .doesNotExist(HttpHeaders.ACCESS_CONTROL_ALLOW_ORIGIN);
+        }
+
+        @Test
+        @WithMockUser
+        void shouldNotResponseAllowOriginHeaderWithSameOrigin() {
+            webClient.get().uri("http://localhost:3000/cors-disabled")
+                .header(HttpHeaders.ORIGIN, "http://localhost:3000")
+                .header(HttpHeaders.AUTHORIZATION, "fake-authorization")
+                .header("FakeHeader", "fake-header-value")
+                .accept(MediaType.APPLICATION_JSON)
+                .exchange()
+                .expectHeader()
+                .doesNotExist(HttpHeaders.ACCESS_CONTROL_ALLOW_ORIGIN);
+        }
+    }
+
+}


### PR DESCRIPTION
#### What type of PR is this?

/kind improvement
/kind api-change

#### What this PR does / why we need it:

目前，Halo 中所有的 API 和页面都配置了默认的 CORS 规则，以至于无法使用 XHR 请求。

这个 PR 主要配置了 API 的 CORS 规则，允许跨域访问。

#### Which issue(s) this PR fixes:

Fixes #

#### Special notes for your reviewer:

/cc @halo-dev/sig-halo 

##### How to test?

1. 启动 Halo
2. 访问 <https://www.test-cors.org/#?client_method=GET&client_credentials=false&server_url=http%3A%2F%2Flocalhost%3A8090%2Fwebjars%2Fswagger-ui%2Findex.html&server_enable=true&server_status=200&server_credentials=false&server_tabs=remote> ，并打开调试工具
3. 点击 `Send Request` 并查看控制台日志
4. 访问 <https://www.test-cors.org/#?client_method=GET&client_credentials=false&server_url=http%3A%2F%2Flocalhost%3A8090%2Fapi%2Ffake&server_enable=true&server_status=200&server_credentials=false&server_tabs=remote> 并点击 `Send Request`。

效果如下：

```js
/#?client_method=GET&client_credentials=false&server_url=http%3A%2F%2Flocalhost%3A8090%2Fwebjars%2Fswagger-ui%2Findex.html&server_enable=true&server_status=200&server_credentials=false&server_tabs=remote:1 Access to XMLHttpRequest at 'http://localhost:8090/webjars/swagger-ui/index.html' from origin 'https://www.test-cors.org' has been blocked by CORS policy: No 'Access-Control-Allow-Origin' header is present on the requested resource.
corsclient.js:613          GET http://localhost:8090/webjars/swagger-ui/index.html net::ERR_FAILED 200
sendRequest @ corsclient.js:613
(anonymous) @ corsclient.js:653
dispatch @ jquery-1.9.1.min.js:3
v.handle @ jquery-1.9.1.min.js:3
corsclient.js:613          GET http://localhost:8090/api/fake 401 (Unauthorized)
```

#### Does this PR introduce a user-facing change?

<!--
如果当前 Pull Request 的修改不会造成用户侧的任何变更，在 `release-note` 代码块儿中填写 `NONE`。
否则请填写用户侧能够理解的 Release Note。如果当前 Pull Request 包含破坏性更新（Break Change），
Release Note 需要以 `action required` 开头。
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->

```release-note
None
```
