### PR TITLE
refactor: permalink automatically appends external url if it is configured

### DIFF
--- a/src/main/java/run/halo/app/config/ExtensionConfiguration.java
+++ b/src/main/java/run/halo/app/config/ExtensionConfiguration.java
@@ -197,10 +197,11 @@ public class ExtensionConfiguration {
 
         @Bean
         Controller singlePageController(ExtensionClient client, ContentService contentService,
-            ApplicationContext applicationContext, CounterService counterService) {
+            ApplicationContext applicationContext, CounterService counterService,
+            ExternalUrlSupplier externalUrlSupplier) {
             return new ControllerBuilder("single-page-controller", client)
                 .reconciler(new SinglePageReconciler(client, contentService,
-                    applicationContext, counterService)
+                    applicationContext, counterService, externalUrlSupplier)
                 )
                 .extension(new SinglePage())
                 .build();

--- a/src/main/java/run/halo/app/content/permalinks/CategoryPermalinkPolicy.java
+++ b/src/main/java/run/halo/app/content/permalinks/CategoryPermalinkPolicy.java
@@ -1,9 +1,13 @@
 package run.halo.app.content.permalinks;
 
+import static org.springframework.web.util.UriUtils.encode;
+
+import java.nio.charset.StandardCharsets;
 import org.springframework.context.ApplicationContext;
 import org.springframework.stereotype.Component;
 import run.halo.app.core.extension.Category;
 import run.halo.app.extension.GroupVersionKind;
+import run.halo.app.infra.ExternalUrlSupplier;
 import run.halo.app.infra.utils.PathUtils;
 import run.halo.app.theme.DefaultTemplateEnum;
 import run.halo.app.theme.router.PermalinkIndexAddCommand;
@@ -23,15 +27,23 @@ public class CategoryPermalinkPolicy
     private final ApplicationContext applicationContext;
     private final PermalinkPatternProvider permalinkPatternProvider;
 
+    private final ExternalUrlSupplier externalUrlSupplier;
+
     public CategoryPermalinkPolicy(ApplicationContext applicationContext,
-        PermalinkPatternProvider permalinkPatternProvider) {
+        PermalinkPatternProvider permalinkPatternProvider,
+        ExternalUrlSupplier externalUrlSupplier) {
         this.applicationContext = applicationContext;
         this.permalinkPatternProvider = permalinkPatternProvider;
+        this.externalUrlSupplier = externalUrlSupplier;
     }
 
     @Override
     public String permalink(Category category) {
-        return PathUtils.combinePath(pattern(), category.getSpec().getSlug());
+        String slug = encode(category.getSpec().getSlug(), StandardCharsets.UTF_8);
+        String path = PathUtils.combinePath(pattern(), slug);
+        return externalUrlSupplier.get()
+            .resolve(path)
+            .normalize().toString();
     }
 
     @Override

--- a/src/main/java/run/halo/app/content/permalinks/PostPermalinkPolicy.java
+++ b/src/main/java/run/halo/app/content/permalinks/PostPermalinkPolicy.java
@@ -1,5 +1,8 @@
 package run.halo.app.content.permalinks;
 
+import static org.springframework.web.util.UriUtils.encode;
+
+import java.nio.charset.StandardCharsets;
 import java.text.DecimalFormat;
 import java.text.NumberFormat;
 import java.time.Instant;
@@ -10,6 +13,7 @@ import org.springframework.context.ApplicationContext;
 import org.springframework.stereotype.Component;
 import run.halo.app.core.extension.Post;
 import run.halo.app.extension.GroupVersionKind;
+import run.halo.app.infra.ExternalUrlSupplier;
 import run.halo.app.infra.utils.PathUtils;
 import run.halo.app.theme.DefaultTemplateEnum;
 import run.halo.app.theme.router.PermalinkIndexAddCommand;
@@ -29,11 +33,13 @@ public class PostPermalinkPolicy implements PermalinkPolicy<Post>, PermalinkWatc
 
     private final PermalinkPatternProvider permalinkPatternProvider;
     private final ApplicationContext applicationContext;
+    private final ExternalUrlSupplier externalUrlSupplier;
 
     public PostPermalinkPolicy(PermalinkPatternProvider permalinkPatternProvider,
-        ApplicationContext applicationContext) {
+        ApplicationContext applicationContext, ExternalUrlSupplier externalUrlSupplier) {
         this.permalinkPatternProvider = permalinkPatternProvider;
         this.applicationContext = applicationContext;
+        this.externalUrlSupplier = externalUrlSupplier;
     }
 
     @Override
@@ -80,12 +86,17 @@ public class PostPermalinkPolicy implements PermalinkPolicy<Post>, PermalinkWatc
         ZonedDateTime zonedDateTime = archiveTime.atZone(ZoneId.systemDefault());
         Properties properties = new Properties();
         properties.put("name", post.getMetadata().getName());
-        properties.put("slug", post.getSpec().getSlug());
+        properties.put("slug", encode(post.getSpec().getSlug(), StandardCharsets.UTF_8));
         properties.put("year", String.valueOf(zonedDateTime.getYear()));
         properties.put("month", NUMBER_FORMAT.format(zonedDateTime.getMonthValue()));
         properties.put("day", NUMBER_FORMAT.format(zonedDateTime.getDayOfMonth()));
 
         String simplifiedPattern = PathUtils.simplifyPathPattern(pattern);
-        return PROPERTY_PLACEHOLDER_HELPER.replacePlaceholders(simplifiedPattern, properties);
+        String permalink =
+            PROPERTY_PLACEHOLDER_HELPER.replacePlaceholders(simplifiedPattern, properties);
+        return externalUrlSupplier.get()
+            .resolve(permalink)
+            .normalize()
+            .toString();
     }
 }

--- a/src/main/java/run/halo/app/content/permalinks/TagPermalinkPolicy.java
+++ b/src/main/java/run/halo/app/content/permalinks/TagPermalinkPolicy.java
@@ -1,9 +1,12 @@
 package run.halo.app.content.permalinks;
 
+import java.nio.charset.StandardCharsets;
 import org.springframework.context.ApplicationContext;
 import org.springframework.stereotype.Component;
+import org.springframework.web.util.UriUtils;
 import run.halo.app.core.extension.Tag;
 import run.halo.app.extension.GroupVersionKind;
+import run.halo.app.infra.ExternalUrlSupplier;
 import run.halo.app.infra.utils.PathUtils;
 import run.halo.app.theme.DefaultTemplateEnum;
 import run.halo.app.theme.router.PermalinkIndexAddCommand;
@@ -22,15 +25,22 @@ public class TagPermalinkPolicy implements PermalinkPolicy<Tag>, PermalinkWatch<
     private final PermalinkPatternProvider permalinkPatternProvider;
     private final ApplicationContext applicationContext;
 
+    private final ExternalUrlSupplier externalUrlSupplier;
+
     public TagPermalinkPolicy(PermalinkPatternProvider permalinkPatternProvider,
-        ApplicationContext applicationContext) {
+        ApplicationContext applicationContext, ExternalUrlSupplier externalUrlSupplier) {
         this.permalinkPatternProvider = permalinkPatternProvider;
         this.applicationContext = applicationContext;
+        this.externalUrlSupplier = externalUrlSupplier;
     }
 
     @Override
     public String permalink(Tag tag) {
-        return PathUtils.combinePath(pattern(), tag.getSpec().getSlug());
+        String slug = UriUtils.encode(tag.getSpec().getSlug(), StandardCharsets.UTF_8);
+        String path = PathUtils.combinePath(pattern(), slug);
+        return externalUrlSupplier.get()
+            .resolve(path)
+            .normalize().toString();
     }
 
     @Override

--- a/src/main/java/run/halo/app/core/extension/reconciler/SinglePageReconciler.java
+++ b/src/main/java/run/halo/app/core/extension/reconciler/SinglePageReconciler.java
@@ -27,8 +27,8 @@ import run.halo.app.extension.Ref;
 import run.halo.app.extension.controller.Reconciler;
 import run.halo.app.infra.Condition;
 import run.halo.app.infra.ConditionStatus;
+import run.halo.app.infra.ExternalUrlSupplier;
 import run.halo.app.infra.utils.JsonUtils;
-import run.halo.app.infra.utils.PathUtils;
 import run.halo.app.metrics.CounterService;
 import run.halo.app.metrics.MeterUtils;
 import run.halo.app.theme.router.PermalinkIndexAddCommand;
@@ -54,12 +54,16 @@ public class SinglePageReconciler implements Reconciler<Reconciler.Request> {
     private final ApplicationContext applicationContext;
     private final CounterService counterService;
 
+    private final ExternalUrlSupplier externalUrlSupplier;
+
     public SinglePageReconciler(ExtensionClient client, ContentService contentService,
-        ApplicationContext applicationContext, CounterService counterService) {
+        ApplicationContext applicationContext, CounterService counterService,
+        ExternalUrlSupplier externalUrlSupplier) {
         this.client = client;
         this.contentService = contentService;
         this.applicationContext = applicationContext;
         this.counterService = counterService;
+        this.externalUrlSupplier = externalUrlSupplier;
     }
 
     @Override
@@ -160,10 +164,16 @@ public class SinglePageReconciler implements Reconciler<Reconciler.Request> {
 
     private void permalinkOnDelete(SinglePage singlePage) {
         singlePage.getStatusOrDefault()
-            .setPermalink(PathUtils.combinePath(singlePage.getSpec().getSlug()));
+            .setPermalink(createPermalink(singlePage));
         ExtensionLocator locator = new ExtensionLocator(GVK, singlePage.getMetadata().getName(),
             singlePage.getSpec().getSlug());
         applicationContext.publishEvent(new PermalinkIndexDeleteCommand(this, locator));
+    }
+
+    String createPermalink(SinglePage page) {
+        var permalink = encodePath(page.getSpec().getSlug(), UTF_8);
+        permalink = StringUtils.prependIfMissing(permalink, "/");
+        return externalUrlSupplier.get().resolve(permalink).normalize().toString();
     }
 
     private void permalinkOnAdd(SinglePage singlePage) {
@@ -178,10 +188,8 @@ public class SinglePageReconciler implements Reconciler<Reconciler.Request> {
             final SinglePage oldPage = JsonUtils.deepCopy(singlePage);
             permalinkOnDelete(oldPage);
 
-            var permalink = encodePath(singlePage.getSpec().getSlug(), UTF_8);
-            permalink = StringUtils.prependIfMissing(permalink, "/");
             singlePage.getStatusOrDefault()
-                .setPermalink(permalink);
+                .setPermalink(createPermalink(singlePage));
             if (isPublished(singlePage)) {
                 permalinkOnAdd(singlePage);
             }

--- a/src/main/java/run/halo/app/core/extension/reconciler/SinglePageReconciler.java
+++ b/src/main/java/run/halo/app/core/extension/reconciler/SinglePageReconciler.java
@@ -163,8 +163,6 @@ public class SinglePageReconciler implements Reconciler<Reconciler.Request> {
     }
 
     private void permalinkOnDelete(SinglePage singlePage) {
-        singlePage.getStatusOrDefault()
-            .setPermalink(createPermalink(singlePage));
         ExtensionLocator locator = new ExtensionLocator(GVK, singlePage.getMetadata().getName(),
             singlePage.getSpec().getSlug());
         applicationContext.publishEvent(new PermalinkIndexDeleteCommand(this, locator));

--- a/src/test/java/run/halo/app/content/permalinks/PostPermalinkPolicyTest.java
+++ b/src/test/java/run/halo/app/content/permalinks/PostPermalinkPolicyTest.java
@@ -102,7 +102,7 @@ class PostPermalinkPolicyTest {
         Post post = TestPost.postV1();
         post.getMetadata().setName("test-post");
         post.getSpec().setSlug("test-post-slug");
-        Instant now = Instant.now();
+        Instant now = Instant.parse("2022-11-01T02:40:06.806310Z");
         post.getSpec().setPublishTime(now);
 
         when(externalUrlSupplier.get()).thenReturn(URI.create("http://example.com"));
@@ -110,11 +110,11 @@ class PostPermalinkPolicyTest {
         when(permalinkPatternProvider.getPattern(DefaultTemplateEnum.POST))
             .thenReturn("/{year}/{month}/{day}/{slug}");
         String permalink = postPermalinkPolicy.permalink(post);
-        assertThat(permalink).isEqualTo("http://example.com/2022/10/31/test-post-slug");
+        assertThat(permalink).isEqualTo("http://example.com/2022/11/01/test-post-slug");
 
         post.getSpec().setSlug("中文 slug");
         permalink = postPermalinkPolicy.permalink(post);
-        assertThat(permalink).isEqualTo("http://example.com/2022/10/31/%E4%B8%AD%E6%96%87%20slug");
+        assertThat(permalink).isEqualTo("http://example.com/2022/11/01/%E4%B8%AD%E6%96%87%20slug");
     }
 
     @Test

--- a/src/test/java/run/halo/app/content/permalinks/PostPermalinkPolicyTest.java
+++ b/src/test/java/run/halo/app/content/permalinks/PostPermalinkPolicyTest.java
@@ -1,8 +1,10 @@
 package run.halo.app.content.permalinks;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.when;
 
+import java.net.URI;
 import java.text.DecimalFormat;
 import java.text.NumberFormat;
 import java.time.Instant;
@@ -16,6 +18,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.context.ApplicationContext;
 import run.halo.app.content.TestPost;
 import run.halo.app.core.extension.Post;
+import run.halo.app.infra.ExternalUrlSupplier;
 import run.halo.app.infra.utils.PathUtils;
 import run.halo.app.theme.DefaultTemplateEnum;
 import run.halo.app.theme.router.PermalinkPatternProvider;
@@ -36,11 +39,16 @@ class PostPermalinkPolicyTest {
     @Mock
     private ApplicationContext applicationContext;
 
+    @Mock
+    private ExternalUrlSupplier externalUrlSupplier;
+
     private PostPermalinkPolicy postPermalinkPolicy;
 
     @BeforeEach
     void setUp() {
-        postPermalinkPolicy = new PostPermalinkPolicy(permalinkPatternProvider, applicationContext);
+        lenient().when(externalUrlSupplier.get()).thenReturn(URI.create(""));
+        postPermalinkPolicy = new PostPermalinkPolicy(permalinkPatternProvider, applicationContext,
+            externalUrlSupplier);
     }
 
     @Test
@@ -87,6 +95,26 @@ class PostPermalinkPolicyTest {
             .thenReturn("/posts/{name}");
         permalink = postPermalinkPolicy.permalink(post);
         assertThat(permalink).isEqualTo("/posts/test-post");
+    }
+
+    @Test
+    void permalinkWithExternalUrl() {
+        Post post = TestPost.postV1();
+        post.getMetadata().setName("test-post");
+        post.getSpec().setSlug("test-post-slug");
+        Instant now = Instant.now();
+        post.getSpec().setPublishTime(now);
+
+        when(externalUrlSupplier.get()).thenReturn(URI.create("http://example.com"));
+
+        when(permalinkPatternProvider.getPattern(DefaultTemplateEnum.POST))
+            .thenReturn("/{year}/{month}/{day}/{slug}");
+        String permalink = postPermalinkPolicy.permalink(post);
+        assertThat(permalink).isEqualTo("http://example.com/2022/10/31/test-post-slug");
+
+        post.getSpec().setSlug("中文 slug");
+        permalink = postPermalinkPolicy.permalink(post);
+        assertThat(permalink).isEqualTo("http://example.com/2022/10/31/%E4%B8%AD%E6%96%87%20slug");
     }
 
     @Test

--- a/src/test/java/run/halo/app/content/permalinks/TagPermalinkPolicyTest.java
+++ b/src/test/java/run/halo/app/content/permalinks/TagPermalinkPolicyTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
 
+import java.net.URI;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -12,6 +13,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.context.ApplicationContext;
 import run.halo.app.core.extension.Tag;
 import run.halo.app.extension.Metadata;
+import run.halo.app.infra.ExternalUrlSupplier;
 import run.halo.app.theme.DefaultTemplateEnum;
 import run.halo.app.theme.router.PermalinkPatternProvider;
 
@@ -30,11 +32,15 @@ class TagPermalinkPolicyTest {
     @Mock
     private ApplicationContext applicationContext;
 
+    @Mock
+    private ExternalUrlSupplier externalUrlSupplier;
+
     private TagPermalinkPolicy tagPermalinkPolicy;
 
     @BeforeEach
     void setUp() {
-        tagPermalinkPolicy = new TagPermalinkPolicy(permalinkPatternProvider, applicationContext);
+        tagPermalinkPolicy = new TagPermalinkPolicy(permalinkPatternProvider, applicationContext,
+            externalUrlSupplier);
     }
 
     @Test
@@ -50,8 +56,19 @@ class TagPermalinkPolicyTest {
         tagSpec.setSlug("test-slug");
         tag.setSpec(tagSpec);
 
+        when(externalUrlSupplier.get()).thenReturn(URI.create(""));
+
         String permalink = tagPermalinkPolicy.permalink(tag);
         assertThat(permalink).isEqualTo("/tags/test-slug");
+
+        when(externalUrlSupplier.get()).thenReturn(URI.create("http://example.com"));
+
+        permalink = tagPermalinkPolicy.permalink(tag);
+        assertThat(permalink).isEqualTo("http://example.com/tags/test-slug");
+
+        tag.getSpec().setSlug("中文slug");
+        permalink = tagPermalinkPolicy.permalink(tag);
+        assertThat(permalink).isEqualTo("http://example.com/tags/%E4%B8%AD%E6%96%87slug");
     }
 
     @Test

--- a/src/test/java/run/halo/app/theme/finders/impl/PostFinderImplTest.java
+++ b/src/test/java/run/halo/app/theme/finders/impl/PostFinderImplTest.java
@@ -28,6 +28,7 @@ import run.halo.app.theme.finders.ContributorFinder;
 import run.halo.app.theme.finders.TagFinder;
 import run.halo.app.theme.finders.vo.ContentVo;
 import run.halo.app.theme.finders.vo.PostArchiveVo;
+import run.halo.app.theme.finders.vo.PostArchiveYearMonthVo;
 
 /**
  * Tests for {@link PostFinderImpl}.
@@ -100,14 +101,12 @@ class PostFinderImplTest {
             .thenReturn(Mono.just(listResult));
         ListResult<PostArchiveVo> archives = postFinder.archives(1, 10);
         List<PostArchiveVo> items = archives.getItems();
-
         assertThat(items.size()).isEqualTo(2);
         assertThat(items.get(0).getYear()).isEqualTo("2022");
-        assertThat(items.get(0).getMonths().size()).isEqualTo(2);
-        assertThat(items.get(0).getMonths().get(0).getMonth()).isEqualTo("10");
-        assertThat(items.get(0).getMonths().get(1).getMonth()).isEqualTo("12");
-        assertThat(items.get(0).getMonths().get(1).getPosts().size()).isEqualTo(1);
-        assertThat(items.get(0).getMonths().get(1).getPosts().size()).isEqualTo(1);
+        assertThat(items.get(0).getMonths().size()).isEqualTo(1);
+        List<PostArchiveYearMonthVo> months = items.get(0).getMonths();
+        assertThat(months.get(0).getMonth()).isEqualTo("12");
+        assertThat(months.get(0).getPosts()).hasSize(2);
 
         assertThat(items.get(1).getYear()).isEqualTo("2021");
         assertThat(items.get(1).getMonths()).hasSize(1);
@@ -126,8 +125,8 @@ class PostFinderImplTest {
         post2.getMetadata().setCreationTimestamp(Instant.now());
 
         Post post3 = post(3);
-        post2.getSpec().setPublished(true);
-        post2.getSpec().setPublishTime(Instant.parse("2022-12-03T00:00:00Z"));
+        post3.getSpec().setPublished(true);
+        post3.getSpec().setPublishTime(Instant.parse("2022-12-03T00:00:00Z"));
         post3.getMetadata().setCreationTimestamp(Instant.now());
         return List.of(post1, post2, post3);
     }


### PR DESCRIPTION
#### What type of PR is this?
/kind improvement
/area core
/milestone 2.0
#### What this PR does / why we need it:
如果配置了 halo.externalUrl 则 permalink 生成时会自动加上 external url

#### Which issue(s) this PR fixes:

Fixes #

#### Special notes for your reviewer:
how to test it?
1. 配置 `halo.externalUrl` 并启动
2. 创建几篇文章、标签、分类、自定义页面
3. console 端能看到访问路径自动带上了 external url 并且通过访问路径能正确访问到相应资源

/cc @halo-dev/sig-halo 
#### Does this PR introduce a user-facing change?

```release-note
文章/分类/标签的访问路径自动追加外部访问地址
```
