### PR TITLE
refactor: plugin reconciler to fix entry path when optimistic lock occurred

### DIFF
--- a/src/main/java/run/halo/app/core/extension/reconciler/PluginReconciler.java
+++ b/src/main/java/run/halo/app/core/extension/reconciler/PluginReconciler.java
@@ -7,7 +7,6 @@ import java.time.Instant;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
@@ -70,10 +69,8 @@ public class PluginReconciler implements Reconciler<Request> {
                 pluginStatus.setReason("PluginNotFound");
                 pluginStatus.setMessage("Plugin " + name + " not found in plugin manager");
             } else {
-                if (!Objects.equals(pluginStatus.getPhase(), pluginWrapper.getPluginState())) {
-                    // Set to the correct state
-                    pluginStatus.setPhase(pluginWrapper.getPluginState());
-                }
+                // Set to the correct state
+                pluginStatus.setPhase(pluginWrapper.getPluginState());
 
                 if (haloPluginManager.getUnresolvedPlugins().contains(pluginWrapper)) {
                     // load and resolve plugin

--- a/src/main/java/run/halo/app/plugin/PluginBeforeStopSyncListener.java
+++ b/src/main/java/run/halo/app/plugin/PluginBeforeStopSyncListener.java
@@ -26,9 +26,11 @@ public class PluginBeforeStopSyncListener {
     @EventListener
     public Mono<Void> onApplicationEvent(@NonNull HaloPluginBeforeStopEvent event) {
         var pluginWrapper = event.getPlugin();
-        var pluginContext = ExtensionContextRegistry.getInstance()
-            .getByPluginId(pluginWrapper.getPluginId());
-
+        ExtensionContextRegistry registry = ExtensionContextRegistry.getInstance();
+        if (!registry.containsContext(pluginWrapper.getPluginId())) {
+            return Mono.empty();
+        }
+        var pluginContext = registry.getByPluginId(pluginWrapper.getPluginId());
         return cleanUpPluginExtensionResources(pluginContext);
     }
 

--- a/src/main/java/run/halo/app/theme/router/PermalinkRefreshHandler.java
+++ b/src/main/java/run/halo/app/theme/router/PermalinkRefreshHandler.java
@@ -59,7 +59,7 @@ public class PermalinkRefreshHandler implements ApplicationListener<PermalinkRul
                 String oldPermalink = post.getStatusOrDefault().getPermalink();
                 String permalink = postPermalinkPolicy.permalink(post);
                 post.getStatusOrDefault().setPermalink(permalink);
-                if (oldPermalink.equals(permalink)) {
+                if (StringUtils.equals(oldPermalink, permalink)) {
                     return;
                 }
                 // update permalink


### PR DESCRIPTION
#### What type of PR is this?
/kind improvement
/area core
/milestone 2.0
#### What this PR does / why we need it:
重构 PluginReconciler，避免因为每一段逻辑的执行时间太长而增加乐观锁错误的发生概率
修复判断逻辑问题导致启动时因为发生乐关锁错误造成没有填充 entry 和 stylesheet 字段的问题
#### Which issue(s) this PR fixes:
Fixes #2616

#### Special notes for your reviewer:
/cc @halo-dev/sig-halo 
#### Does this PR introduce a user-facing change?

```release-note
None
```
