### PR TITLE
fix: Qiniuoss cannot upload non image attachments

### DIFF
--- a/src/main/java/run/halo/app/handler/file/QiniuOssFileHandler.java
+++ b/src/main/java/run/halo/app/handler/file/QiniuOssFileHandler.java
@@ -142,14 +142,15 @@ public class QiniuOssFileHandler implements FileHandler {
             result.setMediaType(MediaType.valueOf(Objects.requireNonNull(file.getContentType())));
             result.setSize(file.getSize());
 
-            if (isImageType(file)) {
+            // Handle thumbnail
+            handleImageMetadata(file, result, () -> {
                 if (ImageUtils.EXTENSION_ICO.equals(pathDescriptor.getExtension())) {
-                    result.setThumbPath(fullPath);
+                    return fullPath;
                 } else {
-                    result.setThumbPath(StringUtils.isBlank(thumbnailStyleRule) ? fullPath :
-                        fullPath + thumbnailStyleRule);
+                    return StringUtils.isBlank(thumbnailStyleRule) ? fullPath :
+                        fullPath + thumbnailStyleRule;
                 }
-            }
+            });
 
             return result;
         } catch (IOException e) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. 如果这是你的第一次，请阅读我们的贡献指南：<https://github.com/halo-dev/halo/blob/master/CONTRIBUTING.md>。
1. If this is your first time, please read our contributor guidelines: <https://github.com/halo-dev/halo/blob/master/CONTRIBUTING.md>.
2. 请根据你解决问题的类型为 Pull Request 添加合适的标签。
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request.
3. 请确保你已经添加并运行了适当的测试。
3. Ensure you have added or ran the appropriate tests for your PR.
-->

#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

发现在七牛的 [QiniuOssFileHandler:145](https://github.com/halo-dev/halo/blob/f8bd4febb9ee59847e1d199b10f3be7ae1c95320/src/main/java/run/halo/app/handler/file/QiniuOssFileHandler.java#L145-L152) 行中，如果文件不是图片类型的话就跳过了setThumbPath
但是在其他文件存储的handler中（如：本地 [LocalFileHandler:125](https://github.com/halo-dev/halo/blob/f8bd4febb9ee59847e1d199b10f3be7ae1c95320/src/main/java/run/halo/app/handler/file/LocalFileHandler.java#L125), [TencentCosFileHandler:128](https://github.com/halo-dev/halo/blob/f8bd4febb9ee59847e1d199b10f3be7ae1c95320/src/main/java/run/halo/app/handler/file/TencentCosFileHandler.java#L128)）调用了handleImageMetadata default方法，该方法最后判断 thumbPath 为空时会将其设为 filePath
故在七牛云handler使用了handleImageMetadata 方法，使得其他类型文件也可以setThumbPath，并成功上传不会引发错误

#### Which issue(s) this PR fixes:

<!--
PR 合并时自动关闭 issue。
Automatically closes linked issue when PR is merged.

用法：`Fixes #<issue 号>`，或者 `Fixes (粘贴 issue 完整链接)`
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #2320

#### Special notes for your reviewer:

看到其他文件handler中[TencentCosFileHandler:130](https://github.com/halo-dev/halo/blob/f8bd4febb9ee59847e1d199b10f3be7ae1c95320/src/main/java/run/halo/app/handler/file/TencentCosFileHandler.java#L130)有一个 `uploadResult.setThumbPath(fullPath);` 好像是没有必要的，也在[HuaweiObsFileHandler](https://github.com/halo-dev/halo/blob/f8bd4febb9ee59847e1d199b10f3be7ae1c95320/src/main/java/run/halo/app/handler/file/HuaweiObsFileHandler.java#L116-L123)中不存在上述代码。

#### Does this PR introduce a user-facing change?

<!--
如果当前 Pull Request 的修改不会造成用户侧的任何变更，在 `release-note` 代码块儿中填写 `NONE`。
否则请填写用户侧能够理解的 Release Note。如果当前 Pull Request 包含破坏性更新（Break Change），
Release Note 需要以 `action required` 开头。
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->

```release-note
修复了七牛云做附件存储时附件无法上传非图片文件的问题
```
