### PR TITLE
chore: rename the default location of the plugin's bundle resources to `console`

### DIFF
--- a/src/main/java/run/halo/app/plugin/resources/JsBundleRuleProvider.java
+++ b/src/main/java/run/halo/app/plugin/resources/JsBundleRuleProvider.java
@@ -17,14 +17,14 @@ import run.halo.app.plugin.HaloPluginManager;
  */
 @Component
 public class JsBundleRuleProvider {
-    private static final String JS_LOCATION = "/admin/main.js";
-    private static final String CSS_LOCATION = "/admin/style.css";
+    private static final String JS_LOCATION = "/console/main.js";
+    private static final String CSS_LOCATION = "/console/style.css";
 
     private static final FileReverseProxyProvider JS_FILE_PROXY =
-        new FileReverseProxyProvider("admin", "main.js");
+        new FileReverseProxyProvider("console", "main.js");
 
     private static final FileReverseProxyProvider CSS_FILE_PROXY =
-        new FileReverseProxyProvider("admin", "style.css");
+        new FileReverseProxyProvider("console", "style.css");
 
     private final HaloPluginManager haloPluginManager;
 


### PR DESCRIPTION
#### What type of PR is this?

/kind api-change
/kind improvement
/milestone 2.0

#### What this PR does / why we need it:

Ref #2519 ，我们已经将 halo-admin 的命名改为了 console，所以相关命名需要同步修改。

#### Which issue(s) this PR fixes:

Fixes #2519 

#### Special notes for your reviewer:

/hold 

等待插件的 PR。

测试方式：

1. 使用 plugin-links 插件的 https://github.com/halo-sigs/plugin-links/pull/3 PR 进行测试，需要 Clone 到本地。
2. 使用 `./graldew build` 的命令编译插件，得到 `build/libs/plugin-link-*.jar`。
3. Halo 的插件运行模式改为 deployment 模式。
4. 启动 Halo 之后，安装第二步得到的插件。
5. 检查浏览器控制台是否正常加载了 `/assets/PluginLinks/console/main.js` 和 `/assets/PluginLinks/admin/style.css`

#### Does this PR introduce a user-facing change?

```release-note
None
```
