### PR TITLE
fix: labels update for post and singlepage

### DIFF
--- a/src/main/java/run/halo/app/content/permalinks/PostPermalinkPolicy.java
+++ b/src/main/java/run/halo/app/content/permalinks/PostPermalinkPolicy.java
@@ -5,6 +5,7 @@ import java.text.NumberFormat;
 import java.time.Instant;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
+import java.util.Objects;
 import java.util.Properties;
 import org.springframework.context.ApplicationContext;
 import org.springframework.stereotype.Component;
@@ -53,6 +54,10 @@ public class PostPermalinkPolicy implements PermalinkPolicy<Post>, PermalinkWatc
 
     @Override
     public void onPermalinkAdd(Post post) {
+        if (!post.isPublished() || Objects.equals(true, post.getSpec().getDeleted())) {
+            return;
+        }
+        // publish when post is published and not deleted
         applicationContext.publishEvent(new PermalinkIndexAddCommand(this, getLocator(post),
             post.getStatusOrDefault().getPermalink()));
     }

--- a/src/main/java/run/halo/app/core/extension/reconciler/PostReconciler.java
+++ b/src/main/java/run/halo/app/core/extension/reconciler/PostReconciler.java
@@ -61,11 +61,6 @@ public class PostReconciler implements Reconciler<Reconciler.Request> {
                     cleanUpResourcesAndRemoveFinalizer(request.name());
                     return;
                 }
-                if (Objects.equals(true, post.getSpec().getDeleted())) {
-                    // remove permalink from permalink indexer
-                    postPermalinkPolicy.onPermalinkDelete(post);
-                    return;
-                }
                 addFinalizerIfNecessary(post);
 
                 reconcileMetadata(request.name());
@@ -110,9 +105,7 @@ public class PostReconciler implements Reconciler<Reconciler.Request> {
 
             post.getStatusOrDefault()
                 .setPermalink(postPermalinkPolicy.permalink(post));
-            if (isPublished(post)) {
-                postPermalinkPolicy.onPermalinkAdd(post);
-            }
+            postPermalinkPolicy.onPermalinkAdd(post);
 
             Post.PostStatus status = post.getStatusOrDefault();
             if (status.getPhase() == null) {

--- a/src/test/java/run/halo/app/core/extension/reconciler/PostReconcilerTest.java
+++ b/src/test/java/run/halo/app/core/extension/reconciler/PostReconcilerTest.java
@@ -71,7 +71,7 @@ class PostReconcilerTest {
         verify(client, times(3)).update(captor.capture());
 
         verify(postPermalinkPolicy, times(1)).permalink(any());
-        verify(postPermalinkPolicy, times(0)).onPermalinkAdd(any());
+        verify(postPermalinkPolicy, times(1)).onPermalinkAdd(any());
         verify(postPermalinkPolicy, times(1)).onPermalinkDelete(any());
         verify(postPermalinkPolicy, times(0)).onPermalinkUpdate(any());
 

--- a/src/test/java/run/halo/app/theme/finders/impl/PostFinderImplTest.java
+++ b/src/test/java/run/halo/app/theme/finders/impl/PostFinderImplTest.java
@@ -31,6 +31,7 @@ import run.halo.app.theme.finders.ContributorFinder;
 import run.halo.app.theme.finders.TagFinder;
 import run.halo.app.theme.finders.vo.ContentVo;
 import run.halo.app.theme.finders.vo.PostArchiveVo;
+import run.halo.app.theme.finders.vo.PostArchiveYearMonthVo;
 
 /**
  * Tests for {@link PostFinderImpl}.
@@ -106,11 +107,10 @@ class PostFinderImplTest {
 
         assertThat(items.size()).isEqualTo(2);
         assertThat(items.get(0).getYear()).isEqualTo("2022");
-        assertThat(items.get(0).getMonths().size()).isEqualTo(2);
-        assertThat(items.get(0).getMonths().get(0).getMonth()).isEqualTo("10");
-        assertThat(items.get(0).getMonths().get(1).getMonth()).isEqualTo("12");
-        assertThat(items.get(0).getMonths().get(1).getPosts().size()).isEqualTo(1);
-        assertThat(items.get(0).getMonths().get(1).getPosts().size()).isEqualTo(1);
+        assertThat(items.get(0).getMonths().size()).isEqualTo(1);
+        List<PostArchiveYearMonthVo> months = items.get(0).getMonths();
+        assertThat(months.get(0).getMonth()).isEqualTo("12");
+        assertThat(months.get(0).getPosts()).hasSize(2);
 
         assertThat(items.get(1).getYear()).isEqualTo("2021");
         assertThat(items.get(1).getMonths()).hasSize(1);
@@ -177,8 +177,8 @@ class PostFinderImplTest {
         post2.getMetadata().setCreationTimestamp(Instant.now());
 
         Post post3 = post(3);
-        post2.getSpec().setPublished(true);
-        post2.getSpec().setPublishTime(Instant.parse("2022-12-03T00:00:00Z"));
+        post3.getSpec().setPublished(true);
+        post3.getSpec().setPublishTime(Instant.parse("2022-12-03T00:00:00Z"));
         post3.getMetadata().setCreationTimestamp(Instant.now());
         return List.of(post1, post2, post3);
     }


### PR DESCRIPTION
#### What type of PR is this?
/kind bug
/area core
/milestone 2.0
#### What this PR does / why we need it:
修复文章和自定义页面的 labels 在文章标记为删除状态时没有更新的问题
#### Which issue(s) this PR fixes:
A part of  #2647

#### Special notes for your reviewer:
how to test it?
1. 创建文章
2. 由于没有发布，此时访问文章的 permalink 访问不到
3. 发布文章，可以正常访问
4. 更新文章的 `spec.deleted=true`,在访问文章期望404，并且 `metadata.labels` 中的数据正确
5. 自定义页面亦如是

/cc @halo-dev/sig-halo 
#### Does this PR introduce a user-facing change?

```release-note
None
```
