### PR TITLE
Add an additional method to fetch Extension by GVK and name

### DIFF
--- a/src/main/java/run/halo/app/extension/DefaultExtensionClient.java
+++ b/src/main/java/run/halo/app/extension/DefaultExtensionClient.java
@@ -62,8 +62,15 @@ public class DefaultExtensionClient implements ExtensionClient {
 
     @Override
     public <E extends Extension> Optional<E> fetch(Class<E> type, String name) {
-        var scheme = schemeManager.get(type);
+        return fetch(schemeManager.get(type), name, type);
+    }
 
+    @Override
+    public Optional<Unstructured> fetch(GroupVersionKind gvk, String name) {
+        return fetch(schemeManager.get(gvk), name, Unstructured.class);
+    }
+
+    private <E extends Extension> Optional<E> fetch(Scheme scheme, String name, Class<E> type) {
         var storeName = ExtensionUtil.buildStoreName(scheme, name);
         return storeClient.fetchByName(storeName)
             .map(extensionStore -> converter.convertFrom(type, extensionStore));

--- a/src/main/java/run/halo/app/extension/ExtensionClient.java
+++ b/src/main/java/run/halo/app/extension/ExtensionClient.java
@@ -50,6 +50,8 @@ public interface ExtensionClient {
      */
     <E extends Extension> Optional<E> fetch(Class<E> type, String name);
 
+    Optional<Unstructured> fetch(GroupVersionKind gvk, String name);
+
 
     /**
      * Creates an Extension.

--- a/src/main/java/run/halo/app/extension/Unstructured.java
+++ b/src/main/java/run/halo/app/extension/Unstructured.java
@@ -14,6 +14,7 @@ import java.time.Instant;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 
 /**
@@ -219,4 +220,20 @@ public class Unstructured implements Extension {
         }
     }
 
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        Unstructured that = (Unstructured) o;
+        return Objects.equals(data, that.data);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(data);
+    }
 }

--- a/src/test/java/run/halo/app/extension/ExtensionCreateHandlerTest.java
+++ b/src/test/java/run/halo/app/extension/ExtensionCreateHandlerTest.java
@@ -6,6 +6,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.same;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -107,6 +108,6 @@ class ExtensionCreateHandlerTest {
             .verifyError(ExtensionNotFoundException.class);
         verify(client, times(1)).create(
             argThat(extension -> Objects.equals("my-fake", extension.getMetadata().getName())));
-        verify(client, times(0)).fetch(any(), anyString());
+        verify(client, times(0)).fetch(same(FakeExtension.class), anyString());
     }
 }

--- a/src/test/java/run/halo/app/extension/ExtensionDeleteHandlerTest.java
+++ b/src/test/java/run/halo/app/extension/ExtensionDeleteHandlerTest.java
@@ -7,6 +7,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.same;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -99,7 +100,7 @@ class ExtensionDeleteHandlerTest {
         StepVerifier.create(responseMono)
             .verifyError(ExtensionNotFoundException.class);
 
-        verify(client, times(1)).fetch(any(), anyString());
+        verify(client, times(1)).fetch(same(FakeExtension.class), anyString());
         verify(client, times(0)).update(any());
         verify(client, times(0)).delete(any());
     }

--- a/src/test/java/run/halo/app/extension/ExtensionUpdateHandlerTest.java
+++ b/src/test/java/run/halo/app/extension/ExtensionUpdateHandlerTest.java
@@ -7,6 +7,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.same;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -119,6 +120,6 @@ class ExtensionUpdateHandlerTest {
 
         verify(client, times(1)).update(
             argThat(extension -> Objects.equals("my-fake", extension.getMetadata().getName())));
-        verify(client, times(0)).fetch(any(), anyString());
+        verify(client, times(0)).fetch(same(FakeExtension.class), anyString());
     }
 }

--- a/src/test/java/run/halo/app/extension/UnstructuredTest.java
+++ b/src/test/java/run/halo/app/extension/UnstructuredTest.java
@@ -1,6 +1,7 @@
 package run.halo.app.extension;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static run.halo.app.extension.MetadataOperator.metadataDeepEquals;
 
@@ -46,7 +47,6 @@ class UnstructuredTest {
         Map extensionMap = objectMapper.readValue(extensionJson, Map.class);
         var extension = new Unstructured(extensionMap);
 
-        System.out.println(objectMapper.writeValueAsString(extension));
         var beforeChange = objectMapper.writeValueAsString(extension);
 
         var metadata = extension.getMetadata();
@@ -75,14 +75,32 @@ class UnstructuredTest {
 
     @Test
     void shouldSetExtensionCorrectly() {
-        var extension = new Unstructured();
-        extension.setApiVersion("fake.halo.run/v1alpha1");
-        extension.setKind("Fake");
-        extension.setMetadata(createMetadata());
+        var extension = createUnstructured();
 
         assertEquals("fake.halo.run/v1alpha1", extension.getApiVersion());
         assertEquals("Fake", extension.getKind());
         assertTrue(metadataDeepEquals(createMetadata(), extension.getMetadata()));
+    }
+
+    @Test
+    void shouldBeEqual() {
+        assertEquals(new Unstructured(), new Unstructured());
+        assertEquals(createUnstructured(), createUnstructured());
+    }
+
+    @Test
+    void shouldNotBeEqual() {
+        var another = createUnstructured();
+        another.getMetadata().setName("fake-extension-2");
+        assertNotEquals(createUnstructured(), another);
+    }
+
+    Unstructured createUnstructured() {
+        var unstructured = new Unstructured();
+        unstructured.setApiVersion("fake.halo.run/v1alpha1");
+        unstructured.setKind("Fake");
+        unstructured.setMetadata(createMetadata());
+        return unstructured;
     }
 
     private Metadata createMetadata() {


### PR DESCRIPTION
#### What type of PR is this?

/kind improvement
/area core
/milestone 2.0

#### What this PR does / why we need it:

Add additional method to fetch Extension by GVK and name. If you are using `ExtensionClient`, now you can fetch an Extension by `GroupVersionKind` and its name instead of its type. Because sometimes we don't know the exact type.

Usage example:
```java
client.fetch(fromAPIVersionAndKind("fake.halo.run/v1alpha1", "Fake"), "fake")
```

#### Which issue(s) this PR fixes:

Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
None
```
