### PR TITLE
Support running Halo with MySQL and MariaDB database

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -87,8 +87,7 @@ dependencies {
     // See https://github.com/spring-projects/spring-data-relational/commit/ee6c2c89b5c433748b22a79cf40dc8e01142caa3
     // for more.
     runtimeOnly 'io.r2dbc:r2dbc-h2'
-    runtimeOnly 'com.h2database:h2'
-    runtimeOnly 'mysql:mysql-connector-java'
+    runtimeOnly 'com.github.jasync-sql:jasync-r2dbc-mysql:2.1.5'
     runtimeOnly 'org.postgresql:postgresql'
     runtimeOnly 'org.postgresql:r2dbc-postgresql'
 

--- a/src/main/resources/application-mysql.yaml
+++ b/src/main/resources/application-mysql.yaml
@@ -1,0 +1,9 @@
+spring:
+  r2dbc:
+    url: r2dbc:pool:mysql://localhost:3306/halo
+    username: root
+    password: openmysql
+  sql:
+    init:
+      mode: always
+      platform: mysql

--- a/src/main/resources/schema-mysql.sql
+++ b/src/main/resources/schema-mysql.sql
@@ -1,0 +1,7 @@
+create table if not exists extensions
+(
+    name    varchar(255) not null,
+    data    blob,
+    version bigint,
+    primary key (name)
+);


### PR DESCRIPTION
#### What type of PR is this?

/kind feature
/area core
/milestone 2.0

#### What this PR does / why we need it:

Add MySQL script to support running Halo with MySQL database due to https://github.com/jasync-sql/jasync-sql/issues/311 has been resolved.

#### Which issue(s) this PR fixes:

Fixes https://github.com/halo-dev/halo/issues/2464

#### Special notes for reviewers

Steps to test:

1. Start up MySQL. e.g.:

    ```yaml
    version: '3.1'
    
    services:
    
      db:
        image: mysql
        # NOTE: use of "mysql_native_password" is not recommended: https://dev.mysql.com/doc/refman/8.0/en/upgrading-from-previous-series.html#upgrade-caching-sha2-password
        # (this is just an example, not intended to be a production configuration)
        command: --default-authentication-plugin=mysql_native_password
        restart: always
        environment:
          MYSQL_ROOT_PASSWORD: openmysql
        ports:
          - 3306:3306
    
      adminer:
        image: adminer
        restart: always
        ports:
          - 8080:8080
    ```
    
    ```bash
    docker-compose -f mysql.yaml up
    ```

2. Start Halo with `mysql` profile. e.g.:

    ```bash
    ./gradlew bootRun --args="--spring.profiles.active=mysql"
    ```

3. Validate the functionality of Halo

#### Does this PR introduce a user-facing change?

```release-note
None
```
