### PR TITLE
feat: create reverse proxy for logo when plugin created

### DIFF
--- a/src/main/java/run/halo/app/core/extension/Plugin.java
+++ b/src/main/java/run/halo/app/core/extension/Plugin.java
@@ -112,6 +112,8 @@ public class Plugin extends AbstractExtension {
         private String entry;
 
         private String stylesheet;
+
+        private String logo;
     }
 
     @JsonIgnore

--- a/src/main/java/run/halo/app/infra/utils/PathUtils.java
+++ b/src/main/java/run/halo/app/infra/utils/PathUtils.java
@@ -1,5 +1,7 @@
 package run.halo.app.infra.utils;
 
+import java.net.URI;
+import java.net.URISyntaxException;
 import lombok.experimental.UtilityClass;
 import org.apache.commons.lang3.StringUtils;
 
@@ -11,6 +13,38 @@ import org.apache.commons.lang3.StringUtils;
  */
 @UtilityClass
 public class PathUtils {
+
+    /**
+     * Every HTTP URL conforms to the syntax of a generic URI. The URI generic syntax consists of
+     * components organized hierarchically in order of decreasing significance from left to
+     * right:
+     * <pre>
+     * URI = scheme ":" ["//" authority] path ["?" query] ["#" fragment]
+     * </pre>
+     * The authority component consists of subcomponents:
+     * <pre>
+     * authority = [userinfo "@"] host [":" port]
+     * </pre>
+     * Examples of popular schemes include http, https, ftp, mailto, file, data and irc. URI
+     * schemes should be registered with the
+     * <a href="https://en.wikipedia.org/wiki/Internet_Assigned_Numbers_Authority">Internet Assigned Numbers Authority (IANA)</a>, although
+     * non-registered schemes are used in practice.
+     *
+     * @param uriString url or path
+     * @return true if the linkBase is absolute, otherwise false
+     * @see <a href="https://en.wikipedia.org/wiki/URL">URL</a>
+     */
+    public static boolean isAbsoluteUri(final String uriString) {
+        if (StringUtils.isBlank(uriString)) {
+            return false;
+        }
+        try {
+            URI uri = new URI(uriString);
+            return uri.isAbsolute();
+        } catch (URISyntaxException e) {
+            throw new RuntimeException(e);
+        }
+    }
 
     /**
      * Combine paths based on the passed in path segments parameters.

--- a/src/main/java/run/halo/app/plugin/resources/BundleResourceUtils.java
+++ b/src/main/java/run/halo/app/plugin/resources/BundleResourceUtils.java
@@ -76,7 +76,7 @@ public abstract class BundleResourceUtils {
     }
 
     @Nullable
-    private static DefaultResourceLoader getResourceLoader(HaloPluginManager pluginManager,
+    public static DefaultResourceLoader getResourceLoader(HaloPluginManager pluginManager,
         String pluginName) {
         Assert.notNull(pluginManager, "Plugin manager must not be null");
         PluginWrapper plugin = pluginManager.getPlugin(pluginName);

--- a/src/main/java/run/halo/app/plugin/resources/ReverseProxyRouterFunctionRegistry.java
+++ b/src/main/java/run/halo/app/plugin/resources/ReverseProxyRouterFunctionRegistry.java
@@ -12,8 +12,6 @@ import org.springframework.web.reactive.function.server.RouterFunction;
 import org.springframework.web.reactive.function.server.ServerResponse;
 import reactor.core.publisher.Mono;
 import run.halo.app.core.extension.ReverseProxy;
-import run.halo.app.plugin.ExtensionContextRegistry;
-import run.halo.app.plugin.PluginApplicationContext;
 
 /**
  * A registry for {@link RouterFunction} of plugin.
@@ -48,11 +46,7 @@ public class ReverseProxyRouterFunctionRegistry {
         long stamp = lock.writeLock();
         try {
             pluginIdReverseProxyMap.put(pluginId, proxyName);
-
-            // Obtain plugin application context
-            PluginApplicationContext pluginApplicationContext =
-                ExtensionContextRegistry.getInstance().getByPluginId(pluginId);
-            return reverseProxyRouterFunctionFactory.create(reverseProxy, pluginApplicationContext)
+            return reverseProxyRouterFunctionFactory.create(reverseProxy, pluginId)
                 .map(routerFunction -> {
                     proxyNameRouterFunctionRegistry.put(proxyName, routerFunction);
                     return routerFunction;

--- a/src/test/java/run/halo/app/infra/utils/PathUtilsTest.java
+++ b/src/test/java/run/halo/app/infra/utils/PathUtilsTest.java
@@ -59,4 +59,40 @@ class PathUtilsTest {
         assertThat(PathUtils.simplifyPathPattern("/archives/{year:\\d{4}}/page/{page:\\d+}"))
             .isEqualTo("/archives/{year}/page/{page}");
     }
+
+    @Test
+    void isAbsoluteUri() {
+        String[] absoluteUris = new String[] {
+            "ftp://ftp.is.co.za/rfc/rfc1808.txt",
+            "http://www.ietf.org/rfc/rfc2396.txt",
+            "ldap://[2001:db8::7]/c=GB?objectClass?one",
+            "mailto:John.Doe@example.com",
+            "news:comp.infosystems.www.servers.unix",
+            "tel:+1-816-555-1212",
+            "telnet://192.0.2.16:80/",
+            "urn:oasis:names:specification:docbook:dtd:xml:4.1.2",
+            "data:text/vnd-example+xyz;foo=bar;base64,R0lGODdh",
+            "irc://irc.example.com:6667/#some-channel",
+            "ircs://irc.example.com:6667/#some-channel",
+            "irc6://irc.example.com:6667/#some-channel"
+        };
+        for (String uri : absoluteUris) {
+            assertThat(PathUtils.isAbsoluteUri(uri)).isTrue();
+        }
+
+        String[] paths = new String[] {
+            "//example.com/path/resource.txt",
+            "/path/resource.txt",
+            "path/resource.txt",
+            "../resource.txt",
+            "./resource.txt",
+            "resource.txt",
+            "#fragment",
+            "",
+            null
+        };
+        for (String path : paths) {
+            assertThat(PathUtils.isAbsoluteUri(path)).isFalse();
+        }
+    }
 }

--- a/src/test/java/run/halo/app/plugin/resources/ReverseProxyRouterFunctionFactoryTest.java
+++ b/src/test/java/run/halo/app/plugin/resources/ReverseProxyRouterFunctionFactoryTest.java
@@ -1,18 +1,17 @@
 package run.halo.app.plugin.resources;
 
-import static org.mockito.Mockito.when;
-
 import java.util.List;
 import java.util.Map;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationContext;
 import reactor.test.StepVerifier;
 import run.halo.app.core.extension.ReverseProxy;
 import run.halo.app.extension.Metadata;
-import run.halo.app.plugin.PluginApplicationContext;
+import run.halo.app.plugin.HaloPluginManager;
 import run.halo.app.plugin.PluginConst;
 
 /**
@@ -25,22 +24,18 @@ import run.halo.app.plugin.PluginConst;
 class ReverseProxyRouterFunctionFactoryTest {
 
     @Mock
-    private PluginApplicationContext pluginApplicationContext;
+    private HaloPluginManager haloPluginManager;
 
+    @Mock
+    private ApplicationContext applicationContext;
+
+    @InjectMocks
     private ReverseProxyRouterFunctionFactory reverseProxyRouterFunctionFactory;
-
-    @BeforeEach
-    void setUp() {
-        reverseProxyRouterFunctionFactory =
-            new ReverseProxyRouterFunctionFactory();
-
-        when(pluginApplicationContext.getPluginId()).thenReturn("fakeA");
-    }
 
     @Test
     void create() {
         var routerFunction =
-            reverseProxyRouterFunctionFactory.create(mockReverseProxy(), pluginApplicationContext);
+            reverseProxyRouterFunctionFactory.create(mockReverseProxy(), "fakeA");
         StepVerifier.create(routerFunction)
             .expectNextCount(1)
             .verifyComplete();


### PR DESCRIPTION
#### What type of PR is this?
/kind improvement
/area core
/milestone 2.0
#### What this PR does / why we need it:
插件 logo 支持配置外部 URL 或相对于 resources 的路径

Console 端展示插件 logo 时使用的字段需要使用 status.logo 而非 spec.logo
#### Which issue(s) this PR fixes:
Fixes #2651

#### Special notes for your reviewer:
how to test it?
1. 插件配置 logo 为外部 url 例如 https://guqing.xyz/avatar
2. 安装此插件后不会注册 ReverseProxy 规则
3. logo 配置为相对于 resources 的路径例如：/logo.png
4. 安装此插件后可以访问到 /plugins/{your-plugin-name}/assets/logo.png
5. 开发模式启动插件后，修改了 plugin.yaml 中的 spec.logo 则也会更新 ReverseProxy 的 rule

/cc @halo-dev/sig-halo 
#### Does this PR introduce a user-facing change?
```release-note
插件 Logo 支持配置外部 URL 或相对于 resources 的路径
```
