### PR TITLE
Fix the problem of generating permalink due to special filename

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -72,3 +72,4 @@ application-local.properties
 
 ### Zip file for test
 !src/test/resources/themes/*.zip
+src/main/resources/console/

--- a/src/test/java/run/halo/app/core/extension/endpoint/AttachmentEndpointTest.java
+++ b/src/test/java/run/halo/app/core/extension/endpoint/AttachmentEndpointTest.java
@@ -1,5 +1,0 @@
-package run.halo.app.core.extension.endpoint;
-
-class AttachmentEndpointTest {
-
-}


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/area core
/milestone 2.0

#### What this PR does / why we need it:

Encode path of attachment permalink instead of using URI#resolve methods directly.

#### Which issue(s) this PR fixes:

Fixes https://github.com/halo-dev/halo/issues/2408

#### Special notes for reviewers

Steps to test:

1. Create a file with special name, e.g.: `hello world.txt`
2. Upload the file and see the permalink

#### Does this PR introduce a user-facing change?

```release-note
None
```
