### PR TITLE
Fix the problem of deleting attachment on USS but failed

### DIFF
--- a/src/main/java/run/halo/app/handler/file/UpOssFileHandler.java
+++ b/src/main/java/run/halo/app/handler/file/UpOssFileHandler.java
@@ -138,7 +138,7 @@ public class UpOssFileHandler implements FileHandler {
 
         try {
             Response result = manager.deleteFile(key, null);
-            if(result.code() != 200) {
+            if (result.code() != 200) {
                 HashMap respondBody = JsonUtils.jsonToObject(result.body().string(), HashMap.class);
                 if (!(result.code() == 404 && respondBody.get("code").equals(40400001))) {
                     log.warn("附件 " + key + " 从又拍云删除失败");

--- a/src/main/java/run/halo/app/handler/file/UpOssFileHandler.java
+++ b/src/main/java/run/halo/app/handler/file/UpOssFileHandler.java
@@ -138,11 +138,12 @@ public class UpOssFileHandler implements FileHandler {
 
         try {
             Response result = manager.deleteFile(key, null);
-            HashMap respondBody = JsonUtils.jsonToObject(result.body().string(), HashMap.class);
-            if (result.code() != 200
-                && !(result.code() == 404 && respondBody.get("code").equals(40400001))) {
-                log.warn("附件 " + key + " 从又拍云删除失败");
-                throw new FileOperationException("附件 " + key + " 从又拍云删除失败");
+            if(result.code() != 200) {
+                HashMap respondBody = JsonUtils.jsonToObject(result.body().string(), HashMap.class);
+                if (!(result.code() == 404 && respondBody.get("code").equals(40400001))) {
+                    log.warn("附件 " + key + " 从又拍云删除失败");
+                    throw new FileOperationException("附件 " + key + " 从又拍云删除失败");
+                }
             }
         } catch (IOException | UpException e) {
             e.printStackTrace();

--- a/src/main/java/run/halo/app/handler/file/UpOssFileHandler.java
+++ b/src/main/java/run/halo/app/handler/file/UpOssFileHandler.java
@@ -139,7 +139,7 @@ public class UpOssFileHandler implements FileHandler {
         try {
             Response result = manager.deleteFile(key, null);
             HashMap respondBody = JsonUtils.jsonToObject(result.body().string(), HashMap.class);
-            if (!result.isSuccessful()
+            if (result.code() != 200
                 && !(result.code() == 404 && respondBody.get("code").equals(40400001))) {
                 log.warn("附件 " + key + " 从又拍云删除失败");
                 throw new FileOperationException("附件 " + key + " 从又拍云删除失败");


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/area core
/milestone 1.6.x

#### What this PR does / why we need it:

修复又拍云附件删除成功，但是管理页面的“internal server error” 报警

#### Which issue(s) this PR fixes:

Fixes https://github.com/halo-dev/halo/issues/2603

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
修复又拍云附件删除成功仍旧提示错误的问题
```
