### PR TITLE
Make field metadata.name of extension required

### DIFF
--- a/src/main/java/run/halo/app/extension/JSONExtensionConverter.java
+++ b/src/main/java/run/halo/app/extension/JSONExtensionConverter.java
@@ -92,7 +92,6 @@ public class JSONExtensionConverter implements ExtensionConverter {
         throws MalformedURLException, ResolutionException {
         var context = new ValidationContext<OAI3>(
             new OAI3Context(new URL("file:/"), scheme.openApiSchema()));
-        context.addValidator("x-validation", ExtraValidationValidator::new);
         context.setFastFail(false);
         return new SchemaValidator(context, null, scheme.openApiSchema());
     }

--- a/src/main/java/run/halo/app/extension/Metadata.java
+++ b/src/main/java/run/halo/app/extension/Metadata.java
@@ -1,8 +1,5 @@
 package run.halo.app.extension;
 
-import io.swagger.v3.oas.annotations.extensions.Extension;
-import io.swagger.v3.oas.annotations.extensions.ExtensionProperty;
-import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.Instant;
 import java.util.Map;
 import java.util.Set;
@@ -16,11 +13,6 @@ import lombok.EqualsAndHashCode;
  */
 @Data
 @EqualsAndHashCode
-@Schema(description = "Metadata information", extensions = {
-    @Extension(name = "x-validation", properties = {
-        @ExtensionProperty(name = "not-blank-at-least-one", value = "name, generateName")
-    })}
-)
 public class Metadata implements MetadataOperator {
 
     /**

--- a/src/main/java/run/halo/app/extension/MetadataOperator.java
+++ b/src/main/java/run/halo/app/extension/MetadataOperator.java
@@ -17,7 +17,7 @@ import java.util.Set;
 @Schema(implementation = Metadata.class)
 public interface MetadataOperator {
 
-    @Schema(name = "name", description = "Metadata name")
+    @Schema(name = "name", description = "Metadata name", required = true)
     @JsonProperty("name")
     String getName();
 

--- a/src/main/java/run/halo/app/infra/utils/YamlUnstructuredLoader.java
+++ b/src/main/java/run/halo/app/infra/utils/YamlUnstructuredLoader.java
@@ -27,7 +27,8 @@ public class YamlUnstructuredLoader extends YamlProcessor {
     private static final DocumentMatcher DEFAULT_UNSTRUCTURED_MATCHER = properties -> {
         if (properties.containsKey("apiVersion")
             && properties.containsKey("kind")
-            && properties.containsKey("metadata.name")) {
+            && (properties.containsKey("metadata.name")
+            || properties.containsKey("metadata.generateName"))) {
             return YamlProcessor.MatchStatus.FOUND;
         }
         return MatchStatus.NOT_FOUND;

--- a/src/test/java/run/halo/app/extension/JsonExtensionConverterTest.java
+++ b/src/test/java/run/halo/app/extension/JsonExtensionConverterTest.java
@@ -2,7 +2,6 @@ package run.halo.app.extension;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -85,8 +84,8 @@ class JsonExtensionConverterTest {
         var error = assertThrows(SchemaViolationException.class, () -> converter.convertTo(fake));
         assertEquals(1, error.getErrors().size());
         var result = error.getErrors().items().get(0);
-        // error.getErrors().items().get(0).message();
-        assertTrue(result.toString().contains("name, generateName"));
+        assertEquals(1026, result.code());
+        assertEquals("Field 'name' is required.", result.message());
     }
 
     FakeExtension createFakeExtension(String name, Long version) {


### PR DESCRIPTION
#### What type of PR is this?

/kind improvement
/area core

#### What this PR does / why we need it:

Remove custom schema validation and make field metadata.name of extension required. So that the API client generated by `openapi-gen` will be more consistent than before.

#### Does this PR introduce a user-facing change?

```release-note
None
```
