### PR TITLE
feat: supports subscribe extension changing events through EventListener annotations

### DIFF
--- a/src/main/java/run/halo/app/event/extension/AbstractExtensionEvent.java
+++ b/src/main/java/run/halo/app/event/extension/AbstractExtensionEvent.java
@@ -1,0 +1,28 @@
+package run.halo.app.event.extension;
+
+import org.springframework.context.ApplicationEvent;
+import run.halo.app.extension.Extension;
+import run.halo.app.plugin.SharedEvent;
+
+/**
+ * <p>Events produced during changing an {@link Extension}.</p>
+ * This event is marked with {@link SharedEvent} annotation and will be propagated to the plugin
+ * when the event is triggered.
+ *
+ * @author guqing
+ * @since 2.0.0
+ */
+@SharedEvent
+public abstract class AbstractExtensionEvent extends ApplicationEvent {
+
+    private final Extension extension;
+
+    public AbstractExtensionEvent(Object source, Extension extension) {
+        super(source);
+        this.extension = extension;
+    }
+
+    public Extension getExtension() {
+        return extension;
+    }
+}

--- a/src/main/java/run/halo/app/event/extension/AbstractExtensionEvent.java
+++ b/src/main/java/run/halo/app/event/extension/AbstractExtensionEvent.java
@@ -2,17 +2,13 @@ package run.halo.app.event.extension;
 
 import org.springframework.context.ApplicationEvent;
 import run.halo.app.extension.Extension;
-import run.halo.app.plugin.SharedEvent;
 
 /**
  * <p>Events produced during changing an {@link Extension}.</p>
- * This event is marked with {@link SharedEvent} annotation and will be propagated to the plugin
- * when the event is triggered.
  *
  * @author guqing
  * @since 2.0.0
  */
-@SharedEvent
 public abstract class AbstractExtensionEvent extends ApplicationEvent {
 
     private final Extension extension;

--- a/src/main/java/run/halo/app/event/extension/ExtensionAddEvent.java
+++ b/src/main/java/run/halo/app/event/extension/ExtensionAddEvent.java
@@ -1,0 +1,16 @@
+package run.halo.app.event.extension;
+
+import run.halo.app.extension.Extension;
+
+/**
+ * <p>Events produced during adding an {@link Extension}.</p>
+ *
+ * @author guqing
+ * @since 2.0.0
+ */
+public class ExtensionAddEvent extends AbstractExtensionEvent {
+
+    public ExtensionAddEvent(Object source, Extension extension) {
+        super(source, extension);
+    }
+}

--- a/src/main/java/run/halo/app/event/extension/ExtensionDeleteEvent.java
+++ b/src/main/java/run/halo/app/event/extension/ExtensionDeleteEvent.java
@@ -1,0 +1,16 @@
+package run.halo.app.event.extension;
+
+import run.halo.app.extension.Extension;
+
+/**
+ * <p>Events produced during deleting an {@link Extension}.</p>
+ *
+ * @author guqing
+ * @since 2.0.0
+ */
+public class ExtensionDeleteEvent extends AbstractExtensionEvent {
+
+    public ExtensionDeleteEvent(Object source, Extension extension) {
+        super(source, extension);
+    }
+}

--- a/src/main/java/run/halo/app/event/extension/ExtensionEmitter.java
+++ b/src/main/java/run/halo/app/event/extension/ExtensionEmitter.java
@@ -1,0 +1,78 @@
+package run.halo.app.event.extension;
+
+import org.springframework.beans.factory.InitializingBean;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.stereotype.Component;
+import run.halo.app.extension.Extension;
+import run.halo.app.extension.ReactiveExtensionClient;
+import run.halo.app.extension.Watcher;
+
+/**
+ * <p>An emitter to emit events produced during changing an {@link Extension}.</p>
+ *
+ * @author guqing
+ * @since 2.0.0
+ */
+@Component
+public class ExtensionEmitter implements Watcher, InitializingBean {
+    private final ApplicationEventPublisher applicationEventPublisher;
+    private final ReactiveExtensionClient client;
+
+    private volatile boolean disposed = false;
+
+    private Runnable disposeHook;
+
+    public ExtensionEmitter(ApplicationEventPublisher applicationEventPublisher,
+        ReactiveExtensionClient client) {
+        this.applicationEventPublisher = applicationEventPublisher;
+        this.client = client;
+    }
+
+    @Override
+    public void onAdd(Extension extension) {
+        if (isDisposed()) {
+            return;
+        }
+        applicationEventPublisher.publishEvent(new ExtensionAddEvent(this, extension));
+    }
+
+    @Override
+    public void onUpdate(Extension oldExtension, Extension newExtension) {
+        if (isDisposed()) {
+            return;
+        }
+        applicationEventPublisher.publishEvent(
+            new ExtensionUpdateEvent(this, oldExtension, newExtension));
+    }
+
+    @Override
+    public void onDelete(Extension extension) {
+        if (isDisposed()) {
+            return;
+        }
+        applicationEventPublisher.publishEvent(new ExtensionDeleteEvent(this, extension));
+    }
+
+    @Override
+    public void registerDisposeHook(Runnable dispose) {
+        this.disposeHook = dispose;
+    }
+
+    @Override
+    public void dispose() {
+        this.disposed = true;
+        if (this.disposeHook != null) {
+            this.disposeHook.run();
+        }
+    }
+
+    @Override
+    public boolean isDisposed() {
+        return this.disposed;
+    }
+
+    @Override
+    public void afterPropertiesSet() throws Exception {
+        client.watch(this);
+    }
+}

--- a/src/main/java/run/halo/app/event/extension/ExtensionUpdateEvent.java
+++ b/src/main/java/run/halo/app/event/extension/ExtensionUpdateEvent.java
@@ -1,0 +1,22 @@
+package run.halo.app.event.extension;
+
+import run.halo.app.extension.Extension;
+
+/**
+ * <p>Events produced during updating an {@link Extension}.</p>
+ *
+ * @author guqing
+ * @since 2.0.0
+ */
+public class ExtensionUpdateEvent extends AbstractExtensionEvent {
+    private final Extension oldExtension;
+
+    public ExtensionUpdateEvent(Object source, Extension oldExtension, Extension extension) {
+        super(source, extension);
+        this.oldExtension = oldExtension;
+    }
+
+    public Extension getOldExtension() {
+        return oldExtension;
+    }
+}

--- a/src/main/java/run/halo/app/plugin/PluginApplicationEventBridgeDispatcher.java
+++ b/src/main/java/run/halo/app/plugin/PluginApplicationEventBridgeDispatcher.java
@@ -1,6 +1,5 @@
 package run.halo.app.plugin;
 
-import java.lang.reflect.AnnotatedElement;
 import java.util.List;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.ApplicationEvent;
@@ -30,13 +29,13 @@ public class PluginApplicationEventBridgeDispatcher
         List<PluginApplicationContext> pluginApplicationContexts =
             ExtensionContextRegistry.getInstance().getPluginApplicationContexts();
         for (PluginApplicationContext pluginApplicationContext : pluginApplicationContexts) {
-            log.debug("Bridging broadcast event [{}] to plugin [{}]", event,
+            log.trace("Bridging broadcast event [{}] to plugin [{}]", event,
                 pluginApplicationContext.getPluginId());
             pluginApplicationContext.publishEvent(event);
         }
     }
 
-    private boolean isSharedEventAnnotationPresent(AnnotatedElement annotatedElement) {
-        return AnnotationUtils.findAnnotation(annotatedElement, SharedEvent.class) != null;
+    private boolean isSharedEventAnnotationPresent(Class<?> clazz) {
+        return AnnotationUtils.findAnnotation(clazz, SharedEvent.class) != null;
     }
 }

--- a/src/main/java/run/halo/app/plugin/SharedApplicationContextHolder.java
+++ b/src/main/java/run/halo/app/plugin/SharedApplicationContextHolder.java
@@ -6,6 +6,7 @@ import org.springframework.stereotype.Component;
 import run.halo.app.extension.DefaultSchemeManager;
 import run.halo.app.extension.ExtensionClient;
 import run.halo.app.extension.ReactiveExtensionClient;
+import run.halo.app.infra.ExternalUrlSupplier;
 
 /**
  * <p>This {@link SharedApplicationContextHolder} class is used to hold a singleton instance of
@@ -61,6 +62,8 @@ public class SharedApplicationContextHolder {
         DefaultSchemeManager defaultSchemeManager =
             rootApplicationContext.getBean(DefaultSchemeManager.class);
         beanFactory.registerSingleton("schemeManager", defaultSchemeManager);
+        beanFactory.registerSingleton("externalUrlSupplier",
+            rootApplicationContext.getBean(ExternalUrlSupplier.class));
         // TODO add more shared instance here
 
         return sharedApplicationContext;


### PR DESCRIPTION
#### What type of PR is this?
/kind feature
/area core
/milestone 2.0

#### What this PR does / why we need it:
Halo 支持通过 EventListener 注解订阅 Extension 事件
- ExtensionAddEvent
- ExtensionUpdateEvent
- ExtensionDeleteEvent
例如
```java
    @EventListener(ExtensionAddEvent.class)
    public void onExtensionAdd(ExtensionAddEvent event) {
        System.out.println("Extension added: " + event.getExtension());
    }

    @EventListener(ExtensionUpdateEvent.class)
    public Mono<Void> onExtensionAdd(ExtensionUpdateEvent event) {
        return Mono.just(event.getExtension()).then();
    }
```

#### Special notes for your reviewer:
how to test it?
如描述中所写监听一下上述 event，修改或添加 Extension 后对应事件触发时能监听到即可

/cc @halo-dev/sig-halo 
#### Does this PR introduce a user-facing change?

```release-note
支持通过 EventListener 注解订阅自定义模型资源状态改变事件
```
