### PR TITLE
Refine Swagger document for Extension APIs

### DIFF
--- a/src/main/java/run/halo/app/config/WebServerSecurityConfig.java
+++ b/src/main/java/run/halo/app/config/WebServerSecurityConfig.java
@@ -86,11 +86,8 @@ public class WebServerSecurityConfig {
     @Order(0)
     SecurityWebFilterChain webFilterChain(ServerHttpSecurity http) {
         http.authorizeExchange(exchanges -> exchanges.pathMatchers(
-                "/v3/api-docs/**",
-                "/v3/api-docs.yaml",
-                "/swagger-ui/**",
-                "/swagger-ui.html",
-                "/webjars/**").permitAll())
+                "/actuator/**"
+            ).permitAll())
             .authorizeExchange(exchanges -> exchanges.anyExchange().authenticated())
             .cors(withDefaults())
             .httpBasic(withDefaults())

--- a/src/main/java/run/halo/app/extension/GroupVersionKind.java
+++ b/src/main/java/run/halo/app/extension/GroupVersionKind.java
@@ -48,4 +48,12 @@ public record GroupVersionKind(String group, String version, String kind) {
         var gv = GroupVersion.parseAPIVersion(apiVersion);
         return new GroupVersionKind(gv.group(), gv.version(), kind);
     }
+
+    @Override
+    public String toString() {
+        if (hasGroup()) {
+            return group + "/" + version + "/" + kind;
+        }
+        return version + "/" + kind;
+    }
 }

--- a/src/main/resources/application-dev.yaml
+++ b/src/main/resources/application-dev.yaml
@@ -52,3 +52,13 @@ springdoc:
   swagger-ui:
     enabled: true
   show-login-endpoint: true
+  show-actuator: true
+  use-management-port: true
+
+management:
+  endpoints:
+    web:
+      exposure:
+        include: openapi, swagger-ui
+  server:
+    port: 9090


### PR DESCRIPTION
#### What type of PR is this?

/kind improvement
/area core
/milestone 2.0

#### What this PR does / why we need it:

为自动生成的自定义模型 API 提供 Swagger 文档描述。请看下图：

<img width="631" alt="image" src="https://user-images.githubusercontent.com/16865714/174937982-dadd923b-3a4b-478e-b33c-1f1233714c9f.png">

参考：
- https://springdoc.org/v2/#spring-webfluxwebmvc-fn-with-functional-endpoints

#### Which issue(s) this PR fixes:

Fixes #

#### Special notes for your reviewer:

##### 如何测试？

1. 以 dev profile 启动 Halo
2. 访问 <http://localhost:9090/actuator/swagger-ui>

> :information_source: 由于 application-dev.yaml 中配置了 management 端口，所以这里访问 Swagger 的端口为 9090，而不是默认的 8090。

#### Does this PR introduce a user-facing change?

```release-note
None
```
