### PR TITLE
refactor: use LinkedHashMultimap to replace MultiValueMap

### DIFF
--- a/src/test/java/run/halo/app/plugin/resources/ReverseProxyRouterFunctionRegistryTest.java
+++ b/src/test/java/run/halo/app/plugin/resources/ReverseProxyRouterFunctionRegistryTest.java
@@ -51,14 +51,7 @@ class ReverseProxyRouterFunctionRegistryTest {
 
     @Test
     void register() {
-        ReverseProxy mock = Mockito.mock(ReverseProxy.class);
-        Metadata metadata = new Metadata();
-        metadata.setName("test-reverse-proxy");
-        when(mock.getMetadata()).thenReturn(metadata);
-        RouterFunction<ServerResponse> routerFunction = request -> Mono.empty();
-
-        when(reverseProxyRouterFunctionFactory.create(any(), any()))
-            .thenReturn(Mono.just(routerFunction));
+        ReverseProxy mock = getMockReverseProxy();
         registry.register("fake-plugin", mock)
             .as(StepVerifier::create)
             .verifyComplete();
@@ -72,6 +65,42 @@ class ReverseProxyRouterFunctionRegistryTest {
 
         assertThat(registry.reverseProxySize("fake-plugin")).isEqualTo(1);
 
-        verify(reverseProxyRouterFunctionFactory, times(1)).create(any(), any());
+        verify(reverseProxyRouterFunctionFactory, times(2)).create(any(), any());
+    }
+
+    @Test
+    void remove() {
+        ReverseProxy mock = getMockReverseProxy();
+        registry.register("fake-plugin", mock)
+            .as(StepVerifier::create)
+            .verifyComplete();
+
+        registry.remove("fake-plugin").block();
+
+        assertThat(registry.reverseProxySize("fake-plugin")).isEqualTo(0);
+    }
+
+    @Test
+    void removeByKeyValue() {
+        ReverseProxy mock = getMockReverseProxy();
+        registry.register("fake-plugin", mock)
+            .as(StepVerifier::create)
+            .verifyComplete();
+
+        registry.remove("fake-plugin", "test-reverse-proxy").block();
+
+        assertThat(registry.reverseProxySize("fake-plugin")).isEqualTo(0);
+    }
+
+    private ReverseProxy getMockReverseProxy() {
+        ReverseProxy mock = Mockito.mock(ReverseProxy.class);
+        Metadata metadata = new Metadata();
+        metadata.setName("test-reverse-proxy");
+        when(mock.getMetadata()).thenReturn(metadata);
+        RouterFunction<ServerResponse> routerFunction = request -> Mono.empty();
+
+        when(reverseProxyRouterFunctionFactory.create(any(), any()))
+            .thenReturn(Mono.just(routerFunction));
+        return mock;
     }
 }


### PR DESCRIPTION
#### What type of PR is this?
/kind improvement
/area core
/milestone 2.0
#### What this PR does / why we need it:
ReverseProxyRouterFunctionRegistry 的注册方法之前使用了一个 LinkedMultiValueMap<String, String>，相当于是一个 Map<String, List<String>>，当插件启动后扫描到 ReverseProxy 资源保存到数据库会触发 ReverseProxyReconciler 调用`ReverseProxyRouterFunctionRegistry#register`，如果此时插件的 PluginApplicationContext 还没有被创建好，register 时会在中途因为获取不到 PluginApplicationContext 而失败然后 requeue，而 LinkedMultiValueMap 此时已经保存了一条记录 requeue后再执行 LinkedMultiValueMap（即`Map<String, List<String>>`） 这个 value 是一个 List 需要更多的判断来防止重复，需要用一个 Map<String, Set<String>>这样的结构来保证 requeue 时 ReverseProxyRouterFunctionRegistry 中集合结构之前的数据一致性这样更方便，所以将从 spring 的 LinkedMultiValueMap 切换到  guava 提供的 LinkedHashMultimap（它的结构是Map<K, Set<V>）

#### Does this PR introduce a user-facing change?

```release-note
None
```
