### PR TITLE
feat: theme finders supports the reactive API

### DIFF
--- a/src/main/java/run/halo/app/theme/ReactivePropertyAccessor.java
+++ b/src/main/java/run/halo/app/theme/ReactivePropertyAccessor.java
@@ -1,0 +1,122 @@
+package run.halo.app.theme;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import java.util.ArrayList;
+import java.util.List;
+import org.springframework.expression.AccessException;
+import org.springframework.expression.EvaluationContext;
+import org.springframework.expression.PropertyAccessor;
+import org.springframework.expression.TypedValue;
+import org.springframework.integration.json.JsonPropertyAccessor;
+import org.springframework.lang.NonNull;
+import org.springframework.lang.Nullable;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+import run.halo.app.infra.utils.JsonUtils;
+
+/**
+ * A SpEL PropertyAccessor that knows how to read properties from {@link Mono} or {@link Flux}
+ * object. It first converts the target to the actual value and then calls other
+ * {@link PropertyAccessor}s to parse the result, If it still cannot be resolved,
+ * {@link JsonPropertyAccessor} will be used to resolve finally.
+ *
+ * @author guqing
+ * @since 2.0.0
+ */
+public class ReactivePropertyAccessor implements PropertyAccessor {
+    private static final Class<?>[] SUPPORTED_CLASSES = {
+        Mono.class,
+        Flux.class
+    };
+    private final JsonPropertyAccessor jsonPropertyAccessor = new JsonPropertyAccessor();
+
+    @Override
+    public Class<?>[] getSpecificTargetClasses() {
+        return SUPPORTED_CLASSES;
+    }
+
+    @Override
+    public boolean canRead(@NonNull EvaluationContext context, Object target, @NonNull String name)
+        throws AccessException {
+        if (target == null) {
+            return false;
+        }
+        return Mono.class.isAssignableFrom(target.getClass())
+            || Flux.class.isAssignableFrom(target.getClass());
+    }
+
+    @Override
+    @NonNull
+    public TypedValue read(@NonNull EvaluationContext context, Object target, @NonNull String name)
+        throws AccessException {
+        if (target == null) {
+            return TypedValue.NULL;
+        }
+        Class<?> clazz = target.getClass();
+        Object value = null;
+        if (Mono.class.isAssignableFrom(clazz)) {
+            value = ((Mono<?>) target).block();
+        }
+        if (Flux.class.isAssignableFrom(clazz)) {
+            assert target instanceof Flux<?>;
+            value = ((Flux<?>) target).toIterable();
+        }
+        if (value == null) {
+            return TypedValue.NULL;
+        }
+
+        List<PropertyAccessor> propertyAccessorsToTry =
+            getPropertyAccessorsToTry(value, context.getPropertyAccessors());
+        for (PropertyAccessor propertyAccessor : propertyAccessorsToTry) {
+            try {
+                return propertyAccessor.read(context, target, name);
+            } catch (AccessException e) {
+                // ignore
+            }
+        }
+        JsonNode jsonNode = JsonUtils.DEFAULT_JSON_MAPPER.convertValue(value, JsonNode.class);
+        return jsonPropertyAccessor.read(context, jsonNode, name);
+    }
+
+    private List<PropertyAccessor> getPropertyAccessorsToTry(
+        @Nullable Object contextObject, List<PropertyAccessor> propertyAccessors) {
+
+        Class<?> targetType = (contextObject != null ? contextObject.getClass() : null);
+
+        List<PropertyAccessor> specificAccessors = new ArrayList<>();
+        List<PropertyAccessor> generalAccessors = new ArrayList<>();
+        for (PropertyAccessor resolver : propertyAccessors) {
+            Class<?>[] targets = resolver.getSpecificTargetClasses();
+            if (targets == null) {
+                // generic resolver that says it can be used for any type
+                generalAccessors.add(resolver);
+            } else if (targetType != null) {
+                for (Class<?> clazz : targets) {
+                    if (clazz == targetType) {
+                        specificAccessors.add(resolver);
+                        break;
+                    } else if (clazz.isAssignableFrom(targetType)) {
+                        generalAccessors.add(resolver);
+                    }
+                }
+            }
+        }
+        List<PropertyAccessor> resolvers = new ArrayList<>(specificAccessors);
+        generalAccessors.removeAll(specificAccessors);
+        resolvers.addAll(generalAccessors);
+        return resolvers;
+    }
+
+    @Override
+    public boolean canWrite(@NonNull EvaluationContext context, Object target, @NonNull String name)
+        throws AccessException {
+        return false;
+    }
+
+    @Override
+    public void write(@NonNull EvaluationContext context, Object target, @NonNull String name,
+        Object newValue)
+        throws AccessException {
+        throw new UnsupportedOperationException("Write is not supported");
+    }
+}

--- a/src/main/java/run/halo/app/theme/ReactiveSpelVariableExpressionEvaluator.java
+++ b/src/main/java/run/halo/app/theme/ReactiveSpelVariableExpressionEvaluator.java
@@ -1,0 +1,44 @@
+package run.halo.app.theme;
+
+import org.thymeleaf.context.IExpressionContext;
+import org.thymeleaf.spring6.expression.SPELVariableExpressionEvaluator;
+import org.thymeleaf.standard.expression.IStandardVariableExpression;
+import org.thymeleaf.standard.expression.IStandardVariableExpressionEvaluator;
+import org.thymeleaf.standard.expression.StandardExpressionExecutionContext;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+/**
+ * Reactive SPEL variable expression evaluator.
+ *
+ * @author guqing
+ * @since 2.0.0
+ */
+public class ReactiveSpelVariableExpressionEvaluator
+    implements IStandardVariableExpressionEvaluator {
+
+    private final SPELVariableExpressionEvaluator delegate =
+        SPELVariableExpressionEvaluator.INSTANCE;
+
+    public static final ReactiveSpelVariableExpressionEvaluator INSTANCE =
+        new ReactiveSpelVariableExpressionEvaluator();
+
+    @Override
+    public Object evaluate(IExpressionContext context, IStandardVariableExpression expression,
+        StandardExpressionExecutionContext expContext) {
+        Object returnValue = delegate.evaluate(context, expression, expContext);
+        if (returnValue == null) {
+            return null;
+        }
+
+        Class<?> clazz = returnValue.getClass();
+        // Note that: 3 instanceof Foo -> syntax error
+        if (Mono.class.isAssignableFrom(clazz)) {
+            return ((Mono<?>) returnValue).block();
+        }
+        if (Flux.class.isAssignableFrom(clazz)) {
+            return ((Flux<?>) returnValue).toIterable();
+        }
+        return returnValue;
+    }
+}

--- a/src/main/java/run/halo/app/theme/TemplateEngineManager.java
+++ b/src/main/java/run/halo/app/theme/TemplateEngineManager.java
@@ -9,6 +9,8 @@ import org.springframework.util.ConcurrentLruCache;
 import org.springframework.util.ResourceUtils;
 import org.thymeleaf.dialect.IDialect;
 import org.thymeleaf.spring6.ISpringWebFluxTemplateEngine;
+import org.thymeleaf.spring6.dialect.SpringStandardDialect;
+import org.thymeleaf.standard.expression.IStandardVariableExpressionEvaluator;
 import org.thymeleaf.templateresolver.FileTemplateResolver;
 import org.thymeleaf.templateresolver.ITemplateResolver;
 import run.halo.app.infra.ExternalUrlSupplier;
@@ -86,6 +88,13 @@ public class TemplateEngineManager {
         var mainResolver = haloTemplateResolver();
         mainResolver.setPrefix(theme.getPath() + "/templates/");
         engine.addTemplateResolver(mainResolver);
+        // replace StandardDialect with SpringStandardDialect
+        engine.setDialect(new SpringStandardDialect() {
+            @Override
+            public IStandardVariableExpressionEvaluator getVariableExpressionEvaluator() {
+                return ReactiveSpelVariableExpressionEvaluator.INSTANCE;
+            }
+        });
         engine.addDialect(new HaloProcessorDialect());
 
         templateResolvers.orderedStream().forEach(engine::addTemplateResolver);

--- a/src/main/java/run/halo/app/theme/ThemeContextBasedVariablesAcquirer.java
+++ b/src/main/java/run/halo/app/theme/ThemeContextBasedVariablesAcquirer.java
@@ -4,9 +4,7 @@ import java.util.Map;
 import org.springframework.stereotype.Component;
 import org.springframework.web.server.ServerWebExchange;
 import reactor.core.publisher.Mono;
-import reactor.core.scheduler.Schedulers;
 import run.halo.app.theme.finders.ThemeFinder;
-import run.halo.app.theme.finders.vo.ThemeVo;
 
 /**
  * Theme context based variables acquirer.
@@ -28,14 +26,11 @@ public class ThemeContextBasedVariablesAcquirer implements ViewContextBasedVaria
     @Override
     public Mono<Map<String, Object>> acquire(ServerWebExchange exchange) {
         return themeResolver.getTheme(exchange.getRequest())
-            .publishOn(Schedulers.boundedElastic())
-            .map(themeContext -> {
+            .flatMap(themeContext -> {
                 String name = themeContext.getName();
-                ThemeVo themeVo = themeFinder.getByName(name);
-                if (themeVo == null) {
-                    return Map.of();
-                }
-                return Map.of("theme", themeVo);
-            });
+                return themeFinder.getByName(name);
+            })
+            .map(themeVo -> Map.<String, Object>of("theme", themeVo))
+            .defaultIfEmpty(Map.of());
     }
 }

--- a/src/main/java/run/halo/app/theme/dialect/JsonNodePropertyAccessorBoundariesProcessor.java
+++ b/src/main/java/run/halo/app/theme/dialect/JsonNodePropertyAccessorBoundariesProcessor.java
@@ -9,6 +9,7 @@ import org.thymeleaf.processor.templateboundaries.ITemplateBoundariesStructureHa
 import org.thymeleaf.spring6.expression.ThymeleafEvaluationContext;
 import org.thymeleaf.standard.StandardDialect;
 import org.thymeleaf.templatemode.TemplateMode;
+import run.halo.app.theme.ReactivePropertyAccessor;
 
 /**
  * A template boundaries processor for add {@link JsonPropertyAccessor} to
@@ -21,6 +22,8 @@ public class JsonNodePropertyAccessorBoundariesProcessor
     extends AbstractTemplateBoundariesProcessor {
     private static final int PRECEDENCE = StandardDialect.PROCESSOR_PRECEDENCE;
     private static final JsonPropertyAccessor JSON_PROPERTY_ACCESSOR = new JsonPropertyAccessor();
+    private static final ReactivePropertyAccessor REACTIVE_PROPERTY_ACCESSOR =
+        new ReactivePropertyAccessor();
 
     public JsonNodePropertyAccessorBoundariesProcessor() {
         super(TemplateMode.HTML, PRECEDENCE);
@@ -34,6 +37,7 @@ public class JsonNodePropertyAccessorBoundariesProcessor
                 ThymeleafEvaluationContext.THYMELEAF_EVALUATION_CONTEXT_CONTEXT_VARIABLE_NAME);
         if (evaluationContext != null) {
             evaluationContext.addPropertyAccessor(JSON_PROPERTY_ACCESSOR);
+            evaluationContext.addPropertyAccessor(REACTIVE_PROPERTY_ACCESSOR);
         }
     }
 

--- a/src/main/java/run/halo/app/theme/dialect/PostTemplateHeadProcessor.java
+++ b/src/main/java/run/halo/app/theme/dialect/PostTemplateHeadProcessor.java
@@ -36,7 +36,7 @@ public class PostTemplateHeadProcessor implements TemplateHeadProcessor {
             return Mono.empty();
         }
         return Mono.justOrEmpty((String) context.getVariable(POST_NAME_VARIABLE))
-            .map(postFinder::getByName)
+            .flatMap(postFinder::getByName)
             .doOnNext(postVo -> {
                 List<Map<String, String>> htmlMetas = postVo.getSpec().getHtmlMetas();
                 String metaHtml = headMetaBuilder(htmlMetas);

--- a/src/main/java/run/halo/app/theme/endpoint/CommentFinderEndpoint.java
+++ b/src/main/java/run/halo/app/theme/endpoint/CommentFinderEndpoint.java
@@ -165,10 +165,8 @@ public class CommentFinderEndpoint implements CustomEndpoint {
 
     Mono<ServerResponse> listComments(ServerRequest request) {
         CommentQuery commentQuery = new CommentQuery(request.queryParams());
-        return Mono.defer(() -> Mono.just(
-                commentFinder.list(commentQuery.toRef(), commentQuery.getPage(),
-                    commentQuery.getSize())))
-            .subscribeOn(Schedulers.boundedElastic())
+        return commentFinder.list(commentQuery.toRef(), commentQuery.getPage(),
+                    commentQuery.getSize())
             .flatMap(list -> ServerResponse.ok().bodyValue(list));
     }
 
@@ -183,9 +181,7 @@ public class CommentFinderEndpoint implements CustomEndpoint {
         String commentName = request.pathVariable("name");
         IListRequest.QueryListRequest queryParams =
             new IListRequest.QueryListRequest(request.queryParams());
-        return Mono.defer(() -> Mono.just(
-                commentFinder.listReply(commentName, queryParams.getPage(), queryParams.getSize())))
-            .subscribeOn(Schedulers.boundedElastic())
+        return commentFinder.listReply(commentName, queryParams.getPage(), queryParams.getSize())
             .flatMap(list -> ServerResponse.ok().bodyValue(list));
     }
 

--- a/src/main/java/run/halo/app/theme/finders/CategoryFinder.java
+++ b/src/main/java/run/halo/app/theme/finders/CategoryFinder.java
@@ -2,6 +2,8 @@ package run.halo.app.theme.finders;
 
 import java.util.List;
 import org.springframework.lang.Nullable;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
 import run.halo.app.core.extension.Category;
 import run.halo.app.extension.ListResult;
 import run.halo.app.theme.finders.vo.CategoryTreeVo;
@@ -15,13 +17,13 @@ import run.halo.app.theme.finders.vo.CategoryVo;
  */
 public interface CategoryFinder {
 
-    CategoryVo getByName(String name);
+    Mono<CategoryVo> getByName(String name);
 
-    List<CategoryVo> getByNames(List<String> names);
+    Flux<CategoryVo> getByNames(List<String> names);
 
-    ListResult<CategoryVo> list(@Nullable Integer page, @Nullable Integer size);
+    Mono<ListResult<CategoryVo>> list(@Nullable Integer page, @Nullable Integer size);
 
-    List<CategoryVo> listAll();
+    Flux<CategoryVo> listAll();
 
-    List<CategoryTreeVo> listAsTree();
+    Flux<CategoryTreeVo> listAsTree();
 }

--- a/src/main/java/run/halo/app/theme/finders/CommentFinder.java
+++ b/src/main/java/run/halo/app/theme/finders/CommentFinder.java
@@ -1,6 +1,7 @@
 package run.halo.app.theme.finders;
 
 import org.springframework.lang.Nullable;
+import reactor.core.publisher.Mono;
 import run.halo.app.core.extension.Comment;
 import run.halo.app.extension.ListResult;
 import run.halo.app.extension.Ref;
@@ -15,11 +16,11 @@ import run.halo.app.theme.finders.vo.ReplyVo;
  */
 public interface CommentFinder {
 
-    CommentVo getByName(String name);
+    Mono<CommentVo> getByName(String name);
 
-    ListResult<CommentVo> list(Ref ref, @Nullable Integer page,
+    Mono<ListResult<CommentVo>> list(Ref ref, @Nullable Integer page,
         @Nullable Integer size);
 
-    ListResult<ReplyVo> listReply(String commentName, @Nullable Integer page,
+    Mono<ListResult<ReplyVo>> listReply(String commentName, @Nullable Integer page,
         @Nullable Integer size);
 }

--- a/src/main/java/run/halo/app/theme/finders/ContributorFinder.java
+++ b/src/main/java/run/halo/app/theme/finders/ContributorFinder.java
@@ -1,6 +1,8 @@
 package run.halo.app.theme.finders;
 
 import java.util.List;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
 import run.halo.app.core.extension.User;
 import run.halo.app.theme.finders.vo.Contributor;
 
@@ -9,7 +11,7 @@ import run.halo.app.theme.finders.vo.Contributor;
  */
 public interface ContributorFinder {
 
-    Contributor getContributor(String name);
+    Mono<Contributor> getContributor(String name);
 
-    List<Contributor> getContributors(List<String> names);
+    Flux<Contributor> getContributors(List<String> names);
 }

--- a/src/main/java/run/halo/app/theme/finders/MenuFinder.java
+++ b/src/main/java/run/halo/app/theme/finders/MenuFinder.java
@@ -1,5 +1,6 @@
 package run.halo.app.theme.finders;
 
+import reactor.core.publisher.Mono;
 import run.halo.app.theme.finders.vo.MenuVo;
 
 /**
@@ -10,7 +11,7 @@ import run.halo.app.theme.finders.vo.MenuVo;
  */
 public interface MenuFinder {
 
-    MenuVo getByName(String name);
+    Mono<MenuVo> getByName(String name);
 
-    MenuVo getPrimary();
+    Mono<MenuVo> getPrimary();
 }

--- a/src/main/java/run/halo/app/theme/finders/PostFinder.java
+++ b/src/main/java/run/halo/app/theme/finders/PostFinder.java
@@ -1,9 +1,11 @@
 package run.halo.app.theme.finders;
 
 import org.springframework.lang.Nullable;
+import reactor.core.publisher.Mono;
 import run.halo.app.core.extension.Post;
 import run.halo.app.extension.ListResult;
 import run.halo.app.theme.finders.vo.ContentVo;
+import run.halo.app.theme.finders.vo.ListedPostVo;
 import run.halo.app.theme.finders.vo.NavigationPostVo;
 import run.halo.app.theme.finders.vo.PostArchiveVo;
 import run.halo.app.theme.finders.vo.PostVo;
@@ -16,22 +18,22 @@ import run.halo.app.theme.finders.vo.PostVo;
  */
 public interface PostFinder {
 
-    PostVo getByName(String postName);
+    Mono<PostVo> getByName(String postName);
 
-    ContentVo content(String postName);
+    Mono<ContentVo> content(String postName);
 
-    NavigationPostVo cursor(String current);
+    Mono<NavigationPostVo> cursor(String current);
 
-    ListResult<PostVo> list(@Nullable Integer page, @Nullable Integer size);
+    Mono<ListResult<ListedPostVo>> list(@Nullable Integer page, @Nullable Integer size);
 
-    ListResult<PostVo> listByCategory(@Nullable Integer page, @Nullable Integer size,
+    Mono<ListResult<ListedPostVo>> listByCategory(@Nullable Integer page, @Nullable Integer size,
         String categoryName);
 
-    ListResult<PostVo> listByTag(@Nullable Integer page, @Nullable Integer size, String tag);
+    Mono<ListResult<ListedPostVo>> listByTag(@Nullable Integer page, @Nullable Integer size, String tag);
 
-    ListResult<PostArchiveVo> archives(Integer page, Integer size);
+    Mono<ListResult<PostArchiveVo>> archives(Integer page, Integer size);
 
-    ListResult<PostArchiveVo> archives(Integer page, Integer size, String year);
+    Mono<ListResult<PostArchiveVo>> archives(Integer page, Integer size, String year);
 
-    ListResult<PostArchiveVo> archives(Integer page, Integer size, String year, String month);
+    Mono<ListResult<PostArchiveVo>> archives(Integer page, Integer size, String year, String month);
 }

--- a/src/main/java/run/halo/app/theme/finders/SinglePageFinder.java
+++ b/src/main/java/run/halo/app/theme/finders/SinglePageFinder.java
@@ -1,9 +1,11 @@
 package run.halo.app.theme.finders;
 
 import org.springframework.lang.Nullable;
+import reactor.core.publisher.Mono;
 import run.halo.app.core.extension.SinglePage;
 import run.halo.app.extension.ListResult;
 import run.halo.app.theme.finders.vo.ContentVo;
+import run.halo.app.theme.finders.vo.ListedSinglePageVo;
 import run.halo.app.theme.finders.vo.SinglePageVo;
 
 /**
@@ -14,9 +16,9 @@ import run.halo.app.theme.finders.vo.SinglePageVo;
  */
 public interface SinglePageFinder {
 
-    SinglePageVo getByName(String pageName);
+    Mono<SinglePageVo> getByName(String pageName);
 
-    ContentVo content(String pageName);
+    Mono<ContentVo> content(String pageName);
 
-    ListResult<SinglePageVo> list(@Nullable Integer page, @Nullable Integer size);
+    Mono<ListResult<ListedSinglePageVo>> list(@Nullable Integer page, @Nullable Integer size);
 }

--- a/src/main/java/run/halo/app/theme/finders/SiteStatsFinder.java
+++ b/src/main/java/run/halo/app/theme/finders/SiteStatsFinder.java
@@ -1,5 +1,6 @@
 package run.halo.app.theme.finders;
 
+import reactor.core.publisher.Mono;
 import run.halo.app.theme.finders.vo.SiteStatsVo;
 
 /**
@@ -10,5 +11,5 @@ import run.halo.app.theme.finders.vo.SiteStatsVo;
  */
 public interface SiteStatsFinder {
 
-    SiteStatsVo getStats();
+    Mono<SiteStatsVo> getStats();
 }

--- a/src/main/java/run/halo/app/theme/finders/TagFinder.java
+++ b/src/main/java/run/halo/app/theme/finders/TagFinder.java
@@ -2,6 +2,8 @@ package run.halo.app.theme.finders;
 
 import java.util.List;
 import org.springframework.lang.Nullable;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
 import run.halo.app.core.extension.Tag;
 import run.halo.app.extension.ListResult;
 import run.halo.app.theme.finders.vo.TagVo;
@@ -14,11 +16,11 @@ import run.halo.app.theme.finders.vo.TagVo;
  */
 public interface TagFinder {
 
-    TagVo getByName(String name);
+    Mono<TagVo> getByName(String name);
 
-    List<TagVo> getByNames(List<String> names);
+    Flux<TagVo> getByNames(List<String> names);
 
-    ListResult<TagVo> list(@Nullable Integer page, @Nullable Integer size);
+    Mono<ListResult<TagVo>> list(@Nullable Integer page, @Nullable Integer size);
 
-    List<TagVo> listAll();
+    Flux<TagVo> listAll();
 }

--- a/src/main/java/run/halo/app/theme/finders/ThemeFinder.java
+++ b/src/main/java/run/halo/app/theme/finders/ThemeFinder.java
@@ -1,5 +1,6 @@
 package run.halo.app.theme.finders;
 
+import reactor.core.publisher.Mono;
 import run.halo.app.theme.finders.vo.ThemeVo;
 
 /**
@@ -10,7 +11,7 @@ import run.halo.app.theme.finders.vo.ThemeVo;
  */
 public interface ThemeFinder {
 
-    ThemeVo activation();
+    Mono<ThemeVo> activation();
 
-    ThemeVo getByName(String themeName);
+    Mono<ThemeVo> getByName(String themeName);
 }

--- a/src/main/java/run/halo/app/theme/finders/impl/ContributorFinderImpl.java
+++ b/src/main/java/run/halo/app/theme/finders/impl/ContributorFinderImpl.java
@@ -1,7 +1,8 @@
 package run.halo.app.theme.finders.impl;
 
 import java.util.List;
-import java.util.Objects;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
 import run.halo.app.core.extension.User;
 import run.halo.app.extension.ReactiveExtensionClient;
 import run.halo.app.theme.finders.ContributorFinder;
@@ -24,20 +25,17 @@ public class ContributorFinderImpl implements ContributorFinder {
     }
 
     @Override
-    public Contributor getContributor(String name) {
+    public Mono<Contributor> getContributor(String name) {
         return client.fetch(User.class, name)
-            .map(Contributor::from)
-            .block();
+            .map(Contributor::from);
     }
 
     @Override
-    public List<Contributor> getContributors(List<String> names) {
+    public Flux<Contributor> getContributors(List<String> names) {
         if (names == null) {
-            return List.of();
+            return Flux.empty();
         }
-        return names.stream()
-            .map(this::getContributor)
-            .filter(Objects::nonNull)
-            .toList();
+        return Flux.fromIterable(names)
+            .flatMap(this::getContributor);
     }
 }

--- a/src/main/java/run/halo/app/theme/finders/impl/SiteStatsFinderImpl.java
+++ b/src/main/java/run/halo/app/theme/finders/impl/SiteStatsFinderImpl.java
@@ -22,7 +22,7 @@ public class SiteStatsFinderImpl implements SiteStatsFinder {
     private final ReactiveExtensionClient client;
 
     @Override
-    public SiteStatsVo getStats() {
+    public Mono<SiteStatsVo> getStats() {
         return client.list(Counter.class, null, null)
             .reduce(SiteStatsVo.empty(), (stats, counter) -> {
                 stats.setVisit(stats.getVisit() + counter.getVisit());
@@ -36,8 +36,7 @@ public class SiteStatsFinderImpl implements SiteStatsFinder {
             )
             .flatMap(siteStatsVo -> categoryCount()
                 .doOnNext(siteStatsVo::setCategory)
-                .thenReturn(siteStatsVo))
-            .block();
+                .thenReturn(siteStatsVo));
     }
 
     Mono<Integer> postCount() {

--- a/src/main/java/run/halo/app/theme/finders/impl/ThemeFinderImpl.java
+++ b/src/main/java/run/halo/app/theme/finders/impl/ThemeFinderImpl.java
@@ -34,19 +34,17 @@ public class ThemeFinderImpl implements ThemeFinder {
     }
 
     @Override
-    public ThemeVo activation() {
+    public Mono<ThemeVo> activation() {
         return environmentFetcher.fetch(SystemSetting.Theme.GROUP, SystemSetting.Theme.class)
             .map(SystemSetting.Theme::getActive)
             .flatMap(themeName -> client.fetch(Theme.class, themeName))
-            .flatMap(theme -> themeWithConfig(ThemeVo.from(theme)))
-            .block();
+            .flatMap(theme -> themeWithConfig(ThemeVo.from(theme)));
     }
 
     @Override
-    public ThemeVo getByName(String themeName) {
+    public Mono<ThemeVo> getByName(String themeName) {
         return client.fetch(Theme.class, themeName)
-            .flatMap(theme -> themeWithConfig(ThemeVo.from(theme)))
-            .block();
+            .flatMap(theme -> themeWithConfig(ThemeVo.from(theme)));
     }
 
     private Mono<ThemeVo> themeWithConfig(ThemeVo themeVo) {
@@ -63,6 +61,6 @@ public class ThemeFinderImpl implements ThemeFinder {
                 JsonNode configJson = JsonUtils.mapToObject(config, JsonNode.class);
                 return themeVo.withConfig(configJson);
             })
-            .switchIfEmpty(Mono.just(themeVo));
+            .defaultIfEmpty(themeVo);
     }
 }

--- a/src/main/java/run/halo/app/theme/finders/vo/ContentVo.java
+++ b/src/main/java/run/halo/app/theme/finders/vo/ContentVo.java
@@ -19,4 +19,14 @@ public class ContentVo {
     String raw;
 
     String content;
+
+    /**
+     * Empty content object.
+     */
+    public static ContentVo empty() {
+        return ContentVo.builder()
+            .raw("")
+            .content("")
+            .build();
+    }
 }

--- a/src/main/java/run/halo/app/theme/finders/vo/ListedPostVo.java
+++ b/src/main/java/run/halo/app/theme/finders/vo/ListedPostVo.java
@@ -7,6 +7,7 @@ import lombok.ToString;
 import lombok.experimental.SuperBuilder;
 import org.springframework.util.Assert;
 import run.halo.app.core.extension.Post;
+import run.halo.app.extension.MetadataOperator;
 
 /**
  * A value object for {@link Post}.
@@ -17,46 +18,42 @@ import run.halo.app.core.extension.Post;
 @Data
 @SuperBuilder
 @ToString
-@EqualsAndHashCode(callSuper = true)
-public class PostVo extends ListedPostVo {
+@EqualsAndHashCode
+public class ListedPostVo {
 
-    private ContentVo content;
+    private MetadataOperator metadata;
+
+    private Post.PostSpec spec;
+
+    private Post.PostStatus status;
+
+    private List<CategoryVo> categories;
+
+    private List<TagVo> tags;
+
+    private List<Contributor> contributors;
+
+    private Contributor owner;
+
+    private StatsVo stats;
 
     /**
-     * Convert {@link Post} to {@link PostVo}.
+     * Convert {@link Post} to {@link ListedPostVo}.
      *
      * @param post post extension
      * @return post value object
      */
-    public static PostVo from(Post post) {
+    public static ListedPostVo from(Post post) {
         Assert.notNull(post, "The post must not be null.");
         Post.PostSpec spec = post.getSpec();
         Post.PostStatus postStatus = post.getStatusOrDefault();
-        return PostVo.builder()
+        return ListedPostVo.builder()
             .metadata(post.getMetadata())
             .spec(spec)
             .status(postStatus)
             .categories(List.of())
             .tags(List.of())
             .contributors(List.of())
-            .content(new ContentVo(null, null))
-            .build();
-    }
-
-    /**
-     * Convert {@link Post} to {@link PostVo}.
-     */
-    public static PostVo from(ListedPostVo postVo) {
-        return builder()
-            .metadata(postVo.getMetadata())
-            .spec(postVo.getSpec())
-            .status(postVo.getStatus())
-            .categories(postVo.getCategories())
-            .tags(postVo.getTags())
-            .contributors(postVo.getContributors())
-            .owner(postVo.getOwner())
-            .stats(postVo.getStats())
-            .content(new ContentVo("", ""))
             .build();
     }
 }

--- a/src/main/java/run/halo/app/theme/finders/vo/ListedSinglePageVo.java
+++ b/src/main/java/run/halo/app/theme/finders/vo/ListedSinglePageVo.java
@@ -7,6 +7,7 @@ import lombok.ToString;
 import lombok.experimental.SuperBuilder;
 import org.springframework.util.Assert;
 import run.halo.app.core.extension.SinglePage;
+import run.halo.app.extension.MetadataOperator;
 
 /**
  * A value object for {@link SinglePage}.
@@ -17,27 +18,36 @@ import run.halo.app.core.extension.SinglePage;
 @Data
 @SuperBuilder
 @ToString
-@EqualsAndHashCode(callSuper = true)
-public class SinglePageVo extends ListedSinglePageVo {
+@EqualsAndHashCode
+public class ListedSinglePageVo {
 
-    private ContentVo content;
+    private MetadataOperator metadata;
+
+    private SinglePage.SinglePageSpec spec;
+
+    private SinglePage.SinglePageStatus status;
+
+    private StatsVo stats;
+
+    private List<Contributor> contributors;
+
+    private Contributor owner;
 
     /**
-     * Convert {@link SinglePage} to {@link SinglePageVo}.
+     * Convert {@link SinglePage} to {@link ListedSinglePageVo}.
      *
      * @param singlePage single page extension
      * @return special page value object
      */
-    public static SinglePageVo from(SinglePage singlePage) {
+    public static ListedSinglePageVo from(SinglePage singlePage) {
         Assert.notNull(singlePage, "The singlePage must not be null.");
         SinglePage.SinglePageSpec spec = singlePage.getSpec();
         SinglePage.SinglePageStatus pageStatus = singlePage.getStatus();
-        return SinglePageVo.builder()
+        return ListedSinglePageVo.builder()
             .metadata(singlePage.getMetadata())
             .spec(spec)
             .status(pageStatus)
             .contributors(List.of())
-            .content(new ContentVo(null, null))
             .build();
     }
 }

--- a/src/main/java/run/halo/app/theme/finders/vo/PostArchiveYearMonthVo.java
+++ b/src/main/java/run/halo/app/theme/finders/vo/PostArchiveYearMonthVo.java
@@ -16,5 +16,5 @@ public class PostArchiveYearMonthVo {
 
     String month;
 
-    List<PostVo> posts;
+    List<ListedPostVo> posts;
 }

--- a/src/main/java/run/halo/app/theme/router/strategy/ArchivesRouteStrategy.java
+++ b/src/main/java/run/halo/app/theme/router/strategy/ArchivesRouteStrategy.java
@@ -13,8 +13,6 @@ import org.springframework.web.reactive.function.server.HandlerFunction;
 import org.springframework.web.reactive.function.server.ServerRequest;
 import org.springframework.web.reactive.function.server.ServerResponse;
 import reactor.core.publisher.Mono;
-import reactor.core.scheduler.Schedulers;
-import run.halo.app.extension.ListResult;
 import run.halo.app.infra.SystemConfigurableEnvironmentFetcher;
 import run.halo.app.infra.utils.PathUtils;
 import run.halo.app.theme.DefaultTemplateEnum;
@@ -47,17 +45,12 @@ public class ArchivesRouteStrategy implements ListPageRouteHandlerStrategy {
         String path = request.path();
         return environmentFetcher.fetchPost()
             .map(postSetting -> defaultIfNull(postSetting.getArchivePageSize(), DEFAULT_PAGE_SIZE))
-            .flatMap(pageSize -> listPost(pageNum(request), pageSize, year, month))
+            .flatMap(pageSize -> postFinder.archives(pageNum(request), pageSize, year, month))
             .map(list -> new UrlContextListResult.Builder<PostArchiveVo>()
                 .listResult(list)
                 .nextUrl(PageUrlUtils.nextPageUrl(path, totalPage(list)))
                 .prevUrl(PageUrlUtils.prevPageUrl(path))
                 .build());
-    }
-
-    Mono<ListResult<PostArchiveVo>> listPost(int pageNum, int pageSize, String year, String month) {
-        return Mono.fromCallable(() -> postFinder.archives(pageNum, pageSize, year, month))
-            .subscribeOn(Schedulers.boundedElastic());
     }
 
     private String pathVariable(ServerRequest request, String name) {

--- a/src/main/java/run/halo/app/theme/router/strategy/CategoriesRouteStrategy.java
+++ b/src/main/java/run/halo/app/theme/router/strategy/CategoriesRouteStrategy.java
@@ -7,11 +7,8 @@ import org.apache.commons.lang3.StringUtils;
 import org.springframework.stereotype.Component;
 import org.springframework.web.reactive.function.server.HandlerFunction;
 import org.springframework.web.reactive.function.server.ServerResponse;
-import reactor.core.publisher.Mono;
-import reactor.core.scheduler.Schedulers;
 import run.halo.app.theme.DefaultTemplateEnum;
 import run.halo.app.theme.finders.CategoryFinder;
-import run.halo.app.theme.finders.vo.CategoryTreeVo;
 
 /**
  * Categories router strategy for generate {@link HandlerFunction} specific to the template
@@ -25,16 +22,11 @@ import run.halo.app.theme.finders.vo.CategoryTreeVo;
 public class CategoriesRouteStrategy implements ListPageRouteHandlerStrategy {
     private final CategoryFinder categoryFinder;
 
-    private Mono<List<CategoryTreeVo>> categories() {
-        return Mono.defer(() -> Mono.just(categoryFinder.listAsTree()))
-            .publishOn(Schedulers.boundedElastic());
-    }
-
     @Override
     public HandlerFunction<ServerResponse> getHandler() {
         return request -> ServerResponse.ok()
             .render(DefaultTemplateEnum.CATEGORIES.getValue(),
-                Map.of("categories", categories(),
+                Map.of("categories", categoryFinder.listAsTree(),
                     ModelConst.TEMPLATE_ID, DefaultTemplateEnum.CATEGORIES.getValue()));
     }
 

--- a/src/main/java/run/halo/app/theme/router/strategy/PostRouteStrategy.java
+++ b/src/main/java/run/halo/app/theme/router/strategy/PostRouteStrategy.java
@@ -8,15 +8,12 @@ import org.springframework.web.reactive.function.server.HandlerFunction;
 import org.springframework.web.reactive.function.server.ServerResponse;
 import org.springframework.web.util.pattern.PathPattern;
 import org.springframework.web.util.pattern.PathPatternParser;
-import reactor.core.publisher.Mono;
-import reactor.core.scheduler.Schedulers;
 import run.halo.app.core.extension.Post;
 import run.halo.app.extension.GVK;
 import run.halo.app.extension.GroupVersionKind;
 import run.halo.app.infra.SystemSetting;
 import run.halo.app.theme.DefaultTemplateEnum;
 import run.halo.app.theme.finders.PostFinder;
-import run.halo.app.theme.finders.vo.PostVo;
 import run.halo.app.theme.router.ViewNameResolver;
 
 /**
@@ -57,7 +54,7 @@ public class PostRouteStrategy implements DetailsPageRouteHandlerStrategy {
             model.put("plural", gvk.plural());
             // used by TemplateGlobalHeadProcessor and PostTemplateHeadProcessor
             model.put(ModelConst.TEMPLATE_ID, DefaultTemplateEnum.POST.getValue());
-            return postByName(name)
+            return postFinder.getByName(name)
                 .flatMap(postVo -> {
                     model.put("post", postVo);
                     String template = postVo.getSpec().getTemplate();
@@ -71,10 +68,5 @@ public class PostRouteStrategy implements DetailsPageRouteHandlerStrategy {
     @Override
     public boolean supports(GroupVersionKind gvk) {
         return groupVersionKind.equals(gvk);
-    }
-
-    private Mono<PostVo> postByName(String name) {
-        return Mono.fromCallable(() -> postFinder.getByName(name))
-            .subscribeOn(Schedulers.boundedElastic());
     }
 }

--- a/src/main/java/run/halo/app/theme/router/strategy/SinglePageRouteStrategy.java
+++ b/src/main/java/run/halo/app/theme/router/strategy/SinglePageRouteStrategy.java
@@ -5,15 +5,12 @@ import java.util.Map;
 import org.springframework.stereotype.Component;
 import org.springframework.web.reactive.function.server.HandlerFunction;
 import org.springframework.web.reactive.function.server.ServerResponse;
-import reactor.core.publisher.Mono;
-import reactor.core.scheduler.Schedulers;
 import run.halo.app.core.extension.SinglePage;
 import run.halo.app.extension.GVK;
 import run.halo.app.extension.GroupVersionKind;
 import run.halo.app.infra.SystemSetting;
 import run.halo.app.theme.DefaultTemplateEnum;
 import run.halo.app.theme.finders.SinglePageFinder;
-import run.halo.app.theme.finders.vo.SinglePageVo;
 import run.halo.app.theme.router.ViewNameResolver;
 
 /**
@@ -40,11 +37,6 @@ public class SinglePageRouteStrategy implements DetailsPageRouteHandlerStrategy 
         return annotation.plural();
     }
 
-    private Mono<SinglePageVo> singlePageByName(String name) {
-        return Mono.fromCallable(() -> singlePageFinder.getByName(name))
-            .subscribeOn(Schedulers.boundedElastic());
-    }
-
     @Override
     public HandlerFunction<ServerResponse> getHandler(SystemSetting.ThemeRouteRules routeRules,
         String name) {
@@ -54,7 +46,7 @@ public class SinglePageRouteStrategy implements DetailsPageRouteHandlerStrategy 
             model.put("plural", getPlural());
             model.put(ModelConst.TEMPLATE_ID, DefaultTemplateEnum.SINGLE_PAGE.getValue());
 
-            return singlePageByName(name).flatMap(singlePageVo -> {
+            return singlePageFinder.getByName(name).flatMap(singlePageVo -> {
                 model.put("singlePage", singlePageVo);
                 String template = singlePageVo.getSpec().getTemplate();
                 return viewNameResolver.resolveViewNameOrDefault(request, template,

--- a/src/main/java/run/halo/app/theme/router/strategy/TagsRouteStrategy.java
+++ b/src/main/java/run/halo/app/theme/router/strategy/TagsRouteStrategy.java
@@ -6,11 +6,8 @@ import org.apache.commons.lang3.StringUtils;
 import org.springframework.stereotype.Component;
 import org.springframework.web.reactive.function.server.HandlerFunction;
 import org.springframework.web.reactive.function.server.ServerResponse;
-import reactor.core.publisher.Mono;
-import reactor.core.scheduler.Schedulers;
 import run.halo.app.theme.DefaultTemplateEnum;
 import run.halo.app.theme.finders.TagFinder;
-import run.halo.app.theme.finders.vo.TagVo;
 
 /**
  * The {@link TagsRouteStrategy} for generate {@link HandlerFunction} specific to the template
@@ -28,16 +25,11 @@ public class TagsRouteStrategy implements ListPageRouteHandlerStrategy {
         this.tagFinder = tagFinder;
     }
 
-    private Mono<List<TagVo>> tags() {
-        return Mono.defer(() -> Mono.just(tagFinder.listAll()))
-            .publishOn(Schedulers.boundedElastic());
-    }
-
     @Override
     public HandlerFunction<ServerResponse> getHandler() {
         return request -> ServerResponse.ok()
             .render(DefaultTemplateEnum.TAGS.getValue(),
-                Map.of("tags", tags(),
+                Map.of("tags", tagFinder.listAll(),
                     ModelConst.TEMPLATE_ID, DefaultTemplateEnum.TAGS.getValue()
                 )
             );

--- a/src/test/java/run/halo/app/theme/dialect/HaloProcessorDialectTest.java
+++ b/src/test/java/run/halo/app/theme/dialect/HaloProcessorDialectTest.java
@@ -142,7 +142,7 @@ class HaloProcessorDialectTest {
         PostVo postVo = PostVo.builder()
             .spec(postSpec)
             .metadata(metadata).build();
-        when(postFinder.getByName(eq("fake-post"))).thenReturn(postVo);
+        when(postFinder.getByName(eq("fake-post"))).thenReturn(Mono.just(postVo));
 
         SystemSetting.Basic basic = new SystemSetting.Basic();
         basic.setFavicon(null);

--- a/src/test/java/run/halo/app/theme/endpoint/CommentFinderEndpointTest.java
+++ b/src/test/java/run/halo/app/theme/endpoint/CommentFinderEndpointTest.java
@@ -60,7 +60,7 @@ class CommentFinderEndpointTest {
     @Test
     void listComments() {
         when(commentFinder.list(any(), anyInt(), anyInt()))
-            .thenReturn(new ListResult<>(1, 10, 0, List.of()));
+            .thenReturn(Mono.just(new ListResult<>(1, 10, 0, List.of())));
 
         Ref ref = new Ref();
         ref.setGroup("content.halo.run");
@@ -104,15 +104,13 @@ class CommentFinderEndpointTest {
     @Test
     void listCommentReplies() {
         when(commentFinder.listReply(any(), anyInt(), anyInt()))
-            .thenReturn(new ListResult<>(2, 20, 0, List.of()));
+            .thenReturn(Mono.just(new ListResult<>(2, 20, 0, List.of())));
 
         webTestClient.get()
-            .uri(uriBuilder -> {
-                return uriBuilder.path("/comments/test-comment/reply")
-                    .queryParam("page", 2)
-                    .queryParam("size", 20)
-                    .build();
-            })
+            .uri(uriBuilder -> uriBuilder.path("/comments/test-comment/reply")
+                .queryParam("page", 2)
+                .queryParam("size", 20)
+                .build())
             .exchange()
             .expectStatus()
             .isOk();

--- a/src/test/java/run/halo/app/theme/finders/impl/CategoryFinderImplTest.java
+++ b/src/test/java/run/halo/app/theme/finders/impl/CategoryFinderImplTest.java
@@ -51,7 +51,7 @@ class CategoryFinderImplTest {
     void getByName() throws JSONException {
         when(client.fetch(eq(Category.class), eq("hello")))
             .thenReturn(Mono.just(category()));
-        CategoryVo categoryVo = categoryFinder.getByName("hello");
+        CategoryVo categoryVo = categoryFinder.getByName("hello").block();
         categoryVo.getMetadata().setCreationTimestamp(null);
         JSONAssert.assertEquals("""
                 {
@@ -87,7 +87,7 @@ class CategoryFinderImplTest {
                 .toList());
         when(client.list(eq(Category.class), eq(null), any(), anyInt(), anyInt()))
             .thenReturn(Mono.just(categories));
-        ListResult<CategoryVo> list = categoryFinder.list(1, 10);
+        ListResult<CategoryVo> list = categoryFinder.list(1, 10).block();
         assertThat(list.getItems()).hasSize(3);
         assertThat(list.get().map(categoryVo -> categoryVo.getMetadata().getName()).toList())
             .isEqualTo(List.of("c3", "c2", "hello"));
@@ -97,7 +97,7 @@ class CategoryFinderImplTest {
     void listAsTree() {
         when(client.list(eq(Category.class), eq(null), any()))
             .thenReturn(Flux.fromIterable(categoriesForTree()));
-        List<CategoryTreeVo> treeVos = categoryFinder.listAsTree();
+        List<CategoryTreeVo> treeVos = categoryFinder.listAsTree().collectList().block();
         assertThat(treeVos).hasSize(1);
     }
 
@@ -110,7 +110,7 @@ class CategoryFinderImplTest {
     void listAsTreeMore() {
         when(client.list(eq(Category.class), eq(null), any()))
             .thenReturn(Flux.fromIterable(moreCategories()));
-        List<CategoryTreeVo> treeVos = categoryFinder.listAsTree();
+        List<CategoryTreeVo> treeVos = categoryFinder.listAsTree().collectList().block();
         String s = visualizeTree(treeVos);
         assertThat(s).isEqualTo("""
             全部 (5)

--- a/src/test/java/run/halo/app/theme/finders/impl/MenuFinderImplTest.java
+++ b/src/test/java/run/halo/app/theme/finders/impl/MenuFinderImplTest.java
@@ -45,7 +45,7 @@ class MenuFinderImplTest {
         Mockito.when(client.list(eq(MenuItem.class), eq(null), any()))
             .thenReturn(Flux.fromIterable(tuple.getT2()));
 
-        List<MenuVo> menuVos = menuFinder.listAsTree();
+        List<MenuVo> menuVos = menuFinder.listAsTree().collectList().block();
         assertThat(visualizeTree(menuVos)).isEqualTo("""
             D
             └── E

--- a/src/test/java/run/halo/app/theme/finders/impl/TagFinderImplTest.java
+++ b/src/test/java/run/halo/app/theme/finders/impl/TagFinderImplTest.java
@@ -47,7 +47,7 @@ class TagFinderImplTest {
     void getByName() throws JSONException {
         when(client.fetch(eq(Tag.class), eq("t1")))
             .thenReturn(Mono.just(tag(1)));
-        TagVo tagVo = tagFinder.getByName("t1");
+        TagVo tagVo = tagFinder.getByName("t1").block();
         tagVo.getMetadata().setCreationTimestamp(null);
         JSONAssert.assertEquals("""
                 {
@@ -82,7 +82,7 @@ class TagFinderImplTest {
                     tags().stream().sorted(TagFinderImpl.DEFAULT_COMPARATOR.reversed()).toList()
                 )
             );
-        List<TagVo> tags = tagFinder.listAll();
+        List<TagVo> tags = tagFinder.listAll().collectList().block();
         assertThat(tags).hasSize(3);
         assertThat(tags.stream()
             .map(tag -> tag.getMetadata().getName())

--- a/src/test/java/run/halo/app/theme/router/strategy/ArchivesRouteStrategyTest.java
+++ b/src/test/java/run/halo/app/theme/router/strategy/ArchivesRouteStrategyTest.java
@@ -1,8 +1,5 @@
 package run.halo.app.theme.router.strategy;
 
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.lenient;
-
 import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -15,7 +12,6 @@ import org.springframework.web.reactive.function.server.HandlerFunction;
 import org.springframework.web.reactive.function.server.RouterFunction;
 import org.springframework.web.reactive.function.server.ServerResponse;
 import run.halo.app.theme.finders.PostFinder;
-import run.halo.app.theme.router.UrlContextListResult;
 
 /**
  * Tests for {@link ArchivesRouteStrategy}.
@@ -30,12 +26,6 @@ class ArchivesRouteStrategyTest extends RouterStrategyTestSuite {
 
     @InjectMocks
     private ArchivesRouteStrategy archivesRouteStrategy;
-
-    @Override
-    public void setUp() {
-        lenient().when(postFinder.list(any(), any())).thenReturn(
-            new UrlContextListResult<>(1, 10, 1, List.of(), null, null));
-    }
 
     @Test
     void getRouteFunctionWhenDefaultPattern() {

--- a/src/test/java/run/halo/app/theme/router/strategy/CategoriesRouteStrategyTest.java
+++ b/src/test/java/run/halo/app/theme/router/strategy/CategoriesRouteStrategyTest.java
@@ -1,6 +1,6 @@
 package run.halo.app.theme.router.strategy;
 
-import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.when;
 
 import java.util.List;
 import org.junit.jupiter.api.Test;
@@ -13,6 +13,7 @@ import org.springframework.test.web.reactive.server.WebTestClient;
 import org.springframework.web.reactive.function.server.HandlerFunction;
 import org.springframework.web.reactive.function.server.RouterFunction;
 import org.springframework.web.reactive.function.server.ServerResponse;
+import reactor.core.publisher.Flux;
 import run.halo.app.theme.finders.CategoryFinder;
 
 /**
@@ -29,12 +30,6 @@ class CategoriesRouteStrategyTest extends RouterStrategyTestSuite {
     @InjectMocks
     private CategoriesRouteStrategy categoriesRouteStrategy;
 
-    @Override
-    public void setUp() {
-        lenient().when(categoryFinder.listAsTree())
-            .thenReturn(List.of());
-    }
-
     @Test
     void getRouteFunction() {
         HandlerFunction<ServerResponse> handler = categoriesRouteStrategy.getHandler();
@@ -47,6 +42,7 @@ class CategoriesRouteStrategyTest extends RouterStrategyTestSuite {
             permalinkHttpGetRouter.insert(routerPath, handler);
         }
 
+        when(categoryFinder.listAsTree()).thenReturn(Flux.empty());
         client.get()
             .uri("/categories-test")
             .exchange()

--- a/src/test/java/run/halo/app/theme/router/strategy/CategoryRouteStrategyTest.java
+++ b/src/test/java/run/halo/app/theme/router/strategy/CategoryRouteStrategyTest.java
@@ -1,10 +1,8 @@
 package run.halo.app.theme.router.strategy;
 
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyInt;
-import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.when;
 
-import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -14,7 +12,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.test.web.reactive.server.WebTestClient;
 import org.springframework.web.reactive.function.server.RouterFunction;
 import org.springframework.web.reactive.function.server.ServerResponse;
-import run.halo.app.extension.ListResult;
+import reactor.core.publisher.Mono;
 import run.halo.app.theme.finders.CategoryFinder;
 import run.halo.app.theme.finders.PostFinder;
 
@@ -36,12 +34,6 @@ class CategoryRouteStrategyTest extends RouterStrategyTestSuite {
     @InjectMocks
     private CategoryRouteStrategy categoryRouteStrategy;
 
-    @Override
-    public void setUp() {
-        lenient().when(postFinder.listByCategory(anyInt(), anyInt(), any()))
-            .thenReturn(new ListResult<>(1, 10, 0, List.of()));
-    }
-
     @Test
     void getRouteFunction() {
         RouterFunction<ServerResponse> routeFunction = getRouterFunction();
@@ -51,6 +43,8 @@ class CategoryRouteStrategyTest extends RouterStrategyTestSuite {
             categoryRouteStrategy.getHandler(null, "category-slug-1"));
         permalinkHttpGetRouter.insert("/categories-test/category-slug-2",
             categoryRouteStrategy.getHandler(null, "category-slug-2"));
+
+        when(categoryFinder.getByName(any())).thenReturn(Mono.empty());
 
         // /{prefix}/{slug}
         client.get()

--- a/src/test/java/run/halo/app/theme/router/strategy/IndexRouteStrategyTest.java
+++ b/src/test/java/run/halo/app/theme/router/strategy/IndexRouteStrategyTest.java
@@ -1,8 +1,5 @@
 package run.halo.app.theme.router.strategy;
 
-import static org.mockito.ArgumentMatchers.anyInt;
-import static org.mockito.Mockito.lenient;
-
 import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -14,7 +11,6 @@ import org.springframework.test.web.reactive.server.WebTestClient;
 import org.springframework.web.reactive.function.server.HandlerFunction;
 import org.springframework.web.reactive.function.server.RouterFunction;
 import org.springframework.web.reactive.function.server.ServerResponse;
-import run.halo.app.extension.ListResult;
 import run.halo.app.theme.finders.PostFinder;
 
 /**
@@ -30,12 +26,6 @@ class IndexRouteStrategyTest extends RouterStrategyTestSuite {
 
     @InjectMocks
     private IndexRouteStrategy indexRouteStrategy;
-
-    @Override
-    public void setUp() {
-        lenient().when(postFinder.list(anyInt(), anyInt()))
-            .thenReturn(new ListResult<>(1, 10, 0, List.of()));
-    }
 
     @Test
     void getRouteFunction() {

--- a/src/test/java/run/halo/app/theme/router/strategy/PostRouteStrategyTest.java
+++ b/src/test/java/run/halo/app/theme/router/strategy/PostRouteStrategyTest.java
@@ -42,7 +42,8 @@ class PostRouteStrategyTest extends RouterStrategyTestSuite {
     public void setUp() {
         lenient().when(viewNameResolver.resolveViewNameOrDefault(any(), any(), any()))
             .thenReturn(Mono.just(DefaultTemplateEnum.POST.getValue()));
-        lenient().when(postFinder.getByName(any())).thenReturn(PostVo.from(TestPost.postV1()));
+        lenient().when(postFinder.getByName(any()))
+            .thenReturn(Mono.just(PostVo.from(TestPost.postV1())));
     }
 
     @Test

--- a/src/test/java/run/halo/app/theme/router/strategy/SinglePageRouteStrategyTest.java
+++ b/src/test/java/run/halo/app/theme/router/strategy/SinglePageRouteStrategyTest.java
@@ -1,12 +1,11 @@
 package run.halo.app.theme.router.strategy;
 
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.when;
 import static run.halo.app.theme.DefaultTemplateEnum.SINGLE_PAGE;
 
-import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -16,7 +15,6 @@ import org.springframework.test.web.reactive.server.WebTestClient;
 import org.springframework.web.reactive.function.server.RouterFunction;
 import org.springframework.web.reactive.function.server.ServerResponse;
 import reactor.core.publisher.Mono;
-import run.halo.app.extension.ListResult;
 import run.halo.app.theme.finders.SinglePageFinder;
 
 /**
@@ -35,8 +33,6 @@ class SinglePageRouteStrategyTest extends RouterStrategyTestSuite {
 
     @Override
     public void setUp() {
-        lenient().when(singlePageFinder.list(anyInt(), anyInt()))
-            .thenReturn(new ListResult<>(1, 10, 0, List.of()));
         lenient().when(viewResolver.resolveViewName(eq(SINGLE_PAGE.getValue()), any()))
             .thenReturn(Mono.just(new EmptyView()));
     }
@@ -53,6 +49,7 @@ class SinglePageRouteStrategyTest extends RouterStrategyTestSuite {
     void shouldResponse200IfPermalinkFound() {
         permalinkHttpGetRouter.insert("/fake-slug",
             strategy.getHandler(getThemeRouteRules(), "fake-name"));
+        when(singlePageFinder.getByName(any())).thenReturn(Mono.empty());
         createClient().get()
             .uri("/fake-slug")
             .exchange()
@@ -64,6 +61,8 @@ class SinglePageRouteStrategyTest extends RouterStrategyTestSuite {
     void shouldResponse200IfSlugNameContainsSpecialChars() {
         permalinkHttpGetRouter.insert("/fake / slug",
             strategy.getHandler(getThemeRouteRules(), "fake-name"));
+
+        when(singlePageFinder.getByName(any())).thenReturn(Mono.empty());
         createClient().get()
             .uri("/fake / slug")
             .exchange()
@@ -74,6 +73,9 @@ class SinglePageRouteStrategyTest extends RouterStrategyTestSuite {
     void shouldResponse200IfSlugNameContainsChineseChars() {
         permalinkHttpGetRouter.insert("/中文",
             strategy.getHandler(getThemeRouteRules(), "fake-name"));
+
+        when(singlePageFinder.getByName(any())).thenReturn(Mono.empty());
+
         createClient().get()
             .uri("/中文")
             .exchange()

--- a/src/test/java/run/halo/app/theme/router/strategy/TagRouteStrategyTest.java
+++ b/src/test/java/run/halo/app/theme/router/strategy/TagRouteStrategyTest.java
@@ -1,10 +1,8 @@
 package run.halo.app.theme.router.strategy;
 
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyInt;
-import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.when;
 
-import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -14,8 +12,9 @@ import org.springframework.http.HttpStatus;
 import org.springframework.test.web.reactive.server.WebTestClient;
 import org.springframework.web.reactive.function.server.RouterFunction;
 import org.springframework.web.reactive.function.server.ServerResponse;
-import run.halo.app.extension.ListResult;
+import reactor.core.publisher.Mono;
 import run.halo.app.theme.finders.PostFinder;
+import run.halo.app.theme.finders.TagFinder;
 
 /**
  * Tests for {@link TagRouteStrategy}.
@@ -28,15 +27,11 @@ class TagRouteStrategyTest extends RouterStrategyTestSuite {
 
     @Mock
     private PostFinder postFinder;
+    @Mock
+    private TagFinder tagFinder;
 
     @InjectMocks
     private TagRouteStrategy tagRouteStrategy;
-
-    @Override
-    public void setUp() {
-        lenient().when(postFinder.listByTag(anyInt(), anyInt(), any()))
-            .thenReturn(new ListResult<>(1, 10, 0, List.of()));
-    }
 
     @Test
     void getRouteFunction() {
@@ -45,6 +40,7 @@ class TagRouteStrategyTest extends RouterStrategyTestSuite {
 
         permalinkHttpGetRouter.insert("/tags-test/fake-slug",
             tagRouteStrategy.getHandler(getThemeRouteRules(), "fake-name"));
+        when(tagFinder.getByName(any())).thenReturn(Mono.empty());
 
         client.get()
             .uri("/tags-test/fake-slug")

--- a/src/test/java/run/halo/app/theme/router/strategy/TagsRouteStrategyTest.java
+++ b/src/test/java/run/halo/app/theme/router/strategy/TagsRouteStrategyTest.java
@@ -1,6 +1,6 @@
 package run.halo.app.theme.router.strategy;
 
-import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.when;
 
 import java.util.List;
 import org.junit.jupiter.api.Test;
@@ -13,6 +13,7 @@ import org.springframework.test.web.reactive.server.WebTestClient;
 import org.springframework.web.reactive.function.server.HandlerFunction;
 import org.springframework.web.reactive.function.server.RouterFunction;
 import org.springframework.web.reactive.function.server.ServerResponse;
+import reactor.core.publisher.Flux;
 import run.halo.app.theme.finders.TagFinder;
 
 /**
@@ -30,11 +31,6 @@ class TagsRouteStrategyTest extends RouterStrategyTestSuite {
     @InjectMocks
     private TagsRouteStrategy tagsRouteStrategy;
 
-    @Override
-    public void setUp() {
-        lenient().when(tagFinder.listAll()).thenReturn(List.of());
-    }
-
     @Test
     void getRouteFunction() {
         RouterFunction<ServerResponse> routeFunction = getRouterFunction();
@@ -45,6 +41,7 @@ class TagsRouteStrategyTest extends RouterStrategyTestSuite {
         for (String routerPath : routerPaths) {
             permalinkHttpGetRouter.insert(routerPath, handler);
         }
+        when(tagFinder.listAll()).thenReturn(Flux.empty());
 
         client.get()
             .uri("/tags-test")


### PR DESCRIPTION
#### What type of PR is this?
/kind feature
/area core
/milestone 2.0

#### What this PR does / why we need it:
将所有 Finder 的返回值都修改为 Mono 或 Flux

#### Which issue(s) this PR fixes:

Fixes #2671

#### Special notes for your reviewer:
how to test it?
切换几个主题都点一下，没有报错即为正常

/cc @halo-dev/sig-halo 
#### Does this PR introduce a user-facing change?

```release-note
主题端 Finder 支持 Reactive API
```
