### PR TITLE
refactor: theme route pattern and permalink indexer

### DIFF
--- a/src/main/java/run/halo/app/content/permalinks/CategoryPermalinkPolicy.java
+++ b/src/main/java/run/halo/app/content/permalinks/CategoryPermalinkPolicy.java
@@ -58,8 +58,8 @@ public class CategoryPermalinkPolicy
 
     @Override
     public void onPermalinkDelete(Category category) {
-        applicationContext.publishEvent(new PermalinkIndexDeleteCommand(this, getLocator(category),
-            category.getStatusOrDefault().getPermalink()));
+        applicationContext.publishEvent(
+            new PermalinkIndexDeleteCommand(this, getLocator(category)));
     }
 
     private ExtensionLocator getLocator(Category category) {

--- a/src/main/java/run/halo/app/content/permalinks/ExtensionLocator.java
+++ b/src/main/java/run/halo/app/content/permalinks/ExtensionLocator.java
@@ -11,6 +11,20 @@ import run.halo.app.extension.GroupVersionKind;
  * @param slug extension slug
  */
 public record ExtensionLocator(GroupVersionKind gvk, String name, String slug) {
+
+    /**
+     * Create a new {@link ExtensionLocator} instance.
+     *
+     * @param gvk group version kind
+     * @param name extension name
+     * @param slug extension slug
+     */
+    public ExtensionLocator {
+        Objects.requireNonNull(gvk, "Group version kind must not be null");
+        Objects.requireNonNull(name, "Extension name must not be null");
+        Objects.requireNonNull(slug, "Extension slug must not be null");
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) {

--- a/src/main/java/run/halo/app/content/permalinks/PostPermalinkPolicy.java
+++ b/src/main/java/run/halo/app/content/permalinks/PostPermalinkPolicy.java
@@ -10,6 +10,7 @@ import org.springframework.context.ApplicationContext;
 import org.springframework.stereotype.Component;
 import run.halo.app.core.extension.Post;
 import run.halo.app.extension.GroupVersionKind;
+import run.halo.app.infra.utils.PathUtils;
 import run.halo.app.theme.DefaultTemplateEnum;
 import run.halo.app.theme.router.PermalinkIndexAddCommand;
 import run.halo.app.theme.router.PermalinkIndexDeleteCommand;
@@ -23,7 +24,6 @@ import run.halo.app.theme.router.PermalinkWatch;
  */
 @Component
 public class PostPermalinkPolicy implements PermalinkPolicy<Post>, PermalinkWatch<Post> {
-
     private final GroupVersionKind gvk = GroupVersionKind.fromExtension(Post.class);
     private static final NumberFormat NUMBER_FORMAT = new DecimalFormat("00");
 
@@ -65,8 +65,7 @@ public class PostPermalinkPolicy implements PermalinkPolicy<Post>, PermalinkWatc
 
     @Override
     public void onPermalinkDelete(Post post) {
-        applicationContext.publishEvent(new PermalinkIndexDeleteCommand(this, getLocator(post),
-            post.getStatusOrDefault().getPermalink()));
+        applicationContext.publishEvent(new PermalinkIndexDeleteCommand(this, getLocator(post)));
     }
 
     private ExtensionLocator getLocator(Post post) {
@@ -85,6 +84,8 @@ public class PostPermalinkPolicy implements PermalinkPolicy<Post>, PermalinkWatc
         properties.put("year", String.valueOf(zonedDateTime.getYear()));
         properties.put("month", NUMBER_FORMAT.format(zonedDateTime.getMonthValue()));
         properties.put("day", NUMBER_FORMAT.format(zonedDateTime.getDayOfMonth()));
-        return PROPERTY_PLACEHOLDER_HELPER.replacePlaceholders(pattern, properties);
+
+        String simplifiedPattern = PathUtils.simplifyPathPattern(pattern);
+        return PROPERTY_PLACEHOLDER_HELPER.replacePlaceholders(simplifiedPattern, properties);
     }
 }

--- a/src/main/java/run/halo/app/content/permalinks/TagPermalinkPolicy.java
+++ b/src/main/java/run/halo/app/content/permalinks/TagPermalinkPolicy.java
@@ -57,8 +57,7 @@ public class TagPermalinkPolicy implements PermalinkPolicy<Tag>, PermalinkWatch<
 
     @Override
     public void onPermalinkDelete(Tag tag) {
-        applicationContext.publishEvent(new PermalinkIndexDeleteCommand(this, getLocator(tag),
-            tag.getStatusOrDefault().getPermalink()));
+        applicationContext.publishEvent(new PermalinkIndexDeleteCommand(this, getLocator(tag)));
     }
 
     private ExtensionLocator getLocator(Tag tag) {

--- a/src/main/java/run/halo/app/core/extension/reconciler/SinglePageReconciler.java
+++ b/src/main/java/run/halo/app/core/extension/reconciler/SinglePageReconciler.java
@@ -133,8 +133,7 @@ public class SinglePageReconciler implements Reconciler<Reconciler.Request> {
             .setPermalink(PathUtils.combinePath(singlePage.getSpec().getSlug()));
         ExtensionLocator locator = new ExtensionLocator(GVK, singlePage.getMetadata().getName(),
             singlePage.getSpec().getSlug());
-        applicationContext.publishEvent(new PermalinkIndexDeleteCommand(this, locator,
-            singlePage.getStatusOrDefault().getPermalink()));
+        applicationContext.publishEvent(new PermalinkIndexDeleteCommand(this, locator));
         templateRouteManager.changeTemplatePattern(DefaultTemplateEnum.SINGLE_PAGE.getValue());
     }
 

--- a/src/main/java/run/halo/app/infra/utils/PathUtils.java
+++ b/src/main/java/run/halo/app/infra/utils/PathUtils.java
@@ -47,4 +47,35 @@ public class PathUtils {
     public static String appendPathSeparatorIfMissing(String path) {
         return StringUtils.appendIfMissing(path, "/", "/");
     }
+
+    /**
+     * <p>Remove the regex in the path pattern placeholder.</p>
+     * <p>For example: </p>
+     * <ul>
+     * <li>'{@code /{year:\d{4}}/{month:\d{2}}}' &rarr; '{@code /{year}/{month}}'</li>
+     * <li>'{@code /archives/{year:\d{4}}/{month:\d{2}}}' &rarr; '{@code /archives/{year}/{month}
+     * }'</li>
+     * <li>'{@code /archives/{year:\d{4}}/{slug}}' &rarr; '{@code /archives/{year}/{slug}}'</li>
+     * </ul>
+     *
+     * @param pattern path pattern
+     * @return Simplified path pattern
+     */
+    public static String simplifyPathPattern(String pattern) {
+        if (StringUtils.isBlank(pattern)) {
+            return StringUtils.EMPTY;
+        }
+        String[] parts = StringUtils.split(pattern, '/');
+        for (int i = 0; i < parts.length; i++) {
+            String part = parts[i];
+            if (part.startsWith("{") && part.endsWith("}")) {
+                int colonIdx = part.indexOf(':');
+                if (colonIdx != -1) {
+                    parts[i] = part.substring(0, colonIdx) + part.charAt(part.length() - 1);
+                }
+
+            }
+        }
+        return combinePath(parts);
+    }
 }

--- a/src/main/java/run/halo/app/theme/router/PermalinkIndexDeleteCommand.java
+++ b/src/main/java/run/halo/app/theme/router/PermalinkIndexDeleteCommand.java
@@ -12,19 +12,13 @@ import run.halo.app.content.permalinks.ExtensionLocator;
  */
 public class PermalinkIndexDeleteCommand extends ApplicationEvent {
     private final ExtensionLocator locator;
-    private final String permalink;
 
-    public PermalinkIndexDeleteCommand(Object source, ExtensionLocator locator, String permalink) {
+    public PermalinkIndexDeleteCommand(Object source, ExtensionLocator locator) {
         super(source);
         this.locator = locator;
-        this.permalink = permalink;
     }
 
     public ExtensionLocator getLocator() {
         return locator;
-    }
-
-    public String getPermalink() {
-        return permalink;
     }
 }

--- a/src/main/java/run/halo/app/theme/router/strategy/ArchivesRouteStrategy.java
+++ b/src/main/java/run/halo/app/theme/router/strategy/ArchivesRouteStrategy.java
@@ -24,9 +24,10 @@ public class ArchivesRouteStrategy implements TemplateRouterStrategy {
     public RouterFunction<ServerResponse> getRouteFunction(String template, String prefix) {
         return RouterFunctions
             .route(GET(prefix)
-                    .or(GET(PathUtils.combinePath(prefix, "/page/{page}")))
-                    .or(GET(PathUtils.combinePath(prefix, "/{year}/{month}")))
-                    .or(GET(PathUtils.combinePath(prefix, "/{year}/{month}/page/{page}")))
+                    .or(GET(PathUtils.combinePath(prefix, "/page/{page:\\d+}")))
+                    .or(GET(PathUtils.combinePath(prefix, "/{year:\\d{4}}/{month:\\d{2}}")))
+                    .or(GET(PathUtils.combinePath(prefix,
+                        "/{year:\\d{4}}/{month:\\d{2}}/page/{page:\\d+}")))
                     .and(accept(MediaType.TEXT_HTML)),
                 request -> ServerResponse.ok()
                     .render(DefaultTemplateEnum.ARCHIVES.getValue()));

--- a/src/main/java/run/halo/app/theme/router/strategy/CategoryRouteStrategy.java
+++ b/src/main/java/run/halo/app/theme/router/strategy/CategoryRouteStrategy.java
@@ -3,7 +3,6 @@ package run.halo.app.theme.router.strategy;
 import static org.springframework.web.reactive.function.server.RequestPredicates.GET;
 import static org.springframework.web.reactive.function.server.RequestPredicates.accept;
 
-import java.util.List;
 import java.util.Map;
 import org.springframework.http.MediaType;
 import org.springframework.web.reactive.function.server.RouterFunction;
@@ -35,13 +34,12 @@ public class CategoryRouteStrategy implements TemplateRouterStrategy {
     public RouterFunction<ServerResponse> getRouteFunction(String template, String prefix) {
         return RouterFunctions
             .route(GET(PathUtils.combinePath(prefix, "/{slug}"))
-                    .or(GET(PathUtils.combinePath(prefix, "/{slug}/page/{page}")))
+                    .or(GET(PathUtils.combinePath(prefix, "/{slug}/page/{page:\\d+}")))
                     .and(accept(MediaType.TEXT_HTML)),
                 request -> {
                     String slug = request.pathVariable("slug");
                     GroupVersionKind gvk = GroupVersionKind.fromExtension(Category.class);
-                    List<String> slugs = permalinkIndexer.getSlugs(gvk);
-                    if (!slugs.contains(slug)) {
+                    if (!permalinkIndexer.containsSlug(gvk, slug)) {
                         return ServerResponse.notFound().build();
                     }
                     String categoryName = permalinkIndexer.getNameBySlug(gvk, slug);

--- a/src/main/java/run/halo/app/theme/router/strategy/IndexRouteStrategy.java
+++ b/src/main/java/run/halo/app/theme/router/strategy/IndexRouteStrategy.java
@@ -22,7 +22,7 @@ public class IndexRouteStrategy implements TemplateRouterStrategy {
     @Override
     public RouterFunction<ServerResponse> getRouteFunction(String template, String pattern) {
         return RouterFunctions
-            .route(GET("/").or(GET("/page/{page}"))
+            .route(GET("/").or(GET("/page/{page:\\d+}"))
                     .and(accept(MediaType.TEXT_HTML)),
                 request -> ServerResponse.ok()
                     .render(DefaultTemplateEnum.INDEX.getValue()));

--- a/src/main/java/run/halo/app/theme/router/strategy/PostRouteStrategy.java
+++ b/src/main/java/run/halo/app/theme/router/strategy/PostRouteStrategy.java
@@ -4,7 +4,6 @@ import static org.springframework.web.reactive.function.server.RequestPredicates
 import static org.springframework.web.reactive.function.server.RequestPredicates.accept;
 
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -74,21 +73,15 @@ public class PostRouteStrategy implements TemplateRouterStrategy {
         return RouterFunctions
             .route(GET(pattern).and(accept(MediaType.TEXT_HTML)),
                 request -> {
-                    List<String> permalinks =
-                        permalinkIndexer.getPermalinks(
-                            PostRequestParamPredicate.GVK);
-                    boolean contains = permalinks.contains(request.path());
-                    if (!contains) {
+                    ExtensionLocator locator = permalinkIndexer.lookup(request.path());
+                    if (locator == null) {
                         return ServerResponse.notFound().build();
                     }
-                    ExtensionLocator extensionLocator =
-                        permalinkIndexer.lookup(request.path());
                     PathPattern parse = PathPatternParser.defaultInstance.parse(pattern);
                     PathPattern.PathMatchInfo pathMatchInfo =
                         parse.matchAndExtract(PathContainer.parsePath(request.path()));
                     Map<String, String> uriVariables = new HashMap<>();
-                    uriVariables.put(PostRequestParamPredicate.NAME_PARAM,
-                        extensionLocator.name());
+                    uriVariables.put(PostRequestParamPredicate.NAME_PARAM, locator.name());
                     if (pathMatchInfo != null) {
                         uriVariables.putAll(pathMatchInfo.getUriVariables());
                     }
@@ -125,17 +118,13 @@ public class PostRouteStrategy implements TemplateRouterStrategy {
             }
 
             if (NAME_PARAM.equals(placeholderName)) {
-                return RequestPredicates.queryParam(paramName, name -> {
-                    List<String> names = permalinkIndexer.getNames(GVK);
-                    return names.contains(name);
-                });
+                return RequestPredicates.queryParam(paramName,
+                    name -> permalinkIndexer.containsName(GVK, name));
             }
 
             if (SLUG_PARAM.equals(placeholderName)) {
-                return RequestPredicates.queryParam(paramName, slug -> {
-                    List<String> slugs = permalinkIndexer.getSlugs(GVK);
-                    return slugs.contains(slug);
-                });
+                return RequestPredicates.queryParam(paramName,
+                    slug -> permalinkIndexer.containsSlug(GVK, slug));
             }
             throw new IllegalArgumentException(
                 String.format("Unknown param value placeholder [%s] in pattern [%s]",

--- a/src/main/java/run/halo/app/theme/router/strategy/SinglePageRouteStrategy.java
+++ b/src/main/java/run/halo/app/theme/router/strategy/SinglePageRouteStrategy.java
@@ -4,7 +4,6 @@ import static org.springframework.web.reactive.function.server.RequestPredicates
 
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.http.MediaType;
 import org.springframework.web.reactive.function.server.RequestPredicate;
@@ -39,8 +38,7 @@ public class SinglePageRouteStrategy implements TemplateRouterStrategy {
 
         RequestPredicate requestPredicate = request -> false;
 
-        List<String> permalinks =
-            Objects.requireNonNullElse(permalinkIndexer.getPermalinks(gvk), List.of());
+        List<String> permalinks = permalinkIndexer.getPermalinks(gvk);
         for (String permalink : permalinks) {
             requestPredicate = requestPredicate.or(RequestPredicates.GET(permalink));
         }

--- a/src/main/java/run/halo/app/theme/router/strategy/TagRouteStrategy.java
+++ b/src/main/java/run/halo/app/theme/router/strategy/TagRouteStrategy.java
@@ -3,7 +3,6 @@ package run.halo.app.theme.router.strategy;
 import static org.springframework.web.reactive.function.server.RequestPredicates.GET;
 import static org.springframework.web.reactive.function.server.RequestPredicates.accept;
 
-import java.util.List;
 import java.util.Map;
 import org.springframework.http.MediaType;
 import org.springframework.web.reactive.function.server.RouterFunction;
@@ -35,15 +34,15 @@ public class TagRouteStrategy implements TemplateRouterStrategy {
     public RouterFunction<ServerResponse> getRouteFunction(String template, String prefix) {
         return RouterFunctions
             .route(GET(PathUtils.combinePath(prefix, "/{slug}"))
-                    .or(GET(PathUtils.combinePath(prefix, "/{slug}/page/{page}")))
+                    .or(GET(PathUtils.combinePath(prefix, "/{slug}/page/{page:\\d+}")))
                     .and(accept(MediaType.TEXT_HTML)),
                 request -> {
                     GroupVersionKind gvk = GroupVersionKind.fromExtension(Tag.class);
-                    List<String> slugs = permalinkIndexer.getSlugs(gvk);
                     String slug = request.pathVariable("slug");
-                    if (!slugs.contains(slug)) {
+                    if (!permalinkIndexer.containsSlug(gvk, slug)) {
                         return ServerResponse.notFound().build();
                     }
+
                     String name = permalinkIndexer.getNameBySlug(gvk, slug);
                     return ServerResponse.ok()
                         .render(DefaultTemplateEnum.TAG.getValue(), Map.of("name", name));

--- a/src/main/resources/extensions/system-setting.yaml
+++ b/src/main/resources/extensions/system-setting.yaml
@@ -32,7 +32,7 @@ spec:
         label: "默认角色"
         name: defaultRole
         validation: required
-  - group: themeRules
+  - group: routeRules
     label: 主题模板路由设置
     formSchema:
       - $formkit: text
@@ -58,9 +58,9 @@ spec:
           - /archives/{name}
           - /?p={name}
           - /?p={slug}
-          - /{year}/{slug}
-          - /{year}/{month}/{slug}
-          - /{year}/{month}/{day}/{slug}
+          - /{year:\d{4}}/{slug}
+          - /{year:\d{4}}/{month:\d{2}}/{slug}
+          - /{year:\d{4}}/{month:\d{2}}/{day:\d{2}}/{slug}
         name: post
         validation: required
   - group: post

--- a/src/test/java/run/halo/app/infra/utils/PathUtilsTest.java
+++ b/src/test/java/run/halo/app/infra/utils/PathUtilsTest.java
@@ -43,4 +43,17 @@ class PathUtilsTest {
         s = PathUtils.appendPathSeparatorIfMissing(null);
         assertThat(s).isEqualTo(null);
     }
+
+    @Test
+    void simplifyPathPattern() {
+        assertThat(PathUtils.simplifyPathPattern("/a/b/c")).isEqualTo("/a/b/c");
+        assertThat(PathUtils.simplifyPathPattern("/a/{b}/c")).isEqualTo("/a/{b}/c");
+        assertThat(PathUtils.simplifyPathPattern("/a/{b}/*")).isEqualTo("/a/{b}/*");
+        assertThat(PathUtils.simplifyPathPattern("/archives/{year:\\d{4}}/{month:\\d{2}}"))
+            .isEqualTo("/archives/{year}/{month}");
+        assertThat(PathUtils.simplifyPathPattern("/archives/{year:\\d{4}}/{slug}"))
+            .isEqualTo("/archives/{year}/{slug}");
+        assertThat(PathUtils.simplifyPathPattern("/archives/{year:\\d{4}}/page/{page:\\d+}"))
+            .isEqualTo("/archives/{year}/page/{page}");
+    }
 }

--- a/src/test/java/run/halo/app/theme/router/PermalinkIndexerTest.java
+++ b/src/test/java/run/halo/app/theme/router/PermalinkIndexerTest.java
@@ -49,7 +49,7 @@ class PermalinkIndexerTest {
         assertThat(permalinkIndexer.permalinkLocatorMapSize()).isEqualTo(1);
         assertThat(permalinkIndexer.permalinkLocatorMapSize()).isEqualTo(1);
 
-        permalinkIndexer.remove(locator, "/fake-permalink");
+        permalinkIndexer.remove(locator);
         assertThat(permalinkIndexer.permalinkLocatorMapSize()).isEqualTo(0);
         assertThat(permalinkIndexer.permalinkLocatorMapSize()).isEqualTo(0);
     }
@@ -77,8 +77,8 @@ class PermalinkIndexerTest {
         ExtensionLocator locator = new ExtensionLocator(gvk, "test-name", "test-slug");
         permalinkIndexer.register(locator, "/test-permalink");
 
-        List<String> names = permalinkIndexer.getNames(gvk);
-        assertThat(names).isEqualTo(List.of("fake-name", "test-name"));
+        assertThat(permalinkIndexer.containsName(gvk, "test-name")).isTrue();
+        assertThat(permalinkIndexer.containsName(gvk, "nothing")).isFalse();
     }
 
     @Test
@@ -86,24 +86,9 @@ class PermalinkIndexerTest {
         ExtensionLocator locator = new ExtensionLocator(gvk, "test-name", "test-slug");
         permalinkIndexer.register(locator, "/test-permalink");
 
-        List<String> slugs = permalinkIndexer.getSlugs(gvk);
-        assertThat(slugs).isEqualTo(List.of("fake-slug", "test-slug"));
-    }
-
-    @Test
-    void getSlugByName() {
-        ExtensionLocator locator = new ExtensionLocator(gvk, "test-name", "test-slug");
-        permalinkIndexer.register(locator, "/test-permalink");
-
-        String slugByName = permalinkIndexer.getSlugByName(gvk, "test-name");
-        assertThat(slugByName).isEqualTo("test-slug");
-
-        slugByName = permalinkIndexer.getSlugByName(gvk, "fake-name");
-        assertThat(slugByName).isEqualTo("fake-slug");
-
-        assertThatThrownBy(() -> {
-            permalinkIndexer.getSlugByName(gvk, "nothing");
-        }).isInstanceOf(NoSuchElementException.class);
+        assertThat(permalinkIndexer.containsSlug(gvk, "fake-slug")).isTrue();
+        assertThat(permalinkIndexer.containsSlug(gvk, "test-slug")).isTrue();
+        assertThat(permalinkIndexer.containsSlug(gvk, "nothing")).isFalse();
     }
 
     @Test

--- a/src/test/java/run/halo/app/theme/router/strategy/ArchivesRouteStrategyTest.java
+++ b/src/test/java/run/halo/app/theme/router/strategy/ArchivesRouteStrategyTest.java
@@ -73,14 +73,20 @@ class ArchivesRouteStrategyTest {
             .expectStatus().isOk();
 
         client.get()
-            .uri(prefix + "/year/month")
+            .uri(prefix + "/2022/09")
             .exchange()
             .expectStatus().isOk();
 
         client.get()
-            .uri(prefix + "/year/month/page/1")
+            .uri(prefix + "/2022/08/page/1")
             .exchange()
             .expectStatus().isOk();
+
+        client.get()
+            .uri(prefix + "/2022/8/page/1")
+            .exchange()
+            .expectStatus()
+            .isEqualTo(HttpStatus.NOT_FOUND);
     }
 
     @Test

--- a/src/test/java/run/halo/app/theme/router/strategy/CategoryRouteStrategyTest.java
+++ b/src/test/java/run/halo/app/theme/router/strategy/CategoryRouteStrategyTest.java
@@ -4,7 +4,6 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
 
-import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -17,6 +16,8 @@ import org.springframework.web.reactive.function.server.RouterFunction;
 import org.springframework.web.reactive.function.server.ServerResponse;
 import org.springframework.web.reactive.result.view.ViewResolver;
 import reactor.core.publisher.Mono;
+import run.halo.app.core.extension.Category;
+import run.halo.app.extension.GroupVersionKind;
 import run.halo.app.theme.DefaultTemplateEnum;
 import run.halo.app.theme.router.PermalinkIndexer;
 
@@ -39,8 +40,11 @@ class CategoryRouteStrategyTest {
     @BeforeEach
     void setUp() {
         categoryRouteStrategy = new CategoryRouteStrategy(permalinkIndexer);
-        when(permalinkIndexer.getSlugs(any()))
-            .thenReturn(List.of("category-slug-1", "category-slug-2"));
+        GroupVersionKind gvk = GroupVersionKind.fromExtension(Category.class);
+        when(permalinkIndexer.containsSlug(eq(gvk), eq("category-slug-1")))
+            .thenReturn(true);
+        when(permalinkIndexer.containsSlug(eq(gvk), eq("category-slug-2")))
+            .thenReturn(true);
         when(permalinkIndexer.getNameBySlug(any(), eq("category-slug-1")))
             .thenReturn("category-name-1");
         when(permalinkIndexer.getNameBySlug(any(), eq("category-slug-2")))

--- a/src/test/java/run/halo/app/theme/router/strategy/PostRouteStrategyTest.java
+++ b/src/test/java/run/halo/app/theme/router/strategy/PostRouteStrategyTest.java
@@ -5,7 +5,6 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.when;
 
-import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -56,9 +55,6 @@ class PostRouteStrategyTest {
 
         piling();
 
-        when(permalinkIndexer.getPermalinks(any()))
-            .thenReturn(List.of("/posts-test/fake-slug"));
-
         client.get()
             .uri("/posts-test/fake-slug")
             .exchange()
@@ -76,9 +72,6 @@ class PostRouteStrategyTest {
 
         piling();
 
-        when(permalinkIndexer.getPermalinks(any()))
-            .thenReturn(List.of("/posts-test/fake-name"));
-
         client.get()
             .uri("/posts-test/fake-name")
             .exchange()
@@ -95,9 +88,6 @@ class PostRouteStrategyTest {
         WebTestClient client = getWebTestClient(routeFunction);
 
         piling();
-
-        when(permalinkIndexer.getPermalinks(any()))
-            .thenReturn(List.of("/2022/08/fake-slug"));
 
         client.get()
             .uri("/2022/08/fake-slug")
@@ -136,14 +126,11 @@ class PostRouteStrategyTest {
     }
 
     private void piling() {
-        lenient().when(permalinkIndexer.getNames(any()))
-            .thenReturn(List.of("fake-name"));
-
-        lenient().when(permalinkIndexer.getSlugs(any()))
-            .thenReturn(List.of("fake-slug"));
-
-        lenient().when(permalinkIndexer.getSlugs(any()))
-            .thenReturn(List.of("fake-slug"));
+        GroupVersionKind postGvk = GroupVersionKind.fromExtension(Post.class);
+        lenient().when(permalinkIndexer.containsName(eq(postGvk), eq("fake-name")))
+            .thenReturn(true);
+        lenient().when(permalinkIndexer.containsSlug(eq(postGvk), eq("fake-slug")))
+            .thenReturn(true);
 
         lenient().when(permalinkIndexer.getNameBySlug(any(), eq("fake-slug")))
             .thenReturn("fake-name");

--- a/src/test/java/run/halo/app/theme/router/strategy/TagRouteStrategyTest.java
+++ b/src/test/java/run/halo/app/theme/router/strategy/TagRouteStrategyTest.java
@@ -4,7 +4,6 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
 
-import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -17,6 +16,8 @@ import org.springframework.web.reactive.function.server.RouterFunction;
 import org.springframework.web.reactive.function.server.ServerResponse;
 import org.springframework.web.reactive.result.view.ViewResolver;
 import reactor.core.publisher.Mono;
+import run.halo.app.core.extension.Tag;
+import run.halo.app.extension.GroupVersionKind;
 import run.halo.app.theme.DefaultTemplateEnum;
 import run.halo.app.theme.router.PermalinkIndexer;
 
@@ -40,8 +41,9 @@ class TagRouteStrategyTest {
     @BeforeEach
     void setUp() {
         tagRouteStrategy = new TagRouteStrategy(permalinkIndexer);
-        when(permalinkIndexer.getSlugs(any()))
-            .thenReturn(List.of("fake-slug"));
+        GroupVersionKind gvk = GroupVersionKind.fromExtension(Tag.class);
+        when(permalinkIndexer.containsSlug(eq(gvk), eq("fake-slug")))
+            .thenReturn(true);
         when(permalinkIndexer.getNameBySlug(any(), eq("fake-slug")))
             .thenReturn("fake-name");
     }


### PR DESCRIPTION
#### What type of PR is this?
/kind improvement
/milestone 2.0
/area core

#### What this PR does / why we need it:
使用正则细化主题端路由并优化

如何测试：
1. 在 admin 系统设置中修改文章文章详情页访问规则
2. 根据规则访问文章详情页，如规则为：`/{year:\d{4}}/{month:\d{2}}/{slug}` 而存在文章 slug 为 fake-slug 且发布日期为 2022-09-08 则 /2022/09/fake-slug 能访问， /2022/9/fake-slug 则不能访问
使用规则 `/{year:\d{4}}/{month:\d{2}}/{day:\d{2}}/{slug}`时 /2022/09/08/fake-slug 能访问 /2022/09/8/fake-slug ，则不能访问
#### Which issue(s) this PR fixes:
Fixes #2396

#### Special notes for your reviewer:
/cc @halo-dev/sig-halo 
#### Does this PR introduce a user-facing change?
```release-note
None
```
