### PR TITLE
Refactor the response structure of Extension list API

### DIFF
--- a/src/main/java/run/halo/app/extension/ExtensionClient.java
+++ b/src/main/java/run/halo/app/extension/ExtensionClient.java
@@ -4,7 +4,6 @@ import java.util.Comparator;
 import java.util.List;
 import java.util.Optional;
 import java.util.function.Predicate;
-import org.springframework.data.domain.Page;
 
 /**
  * ExtensionClient is an interface which contains some operations on Extension instead of
@@ -35,9 +34,9 @@ public interface ExtensionClient {
      * @param page is page number which starts from 0.
      * @param size is page size.
      * @param <E> is Extension type.
-     * @return a page of Extensions.
+     * @return a list of Extensions.
      */
-    <E extends Extension> Page<E> page(Class<E> type, Predicate<E> predicate,
+    <E extends Extension> ListResult<E> list(Class<E> type, Predicate<E> predicate,
         Comparator<E> comparator, int page, int size);
 
     /**

--- a/src/main/java/run/halo/app/extension/ListResult.java
+++ b/src/main/java/run/halo/app/extension/ListResult.java
@@ -1,0 +1,76 @@
+package run.halo.app.extension;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+import lombok.Data;
+import org.springframework.data.util.Streamable;
+import org.springframework.util.Assert;
+
+@Data
+public class ListResult<T> implements Streamable<T> {
+
+    private final int page;
+
+    private final int size;
+
+    private final long total;
+
+    private final List<T> items;
+
+    public ListResult(int page, int size, long total, List<T> items) {
+        Assert.isTrue(total >= 0, "Total elements must be greater than or equal to 0");
+        if (page < 0) {
+            page = 0;
+        }
+        if (size < 0) {
+            size = 0;
+        }
+        if (items == null) {
+            items = Collections.emptyList();
+        }
+        this.page = page;
+        this.size = size;
+        this.total = total;
+        this.items = items;
+    }
+
+    public ListResult(List<T> items) {
+        this(0, 0, items.size(), items);
+    }
+
+    public boolean isFirst() {
+        return !hasPrevious();
+    }
+
+    public boolean isLast() {
+        return !hasNext();
+    }
+
+    @JsonProperty("hasNext")
+    public boolean hasNext() {
+        if (page <= 0) {
+            return false;
+        }
+        var totalPages = size == 0 ? 1 : (int) Math.ceil((double) total / (double) size);
+        return page < totalPages;
+    }
+
+    @JsonProperty("hasPrevious")
+    public boolean hasPrevious() {
+        return page > 1;
+    }
+
+    @Override
+    public Iterator<T> iterator() {
+        return items.iterator();
+    }
+
+    @Override
+    @JsonIgnore
+    public boolean isEmpty() {
+        return Streamable.super.isEmpty();
+    }
+}

--- a/src/main/java/run/halo/app/extension/ListResult.java
+++ b/src/main/java/run/halo/app/extension/ListResult.java
@@ -2,6 +2,7 @@ package run.halo.app.extension;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.v3.oas.annotations.media.Schema;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
@@ -12,12 +13,17 @@ import org.springframework.util.Assert;
 @Data
 public class ListResult<T> implements Streamable<T> {
 
+    @Schema(description = "Page number, starts from 1. If not set or equal to 0, it means no "
+        + "pagination.")
     private final int page;
 
+    @Schema(description = "Size of each page. If not set or equal to 0, it means no pagination.")
     private final int size;
 
+    @Schema(description = "Total elements.")
     private final long total;
 
+    @Schema(description = "A chunk of items.")
     private final List<T> items;
 
     public ListResult(int page, int size, long total, List<T> items) {

--- a/src/main/java/run/halo/app/extension/ListResult.java
+++ b/src/main/java/run/halo/app/extension/ListResult.java
@@ -14,16 +14,16 @@ import org.springframework.util.Assert;
 public class ListResult<T> implements Streamable<T> {
 
     @Schema(description = "Page number, starts from 1. If not set or equal to 0, it means no "
-        + "pagination.")
+        + "pagination.", required = true)
     private final int page;
 
-    @Schema(description = "Size of each page. If not set or equal to 0, it means no pagination.")
+    @Schema(description = "Size of each page. If not set or equal to 0, it means no pagination.", required = true)
     private final int size;
 
-    @Schema(description = "Total elements.")
+    @Schema(description = "Total elements.", required = true)
     private final long total;
 
-    @Schema(description = "A chunk of items.")
+    @Schema(description = "A chunk of items.", required = true)
     private final List<T> items;
 
     public ListResult(int page, int size, long total, List<T> items) {
@@ -47,14 +47,17 @@ public class ListResult<T> implements Streamable<T> {
         this(0, 0, items.size(), items);
     }
 
+    @Schema(description = "Indicates whether current page is the first page.", required = true)
     public boolean isFirst() {
         return !hasPrevious();
     }
 
+    @Schema(description = "Indicates whether current page is the last page.", required = true)
     public boolean isLast() {
         return !hasNext();
     }
 
+    @Schema(description = "Indicates whether current page has previous page.", required = true)
     @JsonProperty("hasNext")
     public boolean hasNext() {
         if (page <= 0) {
@@ -64,6 +67,7 @@ public class ListResult<T> implements Streamable<T> {
         return page < totalPages;
     }
 
+    @Schema(description = "Indicates whether current page has previous page.", required = true)
     @JsonProperty("hasPrevious")
     public boolean hasPrevious() {
         return page > 1;

--- a/src/main/java/run/halo/app/extension/ListResult.java
+++ b/src/main/java/run/halo/app/extension/ListResult.java
@@ -17,7 +17,8 @@ public class ListResult<T> implements Streamable<T> {
         + "pagination.", required = true)
     private final int page;
 
-    @Schema(description = "Size of each page. If not set or equal to 0, it means no pagination.", required = true)
+    @Schema(description = "Size of each page. If not set or equal to 0, it means no pagination.",
+        required = true)
     private final int size;
 
     @Schema(description = "Total elements.", required = true)

--- a/src/test/java/run/halo/app/extension/ExtensionListHandlerTest.java
+++ b/src/test/java/run/halo/app/extension/ExtensionListHandlerTest.java
@@ -3,7 +3,8 @@ package run.halo.app.extension;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.same;
 import static org.mockito.Mockito.when;
 
 import java.util.List;
@@ -38,7 +39,10 @@ class ExtensionListHandlerTest {
         var listHandler = new ExtensionListHandler(scheme, client);
         var serverRequest = MockServerRequest.builder().build();
         final var fake = new FakeExtension();
-        when(client.list(eq(FakeExtension.class), any(), any())).thenReturn(List.of(fake));
+        // when(client.list(same(FakeExtension.class), any(), any())).thenReturn(List.of(fake));
+        var fakeListResult = new ListResult<>(0, 0, 1, List.of(fake));
+        when(client.list(same(FakeExtension.class), any(), any(), anyInt(), anyInt()))
+            .thenReturn(fakeListResult);
 
         var responseMono = listHandler.handle(serverRequest);
 
@@ -47,7 +51,7 @@ class ExtensionListHandlerTest {
                 assertEquals(HttpStatus.OK, response.statusCode());
                 assertEquals(MediaType.APPLICATION_JSON, response.headers().getContentType());
                 assertTrue(response instanceof EntityResponse<?>);
-                assertEquals(List.of(fake), ((EntityResponse<?>) response).entity());
+                assertEquals(fakeListResult, ((EntityResponse<?>) response).entity());
             })
             .verifyComplete();
     }


### PR DESCRIPTION
#### What type of PR is this?

/kind improvement
/kind api-change
/area core
/milestone 2.0

#### What this PR does / why we need it:

This PR is refactoring the response structure of Extension list API as follows:

```json
{
  "page": 0,
  "size": 0,
  "total": 1,
  "items": [
    {
      "spec": {
        "displayName": "Administrator",
        "email": "admin@halo.run",
        "password": "{bcrypt}$2a$10$/YveWyuf9vyYrHE3fiToI.bGBy5Hgs1eViRvKzU7Kl982la5NSwWO",
        "registeredAt": "2022-06-17T09:35:47.237625514Z",
        "twoFactorAuthEnabled": false,
        "disabled": false
      },
      "apiVersion": "v1alpha1",
      "kind": "User",
      "metadata": {
        "name": "admin",
        "annotations": {
          "user.halo.run/roles": "[\"super-role\"]",
          "rbac.authorization.halo.run/role-names": "[\"second-super-role\",\"super-role\"]"
        },
        "version": 3077,
        "creationTimestamp": "2022-06-17T09:35:47.367919552Z"
      }
    }
  ],
  "first": true,
  "last": true,
  "hasNext": false,
  "hasPrevious": false
}
```

Instead of items only.

#### Which issue(s) this PR fixes:

Fixes #

#### Special notes for your reviewer:

Steps to test:

1. Start Halo server
2. Request <http://localhost:8090/swagger-ui.html> from browser and you might be redirected to login page
3. Login with your username and password
4. Try to request the list endpoints and see the result.

#### Does this PR introduce a user-facing change?

```release-note
None
```
