### PR TITLE
Refine menu item reconciler to sync permalinks of other refs

### DIFF
--- a/src/main/java/run/halo/app/core/extension/MenuItem.java
+++ b/src/main/java/run/halo/app/core/extension/MenuItem.java
@@ -8,6 +8,7 @@ import lombok.EqualsAndHashCode;
 import lombok.ToString;
 import run.halo.app.extension.AbstractExtension;
 import run.halo.app.extension.GVK;
+import run.halo.app.extension.Ref;
 
 @Data
 @ToString(callSuper = true)
@@ -40,24 +41,16 @@ public class MenuItem extends AbstractExtension {
         private LinkedHashSet<String> children;
 
         @Schema(description = "Category reference.")
-        private MenuItemRef categoryRef;
+        private Ref categoryRef;
 
         @Schema(description = "Tag reference.")
-        private MenuItemRef tagRef;
+        private Ref tagRef;
 
         @Schema(description = "Post reference.")
-        private MenuItemRef postRef;
+        private Ref postRef;
 
         @Schema(description = "Page reference.")
-        private MenuItemRef pageRef;
-
-    }
-
-    @Data
-    public static class MenuItemRef {
-
-        @Schema(description = "Reference name.", required = true)
-        private String name;
+        private Ref pageRef;
 
     }
 

--- a/src/main/java/run/halo/app/core/extension/reconciler/MenuItemReconciler.java
+++ b/src/main/java/run/halo/app/core/extension/reconciler/MenuItemReconciler.java
@@ -1,9 +1,16 @@
 package run.halo.app.core.extension.reconciler;
 
+import java.time.Duration;
+import java.util.Objects;
 import org.springframework.util.StringUtils;
+import run.halo.app.core.extension.Category;
 import run.halo.app.core.extension.MenuItem;
+import run.halo.app.core.extension.MenuItem.MenuItemSpec;
 import run.halo.app.core.extension.MenuItem.MenuItemStatus;
+import run.halo.app.core.extension.Post;
+import run.halo.app.core.extension.Tag;
 import run.halo.app.extension.ExtensionClient;
+import run.halo.app.extension.Ref;
 import run.halo.app.extension.controller.Reconciler;
 import run.halo.app.extension.controller.Reconciler.Request;
 
@@ -17,7 +24,7 @@ public class MenuItemReconciler implements Reconciler<Request> {
 
     @Override
     public Result reconcile(Request request) {
-        client.fetch(MenuItem.class, request.name()).ifPresent(menuItem -> {
+        return client.fetch(MenuItem.class, request.name()).map(menuItem -> {
             final var spec = menuItem.getSpec();
 
             if (menuItem.getStatus() == null) {
@@ -25,25 +32,69 @@ public class MenuItemReconciler implements Reconciler<Request> {
             }
             var status = menuItem.getStatus();
             if (spec.getCategoryRef() != null) {
-                // TODO resolve permalink from category.
+                return handleCategoryRef(request.name(), status, spec.getCategoryRef());
             } else if (spec.getTagRef() != null) {
-                // TODO resolve permalink from tag.
+                return handleTagRef(request.name(), status, spec.getTagRef());
             } else if (spec.getPageRef() != null) {
-                // TODO resolve permalink from page.
+                // TODO resolve permalink from page. At present, we don't have Page extension.
+                return new Result(false, null);
             } else if (spec.getPostRef() != null) {
-                // TODO resolve permalink from post.
+                return handlePostRef(request.name(), status, spec.getPostRef());
             } else {
-                // at last, we resolve href and display name from spec.
-                if (spec.getHref() == null || !StringUtils.hasText(spec.getDisplayName())) {
-                    throw new IllegalArgumentException("Both href and displayName are required");
-                }
-                status.setHref(spec.getHref());
-                status.setDisplayName(spec.getDisplayName());
-                // update status
-                client.update(menuItem);
+                return handleMenuSpec(request.name(), status, spec);
             }
-        });
+        }).orElseGet(() -> new Result(false, null));
+    }
+
+    private Result handleCategoryRef(String menuItemName, MenuItemStatus status, Ref categoryRef) {
+        client.fetch(Category.class, categoryRef.getName())
+            .filter(category -> category.getStatus() != null)
+            .filter(category -> StringUtils.hasText(category.getStatus().getPermalink()))
+            .ifPresent(category -> {
+                status.setHref(category.getStatus().getPermalink());
+                status.setDisplayName(category.getSpec().getDisplayName());
+                updateStatus(menuItemName, status);
+            });
+        return new Result(true, Duration.ofMinutes(1));
+    }
+
+    private Result handleTagRef(String menuItemName, MenuItemStatus status, Ref tagRef) {
+        client.fetch(Tag.class, tagRef.getName()).filter(tag -> tag.getStatus() != null)
+            .filter(tag -> StringUtils.hasText(tag.getStatus().getPermalink())).ifPresent(tag -> {
+                status.setHref(tag.getStatus().getPermalink());
+                status.setDisplayName(tag.getSpec().getDisplayName());
+                updateStatus(menuItemName, status);
+            });
+        return new Result(true, Duration.ofMinutes(1));
+    }
+
+    private Result handlePostRef(String menuItemName, MenuItemStatus status, Ref postRef) {
+        client.fetch(Post.class, postRef.getName()).filter(post -> post.getStatus() != null)
+            .filter(post -> StringUtils.hasText(post.getStatus().getPermalink()))
+            .ifPresent(post -> {
+                status.setHref(post.getStatus().getPermalink());
+                status.setDisplayName(post.getSpec().getTitle());
+                updateStatus(menuItemName, status);
+            });
+        return new Result(true, Duration.ofMinutes(1));
+    }
+
+    private Result handleMenuSpec(String menuItemName, MenuItemStatus status, MenuItemSpec spec) {
+        if (spec.getHref() != null && StringUtils.hasText(spec.getDisplayName())) {
+            status.setHref(spec.getHref());
+            status.setDisplayName(spec.getDisplayName());
+            updateStatus(menuItemName, status);
+        }
         return new Result(false, null);
+    }
+
+    private void updateStatus(String menuItemName, MenuItemStatus status) {
+        client.fetch(MenuItem.class, menuItemName)
+            .filter(menuItem -> !Objects.deepEquals(menuItem.getStatus(), status))
+            .ifPresent(menuItem -> {
+                menuItem.setStatus(status);
+                client.update(menuItem);
+            });
     }
 
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind improvement
/area core
/milestone 2.0

#### What this PR does / why we need it:

1. Synchronize permalink and display name of category every 1min
2. Synchronize permalink and display name of tag every 1min
3. Synchronize permalink and display name of post every 1min

Please note that we don't handle the synchronization of `Page` because we don't have the extension yet.

#### Which issue(s) this PR fixes:

See https://github.com/halo-dev/halo/pull/2303 for more.

#### Special notes for your reviewer:

**How to test?**

1. Create a Category/Tag/Post and check the permalink
2. Create a menu and a menu item
3. Set `spec.categoryRef.name` of menu item with the extension name we just created
5. Update the menu item and check the permalink
6. Update slug name of Category/Tag/Post and check the permalink
7. Wait for 1min and check the permalink of menu item

#### Does this PR introduce a user-facing change?

```release-note
None
```
