### PR TITLE
Provide an endpoint to upgrade theme

### DIFF
--- a/src/main/java/run/halo/app/core/extension/theme/ThemeUtils.java
+++ b/src/main/java/run/halo/app/core/extension/theme/ThemeUtils.java
@@ -1,0 +1,192 @@
+package run.halo.app.core.extension.theme;
+
+import static java.nio.file.Files.createTempDirectory;
+import static org.springframework.util.FileSystemUtils.copyRecursively;
+import static run.halo.app.infra.utils.FileUtils.deleteRecursivelyAndSilently;
+import static run.halo.app.infra.utils.FileUtils.unzip;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.stream.BaseStream;
+import java.util.stream.Stream;
+import java.util.zip.ZipInputStream;
+import org.apache.commons.lang3.ArrayUtils;
+import org.springframework.core.io.FileSystemResource;
+import org.springframework.core.io.Resource;
+import org.springframework.lang.Nullable;
+import org.springframework.util.CollectionUtils;
+import reactor.core.Exceptions;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+import reactor.core.scheduler.Schedulers;
+import run.halo.app.core.extension.Theme;
+import run.halo.app.extension.Unstructured;
+import run.halo.app.infra.exception.ThemeInstallationException;
+import run.halo.app.infra.utils.FileUtils;
+import run.halo.app.infra.utils.YamlUnstructuredLoader;
+
+class ThemeUtils {
+    private static final String THEME_TMP_PREFIX = "halo-theme-";
+    private static final String[] THEME_MANIFESTS = {"theme.yaml", "theme.yml"};
+
+    private static final String[] THEME_CONFIG = {"config.yaml", "config.yml"};
+
+    private static final String[] THEME_SETTING = {"settings.yaml", "settings.yml"};
+
+    static List<Unstructured> loadThemeSetting(Path themePath) {
+        return loadUnstructured(themePath, THEME_SETTING);
+    }
+
+    static Flux<Theme> listAllThemesFromThemeDir(Path themesDir) {
+        return walkThemesFromPath(themesDir)
+            .filter(Files::isDirectory)
+            .map(themePath -> loadUnstructured(themePath, THEME_MANIFESTS))
+            .flatMap(Flux::fromIterable)
+            .map(unstructured -> Unstructured.OBJECT_MAPPER.convertValue(unstructured,
+                Theme.class))
+            .sort(Comparator.comparing(theme -> theme.getMetadata().getName()));
+    }
+
+    private static Flux<Path> walkThemesFromPath(Path path) {
+        return Flux.using(() -> Files.walk(path, 2),
+                Flux::fromStream,
+                BaseStream::close
+            )
+            .subscribeOn(Schedulers.boundedElastic());
+    }
+
+    private static List<Unstructured> loadUnstructured(Path themePath,
+        String[] themeSetting) {
+        List<Resource> resources = new ArrayList<>(4);
+        for (String themeResource : themeSetting) {
+            Path resourcePath = themePath.resolve(themeResource);
+            if (Files.exists(resourcePath)) {
+                resources.add(new FileSystemResource(resourcePath));
+            }
+        }
+        if (CollectionUtils.isEmpty(resources)) {
+            return List.of();
+        }
+        return new YamlUnstructuredLoader(resources.toArray(new Resource[0]))
+            .load();
+    }
+
+    static List<Unstructured> loadThemeResources(Path themePath) {
+        String[] resourceNames = ArrayUtils.addAll(THEME_SETTING, THEME_CONFIG);
+        return loadUnstructured(themePath, resourceNames);
+    }
+
+    static Mono<Unstructured> unzipThemeTo(InputStream inputStream, Path themeWorkDir) {
+        return unzipThemeTo(inputStream, themeWorkDir, false);
+    }
+
+    static Mono<Unstructured> unzipThemeTo(InputStream inputStream, Path themeWorkDir,
+        boolean override) {
+        AtomicReference<Path> tempDir = new AtomicReference<>();
+        return Mono.fromCallable(
+                () -> {
+                    Path tempDirectory = null;
+                    Path themeTargetPath = null;
+                    try (ZipInputStream zipInputStream = new ZipInputStream(inputStream)) {
+                        tempDirectory = createTempDirectory(THEME_TMP_PREFIX);
+                        unzip(zipInputStream, tempDirectory);
+                        return tempDirectory;
+                    } catch (IOException e) {
+                        deleteRecursivelyAndSilently(themeTargetPath);
+                        throw new ThemeInstallationException("Unable to install theme", e);
+                    }
+                })
+            .doOnNext(tempDir::set)
+            .flatMap(ThemeUtils::locateThemeManifest)
+            .map(themeManifestPath -> {
+                var theme = loadThemeManifest(themeManifestPath);
+                var themeName = theme.getMetadata().getName();
+                var themeTargetPath = themeWorkDir.resolve(themeName);
+                try {
+                    if (!override && !FileUtils.isEmpty(themeTargetPath)) {
+                        throw new ThemeInstallationException("Theme already exists.");
+                    }
+                    // install theme to theme work dir
+                    copyRecursively(themeManifestPath.getParent(), themeTargetPath);
+                    return theme;
+                } catch (IOException e) {
+                    deleteRecursivelyAndSilently(themeTargetPath);
+                    throw Exceptions.propagate(e);
+                }
+            })
+            .doFinally(signalType -> deleteRecursivelyAndSilently(tempDir.get()))
+            .subscribeOn(Schedulers.boundedElastic());
+    }
+
+    static Unstructured loadThemeManifest(Path themeManifestPath) {
+        List<Unstructured> unstructureds =
+            new YamlUnstructuredLoader(new FileSystemResource(themeManifestPath))
+                .load();
+        if (CollectionUtils.isEmpty(unstructureds)) {
+            throw new IllegalArgumentException(
+                "The [theme.yaml] does not conform to the theme specification.");
+        }
+        return unstructureds.get(0);
+    }
+
+    @Nullable
+    static Path resolveThemeManifest(Path tempDirectory) {
+        for (String themeManifest : THEME_MANIFESTS) {
+            Path path = tempDirectory.resolve(themeManifest);
+            if (Files.exists(path)) {
+                return path;
+            }
+        }
+        return null;
+    }
+
+    static Mono<Path> locateThemeManifest(Path dir) {
+        return Mono.justOrEmpty(dir)
+            .filter(Files::isDirectory)
+            .publishOn(Schedulers.boundedElastic())
+            .mapNotNull(path -> {
+                var queue = new LinkedList<Path>();
+                queue.add(dir);
+                var manifest = Optional.<Path>empty();
+                while (!queue.isEmpty()) {
+                    var current = queue.pop();
+                    try (Stream<Path> subPaths = Files.list(current)) {
+                        manifest = subPaths.filter(Files::isReadable)
+                            .filter(subPath -> {
+                                if (Files.isDirectory(subPath)) {
+                                    queue.add(subPath);
+                                    return false;
+                                }
+                                return true;
+                            })
+                            .filter(Files::isRegularFile)
+                            .filter(ThemeUtils::isManifest)
+                            .findFirst();
+                    } catch (IOException e) {
+                        throw Exceptions.propagate(e);
+                    }
+                    if (manifest.isPresent()) {
+                        break;
+                    }
+                }
+                return manifest.orElse(null);
+            });
+    }
+
+    static boolean isManifest(Path file) {
+        if (!Files.isRegularFile(file)) {
+            return false;
+        }
+        return Set.of(THEME_MANIFESTS).contains(file.getFileName().toString());
+    }
+
+}

--- a/src/main/java/run/halo/app/infra/utils/FileUtils.java
+++ b/src/main/java/run/halo/app/infra/utils/FileUtils.java
@@ -1,5 +1,7 @@
 package run.halo.app.infra.utils;
 
+import static org.springframework.util.FileSystemUtils.deleteRecursively;
+
 import java.io.Closeable;
 import java.io.IOException;
 import java.nio.file.DirectoryNotEmptyException;
@@ -21,6 +23,9 @@ import run.halo.app.infra.exception.AccessDeniedException;
  */
 @Slf4j
 public abstract class FileUtils {
+
+    private FileUtils() {
+    }
 
     public static void unzip(@NonNull ZipInputStream zis, @NonNull Path targetPath)
         throws IOException {
@@ -171,4 +176,22 @@ public abstract class FileUtils {
         checkDirectoryTraversal(parentPath, Paths.get(pathToCheck));
     }
 
+    /**
+     * Delete folder recursively without exception throwing.
+     *
+     * @param root the root File to delete
+     */
+    public static void deleteRecursivelyAndSilently(Path root) {
+        try {
+            var deleted = deleteRecursively(root);
+            if (log.isDebugEnabled()) {
+                log.debug("Delete {} result: {}", root, deleted);
+            }
+        } catch (IOException e) {
+            // Ignore this error
+            if (log.isTraceEnabled()) {
+                log.trace("Failed to delete {} recursively", root);
+            }
+        }
+    }
 }

--- a/src/test/java/run/halo/app/core/extension/theme/ThemeEndpointTest.java
+++ b/src/test/java/run/halo/app/core/extension/theme/ThemeEndpointTest.java
@@ -2,10 +2,12 @@ package run.halo.app.core.extension.theme;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.springframework.web.reactive.function.BodyInserters.fromMultipartData;
+import static run.halo.app.extension.Unstructured.OBJECT_MAPPER;
 
 import java.io.File;
 import java.io.IOException;
@@ -15,6 +17,7 @@ import java.util.List;
 import org.json.JSONException;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
@@ -76,6 +79,62 @@ class ThemeEndpointTest {
     @AfterEach
     void tearDown() {
         FileSystemUtils.deleteRecursively(tmpHaloWorkDir.toFile());
+    }
+
+    @Nested
+    class UpgradeTest {
+
+        @Test
+        void shouldNotOkIfThemeNotInstalled() {
+            var bodyBuilder = new MultipartBodyBuilder();
+            bodyBuilder.part("file", new FileSystemResource(defaultTheme))
+                .contentType(MediaType.MULTIPART_FORM_DATA);
+
+            when(extensionClient.fetch(Theme.class, "invalid-theme")).thenReturn(Mono.empty());
+
+            webTestClient.post()
+                .uri("/themes/invalid-theme/upgrade")
+                .body(fromMultipartData(bodyBuilder.build()))
+                .exchange()
+                .expectStatus().isBadRequest();
+        }
+
+        @Test
+        void shouldUpgradeSuccessfullyIfThemeInstalled() {
+            var bodyBuilder = new MultipartBodyBuilder();
+            bodyBuilder.part("file", new FileSystemResource(defaultTheme))
+                .contentType(MediaType.MULTIPART_FORM_DATA);
+
+            var oldTheme = mock(Theme.class);
+            when(extensionClient.fetch(Theme.class, "default"))
+                // for old theme check
+                .thenReturn(Mono.just(oldTheme))
+                // for theme deletion
+                .thenReturn(Mono.just(oldTheme))
+                // for theme deleted check
+                .thenReturn(Mono.empty());
+
+            when(extensionClient.delete(oldTheme)).thenReturn(Mono.just(oldTheme));
+
+            var metadata = new Metadata();
+            metadata.setName("default");
+            var newTheme = new Theme();
+            newTheme.setMetadata(metadata);
+
+            when(extensionClient.create(any(Unstructured.class))).thenReturn(
+                Mono.just(OBJECT_MAPPER.convertValue(newTheme, Unstructured.class)));
+
+            webTestClient.post()
+                .uri("/themes/default/upgrade")
+                .body(fromMultipartData(bodyBuilder.build()))
+                .exchange()
+                .expectStatus().isOk();
+
+            verify(extensionClient, times(3)).fetch(Theme.class, "default");
+            verify(extensionClient).delete(oldTheme);
+            verify(extensionClient).create(any(Unstructured.class));
+        }
+
     }
 
     @Test

--- a/src/test/java/run/halo/app/core/extension/theme/ThemeEndpointTest.java
+++ b/src/test/java/run/halo/app/core/extension/theme/ThemeEndpointTest.java
@@ -1,10 +1,11 @@
-package run.halo.app.core.extension.endpoint;
+package run.halo.app.core.extension.theme;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.springframework.web.reactive.function.BodyInserters.fromMultipartData;
 
 import java.io.File;
 import java.io.IOException;
@@ -26,7 +27,6 @@ import org.springframework.http.client.MultipartBodyBuilder;
 import org.springframework.test.web.reactive.server.WebTestClient;
 import org.springframework.util.FileSystemUtils;
 import org.springframework.util.ResourceUtils;
-import org.springframework.web.reactive.function.BodyInserters;
 import reactor.core.publisher.Mono;
 import run.halo.app.core.extension.Setting;
 import run.halo.app.core.extension.Theme;
@@ -87,7 +87,7 @@ class ThemeEndpointTest {
                 return new YamlUnstructuredLoader(new FileSystemResource(defaultThemeManifestPath))
                     .load()
                     .get(0);
-            })).thenReturn(Mono.empty()).thenReturn(Mono.empty());
+            }));
 
         MultipartBodyBuilder multipartBodyBuilder = new MultipartBodyBuilder();
         multipartBodyBuilder.part("file", new FileSystemResource(defaultTheme))
@@ -95,10 +95,9 @@ class ThemeEndpointTest {
 
         webTestClient.post()
             .uri("/themes/install")
-            .body(BodyInserters.fromMultipartData(multipartBodyBuilder.build()))
+            .body(fromMultipartData(multipartBodyBuilder.build()))
             .exchange()
-            .expectStatus()
-            .isOk()
+            .expectStatus().isOk()
             .expectBody(Theme.class)
             .value(theme -> {
                 verify(extensionClient, times(1)).create(any(Unstructured.class));
@@ -110,10 +109,9 @@ class ThemeEndpointTest {
         // Verify the theme is installed.
         webTestClient.post()
             .uri("/themes/install")
-            .body(BodyInserters.fromMultipartData(multipartBodyBuilder.build()))
+            .body(fromMultipartData(multipartBodyBuilder.build()))
             .exchange()
-            .expectStatus()
-            .is5xxServerError();
+            .expectStatus().is5xxServerError();
     }
 
     @Test


### PR DESCRIPTION
#### What type of PR is this?

/kind feature
/area core
/milestone 2.0

#### What this PR does / why we need it:

This PR mainly provides an endpoint to upgrade theme.

Please see the request sample as follows:

```bash
curl -X 'POST' \
  'http://localhost:8090/apis/api.console.halo.run/v1alpha1/themes/theme-default/upgrade' \
  -H 'accept: */*' \
  -H 'Content-Type: multipart/form-data' \
  -F 'file=@theme-default-main.zip;type=application/x-zip-compressed'
```

We also can refer to API documentation:

![image](https://user-images.githubusercontent.com/16865714/196628148-09900fc2-85d9-49e5-9508-6b7f79df0537.png)

#### Which issue(s) this PR fixes:

Fixes https://github.com/halo-dev/halo/issues/2550

#### How to test?

1. Install any theme you want
2. Unzip the theme and change the content of theme installed just now
3. Zip the theme and try to upgrade it by requesting theme upgrade API

#### Does this PR introduce a user-facing change?

```release-note
提供主题更新功能
```
