### PR TITLE
Initialize required extensions when system starts up

### DIFF
--- a/src/main/java/run/halo/app/infra/properties/HaloProperties.java
+++ b/src/main/java/run/halo/app/infra/properties/HaloProperties.java
@@ -18,6 +18,13 @@ public class HaloProperties {
 
     private Set<String> initialExtensionLocations = new HashSet<>();
 
+    /**
+     * This property could stop initializing required Extensions defined in classpath.
+     * See {@link run.halo.app.infra.ExtensionResourceInitializer#REQUIRED_EXTENSION_LOCATIONS}
+     * for more.
+     */
+    private boolean requiredExtensionDisabled;
+
     private final ExtensionProperties extension = new ExtensionProperties();
 
     private final SecurityProperties security = new SecurityProperties();


### PR DESCRIPTION
#### What type of PR is this?

/kind improvement
/area core
/milestone 2.0

#### What this PR does / why we need it:

This PR makes required extensions got initialized when system starts up. Of course, we can stop the initialization by setting property `halo.required-extension-disabled=true`.

Secondly, we are using [PathMatchingResourcePatternResolver](https://docs.spring.io/spring-framework/docs/current/javadoc-api/org/springframework/core/io/support/PathMatchingResourcePatternResolver.html) support more functional Extension locations, please see the doc for more.

#### Does this PR introduce a user-facing change?

```release-note
None
```
