### PR TITLE
feat: count the number of posts under categories and tags

### DIFF
--- a/src/main/java/run/halo/app/core/extension/Category.java
+++ b/src/main/java/run/halo/app/core/extension/Category.java
@@ -27,6 +27,11 @@ public class Category extends AbstractExtension {
     @Schema
     private CategoryStatus status;
 
+    @JsonIgnore
+    public boolean isDeleted() {
+        return getMetadata().getDeletionTimestamp() != null;
+    }
+
     @Data
     public static class CategorySpec {
 
@@ -64,6 +69,6 @@ public class Category extends AbstractExtension {
         /**
          * 包括当前和其下所有层级的文章 name (depth=max).
          */
-        private List<String> posts;
+        private List<Post.CompactPost> posts;
     }
 }

--- a/src/main/java/run/halo/app/core/extension/Post.java
+++ b/src/main/java/run/halo/app/core/extension/Post.java
@@ -6,6 +6,8 @@ import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
+import lombok.Builder;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
@@ -46,6 +48,17 @@ public class Post extends AbstractExtension {
             this.status = new PostStatus();
         }
         return status;
+    }
+
+    @JsonIgnore
+    public boolean isDeleted() {
+        return Objects.equals(true, spec.getDeleted())
+            || getMetadata().getDeletionTimestamp() != null;
+    }
+
+    @JsonIgnore
+    public boolean isPublished() {
+        return Objects.equals(true, spec.getPublished());
     }
 
     @Data
@@ -148,5 +161,15 @@ public class Post extends AbstractExtension {
         PUBLIC,
         INTERNAL,
         PRIVATE
+    }
+
+    @Data
+    @Builder
+    public static class CompactPost {
+        private String name;
+
+        private VisibleEnum visible;
+
+        private Boolean published;
     }
 }

--- a/src/main/java/run/halo/app/core/extension/Post.java
+++ b/src/main/java/run/halo/app/core/extension/Post.java
@@ -7,7 +7,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import lombok.Builder;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
@@ -164,12 +163,57 @@ public class Post extends AbstractExtension {
     }
 
     @Data
-    @Builder
     public static class CompactPost {
         private String name;
 
         private VisibleEnum visible;
 
         private Boolean published;
+
+        public static Builder builder() {
+            return new Builder();
+        }
+
+        /**
+         * <p>Compact post builder.</p>
+         * <p>Can not replace with lombok builder.</p>
+         * <p>The class used by subclasses of {@link AbstractExtension} must have a no-args
+         * constructor.</p>
+         */
+        public static class Builder {
+            private String name;
+
+            private VisibleEnum visible;
+
+            private Boolean published;
+
+            public Builder name(String name) {
+                this.name = name;
+                return this;
+            }
+
+            public Builder visible(VisibleEnum visible) {
+                this.visible = visible;
+                return this;
+            }
+
+            public Builder published(Boolean published) {
+                this.published = published;
+                return this;
+            }
+
+            /**
+             * Build compact post.
+             *
+             * @return a compact post
+             */
+            public CompactPost build() {
+                CompactPost compactPost = new CompactPost();
+                compactPost.setName(name);
+                compactPost.setVisible(visible);
+                compactPost.setPublished(published);
+                return compactPost;
+            }
+        }
     }
 }

--- a/src/main/java/run/halo/app/core/extension/Tag.java
+++ b/src/main/java/run/halo/app/core/extension/Tag.java
@@ -69,6 +69,6 @@ public class Tag extends AbstractExtension {
 
         private String permalink;
 
-        private List<String> posts;
+        private List<Post.CompactPost> posts;
     }
 }

--- a/src/main/java/run/halo/app/core/extension/reconciler/TagReconciler.java
+++ b/src/main/java/run/halo/app/core/extension/reconciler/TagReconciler.java
@@ -1,8 +1,11 @@
 package run.halo.app.core.extension.reconciler;
 
+import java.time.Duration;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 import run.halo.app.content.permalinks.TagPermalinkPolicy;
+import run.halo.app.core.extension.Post;
 import run.halo.app.core.extension.Tag;
 import run.halo.app.extension.ExtensionClient;
 import run.halo.app.extension.controller.Reconciler;
@@ -26,17 +29,20 @@ public class TagReconciler implements Reconciler<Reconciler.Request> {
 
     @Override
     public Result reconcile(Request request) {
-        client.fetch(Tag.class, request.name())
-            .ifPresent(tag -> {
+        return client.fetch(Tag.class, request.name())
+            .map(tag -> {
                 if (isDeleted(tag)) {
                     cleanUpResourcesAndRemoveFinalizer(request.name());
-                    return;
+                    return new Result(false, null);
                 }
                 addFinalizerIfNecessary(tag);
 
-                this.reconcileStatus(request.name());
-            });
-        return new Result(false, null);
+                this.reconcileStatusPermalink(request.name());
+
+                reconcileStatusPosts(request.name());
+                return new Result(true, Duration.ofMinutes(1));
+            })
+            .orElseGet(() -> new Result(false, null));
     }
 
     private void cleanUpResources(Tag tag) {
@@ -71,7 +77,7 @@ public class TagReconciler implements Reconciler<Reconciler.Request> {
         });
     }
 
-    private void reconcileStatus(String tagName) {
+    private void reconcileStatusPermalink(String tagName) {
         client.fetch(Tag.class, tagName)
             .ifPresent(tag -> {
                 Tag oldTag = JsonUtils.deepCopy(tag);
@@ -85,6 +91,38 @@ public class TagReconciler implements Reconciler<Reconciler.Request> {
                     client.update(tag);
                 }
             });
+    }
+
+    private void reconcileStatusPosts(String tagName) {
+        client.fetch(Tag.class, tagName).ifPresent(tag -> {
+            Tag oldTag = JsonUtils.deepCopy(tag);
+
+            populatePosts(tag);
+
+            if (!oldTag.equals(tag)) {
+                client.update(tag);
+            }
+        });
+    }
+
+    private void populatePosts(Tag tag) {
+        List<Post.CompactPost> compactPosts = client.list(Post.class, null, null)
+            .stream()
+            .filter(post -> includes(post.getSpec().getTags(), tag.getMetadata().getName()))
+            .map(post -> Post.CompactPost.builder()
+                .name(post.getMetadata().getName())
+                .published(post.isPublished())
+                .visible(post.getSpec().getVisible())
+                .build())
+            .toList();
+        tag.getStatusOrDefault().setPosts(compactPosts);
+    }
+
+    private boolean includes(List<String> tags, String tagName) {
+        if (tags == null) {
+            return false;
+        }
+        return tags.contains(tagName);
     }
 
     private boolean isDeleted(Tag tag) {

--- a/src/main/java/run/halo/app/theme/finders/vo/CategoryTreeVo.java
+++ b/src/main/java/run/halo/app/theme/finders/vo/CategoryTreeVo.java
@@ -1,12 +1,14 @@
 package run.halo.app.theme.finders.vo;
 
 import java.util.List;
+import java.util.Objects;
 import lombok.Builder;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 import org.springframework.util.Assert;
 import run.halo.app.core.extension.Category;
+import run.halo.app.core.extension.Post;
 import run.halo.app.extension.MetadataOperator;
 
 /**
@@ -45,5 +47,20 @@ public class CategoryTreeVo {
             .status(category.getStatus())
             .children(List.of())
             .build();
+    }
+
+    /**
+     * Gets the number of posts under the current category and its sub categories.
+     *
+     * @return the number of posts
+     */
+    public long postCount() {
+        if (this.status == null || this.status.getPosts() == null) {
+            return 0;
+        }
+        return this.status.getPosts().stream()
+            .filter(post -> Objects.equals(true, post.getPublished())
+                && Post.VisibleEnum.PUBLIC.equals(post.getVisible()))
+            .count();
     }
 }

--- a/src/main/java/run/halo/app/theme/finders/vo/CategoryVo.java
+++ b/src/main/java/run/halo/app/theme/finders/vo/CategoryVo.java
@@ -1,9 +1,11 @@
 package run.halo.app.theme.finders.vo;
 
+import java.util.Objects;
 import lombok.Builder;
 import lombok.EqualsAndHashCode;
 import lombok.Value;
 import run.halo.app.core.extension.Category;
+import run.halo.app.core.extension.Post;
 import run.halo.app.extension.MetadataOperator;
 
 /**
@@ -35,5 +37,20 @@ public class CategoryVo {
             .spec(category.getSpec())
             .status(category.getStatus())
             .build();
+    }
+
+    /**
+     * Gets the number of posts under the current category and its sub categories.
+     *
+     * @return the number of posts
+     */
+    public long postCount() {
+        if (this.status == null || this.status.getPosts() == null) {
+            return 0;
+        }
+        return this.status.getPosts().stream()
+            .filter(post -> Objects.equals(true, post.getPublished())
+                && Post.VisibleEnum.PUBLIC.equals(post.getVisible()))
+            .count();
     }
 }

--- a/src/main/java/run/halo/app/theme/finders/vo/TagVo.java
+++ b/src/main/java/run/halo/app/theme/finders/vo/TagVo.java
@@ -1,7 +1,9 @@
 package run.halo.app.theme.finders.vo;
 
+import java.util.Objects;
 import lombok.Builder;
 import lombok.Value;
+import run.halo.app.core.extension.Post;
 import run.halo.app.core.extension.Tag;
 import run.halo.app.extension.MetadataOperator;
 
@@ -32,5 +34,21 @@ public class TagVo {
             .spec(spec)
             .status(status)
             .build();
+    }
+
+    /**
+     * Gets the number of posts under the current tag.
+     *
+     * @return the number of posts
+     */
+    public long postCount() {
+        if (this.status == null || this.status.getPosts() == null) {
+            return 0;
+        }
+        return this.status.getPosts()
+            .stream()
+            .filter(post -> Objects.equals(true, post.getPublished())
+                && Post.VisibleEnum.PUBLIC.equals(post.getVisible()))
+            .count();
     }
 }

--- a/src/test/java/run/halo/app/core/extension/reconciler/CategoryReconcilerTest.java
+++ b/src/test/java/run/halo/app/core/extension/reconciler/CategoryReconcilerTest.java
@@ -1,0 +1,224 @@
+package run.halo.app.core.extension.reconciler;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.Optional;
+import org.json.JSONException;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.skyscreamer.jsonassert.JSONAssert;
+import run.halo.app.content.TestPost;
+import run.halo.app.content.permalinks.CategoryPermalinkPolicy;
+import run.halo.app.core.extension.Category;
+import run.halo.app.core.extension.Post;
+import run.halo.app.extension.ExtensionClient;
+import run.halo.app.extension.Metadata;
+import run.halo.app.extension.controller.Reconciler;
+import run.halo.app.infra.utils.JsonUtils;
+
+/**
+ * Tests for {@link CategoryReconciler}.
+ *
+ * @author guqing
+ * @since 2.0.0
+ */
+@ExtendWith(MockitoExtension.class)
+class CategoryReconcilerTest {
+    @Mock
+    private ExtensionClient client;
+
+    @Mock
+    private CategoryPermalinkPolicy categoryPermalinkPolicy;
+
+    @InjectMocks
+    private CategoryReconciler categoryReconciler;
+
+    @Test
+    void reconcileStatusPostForCategoryA() throws JSONException {
+        reconcileStatusPostPilling("category-A");
+
+        ArgumentCaptor<Category> captor = ArgumentCaptor.forClass(Category.class);
+        verify(client, times(2)).update(captor.capture());
+        JSONAssert.assertEquals("""
+            [
+                {
+                    "name": "post-1",
+                    "visible": "PUBLIC",
+                    "published": false
+                },
+                {
+                    "name": "post-2",
+                    "visible": "PUBLIC",
+                    "published": false
+                },
+                {
+                    "name": "post-3",
+                    "visible": "PUBLIC",
+                    "published": false
+                },
+                {
+                    "name": "post-4",
+                    "visible": "PUBLIC",
+                    "published": false
+                }
+            ]
+            """,
+            JsonUtils.objectToJson(captor.getAllValues().get(1).getStatusOrDefault().getPosts()),
+            true);
+    }
+
+    @Test
+    void reconcileStatusPostForCategoryB() throws JSONException {
+        reconcileStatusPostPilling("category-B");
+        ArgumentCaptor<Category> captor = ArgumentCaptor.forClass(Category.class);
+        verify(client, times(2)).update(captor.capture());
+        JSONAssert.assertEquals("""
+            [
+                {
+                    "name": "post-1",
+                    "visible": "PUBLIC",
+                    "published": false
+                },
+                {
+                    "name": "post-2",
+                    "visible": "PUBLIC",
+                    "published": false
+                },
+                {
+                    "name": "post-3",
+                    "visible": "PUBLIC",
+                    "published": false
+                }
+            ]
+            """,
+            JsonUtils.objectToJson(captor.getAllValues().get(1).getStatusOrDefault().getPosts()),
+            true);
+    }
+
+    @Test
+    void reconcileStatusPostForCategoryC() throws JSONException {
+        reconcileStatusPostPilling("category-C");
+        ArgumentCaptor<Category> captor = ArgumentCaptor.forClass(Category.class);
+        verify(client, times(2)).update(captor.capture());
+        JSONAssert.assertEquals("""
+            [
+                {
+                    "name": "post-1",
+                    "visible": "PUBLIC",
+                    "published": false
+                },
+                {
+                    "name": "post-2",
+                    "visible": "PUBLIC",
+                    "published": false
+                }
+            ]
+            """,
+            JsonUtils.objectToJson(captor.getAllValues().get(1).getStatusOrDefault().getPosts()),
+            true);
+    }
+
+    @Test
+    void reconcileStatusPostForCategoryD() throws JSONException {
+        reconcileStatusPostPilling("category-D");
+        ArgumentCaptor<Category> captor = ArgumentCaptor.forClass(Category.class);
+        verify(client, times(2)).update(captor.capture());
+        JSONAssert.assertEquals("""
+            [
+                {
+                    "name": "post-1",
+                    "visible": "PUBLIC",
+                    "published": false
+                }
+            ]
+            """,
+            JsonUtils.objectToJson(captor.getAllValues().get(1).getStatusOrDefault().getPosts()),
+            true);
+    }
+
+
+    private void reconcileStatusPostPilling(String reconcileCategoryName) {
+        categories().forEach(category -> {
+            lenient().when(client.fetch(eq(Category.class), eq(category.getMetadata().getName())))
+                .thenReturn(Optional.of(category));
+        });
+
+        lenient().when(client.list(eq(Post.class), any(), any()))
+            .thenReturn(posts());
+        lenient().when(client.list(eq(Category.class), any(), any()))
+            .thenReturn(categories());
+
+        Reconciler.Result result =
+            categoryReconciler.reconcile(new Reconciler.Request(reconcileCategoryName));
+        assertThat(result.reEnqueue()).isTrue();
+        assertThat(result.retryAfter()).isEqualTo(Duration.ofMinutes(1));
+    }
+
+    private List<Category> categories() {
+        /*
+         * |-A(post-4)
+         *   |-B(post-3)
+         *   |-|-C(post-2,post-1)
+         *   |-D(post-1)
+         */
+        Category categoryA = category("category-A");
+        categoryA.getSpec().setChildren(List.of("category-B", "category-D"));
+
+        Category categoryB = category("category-B");
+        categoryB.getSpec().setChildren(List.of("category-C"));
+
+        Category categoryC = category("category-C");
+        Category categoryD = category("category-D");
+        return List.of(categoryA, categoryB, categoryC, categoryD);
+    }
+
+    private Category category(String name) {
+        Category category = new Category();
+        Metadata metadata = new Metadata();
+        metadata.setName(name);
+        category.setMetadata(metadata);
+        category.setSpec(new Category.CategorySpec());
+        category.setStatus(new Category.CategoryStatus());
+        return category;
+    }
+
+    private List<Post> posts() {
+        /*
+         * |-A(post-4)
+         *   |-B(post-3)
+         *   |-|-C(post-2,post-1)
+         *   |-D(post-1)
+         */
+        Post post1 = TestPost.postV1();
+        post1.getMetadata().setName("post-1");
+        post1.getSpec().setCategories(List.of("category-D", "category-C"));
+        post1.getSpec().setVisible(Post.VisibleEnum.PUBLIC);
+
+        Post post2 = TestPost.postV1();
+        post2.getMetadata().setName("post-2");
+        post2.getSpec().setCategories(List.of("category-C"));
+        post2.getSpec().setVisible(Post.VisibleEnum.PUBLIC);
+
+        Post post3 = TestPost.postV1();
+        post3.getMetadata().setName("post-3");
+        post3.getSpec().setCategories(List.of("category-B"));
+        post3.getSpec().setVisible(Post.VisibleEnum.PUBLIC);
+
+        Post post4 = TestPost.postV1();
+        post4.getMetadata().setName("post-4");
+        post4.getSpec().setCategories(List.of("category-A"));
+        post4.getSpec().setVisible(Post.VisibleEnum.PUBLIC);
+        return List.of(post1, post2, post3, post4);
+    }
+}

--- a/src/test/java/run/halo/app/theme/finders/impl/TagFinderImplTest.java
+++ b/src/test/java/run/halo/app/theme/finders/impl/TagFinderImplTest.java
@@ -65,10 +65,7 @@ class TagFinderImplTest {
                      },
                      "status": {
                          "permalink": "permalink-1",
-                         "posts": [
-                             "p1",
-                             "p2"
-                         ]
+                         "posts": []
                      }
                 }
                 """,
@@ -120,7 +117,7 @@ class TagFinderImplTest {
 
         Tag.TagStatus tagStatus = new Tag.TagStatus();
         tagStatus.setPermalink("permalink-" + i);
-        tagStatus.setPosts(List.of("p1", "p2"));
+        tagStatus.setPosts(List.of());
         tag.setStatus(tagStatus);
         return tag;
     }


### PR DESCRIPTION
#### What type of PR is this?
/kind feature
/milestone 2.0
/area core

#### What this PR does / why we need it:
统计分类和标签下的文章
#### Which issue(s) this PR fixes:
Fixes #2401

#### Special notes for your reviewer:
how to test it?
1. 创建一个多层级的分类及若干文章，查看分类的 status.posts 是否包含当前及其子分类下的文章
2. 创建标签，并将其分配给若干文章，查看标签的 status.posts 是否正确
3. 在主题端查看分类和标签包含的文章数量是否正确，需要注意的是主题端显示的文章数量只包含已发布且 visiable 为 public 且未删除的

/cc @halo-dev/sig-halo 
#### Does this PR introduce a user-facing change?

```release-note
None
```
