### PR TITLE
perf: optimize the update logic of post editTime field

### DIFF
--- a/src/main/java/run/halo/app/controller/admin/api/PostController.java
+++ b/src/main/java/run/halo/app/controller/admin/api/PostController.java
@@ -36,6 +36,7 @@ import run.halo.app.model.vo.PostDetailVO;
 import run.halo.app.service.OptionService;
 import run.halo.app.service.PostService;
 import run.halo.app.service.assembler.PostAssembler;
+import run.halo.app.utils.DateUtils;
 import run.halo.app.utils.HaloUtils;
 
 /**
@@ -164,8 +165,14 @@ public class PostController {
     public BasePostDetailDTO updateDraftBy(
         @PathVariable("postId") Integer postId,
         @RequestBody PostContentParam contentParam) {
-        Post postToUse = postService.getById(postId);
+        Post postToUse = postService.getWithLatestContentById(postId);
         String formattedContent = contentParam.decideContentBy(postToUse.getEditorType());
+        // Update the  editTime when the content of the posts changes
+        if (!postToUse.getContent().getOriginalContent()
+            .equals(contentParam.getOriginalContent())) {
+            postToUse.setEditTime(DateUtils.now());
+            postService.update(postToUse);
+        }
         // Update draft content
         Post post = postService.updateDraftContent(formattedContent,
             contentParam.getOriginalContent(), postId);

--- a/src/main/java/run/halo/app/factory/StringToEnumConverterFactory.java
+++ b/src/main/java/run/halo/app/factory/StringToEnumConverterFactory.java
@@ -13,6 +13,7 @@ import org.springframework.stereotype.Component;
 public class StringToEnumConverterFactory implements ConverterFactory<String, Enum<?>> {
 
     @Override
+    @SuppressWarnings("unchecked")
     @NonNull
     public <T extends Enum<?>> Converter<String, T> getConverter(@NonNull Class<T> targetType) {
         return new StringToEnumConverter(targetType);

--- a/src/main/java/run/halo/app/factory/StringToEnumConverterFactory.java
+++ b/src/main/java/run/halo/app/factory/StringToEnumConverterFactory.java
@@ -13,7 +13,6 @@ import org.springframework.stereotype.Component;
 public class StringToEnumConverterFactory implements ConverterFactory<String, Enum<?>> {
 
     @Override
-    @SuppressWarnings("unchecked")
     @NonNull
     public <T extends Enum<?>> Converter<String, T> getConverter(@NonNull Class<T> targetType) {
         return new StringToEnumConverter(targetType);

--- a/src/main/java/run/halo/app/model/params/BasePostParam.java
+++ b/src/main/java/run/halo/app/model/params/BasePostParam.java
@@ -10,7 +10,7 @@ import run.halo.app.model.entity.BasePost;
 import run.halo.app.model.entity.Content;
 import run.halo.app.model.enums.PostEditorType;
 import run.halo.app.model.enums.PostStatus;
-import run.halo.app.service.impl.BasePostServiceImpl;
+import run.halo.app.utils.DateUtils;
 import run.halo.app.utils.MarkdownUtils;
 
 /**
@@ -73,6 +73,13 @@ public abstract class BasePostParam {
         } else {
             postContent.setContent(content);
         }
+
+        // update the editTime  only when changing the post title or post content
+        if (!Objects.equals(title.length(),post.getTitle().length())
+            || ! Objects.equals(originalContent.length(),post.getContent().getOriginalContent().length()) ){
+            post.setEditTime(DateUtils.now());
+        }
+
         post.setContent(Content.PatchedContent.of(postContent));
     }
 }

--- a/src/main/java/run/halo/app/model/params/BasePostParam.java
+++ b/src/main/java/run/halo/app/model/params/BasePostParam.java
@@ -75,8 +75,8 @@ public abstract class BasePostParam {
         }
 
         // update the editTime  only when changing the post title or post content
-        if (!Objects.equals(title.length(),post.getTitle().length())
-            || ! Objects.equals(originalContent.length(),post.getContent().getOriginalContent().length()) ){
+        if (!Objects.equals(title,post.getTitle())
+            || ! Objects.equals(originalContent,post.getContent().getOriginalContent())){
             post.setEditTime(DateUtils.now());
         }
 

--- a/src/main/java/run/halo/app/model/params/BasePostParam.java
+++ b/src/main/java/run/halo/app/model/params/BasePostParam.java
@@ -75,8 +75,8 @@ public abstract class BasePostParam {
         }
 
         // update the editTime  only when changing the post title or post content
-        if (!Objects.equals(title,post.getTitle())
-            || ! Objects.equals(originalContent,post.getContent().getOriginalContent())){
+        if (!Objects.equals(title, post.getTitle())
+            || !Objects.equals(originalContent, post.getContent().getOriginalContent())) {
             post.setEditTime(DateUtils.now());
         }
 

--- a/src/main/java/run/halo/app/service/impl/BasePostServiceImpl.java
+++ b/src/main/java/run/halo/app/service/impl/BasePostServiceImpl.java
@@ -314,8 +314,6 @@ public abstract class BasePostServiceImpl<POST extends BasePost>
                 postContent.getContent(), postContent.getOriginalContent());
         } else {
             // The sheet will be updated
-            // Set edit time
-            post.setEditTime(DateUtils.now());
             contentService.createOrUpdateDraftBy(post.getId(),
                 postContent.getContent(), postContent.getOriginalContent());
             // Update it

--- a/src/main/java/run/halo/app/service/impl/PostServiceImpl.java
+++ b/src/main/java/run/halo/app/service/impl/PostServiceImpl.java
@@ -194,8 +194,6 @@ public class PostServiceImpl extends BasePostServiceImpl<Post> implements PostSe
     @Transactional(rollbackFor = Exception.class)
     public PostDetailVO updateBy(Post postToUpdate, Set<Integer> tagIds, Set<Integer> categoryIds,
         Set<PostMeta> metas, boolean autoSave) {
-        // Set edit time
-        postToUpdate.setEditTime(DateUtils.now());
         PostDetailVO updatedPost = createOrUpdate(postToUpdate, tagIds, categoryIds, metas);
         if (!autoSave) {
             // Log the creation


### PR DESCRIPTION
#### What type of PR is this?
/kind improvement

#### What this PR does / why we need it:
Article update time logic optimization;
Update the Edit_time field in the Posts table only when you change the post title or post content

#### Which issue(s) this PR fixes:
Fixes #2193 
#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
NONE
```