### PR TITLE
Create super admin initializer and run extension controllers conditionally

### DIFF
--- a/src/main/java/run/halo/app/config/WebServerSecurityConfig.java
+++ b/src/main/java/run/halo/app/config/WebServerSecurityConfig.java
@@ -9,6 +9,7 @@ import com.nimbusds.jose.jwk.RSAKey;
 import com.nimbusds.jose.jwk.source.ImmutableJWKSet;
 import java.util.Arrays;
 import java.util.List;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
 import org.springframework.core.Ordered;
 import org.springframework.core.annotation.Order;
@@ -33,8 +34,11 @@ import org.springframework.web.cors.reactive.UrlBasedCorsConfigurationSource;
 import org.springframework.web.reactive.function.server.ServerResponse;
 import run.halo.app.core.extension.service.RoleService;
 import run.halo.app.core.extension.service.UserService;
+import run.halo.app.extension.ExtensionClient;
+import run.halo.app.infra.properties.HaloProperties;
 import run.halo.app.infra.properties.JwtProperties;
 import run.halo.app.security.DefaultUserDetailService;
+import run.halo.app.security.SuperAdminInitializer;
 import run.halo.app.security.authentication.jwt.LoginAuthenticationFilter;
 import run.halo.app.security.authentication.jwt.LoginAuthenticationManager;
 import run.halo.app.security.authorization.RequestInfoAuthorizationManager;
@@ -143,4 +147,13 @@ public class WebServerSecurityConfig {
         return new NimbusJwtEncoder(jwks);
     }
 
+    @Bean
+    @ConditionalOnProperty(name = "halo.security.initializer.disabled",
+        havingValue = "false",
+        matchIfMissing = true)
+    SuperAdminInitializer superAdminInitializer(ExtensionClient client, HaloProperties halo) {
+        return new SuperAdminInitializer(client,
+            passwordEncoder(),
+            halo.getSecurity().getInitializer());
+    }
 }

--- a/src/main/java/run/halo/app/extension/controller/ControllerManager.java
+++ b/src/main/java/run/halo/app/extension/controller/ControllerManager.java
@@ -1,22 +1,18 @@
 package run.halo.app.extension.controller;
 
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.BeansException;
 import org.springframework.beans.factory.DisposableBean;
 import org.springframework.boot.context.event.ApplicationReadyEvent;
 import org.springframework.context.ApplicationContext;
+import org.springframework.context.ApplicationContextAware;
 import org.springframework.context.ApplicationListener;
-import org.springframework.stereotype.Component;
 
 @Slf4j
-@Component
 public class ControllerManager implements ApplicationListener<ApplicationReadyEvent>,
-    DisposableBean {
+    ApplicationContextAware, DisposableBean {
 
-    private final ApplicationContext applicationContext;
-
-    public ControllerManager(ApplicationContext applicationContext) {
-        this.applicationContext = applicationContext;
-    }
+    private ApplicationContext applicationContext;
 
     @Override
     public void onApplicationEvent(ApplicationReadyEvent event) {
@@ -39,4 +35,8 @@ public class ControllerManager implements ApplicationListener<ApplicationReadyEv
         log.info("Shutdown {} controllers.", controllers.size());
     }
 
+    @Override
+    public void setApplicationContext(ApplicationContext applicationContext) throws BeansException {
+        this.applicationContext = applicationContext;
+    }
 }

--- a/src/main/java/run/halo/app/infra/properties/ExtensionProperties.java
+++ b/src/main/java/run/halo/app/infra/properties/ExtensionProperties.java
@@ -1,0 +1,17 @@
+package run.halo.app.infra.properties;
+
+import lombok.Data;
+
+@Data
+public class ExtensionProperties {
+
+    private Controller controller = new Controller();
+
+    @Data
+    public static class Controller {
+
+        private boolean disabled;
+
+    }
+
+}

--- a/src/main/java/run/halo/app/infra/properties/HaloProperties.java
+++ b/src/main/java/run/halo/app/infra/properties/HaloProperties.java
@@ -1,5 +1,6 @@
 package run.halo.app.infra.properties;
 
+import java.util.HashSet;
 import java.util.Set;
 import lombok.Data;
 import org.springframework.boot.context.properties.ConfigurationProperties;
@@ -12,5 +13,10 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 @ConfigurationProperties(prefix = "halo")
 public class HaloProperties {
 
-    private Set<String> initialExtensionLocations;
+    private Set<String> initialExtensionLocations = new HashSet<>();
+
+    private final ExtensionProperties extension = new ExtensionProperties();
+
+    private final SecurityProperties security = new SecurityProperties();
+
 }

--- a/src/main/java/run/halo/app/infra/properties/SecurityProperties.java
+++ b/src/main/java/run/halo/app/infra/properties/SecurityProperties.java
@@ -1,0 +1,21 @@
+package run.halo.app.infra.properties;
+
+import lombok.Data;
+
+@Data
+public class SecurityProperties {
+
+    private final Initializer initializer = new Initializer();
+
+    @Data
+    public static class Initializer {
+
+        private boolean disabled;
+
+        private String superAdminUsername = "admin";
+
+        private String superAdminPassword;
+
+    }
+
+}

--- a/src/test/resources/application.yaml
+++ b/src/test/resources/application.yaml
@@ -19,10 +19,15 @@ spring:
 
 halo:
   security:
+    initializer:
+      disabled: true
     oauth2:
       jwt:
         public-key-location: classpath:app.pub
         private-key-location: classpath:app.key
+  extension:
+    controller:
+      disabled: true
 
 springdoc:
   api-docs:


### PR DESCRIPTION
#### What type of PR is this?

/kind improvement
/kind failing-test
/area core
/milestone 2.0

#### What this PR does / why we need it:

Before this PR, our unit tests were flaky to run. After my inspection, I found that extension controllers will run asynchronously at every unit test that is annotated `@SpringBootTest` annotation. Please see the log of failing test:

```java
ExtensionConfigurationTest > shouldReturnNotFoundWhenSchemeNotRegistered() FAILED
    java.lang.AssertionError at ExtensionConfigurationTest.java:72
```

So this PR makes Halo create super admin initializer and run extension controllers conditionally, especially in tests.

You can configure the following property to disable super admin initialization and extension controllers running:

```yaml
halo:
  security:
    initializer:
      disabled: true
  extension:
    controller:
      disabled: true
```

BTW, we can configure the initial username and password for super administrator:

```yaml
halo:
  security:
    initializer:
      super-admin-username: admin
      super-admin-password: P@88w0rd
```

#### Which issue(s) this PR fixes:

Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
如果当前 Pull Request 的修改不会造成用户侧的任何变更，在 `release-note` 代码块儿中填写 `NONE`。
否则请填写用户侧能够理解的 Release Note。如果当前 Pull Request 包含破坏性更新（Break Change），
Release Note 需要以 `action required` 开头。
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->

```release-note
None
```
