### PR TITLE
Fix test issues on Windows

### DIFF
--- a/src/main/java/run/halo/app/infra/utils/PathUtils.java
+++ b/src/main/java/run/halo/app/infra/utils/PathUtils.java
@@ -2,6 +2,9 @@ package run.halo.app.infra.utils;
 
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Arrays;
 import lombok.experimental.UtilityClass;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
@@ -55,6 +58,7 @@ public class PathUtils {
      *
      * @param pathSegments Path segments to be combined
      * @return the combined path
+     * @apiNote This method doesn't work for Windows system currently.
      */
     public static String combinePath(String... pathSegments) {
         StringBuilder sb = new StringBuilder();

--- a/src/main/java/run/halo/app/infra/utils/PathUtils.java
+++ b/src/main/java/run/halo/app/infra/utils/PathUtils.java
@@ -2,9 +2,6 @@ package run.halo.app.infra.utils;
 
 import java.net.URI;
 import java.net.URISyntaxException;
-import java.nio.file.Path;
-import java.nio.file.Paths;
-import java.util.Arrays;
 import lombok.experimental.UtilityClass;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;

--- a/src/main/java/run/halo/app/plugin/YamlPluginFinder.java
+++ b/src/main/java/run/halo/app/plugin/YamlPluginFinder.java
@@ -3,7 +3,6 @@ package run.halo.app.plugin;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.List;
 import lombok.extern.slf4j.Slf4j;
 import org.pf4j.DevelopmentPluginClasspath;
@@ -14,7 +13,6 @@ import org.springframework.core.io.FileSystemResource;
 import org.springframework.core.io.Resource;
 import run.halo.app.core.extension.Plugin;
 import run.halo.app.extension.Unstructured;
-import run.halo.app.infra.utils.PathUtils;
 import run.halo.app.infra.utils.YamlUnstructuredLoader;
 
 /**

--- a/src/main/java/run/halo/app/plugin/YamlPluginFinder.java
+++ b/src/main/java/run/halo/app/plugin/YamlPluginFinder.java
@@ -102,9 +102,7 @@ public class YamlPluginFinder {
     protected Path getManifestPath(Path pluginPath, String propertiesFileName) {
         if (Files.isDirectory(pluginPath)) {
             for (String location : PLUGIN_CLASSPATH.getClassesDirectories()) {
-                String s = PathUtils.combinePath(pluginPath.toString(),
-                    location, propertiesFileName);
-                Path path = Paths.get(s);
+                var path = pluginPath.resolve(location).resolve(propertiesFileName);
                 Resource propertyResource = new FileSystemResource(path);
                 if (propertyResource.exists()) {
                     return path;

--- a/src/test/java/run/halo/app/core/extension/SettingTest.java
+++ b/src/test/java/run/halo/app/core/extension/SettingTest.java
@@ -25,7 +25,7 @@ class SettingTest {
             apiVersion: v1alpha1
             kind: Setting
             metadata:
-                name: setting-name
+              name: setting-name
             spec:
               forms:
                 - group: basic

--- a/src/test/java/run/halo/app/core/extension/SettingTest.java
+++ b/src/test/java/run/halo/app/core/extension/SettingTest.java
@@ -1,8 +1,8 @@
 package run.halo.app.core.extension;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.assertj.core.api.Assertions.assertThat;
 
-import java.util.List;
 import org.json.JSONException;
 import org.junit.jupiter.api.Test;
 import org.skyscreamer.jsonassert.JSONAssert;
@@ -47,8 +47,9 @@ class SettingTest {
                       name: color
                       validation: required
             """;
-        List<Unstructured> unstructureds =
-            new YamlUnstructuredLoader(new InMemoryResource(settingYaml)).load();
+        var unstructureds = new YamlUnstructuredLoader(
+            new InMemoryResource(settingYaml.getBytes(UTF_8), "In-memory setting YAML"))
+            .load();
         assertThat(unstructureds).hasSize(1);
         Unstructured unstructured = unstructureds.get(0);
 

--- a/src/test/java/run/halo/app/plugin/PluginStartedListenerTest.java
+++ b/src/test/java/run/halo/app/plugin/PluginStartedListenerTest.java
@@ -34,7 +34,8 @@ class PluginStartedListenerTest {
 
             Set<String> extensionResources =
                 PluginStartedListener.PluginExtensionLoaderUtils.lookupFromClasses(tempPluginPath);
-            assertThat(extensionResources).containsAll(Set.of("extensions/roles.yaml"));
+            assertThat(extensionResources)
+                .containsAll(Set.of(Path.of("extensions/roles.yaml").toString()));
         }
 
         @Test

--- a/src/test/java/run/halo/app/plugin/YamlPluginFinderTest.java
+++ b/src/test/java/run/halo/app/plugin/YamlPluginFinderTest.java
@@ -105,10 +105,9 @@ class YamlPluginFinderTest {
 
     @Test
     void findFailedWhenFileNotFound() {
-        Path test = Paths.get("/tmp");
-        assertThatThrownBy(() -> {
-            pluginFinder.find(test);
-        }).isInstanceOf(PluginRuntimeException.class)
+        var test = Paths.get("");
+        assertThatThrownBy(() -> pluginFinder.find(test))
+            .isInstanceOf(PluginRuntimeException.class)
             .hasMessage("Unable to find plugin descriptor file: plugin.yaml");
     }
 

--- a/src/test/java/run/halo/app/theme/ThemeContextTest.java
+++ b/src/test/java/run/halo/app/theme/ThemeContextTest.java
@@ -1,5 +1,6 @@
 package run.halo.app.theme;
 
+import java.nio.file.Path;
 import java.nio.file.Paths;
 import org.json.JSONException;
 import org.junit.jupiter.api.Test;
@@ -16,20 +17,20 @@ class ThemeContextTest {
 
     @Test
     void constructorBuilderTest() throws JSONException {
-        ThemeContext testTheme = ThemeContext.builder()
+        var path = Path.of("/tmp/themes/testTheme");
+        var testTheme = ThemeContext.builder()
             .name("testTheme")
-            .path(Paths.get("/tmp/themes/testTheme"))
+            .path(path)
             .active(true)
             .build();
-        String s = JsonUtils.objectToJson(testTheme);
-        JSONAssert.assertEquals("""
+        var got = JsonUtils.objectToJson(testTheme);
+        var expect = String.format("""
                 {
                     "name": "testTheme",
-                    "path": "file:///tmp/themes/testTheme",
+                    "path": "%s",
                     "active": true
                 }
-                """,
-            s,
-            false);
+                """, path.toUri());
+        JSONAssert.assertEquals(expect, got, false);
     }
 }

--- a/src/test/java/run/halo/app/theme/ThemeContextTest.java
+++ b/src/test/java/run/halo/app/theme/ThemeContextTest.java
@@ -1,7 +1,6 @@
 package run.halo.app.theme;
 
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import org.json.JSONException;
 import org.junit.jupiter.api.Test;
 import org.skyscreamer.jsonassert.JSONAssert;

--- a/src/test/java/run/halo/app/theme/message/ThemeMessageResolutionUtilsTest.java
+++ b/src/test/java/run/halo/app/theme/message/ThemeMessageResolutionUtilsTest.java
@@ -3,7 +3,9 @@ package run.halo.app.theme.message;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.FileNotFoundException;
+import java.net.URISyntaxException;
 import java.net.URL;
+import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Locale;
 import java.util.Map;
@@ -25,7 +27,7 @@ class ThemeMessageResolutionUtilsTest {
     }
 
     @Test
-    void resolveMessagesForTemplateForDefault() {
+    void resolveMessagesForTemplateForDefault() throws URISyntaxException {
         Map<String, String> properties =
             ThemeMessageResolutionUtils.resolveMessagesForTemplate(Locale.CHINESE, getTheme());
         assertThat(properties).hasSize(1);
@@ -33,7 +35,7 @@ class ThemeMessageResolutionUtilsTest {
     }
 
     @Test
-    void resolveMessagesForTemplateForEnglish() {
+    void resolveMessagesForTemplateForEnglish() throws URISyntaxException {
         Map<String, String> properties =
             ThemeMessageResolutionUtils.resolveMessagesForTemplate(Locale.ENGLISH, getTheme());
         assertThat(properties).hasSize(1);
@@ -48,10 +50,10 @@ class ThemeMessageResolutionUtilsTest {
         assertThat(s).isEqualTo("Welcome Halo to the index");
     }
 
-    ThemeContext getTheme() {
+    ThemeContext getTheme() throws URISyntaxException {
         return ThemeContext.builder()
             .name("default")
-            .path(Paths.get(defaultThemeUrl.getPath()))
+            .path(Path.of(defaultThemeUrl.toURI()))
             .active(true)
             .build();
     }

--- a/src/test/java/run/halo/app/theme/message/ThemeMessageResolutionUtilsTest.java
+++ b/src/test/java/run/halo/app/theme/message/ThemeMessageResolutionUtilsTest.java
@@ -6,7 +6,6 @@ import java.io.FileNotFoundException;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.Locale;
 import java.util.Map;
 import org.junit.jupiter.api.BeforeEach;

--- a/src/test/java/run/halo/app/theme/message/ThemeMessageResolverIntegrationTest.java
+++ b/src/test/java/run/halo/app/theme/message/ThemeMessageResolverIntegrationTest.java
@@ -4,7 +4,6 @@ import java.io.FileNotFoundException;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;

--- a/src/test/java/run/halo/app/theme/message/ThemeMessageResolverIntegrationTest.java
+++ b/src/test/java/run/halo/app/theme/message/ThemeMessageResolverIntegrationTest.java
@@ -1,7 +1,9 @@
 package run.halo.app.theme.message;
 
 import java.io.FileNotFoundException;
+import java.net.URISyntaxException;
 import java.net.URL;
+import java.nio.file.Path;
 import java.nio.file.Paths;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -45,7 +47,7 @@ public class ThemeMessageResolverIntegrationTest {
     private WebTestClient webTestClient;
 
     @BeforeEach
-    void setUp() throws FileNotFoundException {
+    void setUp() throws FileNotFoundException, URISyntaxException {
         defaultThemeUrl = ResourceUtils.getURL("classpath:themes/default");
         otherThemeUrl = ResourceUtils.getURL("classpath:themes/other");
 
@@ -126,7 +128,7 @@ public class ThemeMessageResolverIntegrationTest {
     }
 
     @Test
-    void switchTheme() {
+    void switchTheme() throws URISyntaxException {
         webTestClient.get()
             .uri("/index?language=zh")
             .exchange()
@@ -185,18 +187,18 @@ public class ThemeMessageResolverIntegrationTest {
                 """);
     }
 
-    ThemeContext createDefaultContext() {
+    ThemeContext createDefaultContext() throws URISyntaxException {
         return ThemeContext.builder()
             .name("default")
-            .path(Paths.get(defaultThemeUrl.getPath()))
+            .path(Path.of(defaultThemeUrl.toURI()))
             .active(true)
             .build();
     }
 
-    ThemeContext createOtherContext() {
+    ThemeContext createOtherContext() throws URISyntaxException {
         return ThemeContext.builder()
             .name("other")
-            .path(Paths.get(otherThemeUrl.getPath()))
+            .path(Path.of(otherThemeUrl.toURI()))
             .active(false)
             .build();
     }


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Fix failing tests on Windows.

```bash
╰─$ ./gradlew check

> Task :checkstyleTest
Checkstyle rule violations were found. See the report at: file:///C:/Users/johnn/workspaces/halo-dev/halo/build/reports/checkstyle/test.html
Checkstyle files with violations: 8
Checkstyle violations by severity: [warning:20]


> Task :test
2022-11-11T14:19:41.265+08:00 DEBUG 5948 --- [ionShutdownHook] r.halo.app.metrics.CounterMeterHandler   : Persist counter meters to database before destroy...
2022-11-11T14:19:41.277+08:00 DEBUG 5948 --- [ionShutdownHook] r.halo.app.metrics.CounterMeterHandler   : Persist counter meters to database before destroy...
2022-11-11T14:19:41.281+08:00 DEBUG 5948 --- [ionShutdownHook] r.halo.app.metrics.CounterMeterHandler   : Persist counter meters to database before destroy...
2022-11-11T14:19:41.285+08:00 DEBUG 5948 --- [ionShutdownHook] r.halo.app.metrics.CounterMeterHandler   : Persist counter meters to database before destroy...
2022-11-11T14:19:41.289+08:00 DEBUG 5948 --- [ionShutdownHook] r.halo.app.metrics.CounterMeterHandler   : Persist counter meters to database before destroy...
2022-11-11T14:19:41.298+08:00 DEBUG 5948 --- [ionShutdownHook] r.halo.app.metrics.CounterMeterHandler   : Persist counter meters to database before destroy...
2022-11-11T14:19:41.301+08:00 DEBUG 5948 --- [ionShutdownHook] r.halo.app.metrics.CounterMeterHandler   : Persist counter meters to database before destroy...
2022-11-11T14:19:41.304+08:00 DEBUG 5948 --- [ionShutdownHook] r.halo.app.metrics.CounterMeterHandler   : Persist counter meters to database before destroy...
2022-11-11T14:19:41.306+08:00 DEBUG 5948 --- [ionShutdownHook] r.halo.app.metrics.CounterMeterHandler   : Persist counter meters to database before destroy...
2022-11-11T14:19:41.309+08:00 DEBUG 5948 --- [ionShutdownHook] r.halo.app.metrics.CounterMeterHandler   : Persist counter meters to database before destroy...
2022-11-11T14:19:41.311+08:00 DEBUG 5948 --- [ionShutdownHook] r.halo.app.metrics.CounterMeterHandler   : Persist counter meters to database before destroy...

BUILD SUCCESSFUL in 47s
7 actionable tasks: 2 executed, 5 up-to-date

```
#### Does this PR introduce a user-facing change?

```release-note
None
```
