### PR TITLE
Add an API to change password of user

### DIFF
--- a/src/main/java/run/halo/app/core/extension/endpoint/UserEndpoint.java
+++ b/src/main/java/run/halo/app/core/extension/endpoint/UserEndpoint.java
@@ -46,6 +46,73 @@ public class UserEndpoint implements CustomEndpoint {
         this.userService = userService;
     }
 
+    @Override
+    public RouterFunction<ServerResponse> endpoint() {
+        var tag = "api.halo.run/v1alpha1/User";
+        return SpringdocRouteBuilder.route()
+            .GET("/users/-", this::me, builder -> builder.operationId("GetCurrentUserDetail")
+                .description("Get current user detail")
+                .tag(tag)
+                .response(responseBuilder().implementation(User.class)))
+            .POST("/users/{name}/permissions", this::grantPermission,
+                builder -> builder.operationId("GrantPermission")
+                    .description("Grant permissions to user")
+                    .tag(tag)
+                    .parameter(parameterBuilder().in(ParameterIn.PATH).name("name")
+                        .description("User name")
+                        .required(true))
+                    .requestBody(requestBodyBuilder()
+                        .required(true)
+                        .implementation(GrantRequest.class))
+                    .response(responseBuilder().implementation(User.class)))
+            .GET("/users/{name}/permissions", this::getUserPermission,
+                builder -> builder.operationId("GetPermissions")
+                    .description("Get permissions of user")
+                    .tag(tag)
+                    .parameter(parameterBuilder().in(ParameterIn.PATH).name("name")
+                        .description("User name")
+                        .required(true))
+                    .response(responseBuilder().implementation(UserPermission.class)))
+            .PUT("/users/{name}/password", this::changePassword,
+                builder -> builder.operationId("ChangePassword")
+                    .description("Change password of user.")
+                    .tag(tag)
+                    .parameter(parameterBuilder().in(ParameterIn.PATH).name("name")
+                        .description(
+                            "Name of user. If the name is equal to '-', it will change the "
+                                + "password of current user.")
+                        .required(true))
+                    .requestBody(requestBodyBuilder()
+                        .required(true)
+                        .implementation(ChangePasswordRequest.class))
+                    .response(responseBuilder()
+                        .implementation(User.class))
+            )
+            .build();
+    }
+
+    Mono<ServerResponse> changePassword(ServerRequest request) {
+        final var nameInPath = request.pathVariable("name");
+        return ReactiveSecurityContextHolder.getContext()
+            .map(ctx -> "-".equals(nameInPath) ? ctx.getAuthentication().getName() : nameInPath)
+            .flatMap(username -> request.bodyToMono(ChangePasswordRequest.class)
+                .switchIfEmpty(Mono.defer(() ->
+                    Mono.error(new ServerWebInputException("Request body is empty"))))
+                .flatMap(changePasswordRequest -> {
+                    var password = changePasswordRequest.password();
+                    // encode password
+                    return userService.updateWithRawPassword(username, password);
+                }))
+            .flatMap(updatedUser -> ServerResponse.ok()
+                .contentType(MediaType.APPLICATION_JSON)
+                .bodyValue(updatedUser));
+    }
+
+    record ChangePasswordRequest(
+        @Schema(description = "New password.", required = true, minLength = 6)
+        String password) {
+    }
+
     @NonNull
     Mono<ServerResponse> me(ServerRequest request) {
         return ReactiveSecurityContextHolder.getContext()
@@ -63,7 +130,8 @@ public class UserEndpoint implements CustomEndpoint {
     Mono<ServerResponse> grantPermission(ServerRequest request) {
         var username = request.pathVariable("name");
         return request.bodyToMono(GrantRequest.class)
-            .switchIfEmpty(Mono.error(() -> new ServerWebInputException("Request body is empty")))
+            .switchIfEmpty(
+                Mono.error(() -> new ServerWebInputException("Request body is empty")))
             .flatMap(grant -> {
                 // preflight check
                 client.fetch(User.class, username)
@@ -111,35 +179,6 @@ public class UserEndpoint implements CustomEndpoint {
     record GrantRequest(Set<String> roles) {
     }
 
-    @Override
-    public RouterFunction<ServerResponse> endpoint() {
-        var tag = "api.halo.run/v1alpha1/User";
-        return SpringdocRouteBuilder.route()
-            .GET("/users/-", this::me, builder -> builder.operationId("GetCurrentUserDetail")
-                .description("Get current user detail")
-                .tag(tag)
-                .response(responseBuilder().implementation(User.class)))
-            .POST("/users/{name}/permissions", this::grantPermission,
-                builder -> builder.operationId("GrantPermission")
-                    .description("Grant permissions to user")
-                    .tag(tag)
-                    .parameter(parameterBuilder().in(ParameterIn.PATH).name("name")
-                        .description("User name")
-                        .required(true))
-                    .requestBody(
-                        requestBodyBuilder().required(true).implementation(GrantRequest.class))
-                    .response(responseBuilder().implementation(User.class)))
-            .GET("/users/{name}/permissions", this::getUserPermission,
-                builder -> builder.operationId("GetPermissions")
-                    .description("Get permissions of user")
-                    .tag(tag)
-                    .parameter(parameterBuilder().in(ParameterIn.PATH).name("name")
-                        .description("User name")
-                        .required(true))
-                    .response(responseBuilder().implementation(UserPermission.class)))
-            .build();
-    }
-
     @NonNull
     private Mono<ServerResponse> getUserPermission(ServerRequest request) {
         String name = request.pathVariable("name");
@@ -150,11 +189,11 @@ public class UserEndpoint implements CustomEndpoint {
             })
             .map(roles -> {
                 Set<String> uiPermissions = roles.stream()
-                        .map(role -> role.getMetadata().getAnnotations())
-                        .filter(Objects::nonNull)
-                        .map(this::mergeUiPermissions)
-                        .flatMap(Set::stream)
-                        .collect(Collectors.toSet());
+                    .map(role -> role.getMetadata().getAnnotations())
+                    .filter(Objects::nonNull)
+                    .map(this::mergeUiPermissions)
+                    .flatMap(Set::stream)
+                    .collect(Collectors.toSet());
                 return new UserPermission(roles, uiPermissions);
             })
             .flatMap(result -> ServerResponse.ok()

--- a/src/main/java/run/halo/app/core/extension/service/UserService.java
+++ b/src/main/java/run/halo/app/core/extension/service/UserService.java
@@ -9,7 +9,10 @@ public interface UserService {
 
     Mono<User> getUser(String username);
 
+    @Deprecated
     Mono<Void> updatePassword(String username, String newPassword);
+
+    Mono<User> updateWithRawPassword(String username, String rawPassword);
 
     Flux<Role> listRoles(String username);
 }

--- a/src/main/java/run/halo/app/core/extension/service/UserServiceImpl.java
+++ b/src/main/java/run/halo/app/core/extension/service/UserServiceImpl.java
@@ -3,6 +3,7 @@ package run.halo.app.core.extension.service;
 import static run.halo.app.core.extension.RoleBinding.containsUser;
 
 import java.util.Objects;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
@@ -16,8 +17,11 @@ public class UserServiceImpl implements UserService {
 
     private final ExtensionClient client;
 
-    public UserServiceImpl(ExtensionClient client) {
+    private final PasswordEncoder passwordEncoder;
+
+    public UserServiceImpl(ExtensionClient client, PasswordEncoder passwordEncoder) {
         this.client = client;
+        this.passwordEncoder = passwordEncoder;
     }
 
     @Override
@@ -33,6 +37,19 @@ public class UserServiceImpl implements UserService {
                 client.update(user);
             })
             .then();
+    }
+
+    @Override
+    public Mono<User> updateWithRawPassword(String username, String rawPassword) {
+        return getUser(username)
+            .filter(user -> !passwordEncoder.matches(rawPassword, user.getSpec().getPassword()))
+            .flatMap(user -> {
+                // TODO Validate the password
+                user.getSpec().setPassword(passwordEncoder.encode(rawPassword));
+                client.update(user);
+                // get the latest user
+                return getUser(username);
+            });
     }
 
     @Override

--- a/src/test/java/run/halo/app/core/extension/endpoint/UserEndpointTest.java
+++ b/src/test/java/run/halo/app/core/extension/endpoint/UserEndpointTest.java
@@ -128,6 +128,7 @@ class UserEndpointTest {
             verify(userService, times(1)).updateWithRawPassword("another-fake-user",
                 "new-password");
         }
+
     }
 
     @Nested

--- a/src/test/java/run/halo/app/core/extension/service/UserServiceImplTest.java
+++ b/src/test/java/run/halo/app/core/extension/service/UserServiceImplTest.java
@@ -230,6 +230,24 @@ class UserServiceImplTest {
         }
 
         @Test
+        void shouldUpdatePasswordIfNoPasswordBefore() {
+            userService = spy(userService);
+
+            doReturn(
+                Mono.just(createUser("")),
+                Mono.just(createUser("new-password")))
+                .when(userService)
+                .getUser("fake-user");
+            StepVerifier.create(userService.updateWithRawPassword("fake-user", "new-password"))
+                .expectNext(createUser("new-password"))
+                .verifyComplete();
+
+            verify(passwordEncoder, never()).matches(anyString(), anyString());
+            verify(passwordEncoder, times(1)).encode("new-password");
+            verify(userService, times(2)).getUser("fake-user");
+        }
+
+        @Test
         void shouldDoNothingIfPasswordNotChanged() {
             userService = spy(userService);
 

--- a/src/test/java/run/halo/app/core/extension/service/UserServiceImplTest.java
+++ b/src/test/java/run/halo/app/core/extension/service/UserServiceImplTest.java
@@ -2,20 +2,28 @@ package run.halo.app.core.extension.service;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.util.List;
 import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
 import run.halo.app.core.extension.Role;
 import run.halo.app.core.extension.RoleBinding;
@@ -29,6 +37,9 @@ class UserServiceImplTest {
 
     @Mock
     ExtensionClient client;
+
+    @Mock
+    PasswordEncoder passwordEncoder;
 
     @InjectMocks
     UserServiceImpl userService;
@@ -194,4 +205,70 @@ class UserServiceImplTest {
             JsonUtils.jsonToObject(bindB, RoleBinding.class),
             JsonUtils.jsonToObject(bindC, RoleBinding.class));
     }
+
+    @Nested
+    @DisplayName("UpdateWithRawPassword")
+    class UpdateWithRawPasswordTest {
+
+        @Test
+        void shouldUpdatePasswordWithDifferentPassword() {
+            userService = spy(userService);
+
+            doReturn(
+                Mono.just(createUser("fake-password")),
+                Mono.just(createUser("new-password")))
+                .when(userService)
+                .getUser("fake-user");
+            when(passwordEncoder.matches("new-password", "fake-password")).thenReturn(false);
+            StepVerifier.create(userService.updateWithRawPassword("fake-user", "new-password"))
+                .expectNext(createUser("new-password"))
+                .verifyComplete();
+
+            verify(passwordEncoder, times(1)).matches("new-password", "fake-password");
+            verify(passwordEncoder, times(1)).encode("new-password");
+            verify(userService, times(2)).getUser("fake-user");
+        }
+
+        @Test
+        void shouldDoNothingIfPasswordNotChanged() {
+            userService = spy(userService);
+
+            doReturn(
+                Mono.just(createUser("fake-password")),
+                Mono.just(createUser("new-password")))
+                .when(userService)
+                .getUser("fake-user");
+            when(passwordEncoder.matches("fake-password", "fake-password")).thenReturn(true);
+
+            StepVerifier.create(userService.updateWithRawPassword("fake-user", "fake-password"))
+                .expectNextCount(0)
+                .verifyComplete();
+
+            verify(passwordEncoder, times(1)).matches("fake-password", "fake-password");
+            verify(passwordEncoder, never()).encode("fake-password");
+            verify(userService, times(1)).getUser("fake-user");
+        }
+
+        @Test
+        void shouldDoNothingIfUserNotFound() {
+            userService = spy(userService);
+
+            doReturn(Mono.empty()).when(userService).getUser("fake-user");
+            StepVerifier.create(userService.updateWithRawPassword("fake-user", "new-password"))
+                .expectNextCount(0)
+                .verifyComplete();
+
+            verify(passwordEncoder, never()).matches(anyString(), anyString());
+            verify(passwordEncoder, never()).encode(anyString());
+            verify(userService, times(1)).getUser(anyString());
+        }
+
+        User createUser(String password) {
+            var user = new User();
+            user.setSpec(new User.UserSpec());
+            user.getSpec().setPassword(password);
+            return user;
+        }
+    }
+
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind feature
/area core
/milestone 2.0

#### What this PR does / why we need it:

This PR provides an API to change password of user. If the username is equal to `-`, we will change the password of current login user. Otherwise, we update the password according the request URI.

Here is an example:

- Request

```bash
curl -X 'PUT' \
  'http://localhost:8090/apis/api.halo.run/v1alpha1/users/-/password' \
  -H 'accept: */*' \
  -H 'Content-Type: */*' \
  -d '{
  "password": "openhalo"
}'
```

- Response

```json
{
  "spec": {
    "displayName": "Administrator",
    "email": "admin@halo.run",
    "password": "{bcrypt}$2a$10$/v8/nbxoUFGBDoWfOF2NHOHk.2RS0OFfS5AtN2g/mCGjScX19KvSG",
    "registeredAt": "2022-07-15T07:50:25.151513387Z",
    "twoFactorAuthEnabled": false,
    "disabled": false
  },
  "apiVersion": "v1alpha1",
  "kind": "User",
  "metadata": {
    "name": "admin",
    "annotations": {
      "rbac.authorization.halo.run/role-names": "[\"super-role\"]"
    },
    "version": 5,
    "creationTimestamp": "2022-07-15T07:50:25.255909669Z"
  }
}
```
#### Which issue(s) this PR fixes:

<!--
PR 合并时自动关闭 issue。
Automatically closes linked issue when PR is merged.

用法：`Fixes #<issue 号>`，或者 `Fixes (粘贴 issue 完整链接)`
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
None
```
