### PR TITLE
refactor: Unstructured loading opportunity for plugin

### DIFF
--- a/src/main/java/run/halo/app/plugin/PluginLoadedListener.java
+++ b/src/main/java/run/halo/app/plugin/PluginLoadedListener.java
@@ -1,16 +1,10 @@
 package run.halo.app.plugin;
 
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
 import org.pf4j.PluginWrapper;
 import org.springframework.context.ApplicationListener;
-import org.springframework.core.io.DefaultResourceLoader;
-import org.springframework.core.io.Resource;
 import org.springframework.stereotype.Component;
 import run.halo.app.core.extension.Plugin;
 import run.halo.app.extension.ExtensionClient;
-import run.halo.app.infra.utils.YamlUnstructuredLoader;
 import run.halo.app.plugin.event.HaloPluginLoadedEvent;
 
 /**
@@ -32,26 +26,10 @@ public class PluginLoadedListener implements ApplicationListener<HaloPluginLoade
         // load plugin.yaml
         YamlPluginFinder yamlPluginFinder = new YamlPluginFinder();
         Plugin plugin = yamlPluginFinder.find(pluginWrapper.getPluginPath());
-        extensionClient.create(plugin);
-
-        // load unstructured
-        DefaultResourceLoader resourceLoader =
-            new DefaultResourceLoader(pluginWrapper.getPluginClassLoader());
-        plugin.getSpec().getExtensionLocations()
-            .stream()
-            .map(resourceLoader::getResource)
-            .filter(Resource::exists)
-            .map(resource -> new YamlUnstructuredLoader(resource).load())
-            .flatMap(List::stream)
-            .forEach(unstructured -> {
-                Map<String, String> labels = unstructured.getMetadata().getLabels();
-                if (labels == null) {
-                    unstructured.getMetadata().setLabels(new HashMap<>());
-                }
-                unstructured.getMetadata()
-                    .getLabels()
-                    .put(PluginConst.PLUGIN_NAME_LABEL_NAME, plugin.getMetadata().getName());
-                extensionClient.create(unstructured);
-            });
+        extensionClient.fetch(Plugin.class, plugin.getMetadata().getName())
+            .ifPresentOrElse(persisted -> {
+                plugin.getMetadata().setVersion(persisted.getMetadata().getVersion());
+                extensionClient.update(plugin);
+            }, () -> extensionClient.create(plugin));
     }
 }

--- a/src/main/java/run/halo/app/plugin/PluginStartedListener.java
+++ b/src/main/java/run/halo/app/plugin/PluginStartedListener.java
@@ -1,0 +1,64 @@
+package run.halo.app.plugin;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.pf4j.PluginWrapper;
+import org.springframework.context.ApplicationListener;
+import org.springframework.core.io.DefaultResourceLoader;
+import org.springframework.core.io.Resource;
+import org.springframework.stereotype.Component;
+import run.halo.app.core.extension.Plugin;
+import run.halo.app.extension.ExtensionClient;
+import run.halo.app.extension.GroupVersionKind;
+import run.halo.app.extension.MetadataOperator;
+import run.halo.app.infra.utils.YamlUnstructuredLoader;
+import run.halo.app.plugin.event.HaloPluginStartedEvent;
+
+/**
+ * TODO Optimized Unstructured loading.
+ *
+ * @author guqing
+ * @since 2.0.0
+ */
+@Component
+public class PluginStartedListener implements ApplicationListener<HaloPluginStartedEvent> {
+
+    private final ExtensionClient extensionClient;
+
+    public PluginStartedListener(ExtensionClient extensionClient) {
+        this.extensionClient = extensionClient;
+    }
+
+    @Override
+    public void onApplicationEvent(HaloPluginStartedEvent event) {
+        PluginWrapper pluginWrapper = event.getPlugin();
+        Plugin plugin =
+            extensionClient.fetch(Plugin.class, pluginWrapper.getPluginId()).orElseThrow();
+        // load unstructured
+        DefaultResourceLoader resourceLoader =
+            new DefaultResourceLoader(pluginWrapper.getPluginClassLoader());
+        plugin.getSpec().getExtensionLocations()
+            .stream()
+            .map(resourceLoader::getResource)
+            .filter(Resource::exists)
+            .map(resource -> new YamlUnstructuredLoader(resource).load())
+            .flatMap(List::stream)
+            .forEach(unstructured -> {
+                MetadataOperator metadata = unstructured.getMetadata();
+                Map<String, String> labels = metadata.getLabels();
+                if (labels == null) {
+                    labels = new HashMap<>();
+                    metadata.setLabels(labels);
+                }
+                labels.put(PluginConst.PLUGIN_NAME_LABEL_NAME, plugin.getMetadata().getName());
+                extensionClient.fetch(
+                        GroupVersionKind.fromAPIVersionAndKind(unstructured.getApiVersion(),
+                            unstructured.getKind()), metadata.getName())
+                    .ifPresentOrElse(persisted -> {
+                        unstructured.getMetadata().setVersion(persisted.getMetadata().getVersion());
+                        extensionClient.update(unstructured);
+                    }, () -> extensionClient.create(unstructured));
+            });
+    }
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. 如果这是你的第一次，请阅读我们的贡献指南：<https://github.com/halo-dev/halo/blob/master/CONTRIBUTING.md>。
1. If this is your first time, please read our contributor guidelines: <https://github.com/halo-dev/halo/blob/master/CONTRIBUTING.md>.
2. 请根据你解决问题的类型为 Pull Request 添加合适的标签。
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request.
3. 请确保你已经添加并运行了适当的测试。
3. Ensure you have added or ran the appropriate tests for your PR.
-->

#### What type of PR is this?
/kind improvment
/area core
/milestone 2.0
<!--
添加其中一个类别：
Add one of the following kinds:

/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind optimization

适当添加其中一个或多个类别（可选）：
Optionally add one or more of the following kinds if applicable:

/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
1. 插件启动后再加载 Unstructured，避免 Scheme 还没有注册。
2. 如果 Unstructured 已经存在则更新它，没有则创建。

在这之前，出于无法查询 Unstructured record 是否已经存在数据而只能配置数据库为内存模式，现在得益于 ExtensionClient 增加了可以根据 GVK 查询的方法（#2190），已经可以配置数据库为 file 模式。
#### Which issue(s) this PR fixes:

<!--
PR 合并时自动关闭 issue。
Automatically closes linked issue when PR is merged.

用法：`Fixes #<issue 号>`，或者 `Fixes (粘贴 issue 完整链接)`
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
/cc @halo-dev/sig-halo 
#### Does this PR introduce a user-facing change?

<!--
如果当前 Pull Request 的修改不会造成用户侧的任何变更，在 `release-note` 代码块儿中填写 `NONE`。
否则请填写用户侧能够理解的 Release Note。如果当前 Pull Request 包含破坏性更新（Break Change），
Release Note 需要以 `action required` 开头。
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->

```release-note
None
```
