### PR TITLE
Revert huaweicloud-sdk-java-obs from 3.21.8.1 to 3.21.4

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -70,7 +70,7 @@ ext {
     levelDbVersion = "0.12"
     annotationsVersion = "3.0.1u2"
     zxingVersion = '3.4.1'
-    huaweiObsVersion = '3.21.8.1'
+    huaweiObsVersion = '3.21.4'
     templateInheritanceVersion = "0.4.RELEASE"
     jsoupVersion = '1.14.3'
     embeddedRedisVersion = '0.6'

--- a/src/test/java/run/halo/app/handler/file/HuaweiObsSdkTest.java
+++ b/src/test/java/run/halo/app/handler/file/HuaweiObsSdkTest.java
@@ -1,0 +1,46 @@
+package run.halo.app.handler.file;
+
+import com.obs.services.internal.ObsProperties;
+import com.obs.services.internal.RestConnectionService;
+import com.obs.services.internal.ServiceException;
+import com.obs.services.model.HttpMethodEnum;
+import java.util.Map;
+import okhttp3.Request;
+import okhttp3.RequestBody;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+class HuaweiObsSdkTest {
+
+    /**
+     * See
+     * <a href="https://github.com/halo-dev/halo/issues/1909">
+     * https://github.com/halo-dev/halo/issues/1909
+     * </a>
+     * for more.
+     */
+    @Test
+    void shouldSetUpConnectionCorrectly() {
+        var connSvc = new RestConnectionService() {
+
+            {
+                // We have to initialize the obsProperties, or we will get a NPE while setting up
+                // connection.
+                obsProperties = new ObsProperties();
+            }
+
+            @Override
+            public Request.Builder setupConnection(HttpMethodEnum method, String bucketName,
+                String objectKey,
+                Map<String, String> requestParameters,
+                RequestBody body) throws ServiceException {
+                return super.setupConnection(method, bucketName, objectKey, requestParameters,
+                    body);
+            }
+        };
+        var builder = connSvc.setupConnection(HttpMethodEnum.GET, "fake-bucket-name",
+            "fake-object-key", Map.of(), null);
+        Assertions.assertNotNull(builder);
+    }
+
+}


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/kind regression
/area core
/milestone 1.5.x

#### What this PR does / why we need it:

Revert huaweicloud-sdk-java-obs from 3.21.8.1 to 3.21.4.

Please see the release notes of the sdk from <https://github.com/huaweicloud/huaweicloud-sdk-java-obs/blob/81539706e743b3fceaaa7b3bac99c4ddcda7fdda/README.MD>.

#### Which issue(s) this PR fixes:

Fixes #1909 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
修复上传附件到华为云时提示“NoSuchMethodError，okhttp3.RequestBody.create”错误
```
