### PR TITLE
refactor: system role templates

### DIFF
--- a/src/main/resources/extensions/role-template-authenticated.yaml
+++ b/src/main/resources/extensions/role-template-authenticated.yaml
@@ -7,9 +7,12 @@ metadata:
     halo.run/hidden: "true"
   annotations:
     rbac.authorization.halo.run/dependencies: |
-      [ "role-template-own-user-info", "role-template-own-permissions", "role-template-change-own-password",
-      "role-template-manage-configmaps" ]
-rules: [ ]
+      [ "role-template-own-user-info", "role-template-own-permissions", "role-template-change-own-password" ]
+rules:
+  - apiGroups: [ "" ]
+    resources: [ "configmaps" ]
+    resourceNames: [ "system-states" ]
+    verbs: [ "get" ]
 ---
 apiVersion: v1alpha1
 kind: "Role"

--- a/src/main/resources/extensions/role-template-menu.yaml
+++ b/src/main/resources/extensions/role-template-menu.yaml
@@ -23,7 +23,7 @@ metadata:
     halo.run/role-template: "true"
   annotations:
     rbac.authorization.halo.run/module: "Menus Management"
-    rbac.authorization.halo.run/display-name: "Menu Manage"
+    rbac.authorization.halo.run/display-name: "Menu View"
     rbac.authorization.halo.run/ui-permissions: |
       ["system:menus:view"]
 rules:

--- a/src/main/resources/extensions/role-template-plugin.yaml
+++ b/src/main/resources/extensions/role-template-plugin.yaml
@@ -6,7 +6,7 @@ metadata:
     halo.run/role-template: "true"
   annotations:
     rbac.authorization.halo.run/dependencies: |
-      [ "role-template-view-plugins", "role-template-manage-configmaps" ]
+      [ "role-template-view-plugins" ]
     rbac.authorization.halo.run/module: "Plugins Management"
     rbac.authorization.halo.run/display-name: "Plugin Manage"
     rbac.authorization.halo.run/ui-permissions: |
@@ -15,6 +15,8 @@ rules:
   - apiGroups: [ "plugin.halo.run" ]
     resources: [ "plugins" ]
     verbs: [ "create", "patch", "update", "delete", "deletecollection" ]
+  - nonResourceURLs: [ "/apis/api.console.halo.run/v1alpha1/plugins/install" ]
+    verbs: [ "create" ]
 ---
 apiVersion: v1alpha1
 kind: "Role"
@@ -23,12 +25,14 @@ metadata:
   labels:
     halo.run/role-template: "true"
   annotations:
-    rbac.authorization.halo.run/dependencies: "[ \"role-template-view-settings\" ]"
     rbac.authorization.halo.run/module: "Plugins Management"
     rbac.authorization.halo.run/display-name: "Plugin View"
     rbac.authorization.halo.run/ui-permissions: |
       ["system:plugins:view"]
 rules:
   - apiGroups: [ "plugin.halo.run" ]
+    resources: [ "plugins" ]
+    verbs: [ "get", "list" ]
+  - apiGroups: [ "api.console.halo.run" ]
     resources: [ "plugins" ]
     verbs: [ "get", "list" ]


### PR DESCRIPTION
#### What type of PR is this?
/kind improvement
/area core
/milestone 2.0

#### What this PR does / why we need it:
优化系统角色模板配置
- 认证用户仅具有名为 system-states 的 ConfigMap 查看权限而非所有 ConfigMap查看权限
- 主题和插件的管理权限目前需要单独勾选 ConfigMap 和 Setting 的权限才可以看到表单和值
#### Which issue(s) this PR fixes:

Fixes #2523

#### Special notes for your reviewer:
/cc @halo-dev/sig-halo 
#### Does this PR introduce a user-facing change?

```release-note
None
```
