### PR TITLE
Bump version of Spring Boot & SpringDoc

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 plugins {
-    id 'org.springframework.boot' version '3.0.0-M4'
-    id 'io.spring.dependency-management' version '1.0.12.RELEASE'
+    id 'org.springframework.boot' version '3.0.0-M5'
+    id 'io.spring.dependency-management' version '1.0.14.RELEASE'
     id "checkstyle"
     id 'java'
 }
@@ -62,7 +62,7 @@ dependencies {
     implementation 'org.springframework.security:spring-security-oauth2-jose'
     implementation 'org.springframework.security:spring-security-oauth2-resource-server'
 
-    implementation 'org.springdoc:springdoc-openapi-starter-webflux-ui:2.0.0-M5'
+    implementation 'org.springdoc:springdoc-openapi-starter-webflux-ui:2.0.0-M6'
     implementation 'org.openapi4j:openapi-schema-validator:1.0.7'
     implementation "net.bytebuddy:byte-buddy"
 


### PR DESCRIPTION
#### What type of PR is this?

/kind improvement
/area core
/milestone 2.0

#### What this PR does / why we need it:

1. Upgrade Spring Boot to 3.0.0-M5. See https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-3.0.0-M5-Release-Notes for more.
2. Upgrade SpringDoc to 2.0.0-M6. The version is compatible to Spring Boot 3.0.0-M5. See https://github.com/springdoc/springdoc-openapi/issues/1865 for more.

#### Special notes for your reviewer:

Please check the API documentation endpoint: <http://localhost:8090/swagger-ui.html>.

#### Does this PR introduce a user-facing change?

```release-note
None
```
