### PR TITLE
feat: add plugin finder for theme-side

### DIFF
--- a/src/main/java/run/halo/app/theme/finders/PluginFinder.java
+++ b/src/main/java/run/halo/app/theme/finders/PluginFinder.java
@@ -9,6 +9,4 @@ package run.halo.app.theme.finders;
 public interface PluginFinder {
 
     boolean enabled(String pluginName);
-
-    boolean installed(String pluginName);
 }

--- a/src/main/java/run/halo/app/theme/finders/PluginFinder.java
+++ b/src/main/java/run/halo/app/theme/finders/PluginFinder.java
@@ -10,5 +10,5 @@ public interface PluginFinder {
 
     boolean enabled(String pluginName);
 
-    boolean hasInstalled(String pluginName);
+    boolean installed(String pluginName);
 }

--- a/src/main/java/run/halo/app/theme/finders/PluginFinder.java
+++ b/src/main/java/run/halo/app/theme/finders/PluginFinder.java
@@ -8,5 +8,5 @@ package run.halo.app.theme.finders;
  */
 public interface PluginFinder {
 
-    boolean enabled(String pluginName);
+    boolean available(String pluginName);
 }

--- a/src/main/java/run/halo/app/theme/finders/PluginFinder.java
+++ b/src/main/java/run/halo/app/theme/finders/PluginFinder.java
@@ -1,0 +1,14 @@
+package run.halo.app.theme.finders;
+
+/**
+ * A finder for {@link run.halo.app.core.extension.Plugin}.
+ *
+ * @author guqing
+ * @since 2.0.0
+ */
+public interface PluginFinder {
+
+    boolean enabled(String pluginName);
+
+    boolean hasInstalled(String pluginName);
+}

--- a/src/main/java/run/halo/app/theme/finders/impl/PluginFinderImpl.java
+++ b/src/main/java/run/halo/app/theme/finders/impl/PluginFinderImpl.java
@@ -20,7 +20,7 @@ public class PluginFinderImpl implements PluginFinder {
     private final HaloPluginManager haloPluginManager;
 
     @Override
-    public boolean enabled(String pluginName) {
+    public boolean available(String pluginName) {
         if (StringUtils.isBlank(pluginName)) {
             return false;
         }

--- a/src/main/java/run/halo/app/theme/finders/impl/PluginFinderImpl.java
+++ b/src/main/java/run/halo/app/theme/finders/impl/PluginFinderImpl.java
@@ -1,12 +1,9 @@
 package run.halo.app.theme.finders.impl;
 
-import java.util.Optional;
 import lombok.AllArgsConstructor;
 import org.apache.commons.lang3.StringUtils;
 import org.pf4j.PluginState;
 import org.pf4j.PluginWrapper;
-import run.halo.app.core.extension.Plugin;
-import run.halo.app.extension.ReactiveExtensionClient;
 import run.halo.app.plugin.HaloPluginManager;
 import run.halo.app.theme.finders.Finder;
 import run.halo.app.theme.finders.PluginFinder;
@@ -21,7 +18,6 @@ import run.halo.app.theme.finders.PluginFinder;
 @AllArgsConstructor
 public class PluginFinderImpl implements PluginFinder {
     private final HaloPluginManager haloPluginManager;
-    private final ReactiveExtensionClient client;
 
     @Override
     public boolean enabled(String pluginName) {
@@ -33,14 +29,5 @@ public class PluginFinderImpl implements PluginFinder {
             return false;
         }
         return PluginState.STARTED.equals(pluginWrapper.getPluginState());
-    }
-
-    @Override
-    public boolean installed(String pluginName) {
-        if (StringUtils.isBlank(pluginName)) {
-            return false;
-        }
-        Optional<Plugin> plugin = client.fetch(Plugin.class, pluginName).blockOptional();
-        return plugin.isPresent();
     }
 }

--- a/src/main/java/run/halo/app/theme/finders/impl/PluginFinderImpl.java
+++ b/src/main/java/run/halo/app/theme/finders/impl/PluginFinderImpl.java
@@ -36,7 +36,7 @@ public class PluginFinderImpl implements PluginFinder {
     }
 
     @Override
-    public boolean hasInstalled(String pluginName) {
+    public boolean installed(String pluginName) {
         if (StringUtils.isBlank(pluginName)) {
             return false;
         }

--- a/src/main/java/run/halo/app/theme/finders/impl/PluginFinderImpl.java
+++ b/src/main/java/run/halo/app/theme/finders/impl/PluginFinderImpl.java
@@ -1,0 +1,46 @@
+package run.halo.app.theme.finders.impl;
+
+import java.util.Optional;
+import lombok.AllArgsConstructor;
+import org.apache.commons.lang3.StringUtils;
+import org.pf4j.PluginState;
+import org.pf4j.PluginWrapper;
+import run.halo.app.core.extension.Plugin;
+import run.halo.app.extension.ReactiveExtensionClient;
+import run.halo.app.plugin.HaloPluginManager;
+import run.halo.app.theme.finders.Finder;
+import run.halo.app.theme.finders.PluginFinder;
+
+/**
+ * Plugin finder implementation.
+ *
+ * @author guqing
+ * @since 2.0.0
+ */
+@Finder("pluginFinder")
+@AllArgsConstructor
+public class PluginFinderImpl implements PluginFinder {
+    private final HaloPluginManager haloPluginManager;
+    private final ReactiveExtensionClient client;
+
+    @Override
+    public boolean enabled(String pluginName) {
+        if (StringUtils.isBlank(pluginName)) {
+            return false;
+        }
+        PluginWrapper pluginWrapper = haloPluginManager.getPlugin(pluginName);
+        if (pluginWrapper == null) {
+            return false;
+        }
+        return PluginState.STARTED.equals(pluginWrapper.getPluginState());
+    }
+
+    @Override
+    public boolean hasInstalled(String pluginName) {
+        if (StringUtils.isBlank(pluginName)) {
+            return false;
+        }
+        Optional<Plugin> plugin = client.fetch(Plugin.class, pluginName).blockOptional();
+        return plugin.isPresent();
+    }
+}

--- a/src/test/java/run/halo/app/theme/finders/impl/PluginFinderImplTest.java
+++ b/src/test/java/run/halo/app/theme/finders/impl/PluginFinderImplTest.java
@@ -29,22 +29,22 @@ class PluginFinderImplTest {
     private PluginFinderImpl pluginFinder;
 
     @Test
-    void enabled() {
+    void available() {
         assertThat(pluginFinder.available(null)).isFalse();
 
-        boolean enabled = pluginFinder.available("fake-plugin");
-        assertThat(enabled).isFalse();
+        boolean available = pluginFinder.available("fake-plugin");
+        assertThat(available).isFalse();
 
         PluginWrapper mockPluginWrapper = Mockito.mock(PluginWrapper.class);
         when(haloPluginManager.getPlugin(eq("fake-plugin")))
             .thenReturn(mockPluginWrapper);
-        when(mockPluginWrapper.getPluginState()).thenReturn(PluginState.RESOLVED);
 
-        enabled = pluginFinder.available("fake-plugin");
-        assertThat(enabled).isFalse();
+        when(mockPluginWrapper.getPluginState()).thenReturn(PluginState.RESOLVED);
+        available = pluginFinder.available("fake-plugin");
+        assertThat(available).isFalse();
 
         when(mockPluginWrapper.getPluginState()).thenReturn(PluginState.STARTED);
-        enabled = pluginFinder.available("fake-plugin");
-        assertThat(enabled).isTrue();
+        available = pluginFinder.available("fake-plugin");
+        assertThat(available).isTrue();
     }
 }

--- a/src/test/java/run/halo/app/theme/finders/impl/PluginFinderImplTest.java
+++ b/src/test/java/run/halo/app/theme/finders/impl/PluginFinderImplTest.java
@@ -30,9 +30,9 @@ class PluginFinderImplTest {
 
     @Test
     void enabled() {
-        assertThat(pluginFinder.enabled(null)).isFalse();
+        assertThat(pluginFinder.available(null)).isFalse();
 
-        boolean enabled = pluginFinder.enabled("fake-plugin");
+        boolean enabled = pluginFinder.available("fake-plugin");
         assertThat(enabled).isFalse();
 
         PluginWrapper mockPluginWrapper = Mockito.mock(PluginWrapper.class);
@@ -40,11 +40,11 @@ class PluginFinderImplTest {
             .thenReturn(mockPluginWrapper);
         when(mockPluginWrapper.getPluginState()).thenReturn(PluginState.RESOLVED);
 
-        enabled = pluginFinder.enabled("fake-plugin");
+        enabled = pluginFinder.available("fake-plugin");
         assertThat(enabled).isFalse();
 
         when(mockPluginWrapper.getPluginState()).thenReturn(PluginState.STARTED);
-        enabled = pluginFinder.enabled("fake-plugin");
+        enabled = pluginFinder.available("fake-plugin");
         assertThat(enabled).isTrue();
     }
 }

--- a/src/test/java/run/halo/app/theme/finders/impl/PluginFinderImplTest.java
+++ b/src/test/java/run/halo/app/theme/finders/impl/PluginFinderImplTest.java
@@ -1,0 +1,50 @@
+package run.halo.app.theme.finders.impl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.pf4j.PluginState;
+import org.pf4j.PluginWrapper;
+import run.halo.app.plugin.HaloPluginManager;
+
+/**
+ * Tests for {@link PluginFinderImpl}.
+ *
+ * @author guqing
+ * @since 2.0.0
+ */
+@ExtendWith(MockitoExtension.class)
+class PluginFinderImplTest {
+    @Mock
+    private HaloPluginManager haloPluginManager;
+
+    @InjectMocks
+    private PluginFinderImpl pluginFinder;
+
+    @Test
+    void enabled() {
+        assertThat(pluginFinder.enabled(null)).isFalse();
+
+        boolean enabled = pluginFinder.enabled("fake-plugin");
+        assertThat(enabled).isFalse();
+
+        PluginWrapper mockPluginWrapper = Mockito.mock(PluginWrapper.class);
+        when(haloPluginManager.getPlugin(eq("fake-plugin")))
+            .thenReturn(mockPluginWrapper);
+        when(mockPluginWrapper.getPluginState()).thenReturn(PluginState.RESOLVED);
+
+        enabled = pluginFinder.enabled("fake-plugin");
+        assertThat(enabled).isFalse();
+
+        when(mockPluginWrapper.getPluginState()).thenReturn(PluginState.STARTED);
+        enabled = pluginFinder.enabled("fake-plugin");
+        assertThat(enabled).isTrue();
+    }
+}


### PR DESCRIPTION
#### What type of PR is this?
/kind feature
/milestone 2.0
/area core
#### What this PR does / why we need it:
主题端提供判断插件是否已经启用的方法

#### Which issue(s) this PR fixes:
Fixes #2677

#### Special notes for your reviewer:
how to test it?
在主题端使用 `${pluginFinder.available(your-plugin-name)}`  来查看某个插件是否已经启用，如果是则得到 true ，否则 false，如果插件没有安装也得到 false

/cc @halo-dev/sig-halo 
#### Does this PR introduce a user-facing change?

```release-note
主题端支持获取插件启用状态
```