### PR TITLE
feat: support custom rendering templates configure through themes

### DIFF
--- a/src/main/java/run/halo/app/core/extension/Theme.java
+++ b/src/main/java/run/halo/app/core/extension/Theme.java
@@ -1,6 +1,7 @@
 package run.halo.app.core.extension;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
@@ -10,6 +11,8 @@ import run.halo.app.extension.AbstractExtension;
 import run.halo.app.extension.GVK;
 
 /**
+ * <p>Theme extension.</p>
+ *
  * @author guqing
  * @since 2.0.0
  */
@@ -54,6 +57,9 @@ public class Theme extends AbstractExtension {
 
         private String configMapName;
 
+        @Schema
+        private CustomTemplates customTemplates;
+
         @NonNull
         public String getVersion() {
             if (StringUtils.isBlank(this.version)) {
@@ -85,4 +91,33 @@ public class Theme extends AbstractExtension {
 
         private String website;
     }
+
+    @Data
+    public static class CustomTemplates {
+        private List<TemplateDescriptor> post;
+        private List<TemplateDescriptor> category;
+        private List<TemplateDescriptor> page;
+    }
+
+
+    /**
+     * Type used to describe custom template page.
+     *
+     * @author guqing
+     * @since 2.0.0
+     */
+    @Data
+    public static class TemplateDescriptor {
+
+        @Schema(required = true, minLength = 1)
+        private String name;
+
+        private String description;
+
+        private String screenshot;
+
+        @Schema(required = true, minLength = 1)
+        private String file;
+    }
+
 }

--- a/src/main/java/run/halo/app/theme/router/ViewNameResolver.java
+++ b/src/main/java/run/halo/app/theme/router/ViewNameResolver.java
@@ -1,0 +1,48 @@
+package run.halo.app.theme.router;
+
+import java.util.Locale;
+import lombok.AllArgsConstructor;
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.boot.autoconfigure.thymeleaf.ThymeleafProperties;
+import org.springframework.context.i18n.LocaleContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.server.ServerRequest;
+import reactor.core.publisher.Mono;
+import run.halo.app.theme.HaloViewResolver;
+
+/**
+ * The {@link ViewNameResolver} is used to resolve view name.
+ *
+ * @author guqing
+ * @since 2.0.0
+ */
+@Component
+@AllArgsConstructor
+public class ViewNameResolver {
+    private final HaloViewResolver haloViewResolver;
+    private final ThymeleafProperties thymeleafProperties;
+
+    /**
+     * Resolves view name.
+     * If the {@param #name} cannot be resolved to the view, the {@param #defaultName} is returned.
+     */
+    public Mono<String> resolveViewNameOrDefault(ServerRequest request, String name,
+        String defaultName) {
+        if (StringUtils.isBlank(name)) {
+            return Mono.just(defaultName);
+        }
+        final String nameToUse = processName(name);
+        Locale locale = LocaleContextHolder.getLocale(request.exchange().getLocaleContext());
+        return haloViewResolver.resolveViewName(nameToUse, locale)
+            .map(view -> nameToUse)
+            .switchIfEmpty(Mono.just(defaultName));
+    }
+
+    String processName(String name) {
+        String nameToLookup = name;
+        if (StringUtils.endsWith(name, thymeleafProperties.getSuffix())) {
+            nameToLookup = StringUtils.substringBeforeLast(name, thymeleafProperties.getSuffix());
+        }
+        return nameToLookup;
+    }
+}

--- a/src/test/java/run/halo/app/theme/router/ViewNameResolverTest.java
+++ b/src/test/java/run/halo/app/theme/router/ViewNameResolverTest.java
@@ -1,0 +1,93 @@
+package run.halo.app.theme.router;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.springframework.boot.autoconfigure.thymeleaf.ThymeleafProperties;
+import org.springframework.http.HttpMethod;
+import org.springframework.mock.web.reactive.function.server.MockServerRequest;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.web.reactive.result.view.View;
+import org.springframework.web.server.ServerWebExchange;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+import run.halo.app.theme.HaloViewResolver;
+import run.halo.app.theme.router.strategy.EmptyView;
+
+/**
+ * Tests for {@link ViewNameResolver}.
+ *
+ * @author guqing
+ * @since 2.0.0
+ */
+@ExtendWith(SpringExtension.class)
+class ViewNameResolverTest {
+
+    @Mock
+    private HaloViewResolver haloViewResolver;
+
+    @Mock
+    private ThymeleafProperties thymeleafProperties;
+
+    @InjectMocks
+    private ViewNameResolver viewNameResolver;
+
+    @BeforeEach
+    void setUp() {
+        when(thymeleafProperties.getSuffix()).thenReturn(ThymeleafProperties.DEFAULT_SUFFIX);
+
+        when(haloViewResolver.resolveViewName(eq("post_news"), any()))
+            .thenReturn(Mono.just(Mockito.mock(View.class)));
+        when(haloViewResolver.resolveViewName(eq("post_docs"), any()))
+            .thenReturn(Mono.just(new EmptyView()));
+
+        when(haloViewResolver.resolveViewName(eq("post_nothing"), any()))
+            .thenReturn(Mono.empty());
+    }
+
+    @Test
+    void resolveViewNameOrDefault() throws URISyntaxException {
+        ServerWebExchange exchange = Mockito.mock(ServerWebExchange.class);
+        MockServerRequest request = MockServerRequest.builder()
+            .uri(new URI("/")).method(HttpMethod.GET)
+            .exchange(exchange)
+            .build();
+
+        viewNameResolver.resolveViewNameOrDefault(request, "post_news", "post")
+            .as(StepVerifier::create)
+            .expectNext("post_news")
+            .verifyComplete();
+
+        // post_docs.html
+        String viewName = "post_docs" + thymeleafProperties.getSuffix();
+        viewNameResolver.resolveViewNameOrDefault(request, viewName, "post")
+            .as(StepVerifier::create)
+            .expectNext("post_docs")
+            .verifyComplete();
+
+        viewNameResolver.resolveViewNameOrDefault(request, "post_nothing", "post")
+            .as(StepVerifier::create)
+            .expectNext("post")
+            .verifyComplete();
+    }
+
+    @Test
+    void processName() {
+        assertThat(viewNameResolver.processName("post_news")).isEqualTo("post_news");
+        assertThat(viewNameResolver.processName("post_news" + thymeleafProperties.getSuffix()))
+            .isEqualTo("post_news");
+        assertThat(viewNameResolver.processName("post_news.test"))
+            .isEqualTo("post_news.test");
+        assertThat(viewNameResolver.processName(null)).isNull();
+    }
+}

--- a/src/test/java/run/halo/app/theme/router/strategy/CategoryRouteStrategyTest.java
+++ b/src/test/java/run/halo/app/theme/router/strategy/CategoryRouteStrategyTest.java
@@ -15,6 +15,7 @@ import org.springframework.test.web.reactive.server.WebTestClient;
 import org.springframework.web.reactive.function.server.RouterFunction;
 import org.springframework.web.reactive.function.server.ServerResponse;
 import run.halo.app.extension.ListResult;
+import run.halo.app.theme.finders.CategoryFinder;
 import run.halo.app.theme.finders.PostFinder;
 
 /**
@@ -28,6 +29,9 @@ class CategoryRouteStrategyTest extends RouterStrategyTestSuite {
 
     @Mock
     private PostFinder postFinder;
+
+    @Mock
+    private CategoryFinder categoryFinder;
 
     @InjectMocks
     private CategoryRouteStrategy categoryRouteStrategy;

--- a/src/test/java/run/halo/app/theme/router/strategy/PostRouteStrategyTest.java
+++ b/src/test/java/run/halo/app/theme/router/strategy/PostRouteStrategyTest.java
@@ -12,10 +12,13 @@ import org.springframework.http.HttpStatus;
 import org.springframework.test.web.reactive.server.WebTestClient;
 import org.springframework.web.reactive.function.server.RouterFunction;
 import org.springframework.web.reactive.function.server.ServerResponse;
+import reactor.core.publisher.Mono;
 import run.halo.app.content.TestPost;
 import run.halo.app.infra.SystemSetting;
+import run.halo.app.theme.DefaultTemplateEnum;
 import run.halo.app.theme.finders.PostFinder;
 import run.halo.app.theme.finders.vo.PostVo;
+import run.halo.app.theme.router.ViewNameResolver;
 
 /**
  * Tests for {@link PostRouteStrategy}.
@@ -29,11 +32,16 @@ class PostRouteStrategyTest extends RouterStrategyTestSuite {
     @Mock
     private PostFinder postFinder;
 
+    @Mock
+    private ViewNameResolver viewNameResolver;
+
     @InjectMocks
     private PostRouteStrategy postRouteStrategy;
 
     @Override
     public void setUp() {
+        lenient().when(viewNameResolver.resolveViewNameOrDefault(any(), any(), any()))
+            .thenReturn(Mono.just(DefaultTemplateEnum.POST.getValue()));
         lenient().when(postFinder.getByName(any())).thenReturn(PostVo.from(TestPost.postV1()));
     }
 

--- a/src/test/java/run/halo/app/theme/router/strategy/RouterStrategyTestSuite.java
+++ b/src/test/java/run/halo/app/theme/router/strategy/RouterStrategyTestSuite.java
@@ -3,7 +3,6 @@ package run.halo.app.theme.router.strategy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.lenient;
-import static org.mockito.Mockito.when;
 
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -51,7 +50,7 @@ abstract class RouterStrategyTestSuite {
         lenient().when(environmentFetcher.fetch(eq(SystemSetting.ThemeRouteRules.GROUP),
             eq(SystemSetting.ThemeRouteRules.class))).thenReturn(Mono.just(getThemeRouteRules()));
         lenient().when(haloProperties.getExternalUrl()).thenReturn(new URI("http://example.com"));
-        when(viewResolver.resolveViewName(any(), any()))
+        lenient().when(viewResolver.resolveViewName(any(), any()))
             .thenReturn(Mono.just(new EmptyView()));
         setUp();
     }


### PR DESCRIPTION
#### What type of PR is this?
/kind feature
/milestone 2.0
/area core
#### What this PR does / why we need it:
文章/自定义页面/分类支持通过主题配置多套渲染模板
首先需要在 theme.yaml 中声明模板，以文章为例：
```yaml
apiVersion: theme.halo.run/v1alpha1
kind: Theme
metadata:
  name: fake-theme-name
spec:
  # ...
  customTemplates:
    # 支持通过以下形式配置 post, category, page 
    post:
      - name: 新闻
        description: 新闻类型的文章模板
        screenshot: foo.png
        # file 路径相对于主题目录的 templates 目录，.html 后缀可以带也可以省略
        # 默认 thymeleaf 查找 html 文件，除非修改了 thymeleaf suffix 配置
        file: post_news.html
```
当文章页选择模板时便可得到下拉列表以配置使用哪个模板 see https://github.com/halo-dev/halo/issues/2322#issuecomment-1215135195
选择了模板之后将模板名存储到 post 的 spec.template 中，渲染时便会首先使用 spec.template，如果该模板不存在则渲染默认模板
#### Which issue(s) this PR fixes:

Fixes #2569

#### Special notes for your reviewer:
how to test it?
1. 创建一篇文章并发布
2. 安装一个主题并查看文章详情，默认渲染主题提供的 post.html 页面
3. 修改此文章的 spec.template 字段为一个新的 html 例如 spec.template=post_docs
4. 查看该文章的详情页会渲染为 post_docs.html
5. 分类、自定义页面亦如是

/cc @halo-dev/sig-halo 
#### Does this PR introduce a user-facing change?

```release-note
文章/自定义页面/分类支持通过主题配置多套渲染模板
```
