### PR TITLE
fix:解决windows环境下yaml配置文件获取user.home非法字符问题

### DIFF
--- a/src/main/java/run/halo/app/Application.java
+++ b/src/main/java/run/halo/app/Application.java
@@ -1,11 +1,14 @@
 package run.halo.app;
 
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.autoconfigure.integration.IntegrationAutoConfiguration;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import run.halo.app.infra.properties.HaloProperties;
 import run.halo.app.infra.properties.JwtProperties;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 
 /**
  * Halo main class.
@@ -21,6 +24,12 @@ import run.halo.app.infra.properties.JwtProperties;
 public class Application {
 
     public static void main(String[] args) {
+        System.setProperty("halo.work-dir",
+            StringUtils.isNoneEmpty(System.getProperty("halo.work-dir")) ?
+                URLEncoder.encode(System.getProperty("user.home"), StandardCharsets.UTF_8)
+                    + "/halo-next"
+                : URLEncoder.encode(System.getProperty("user.home"), StandardCharsets.UTF_8)
+                    + System.getProperty("halo.work-dir"));
         SpringApplication.run(Application.class, args);
     }
 

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -22,7 +22,7 @@ halo:
       jwt:
         public-key-location: classpath:app.pub
         private-key-location: classpath:app.key
-  work-dir: ${user.home}/halo-next
+  work-dir: /halo-next
   plugin:
     plugins-root: ${halo.work-dir}/plugins
 

--- a/src/test/resources/application.yaml
+++ b/src/test/resources/application.yaml
@@ -13,7 +13,7 @@ spring:
       platform: h2
 
 halo:
-  work-dir: ${user.home}/halo-next-test
+  work-dir: /halo-next-test
   external-url: "http://${server.address:localhost}:${server.port}"
   security:
     initializer:


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Windows环境下yaml配置文件中获取环境变量带有"\"特殊字符

#### Does this PR introduce a user-facing change?

```release-note
None
```
