### PR TITLE
Fix the problem of unpublishing and recycling posts by member of post manager

### DIFF
--- a/src/main/resources/extensions/role-template-post.yaml
+++ b/src/main/resources/extensions/role-template-post.yaml
@@ -16,7 +16,7 @@ rules:
     resources: [ "posts" ]
     verbs: [ "*" ]
   - apiGroups: [ "api.console.halo.run" ]
-    resources: [ "posts", "posts/publish", "contents", "contents/publish" ]
+    resources: [ "posts", "posts/publish", "posts/unpublish", "posts/recycle", "contents", "contents/publish" ]
     verbs: [ "create", "patch", "update", "delete", "deletecollection" ]
 ---
 apiVersion: v1alpha1


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/area core
/milestone 2.0

#### What this PR does / why we need it:

This PR refines the role template of posts to allow post managers to unpublish and recycle a specific post.

Before that, post managers will be forbidden to unpublishing and recycling posts. You can see the screenshot below:

![image](https://user-images.githubusercontent.com/16865714/201571476-4bbe6007-94a2-45c1-99fd-1e6c76918eae.png)

After that, we can unpublish and recycle posts successfully. You can see the screenshot below:

![image](https://user-images.githubusercontent.com/16865714/201571537-6179fab4-aecf-46a3-8c5b-bafe0c0accee.png)

#### Special notes for your reviewer:

Steps to test manually:

1. Create a `Role` with `Posts Management` permission
2. Create an `User` with the role bound
3. Login with the `User`
4. Create a `Post` and publish it
5. Unpublish the post and Recycle it

#### Does this PR introduce a user-facing change?

```release-note
修复无法“取消发布”和“删除”文章的错误
```
