### PR TITLE
feat: add setup primary menu support

### DIFF
--- a/src/main/java/run/halo/app/infra/SystemSetting.java
+++ b/src/main/java/run/halo/app/infra/SystemSetting.java
@@ -79,4 +79,10 @@ public class SystemSetting {
         Boolean requireReviewForNew;
         Boolean systemUserOnly;
     }
+
+    @Data
+    public static class Menu {
+        public static final String GROUP = "menu";
+        public String primary;
+    }
 }

--- a/src/main/java/run/halo/app/theme/finders/MenuFinder.java
+++ b/src/main/java/run/halo/app/theme/finders/MenuFinder.java
@@ -12,5 +12,5 @@ public interface MenuFinder {
 
     MenuVo getByName(String name);
 
-    MenuVo getDefault();
+    MenuVo getPrimary();
 }

--- a/src/main/resources/extensions/system-configurable-configmap.yaml
+++ b/src/main/resources/extensions/system-configurable-configmap.yaml
@@ -19,3 +19,7 @@ data:
      "globalHead": "",
      "footer": ""
     }
+  menu: |
+    {
+      "primary": "primary"
+    }

--- a/src/test/java/run/halo/app/theme/finders/impl/MenuFinderImplTest.java
+++ b/src/test/java/run/halo/app/theme/finders/impl/MenuFinderImplTest.java
@@ -7,9 +7,9 @@ import static org.mockito.ArgumentMatchers.eq;
 import java.util.Collections;
 import java.util.LinkedHashSet;
 import java.util.List;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -34,12 +34,8 @@ class MenuFinderImplTest {
     @Mock
     private ReactiveExtensionClient client;
 
+    @InjectMocks
     private MenuFinderImpl menuFinder;
-
-    @BeforeEach
-    void setUp() {
-        menuFinder = new MenuFinderImpl(client);
-    }
 
     @Test
     void listAsTree() {


### PR DESCRIPTION
#### What type of PR is this?
/kind feature
/milestone 2.0
/area core

#### What this PR does / why we need it:
新增主菜单选择配置项
menuFinder 方法从 getDefault 改为 getPrimary 需要主题适配

#### Which issue(s) this PR fixes:
Fixes #2533

#### Special notes for your reviewer:
how to test it?
新增几组菜单选择后切换看主题端是否生效

/cc @halo-dev/sig-halo 
#### Does this PR introduce a user-facing change?

```release-note
Action Required: MenuFinder 的 getDefault 方法已更名为 getPrimary，如果在主题中调用过该方法则需要手动修改。
```
