### PR TITLE
Refactor deletion of Extension in Extension client

### DIFF
--- a/src/main/java/run/halo/app/extension/DefaultExtensionClient.java
+++ b/src/main/java/run/halo/app/extension/DefaultExtensionClient.java
@@ -105,8 +105,10 @@ public class DefaultExtensionClient implements ExtensionClient {
 
     @Override
     public <E extends Extension> void delete(E extension) {
+        extension.getMetadata().setDeletionTimestamp(Instant.now());
         var extensionStore = converter.convertTo(extension);
-        var deleteStore = storeClient.delete(extensionStore.getName(), extensionStore.getVersion());
+        var deleteStore = storeClient.update(extensionStore.getName(), extensionStore.getVersion(),
+            extensionStore.getData());
         Extension deleteExt = converter.convertFrom(extension.getClass(), deleteStore);
         watchers.onDelete(deleteExt);
     }

--- a/src/main/java/run/halo/app/extension/ExtensionRouterFunctionFactory.java
+++ b/src/main/java/run/halo/app/extension/ExtensionRouterFunctionFactory.java
@@ -6,7 +6,6 @@ import static org.springdoc.core.fn.builders.requestbody.Builder.requestBodyBuil
 
 import io.swagger.v3.oas.annotations.enums.ParameterIn;
 import java.net.URI;
-import java.time.Instant;
 import java.util.Objects;
 import net.bytebuddy.ByteBuddy;
 import net.bytebuddy.description.type.TypeDescription;
@@ -299,10 +298,7 @@ public class ExtensionRouterFunctionFactory {
             String name = request.pathVariable("name");
             return getExtension(name)
                 .flatMap(extension ->
-                    Mono.fromRunnable(() -> {
-                        extension.getMetadata().setDeletionTimestamp(Instant.now());
-                        client.update(extension);
-                    }).thenReturn(extension))
+                    Mono.fromRunnable(() -> client.delete(extension)).thenReturn(extension))
                 .flatMap(extension -> this.getExtension(name))
                 .flatMap(extension -> ServerResponse
                     .ok()

--- a/src/test/java/run/halo/app/config/ExtensionConfigurationTest.java
+++ b/src/test/java/run/halo/app/config/ExtensionConfigurationTest.java
@@ -29,6 +29,7 @@ import run.halo.app.extension.FakeExtension;
 import run.halo.app.extension.Metadata;
 import run.halo.app.extension.Scheme;
 import run.halo.app.extension.SchemeManager;
+import run.halo.app.extension.store.ExtensionStoreRepository;
 
 @SpringBootTest
 @AutoConfigureWebTestClient
@@ -57,6 +58,11 @@ class ExtensionConfigurationTest {
 
         // register scheme
         schemeManager.register(FakeExtension.class);
+    }
+
+    @AfterEach
+    void cleanUp(@Autowired ExtensionStoreRepository repository) {
+        repository.deleteAll();
     }
 
     @Test
@@ -128,12 +134,6 @@ class ExtensionConfigurationTest {
                 })
                 .returnResult()
                 .getResponseBody();
-        }
-
-        @AfterEach
-        void cleanUp() {
-            FakeExtension fakeToDelete = getFakeExtension(createdFake.getMetadata().getName());
-            extClient.delete(fakeToDelete);
         }
 
         @Test

--- a/src/test/java/run/halo/app/extension/DefaultExtensionClientTest.java
+++ b/src/test/java/run/halo/app/extension/DefaultExtensionClientTest.java
@@ -12,6 +12,7 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isA;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -340,13 +341,14 @@ class DefaultExtensionClientTest {
         var fake = createFakeExtension("fake", 2L);
         when(converter.convertTo(any())).thenReturn(
             createExtensionStore("/registry/fake.halo.run/fakes/fake"));
-        when(storeClient.delete(any(), any())).thenReturn(
+        when(storeClient.update(any(), any(), any())).thenReturn(
             createExtensionStore("/registry/fake.halo.run/fakes/fake"));
 
         client.delete(fake);
 
         verify(converter, times(1)).convertTo(any());
-        verify(storeClient, times(1)).delete(any(), any());
+        verify(storeClient, times(1)).update(any(), any(), any());
+        verify(storeClient, never()).delete(any(), any());
     }
 
     @Nested

--- a/src/test/java/run/halo/app/extension/ExtensionDeleteHandlerTest.java
+++ b/src/test/java/run/halo/app/extension/ExtensionDeleteHandlerTest.java
@@ -5,7 +5,6 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.same;
 import static org.mockito.Mockito.doNothing;
@@ -57,7 +56,7 @@ class ExtensionDeleteHandlerTest {
             .pathVariable("name", "my-fake")
             .body(Mono.just(unstructured));
         when(client.fetch(eq(FakeExtension.class), eq("my-fake"))).thenReturn(Optional.of(fake));
-        doNothing().when(client).update(any());
+        doNothing().when(client).delete(any());
 
         var scheme = Scheme.buildFromType(FakeExtension.class);
         var deleteHandler = new ExtensionDeleteHandler(scheme, client);
@@ -72,9 +71,8 @@ class ExtensionDeleteHandlerTest {
             })
             .verifyComplete();
         verify(client, times(2)).fetch(eq(FakeExtension.class), eq("my-fake"));
-        verify(client, times(1)).update(
-            argThat(fakeToDelete -> fakeToDelete.getMetadata().getDeletionTimestamp() != null));
-        verify(client, times(0)).delete(any());
+        verify(client, times(1)).delete(any());
+        verify(client, times(0)).update(any());
     }
 
     @Test


### PR DESCRIPTION
#### What type of PR is this?

/kind improvement
/area core
/milestone 2.0

#### What this PR does / why we need it:

Do not delete directly when invoking ExtensionClient#delete. We just flag it by setting metadata.deletionTimestamp.

The rest should be done by garbage collector.

#### Does this PR introduce a user-facing change?

```release-note
None
```
