### PR TITLE
docs: remove readme documentation about running with jar

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,20 +32,6 @@
 
 ## 快速开始
 
-### Fat Jar
-
-下载最新的 Halo 运行包：
-
-```bash
-curl -L https://github.com/halo-dev/halo/releases/download/v2.0.0-alpha.1/halo-2.0.0-alpha.1.jar --output halo-next.jar
-```
-
-其他地址：<https://docs.halo.run/next/getting-started/downloads>
-
-```bash
-java -jar halo-next.jar
-```
-
 ### Docker
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@
 docker run -it -d --name halo-next -p 8090:8090 -v ~/halo-next:/root/halo-next --restart=unless-stopped halohub/halo-dev:2.0.0-alpha.1
 ```
 
-详细部署文档请查阅：<https://docs.halo.run/next/getting-started/install/linux>
+详细部署文档请查阅：<https://docs.halo.run/2.0.0-SNAPSHOT/getting-started/install/docker>
 
 ## 生态
 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@
 ### Docker
 
 ```bash
-docker run -it -d --name halo-next -p 8090:8090 -v ~/halo-next:/root/halo-next --restart=unless-stopped halohub/halo-dev:next
+docker run -it -d --name halo-next -p 8090:8090 -v ~/halo-next:/root/halo-next --restart=unless-stopped halohub/halo-dev:2.0.0-alpha.1
 ```
 
 详细部署文档请查阅：<https://docs.halo.run/next/getting-started/install/linux>


### PR DESCRIPTION
#### What type of PR is this?

/kind documentation
/milestone 2.0

#### What this PR does / why we need it:

因为目前暂时没有提供 JAR 包，所以移除 README 有关使用 JAR 包运行的文档。


#### Special notes for your reviewer:

/cc @halo-dev/sig-halo 

#### Does this PR introduce a user-facing change?

```release-note
None
```
