### PR TITLE
Disable CSRF token check for RESTful APIs

### DIFF
--- a/src/main/java/run/halo/app/security/CorsConfigurer.java
+++ b/src/main/java/run/halo/app/security/CorsConfigurer.java
@@ -1,0 +1,33 @@
+package run.halo.app.security;
+
+import com.google.common.net.HttpHeaders;
+import java.util.List;
+import org.springframework.security.config.web.server.ServerHttpSecurity;
+import org.springframework.stereotype.Component;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.reactive.CorsConfigurationSource;
+import org.springframework.web.cors.reactive.UrlBasedCorsConfigurationSource;
+import run.halo.app.security.authentication.SecurityConfigurer;
+
+@Component
+public class CorsConfigurer implements SecurityConfigurer {
+    @Override
+    public void configure(ServerHttpSecurity http) {
+        http.cors(spec -> spec.configurationSource(apiCorsConfigSource()));
+    }
+
+    CorsConfigurationSource apiCorsConfigSource() {
+        var configuration = new CorsConfiguration();
+        configuration.setAllowedOriginPatterns(List.of("*"));
+        configuration.setAllowedHeaders(
+            List.of(HttpHeaders.AUTHORIZATION, HttpHeaders.CONTENT_TYPE, HttpHeaders.ACCEPT,
+                "X-XSRF-TOKEN", HttpHeaders.COOKIE));
+        configuration.setAllowCredentials(true);
+        configuration.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE", "PATCH"));
+
+        var source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/api/**", configuration);
+        source.registerCorsConfiguration("/apis/**", configuration);
+        return source;
+    }
+}

--- a/src/main/java/run/halo/app/security/CsrfConfigurer.java
+++ b/src/main/java/run/halo/app/security/CsrfConfigurer.java
@@ -1,0 +1,27 @@
+package run.halo.app.security;
+
+import static org.springframework.security.web.server.util.matcher.ServerWebExchangeMatchers.pathMatchers;
+
+import org.springframework.security.config.web.server.ServerHttpSecurity;
+import org.springframework.security.web.server.csrf.CookieServerCsrfTokenRepository;
+import org.springframework.security.web.server.csrf.CsrfWebFilter;
+import org.springframework.security.web.server.util.matcher.AndServerWebExchangeMatcher;
+import org.springframework.security.web.server.util.matcher.NegatedServerWebExchangeMatcher;
+import org.springframework.stereotype.Component;
+import run.halo.app.security.authentication.SecurityConfigurer;
+
+@Component
+public class CsrfConfigurer implements SecurityConfigurer {
+
+    @Override
+    public void configure(ServerHttpSecurity http) {
+        var csrfMatcher = new AndServerWebExchangeMatcher(
+            CsrfWebFilter.DEFAULT_CSRF_MATCHER,
+            new NegatedServerWebExchangeMatcher(pathMatchers("/api/**", "/apis/**")
+            ));
+
+        http.csrf().csrfTokenRepository(CookieServerCsrfTokenRepository.withHttpOnlyFalse())
+            .requireCsrfProtectionMatcher(csrfMatcher);
+    }
+
+}


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/area core
/milestone 2.0
/kind api-change

#### What this PR does / why we need it:

1. Disable CSRF token check for RESTful APIs but login and logout APIs.
2. Enable CORS check for login and logout APIs

#### Which issue(s) this PR fixes:

Fixes https://github.com/halo-dev/halo/issues/2571

#### How to test?

1. Install a valid theme and create a sample post
2. View the post at theme end
3. Check the response of counter API

#### Does this PR introduce a user-facing change?

```release-note
None
禁用对 RESTful API 的 CSRF 检查
```
