### PR TITLE
fix: fail to delete multiple files if the files are removed from upstream storage

### DIFF
--- a/src/main/java/run/halo/app/handler/file/QiniuOssFileHandler.java
+++ b/src/main/java/run/halo/app/handler/file/QiniuOssFileHandler.java
@@ -183,7 +183,10 @@ public class QiniuOssFileHandler implements FileHandler {
         BucketManager bucketManager = new BucketManager(auth, configuration);
 
         try {
-            bucketManager.delete(bucket, key);
+            Response response = bucketManager.delete(bucket, key);
+            if (!response.isOK()) {
+                log.warn("附件 " + key + " 从七牛云删除失败");
+            }
         } catch (QiniuException e) {
             log.error("Qiniu oss error response: [{}]", e.response);
             throw new FileOperationException("附件 " + key + " 从七牛云删除失败", e);

--- a/src/main/java/run/halo/app/handler/file/QiniuOssFileHandler.java
+++ b/src/main/java/run/halo/app/handler/file/QiniuOssFileHandler.java
@@ -184,8 +184,9 @@ public class QiniuOssFileHandler implements FileHandler {
 
         try {
             Response response = bucketManager.delete(bucket, key);
-            if (!response.isOK()) {
+            if (!response.isOK() && response.statusCode != 404) {
                 log.warn("附件 " + key + " 从七牛云删除失败");
+                throw new FileOperationException("附件 " + key + " 从七牛云删除失败");
             }
         } catch (QiniuException e) {
             log.error("Qiniu oss error response: [{}]", e.response);

--- a/src/main/java/run/halo/app/handler/file/QiniuOssFileHandler.java
+++ b/src/main/java/run/halo/app/handler/file/QiniuOssFileHandler.java
@@ -183,11 +183,7 @@ public class QiniuOssFileHandler implements FileHandler {
         BucketManager bucketManager = new BucketManager(auth, configuration);
 
         try {
-            Response response = bucketManager.delete(bucket, key);
-            if (!response.isOK()) {
-                log.warn("附件 " + key + " 从七牛云删除失败");
-                throw new FileOperationException("附件 " + key + " 从七牛云删除失败");
-            }
+            bucketManager.delete(bucket, key);
         } catch (QiniuException e) {
             log.error("Qiniu oss error response: [{}]", e.response);
             throw new FileOperationException("附件 " + key + " 从七牛云删除失败", e);

--- a/src/main/java/run/halo/app/handler/file/QiniuOssFileHandler.java
+++ b/src/main/java/run/halo/app/handler/file/QiniuOssFileHandler.java
@@ -184,13 +184,15 @@ public class QiniuOssFileHandler implements FileHandler {
 
         try {
             Response response = bucketManager.delete(bucket, key);
-            if (!response.isOK() && response.statusCode != 404) {
+            if (!response.isOK()) {
                 log.warn("附件 " + key + " 从七牛云删除失败");
                 throw new FileOperationException("附件 " + key + " 从七牛云删除失败");
             }
         } catch (QiniuException e) {
             log.error("Qiniu oss error response: [{}]", e.response);
-            throw new FileOperationException("附件 " + key + " 从七牛云删除失败", e);
+            if (e.response.statusCode != 612) {
+                throw new FileOperationException("附件 " + key + " 从七牛云删除失败", e);
+            }
         }
     }
 

--- a/src/main/java/run/halo/app/handler/file/UpOssFileHandler.java
+++ b/src/main/java/run/halo/app/handler/file/UpOssFileHandler.java
@@ -136,7 +136,10 @@ public class UpOssFileHandler implements FileHandler {
         manager.setApiDomain(RestManager.ED_AUTO);
 
         try {
-            manager.deleteFile(key, null);
+            Response result = manager.deleteFile(key, null);
+            if (!result.isSuccessful()) {
+                log.warn("附件 " + key + " 从又拍云删除失败");
+            }
         } catch (IOException | UpException e) {
             e.printStackTrace();
             throw new FileOperationException("附件 " + key + " 从又拍云删除失败", e);

--- a/src/main/java/run/halo/app/handler/file/UpOssFileHandler.java
+++ b/src/main/java/run/halo/app/handler/file/UpOssFileHandler.java
@@ -136,11 +136,7 @@ public class UpOssFileHandler implements FileHandler {
         manager.setApiDomain(RestManager.ED_AUTO);
 
         try {
-            Response result = manager.deleteFile(key, null);
-            if (!result.isSuccessful()) {
-                log.warn("附件 " + key + " 从又拍云删除失败");
-                throw new FileOperationException("附件 " + key + " 从又拍云删除失败");
-            }
+            manager.deleteFile(key, null);
         } catch (IOException | UpException e) {
             e.printStackTrace();
             throw new FileOperationException("附件 " + key + " 从又拍云删除失败", e);

--- a/src/main/java/run/halo/app/handler/file/UpOssFileHandler.java
+++ b/src/main/java/run/halo/app/handler/file/UpOssFileHandler.java
@@ -137,7 +137,8 @@ public class UpOssFileHandler implements FileHandler {
 
         try {
             Response result = manager.deleteFile(key, null);
-            if (!result.isSuccessful() && result.code() != 404) {
+            String code = result.body().string().split(",")[1].split(":")[1];
+            if (!result.isSuccessful() && !code.equals("40400001")) {
                 log.warn("附件 " + key + " 从又拍云删除失败");
                 throw new FileOperationException("附件 " + key + " 从又拍云删除失败");
             }

--- a/src/main/java/run/halo/app/handler/file/UpOssFileHandler.java
+++ b/src/main/java/run/halo/app/handler/file/UpOssFileHandler.java
@@ -21,6 +21,7 @@ import run.halo.app.model.support.UploadResult;
 import run.halo.app.repository.AttachmentRepository;
 import run.halo.app.service.OptionService;
 import run.halo.app.utils.ImageUtils;
+import run.halo.app.utils.JsonUtils;
 
 /**
  * Up oss file handler.
@@ -137,8 +138,9 @@ public class UpOssFileHandler implements FileHandler {
 
         try {
             Response result = manager.deleteFile(key, null);
-            String code = result.body().string().split(",")[1].split(":")[1];
-            if (!result.isSuccessful() && !code.equals("40400001")) {
+            HashMap respondBody = JsonUtils.jsonToObject(result.body().string(), HashMap.class);
+            if (!result.isSuccessful() &&
+                !(result.code() == 404 && respondBody.get("code").equals(40400001))) {
                 log.warn("附件 " + key + " 从又拍云删除失败");
                 throw new FileOperationException("附件 " + key + " 从又拍云删除失败");
             }

--- a/src/main/java/run/halo/app/handler/file/UpOssFileHandler.java
+++ b/src/main/java/run/halo/app/handler/file/UpOssFileHandler.java
@@ -139,8 +139,8 @@ public class UpOssFileHandler implements FileHandler {
         try {
             Response result = manager.deleteFile(key, null);
             HashMap respondBody = JsonUtils.jsonToObject(result.body().string(), HashMap.class);
-            if (!result.isSuccessful() &&
-                !(result.code() == 404 && respondBody.get("code").equals(40400001))) {
+            if (!result.isSuccessful()
+                && !(result.code() == 404 && respondBody.get("code").equals(40400001))) {
                 log.warn("附件 " + key + " 从又拍云删除失败");
                 throw new FileOperationException("附件 " + key + " 从又拍云删除失败");
             }

--- a/src/main/java/run/halo/app/handler/file/UpOssFileHandler.java
+++ b/src/main/java/run/halo/app/handler/file/UpOssFileHandler.java
@@ -137,8 +137,9 @@ public class UpOssFileHandler implements FileHandler {
 
         try {
             Response result = manager.deleteFile(key, null);
-            if (!result.isSuccessful()) {
+            if (!result.isSuccessful() && result.code() != 404) {
                 log.warn("附件 " + key + " 从又拍云删除失败");
+                throw new FileOperationException("附件 " + key + " 从又拍云删除失败");
             }
         } catch (IOException | UpException e) {
             e.printStackTrace();


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

修复了在云端删除文件后，在Halo同时删除多个附件失败的bug。

Halo数据库里的附件并不会和云端文件实时同步，如果在云端删除文件多个后又在Halo删除，在删除第一个文件后则会抛出异常导致其它文件无法在halo的数据库中正常删除。这个PR通过删除在删除又拍云和七牛云的附件后判断返回状态和抛出异常的代码来解决这个问题。

#### Which issue(s) this PR fixes:

Fixes #2283

#### Special notes for your reviewer:
该bug只在七牛云和又拍云存在，其它云储存没有判断返回状态和抛出异常的代码，因此不存在这个问题。

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
