### PR TITLE
chore: degrade springboot version from 3.0.0-M5 to 3.0.0-M4

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'org.springframework.boot' version '3.0.0-M5'
+    id 'org.springframework.boot' version '3.0.0-M4'
     id 'io.spring.dependency-management' version '1.0.12.RELEASE'
     id "checkstyle"
     id 'java'


### PR DESCRIPTION
#### What type of PR is this?
/kind improvement
/area core
/milestone 2.0

#### What this PR does / why we need it:
将 spring boot 的版本从 3.0.0-M5 降级到 3.0.0-M5 以解决 swragger 无法使用的问题
#### Which issue(s) this PR fixes:

Fixes #

#### Special notes for your reviewer:
/cc @halo-dev/sig-halo 
#### Does this PR introduce a user-facing change?


```release-note
None
```
