### PR TITLE
refactor: ThemeLinkBuilder needs to rely on external url

### DIFF
--- a/src/main/java/run/halo/app/theme/TemplateEngineManager.java
+++ b/src/main/java/run/halo/app/theme/TemplateEngineManager.java
@@ -11,6 +11,7 @@ import org.thymeleaf.dialect.IDialect;
 import org.thymeleaf.spring6.ISpringWebFluxTemplateEngine;
 import org.thymeleaf.templateresolver.FileTemplateResolver;
 import org.thymeleaf.templateresolver.ITemplateResolver;
+import run.halo.app.infra.ExternalUrlSupplier;
 import run.halo.app.infra.exception.NotFoundException;
 import run.halo.app.theme.dialect.HaloProcessorDialect;
 import run.halo.app.theme.engine.SpringWebFluxTemplateEngine;
@@ -38,14 +39,18 @@ public class TemplateEngineManager {
 
     private final ThymeleafProperties thymeleafProperties;
 
+    private final ExternalUrlSupplier externalUrlSupplier;
+
     private final ObjectProvider<ITemplateResolver> templateResolvers;
 
     private final ObjectProvider<IDialect> dialects;
 
     public TemplateEngineManager(ThymeleafProperties thymeleafProperties,
+        ExternalUrlSupplier externalUrlSupplier,
         ObjectProvider<ITemplateResolver> templateResolvers,
         ObjectProvider<IDialect> dialects) {
         this.thymeleafProperties = thymeleafProperties;
+        this.externalUrlSupplier = externalUrlSupplier;
         this.templateResolvers = templateResolvers;
         this.dialects = dialects;
         engineCache = new ConcurrentLruCache<>(CACHE_SIZE_LIMIT, this::templateEngineGenerator);
@@ -74,7 +79,7 @@ public class TemplateEngineManager {
         var engine = new SpringWebFluxTemplateEngine();
         engine.setEnableSpringELCompiler(thymeleafProperties.isEnableSpringElCompiler());
         engine.setMessageResolver(new ThemeMessageResolver(theme));
-        engine.setLinkBuilder(new ThemeLinkBuilder(theme));
+        engine.setLinkBuilder(new ThemeLinkBuilder(theme, externalUrlSupplier));
         engine.setRenderHiddenMarkersBeforeCheckboxes(
             thymeleafProperties.isRenderHiddenMarkersBeforeCheckboxes());
 

--- a/src/test/java/run/halo/app/theme/ThemeLinkBuilderTest.java
+++ b/src/test/java/run/halo/app/theme/ThemeLinkBuilderTest.java
@@ -1,9 +1,10 @@
 package run.halo.app.theme;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.lenient;
 
 import java.net.URI;
+import java.net.URISyntaxException;
 import java.nio.file.Paths;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -26,7 +27,7 @@ class ThemeLinkBuilderTest {
     @BeforeEach
     void setUp() {
         // Mock external url supplier
-        when(externalUrlSupplier.get()).thenReturn(URI.create(""));
+        lenient().when(externalUrlSupplier.get()).thenReturn(URI.create(""));
     }
 
     @Test
@@ -98,24 +99,28 @@ class ThemeLinkBuilderTest {
     }
 
     @Test
-    void linkInSite() {
-        when(externalUrlSupplier.get()).thenReturn(URI.create(""));
+    void linkInSite() throws URISyntaxException {
+        URI uri = new URI("");
         // relative link is always in site
-        assertThat(ThemeLinkBuilder.linkInSite(externalUrlSupplier.get(), "/post")).isTrue();
+        assertThat(ThemeLinkBuilder.linkInSite(uri, "/post")).isTrue();
 
         // absolute link is not in site
-        assertThat(ThemeLinkBuilder.linkInSite(externalUrlSupplier.get(), "https://example.com")).isFalse();
+        assertThat(ThemeLinkBuilder.linkInSite(uri, "https://example.com")).isFalse();
 
-        when(externalUrlSupplier.get()).thenReturn(URI.create("http://example.com"));
+        uri = new URI("https://example.com");
         // link in externalUrl is in site link
-        assertThat(ThemeLinkBuilder.linkInSite(externalUrlSupplier.get(), "http://example.com/hello/world")).isTrue();
+        assertThat(ThemeLinkBuilder.linkInSite(uri, "http://example.com/hello/world")).isTrue();
         // scheme is different but authority is same
-        assertThat(ThemeLinkBuilder.linkInSite(externalUrlSupplier.get(), "https://example.com/hello/world")).isTrue();
+        assertThat(ThemeLinkBuilder.linkInSite(uri, "https://example.com/hello/world")).isTrue();
 
         // scheme is same and authority is different
-        assertThat(ThemeLinkBuilder.linkInSite(externalUrlSupplier.get(), "http://halo.run/hello/world")).isFalse();
+        assertThat(ThemeLinkBuilder.linkInSite(uri, "http://halo.run/hello/world")).isFalse();
         // scheme is different and authority is different
-        assertThat(ThemeLinkBuilder.linkInSite(externalUrlSupplier.get(), "https://halo.run/hello/world")).isFalse();
+        assertThat(ThemeLinkBuilder.linkInSite(uri, "https://halo.run/hello/world")).isFalse();
+
+        // port is different
+        uri = new URI("http://localhost:8090");
+        assertThat(ThemeLinkBuilder.linkInSite(uri, "http://localhost:3000")).isFalse();
     }
 
     private ThemeContext getTheme(boolean isActive) {


### PR DESCRIPTION
#### What type of PR is this?
/kind improvement
/area core
/milestone 2.0
#### What this PR does / why we need it:
主题预览使用的 ThemeLinkBuilder 需要根据 `halo.externalUrl` 配置来决策是否带预览参数

#### Special notes for your reviewer:
how to test it?
安装几个主题后预览看链接是否正确
see also https://github.com/halo-dev/halo/blob/69a112a060ef9c8ae33a3ced489b475b22e6a1bb/src/test/java/run/halo/app/theme/ThemeLinkBuilderTest.java#L101-L124
/cc @halo-dev/sig-halo 
#### Does this PR introduce a user-facing change?

```release-note
None
```
