### PR TITLE
refactor: register method for reverse proxy registry

### DIFF
--- a/src/main/java/run/halo/app/plugin/resources/ReverseProxyRouterFunctionRegistry.java
+++ b/src/main/java/run/halo/app/plugin/resources/ReverseProxyRouterFunctionRegistry.java
@@ -68,6 +68,14 @@ public class ReverseProxyRouterFunctionRegistry {
     }
 
     /**
+     * Only for test.
+     */
+    protected int reverseProxySize(String pluginId) {
+        List<String> names = pluginIdReverseProxyMap.get(pluginId);
+        return names == null ? 0 : names.size();
+    }
+
+    /**
      * Remove reverse proxy router function by plugin id.
      *
      * @param pluginId plugin id

--- a/src/main/java/run/halo/app/plugin/resources/ReverseProxyRouterFunctionRegistry.java
+++ b/src/main/java/run/halo/app/plugin/resources/ReverseProxyRouterFunctionRegistry.java
@@ -47,7 +47,12 @@ public class ReverseProxyRouterFunctionRegistry {
         final String proxyName = reverseProxy.getMetadata().getName();
         long stamp = lock.writeLock();
         try {
+            List<String> reverseProxyNames = pluginIdReverseProxyMap.get(pluginId);
+            if (reverseProxyNames != null && reverseProxyNames.contains(proxyName)) {
+                return Mono.empty();
+            }
             pluginIdReverseProxyMap.add(pluginId, proxyName);
+
             // Obtain plugin application context
             PluginApplicationContext pluginApplicationContext =
                 ExtensionContextRegistry.getInstance().getByPluginId(pluginId);

--- a/src/test/java/run/halo/app/plugin/resources/ReverseProxyRouterFunctionRegistryTest.java
+++ b/src/test/java/run/halo/app/plugin/resources/ReverseProxyRouterFunctionRegistryTest.java
@@ -1,0 +1,58 @@
+package run.halo.app.plugin.resources;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.web.reactive.function.server.RouterFunction;
+import reactor.test.StepVerifier;
+import run.halo.app.core.extension.ReverseProxy;
+import run.halo.app.extension.Metadata;
+import run.halo.app.plugin.ExtensionContextRegistry;
+import run.halo.app.plugin.PluginApplicationContext;
+
+/**
+ * @author guqing
+ * @since 2.0.0
+ */
+@ExtendWith(MockitoExtension.class)
+class ReverseProxyRouterFunctionRegistryTest {
+
+    @InjectMocks
+    private ReverseProxyRouterFunctionRegistry registry;
+
+    @MockBean
+    private ReverseProxyRouterFunctionFactory reverseProxyRouterFunctionFactory;
+
+    @BeforeEach
+    void setUp() {
+        ExtensionContextRegistry instance = ExtensionContextRegistry.getInstance();
+        instance.register("fake-plugin", Mockito.mock(PluginApplicationContext.class));
+    }
+
+    @AfterEach
+    void tearDown() {
+        ExtensionContextRegistry.getInstance().remove("fake-plugin");
+    }
+
+    @Test
+    void register() {
+        ReverseProxy mock = Mockito.mock(ReverseProxy.class);
+        Metadata metadata = new Metadata();
+        metadata.setName("test-reverse-proxy");
+        when(mock.getMetadata()).thenReturn(metadata);
+
+        when(reverseProxyRouterFunctionFactory.create(any(), any()))
+            .thenReturn(Mockito.mock(RouterFunction.class));
+        registry.register("fake-plugin", mock)
+            .as(StepVerifier::create)
+            .verifyComplete();
+    }
+}


### PR DESCRIPTION
#### What type of PR is this?
/kind improvement
/area core
/milestone 2.0

#### What this PR does / why we need it:
对反向代理规则注册增加重复注册检查

场景：
ReverseProxyRouterFunctionRegistry 中有一个 pluginIdReverseProxyMap 记录了 插件名称和插件的 ReverseProxy 名称对应关系
当重复 fake-plugin -> test-reverse-proxy 时，pluginIdReverseProxyMap 的 value 不会去重，因此需要增加重复注册检查
#### Which issue(s) this PR fixes:

Fixes #

#### Special notes for your reviewer:
how to test it?
本 PR 不需要测试，已经对上述场景添加了单元测试

/cc @halo-dev/sig-halo 
#### Does this PR introduce a user-facing change?

```release-note
None
```
