### PR TITLE
Bump version of SpringDoc to 2.0.0-M7

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -62,7 +62,7 @@ dependencies {
     implementation 'org.springframework.security:spring-security-oauth2-jose'
     implementation 'org.springframework.security:spring-security-oauth2-resource-server'
 
-    implementation 'org.springdoc:springdoc-openapi-starter-webflux-ui:2.0.0-M6'
+    implementation 'org.springdoc:springdoc-openapi-starter-webflux-ui:2.0.0-M7'
     implementation 'org.openapi4j:openapi-schema-validator:1.0.7'
     implementation "net.bytebuddy:byte-buddy"
 


### PR DESCRIPTION
#### What type of PR is this?

/kind improvement
/area core
/milestone 2.0

#### What this PR does / why we need it:

See https://github.com/springdoc/springdoc-openapi/releases/tag/v2.0.0-M7 for more.

![image](https://user-images.githubusercontent.com/16865714/196356805-ce028139-4e5f-48d7-ba63-d29cefb17683.png)


#### Does this PR introduce a user-facing change?

```release-note
None
```
