### PR TITLE
feat: add theme setting reload API

### DIFF
--- a/src/test/java/run/halo/app/core/extension/endpoint/ThemeEndpointTest.java
+++ b/src/test/java/run/halo/app/core/extension/endpoint/ThemeEndpointTest.java
@@ -10,12 +10,16 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.List;
+import org.json.JSONException;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.skyscreamer.jsonassert.JSONAssert;
 import org.springframework.core.io.FileSystemResource;
 import org.springframework.http.MediaType;
 import org.springframework.http.client.MultipartBodyBuilder;
@@ -24,10 +28,13 @@ import org.springframework.util.FileSystemUtils;
 import org.springframework.util.ResourceUtils;
 import org.springframework.web.reactive.function.BodyInserters;
 import reactor.core.publisher.Mono;
+import run.halo.app.core.extension.Setting;
 import run.halo.app.core.extension.Theme;
+import run.halo.app.extension.Metadata;
 import run.halo.app.extension.ReactiveExtensionClient;
 import run.halo.app.extension.Unstructured;
 import run.halo.app.infra.properties.HaloProperties;
+import run.halo.app.infra.utils.JsonUtils;
 import run.halo.app.infra.utils.YamlUnstructuredLoader;
 
 /**
@@ -107,5 +114,80 @@ class ThemeEndpointTest {
             .exchange()
             .expectStatus()
             .is5xxServerError();
+    }
+
+    @Test
+    void reloadSetting() throws IOException {
+        Theme theme = new Theme();
+        theme.setMetadata(new Metadata());
+        theme.getMetadata().setName("fake-theme");
+        theme.setSpec(new Theme.ThemeSpec());
+        theme.getSpec().setSettingName("fake-setting");
+        when(extensionClient.fetch(Theme.class, "fake-theme"))
+            .thenReturn(Mono.just(theme));
+        Setting setting = new Setting();
+        setting.setMetadata(new Metadata());
+        setting.setSpec(List.of());
+        when(extensionClient.fetch(Setting.class, "fake-setting"))
+            .thenReturn(Mono.just(setting));
+
+        when(haloProperties.getWorkDir()).thenReturn(tmpHaloWorkDir);
+        Path themeWorkDir = tmpHaloWorkDir.resolve("themes")
+            .resolve(theme.getMetadata().getName());
+        if (!Files.exists(themeWorkDir)) {
+            Files.createDirectories(themeWorkDir);
+        }
+        Files.writeString(themeWorkDir.resolve("settings.yaml"), """
+            apiVersion: v1alpha1
+            kind: Setting
+            metadata:
+              name: fake-setting
+            spec:
+              - group: sns
+                label: 社交资料
+                formSchema:
+                  - $el: h1
+                    children: Register
+            """);
+
+        when(extensionClient.update(any(Setting.class)))
+            .thenReturn(Mono.just(setting));
+        ArgumentCaptor<Setting> captor = ArgumentCaptor.forClass(Setting.class);
+        webTestClient.put()
+            .uri("/themes/fake-theme/reload-setting")
+            .exchange()
+            .expectStatus()
+            .isOk()
+            .expectBody(Setting.class)
+            .value(settingRes -> {
+                verify(extensionClient, times(1)).update(captor.capture());
+                verify(extensionClient, times(0)).create(any(Setting.class));
+                Setting value = captor.getValue();
+                try {
+                    JSONAssert.assertEquals("""
+                            {
+                                "spec": [
+                                    {
+                                        "group": "sns",
+                                        "label": "社交资料",
+                                        "formSchema": [
+                                            {
+                                                "$el": "h1",
+                                                "children": "Register"
+                                            }
+                                        ]
+                                    }
+                                ],
+                                "apiVersion": "v1alpha1",
+                                "kind": "Setting",
+                                "metadata": {}
+                            }
+                            """,
+                        JsonUtils.objectToJson(value),
+                        true);
+                } catch (JSONException e) {
+                    throw new RuntimeException(e);
+                }
+            });
     }
 }

--- a/src/test/java/run/halo/app/core/extension/endpoint/ThemeEndpointTest.java
+++ b/src/test/java/run/halo/app/core/extension/endpoint/ThemeEndpointTest.java
@@ -127,7 +127,8 @@ class ThemeEndpointTest {
             .thenReturn(Mono.just(theme));
         Setting setting = new Setting();
         setting.setMetadata(new Metadata());
-        setting.setSpec(List.of());
+        setting.setSpec(new Setting.SettingSpec());
+        setting.getSpec().setForms(List.of());
         when(extensionClient.fetch(Setting.class, "fake-setting"))
             .thenReturn(Mono.just(setting));
 
@@ -143,11 +144,12 @@ class ThemeEndpointTest {
             metadata:
               name: fake-setting
             spec:
-              - group: sns
-                label: 社交资料
-                formSchema:
-                  - $el: h1
-                    children: Register
+              forms:
+                - group: sns
+                  label: 社交资料
+                  formSchema:
+                    - $el: h1
+                      children: Register
             """);
 
         when(extensionClient.update(any(Setting.class)))
@@ -163,25 +165,28 @@ class ThemeEndpointTest {
                 verify(extensionClient, times(1)).update(captor.capture());
                 verify(extensionClient, times(0)).create(any(Setting.class));
                 Setting value = captor.getValue();
+                System.out.println(JsonUtils.objectToJson(value));
                 try {
                     JSONAssert.assertEquals("""
                             {
-                                "spec": [
-                                    {
-                                        "group": "sns",
-                                        "label": "社交资料",
-                                        "formSchema": [
-                                            {
-                                                "$el": "h1",
-                                                "children": "Register"
-                                            }
-                                        ]
-                                    }
-                                ],
-                                "apiVersion": "v1alpha1",
-                                "kind": "Setting",
-                                "metadata": {}
-                            }
+                               "spec": {
+                                 "forms": [
+                                   {
+                                     "group": "sns",
+                                     "label": "社交资料",
+                                     "formSchema": [
+                                       {
+                                         "$el": "h1",
+                                         "children": "Register"
+                                       }
+                                     ]
+                                   }
+                                 ]
+                               },
+                               "apiVersion": "v1alpha1",
+                               "kind": "Setting",
+                               "metadata": {}
+                             }
                             """,
                         JsonUtils.objectToJson(value),
                         true);


### PR DESCRIPTION
#### What type of PR is this?
/kind feature
/milestone 2.0
/area core
/kind api-change

#### What this PR does / why we need it:
新增主题设置重载 API，调用此 API 会从主题文件中重新加载 settings.yaml 复盖原有记录，便于主题开发和测试
插件不需要此功能，配置了 `fixedPluginPath` 后每次重启都会加载新的配置项
#### Which issue(s) this PR fixes:

Fixes #2426

#### Special notes for your reviewer:
/cc @halo-dev/sig-halo 
#### Does this PR introduce a user-facing change?

```release-note
None
```
