### PR TITLE
Fix directory traversal issue while renaming static file

### DIFF
--- a/src/main/java/run/halo/app/utils/FileUtils.java
+++ b/src/main/java/run/halo/app/utils/FileUtils.java
@@ -107,6 +107,12 @@ public class FileUtils {
         Assert.notNull(newName, "New name must not be null");
 
         Path newPath = pathToRename.resolveSibling(newName);
+        var parent = pathToRename.getParent();
+        if (parent == null) {
+            parent = pathToRename;
+        }
+        checkDirectoryTraversal(parent, newPath);
+
         log.info("Rename [{}] to [{}]", pathToRename, newPath);
 
         Files.move(pathToRename, newPath);

--- a/src/test/java/run/halo/app/utils/FileUtilsTest.java
+++ b/src/test/java/run/halo/app/utils/FileUtilsTest.java
@@ -3,6 +3,7 @@ package run.halo.app.utils;
 import static org.apache.commons.lang3.RandomStringUtils.randomAlphabetic;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.ByteArrayInputStream;
@@ -22,6 +23,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
+import run.halo.app.exception.ForbiddenException;
 import run.halo.app.model.support.HaloConst;
 
 /**
@@ -132,6 +134,14 @@ class FileUtilsTest {
         assertFalse(Files.exists(filePath));
         assertTrue(Files.isRegularFile(newPath));
         assertEquals(content, new String(Files.readAllBytes(newPath)));
+    }
+
+    @Test
+    void shouldThrowErrorIfNewNameIsInvalidWhenRenaming() {
+        final var target = tempDirectory.resolve("fake.file");
+        assertThrows(ForbiddenException.class, () -> FileUtils.rename(target, "../fake.file"));
+        assertThrows(ForbiddenException.class, () -> FileUtils.rename(target, "../../fake.file"));
+        assertThrows(ForbiddenException.class, () -> FileUtils.rename(target, "/fake.file"));
     }
 
     @Test


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/area core
/milestone 1.5.x

#### What this PR does / why we need it:

Check directory traversal while renaming file.

#### Which issue(s) this PR fixes:

Fixes #2202 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
如果当前 Pull Request 的修改不会造成用户侧的任何变更，在 `release-note` 代码块儿中填写 `NONE`。
否则请填写用户侧能够理解的 Release Note。如果当前 Pull Request 包含破坏性更新（Break Change），
Release Note 需要以 `action required` 开头。
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->

```release-note
修复静态存储文件重命名时文件名造成的目录逃逸问题
```
