### PR TITLE
Provide sort query param for sorting attachment

### DIFF
--- a/src/main/java/run/halo/app/core/extension/endpoint/PluginEndpoint.java
+++ b/src/main/java/run/halo/app/core/extension/endpoint/PluginEndpoint.java
@@ -22,7 +22,9 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.time.Duration;
+import java.util.ArrayList;
 import java.util.Comparator;
+import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Predicate;
@@ -47,6 +49,7 @@ import reactor.core.publisher.Mono;
 import reactor.core.scheduler.Schedulers;
 import reactor.util.retry.Retry;
 import run.halo.app.core.extension.Plugin;
+import run.halo.app.extension.Comparators;
 import run.halo.app.extension.ReactiveExtensionClient;
 import run.halo.app.extension.router.IListRequest.QueryListRequest;
 import run.halo.app.infra.utils.FileUtils;
@@ -243,14 +246,19 @@ public class PluginEndpoint implements CustomEndpoint {
         public Comparator<Plugin> toComparator() {
             var sort = getSort();
             var ctOrder = sort.getOrderFor("creationTimestamp");
-            Comparator<Plugin> comparator = null;
+            List<Comparator<Plugin>> comparators = new ArrayList<>();
             if (ctOrder != null) {
-                comparator = comparing(plugin -> plugin.getMetadata().getCreationTimestamp());
+                Comparator<Plugin> comparator = comparing(plugin -> plugin.getMetadata().getCreationTimestamp());
                 if (ctOrder.isDescending()) {
                     comparator = comparator.reversed();
                 }
+                comparators.add(comparator);
             }
-            return comparator;
+            comparators.add(Comparators.compareCreationTimestamp(false));
+            comparators.add(Comparators.compareName(true));
+            return comparators.stream()
+                .reduce(Comparator::thenComparing)
+                .orElse(null);
         }
     }
 

--- a/src/main/java/run/halo/app/core/extension/endpoint/PluginEndpoint.java
+++ b/src/main/java/run/halo/app/core/extension/endpoint/PluginEndpoint.java
@@ -248,7 +248,8 @@ public class PluginEndpoint implements CustomEndpoint {
             var ctOrder = sort.getOrderFor("creationTimestamp");
             List<Comparator<Plugin>> comparators = new ArrayList<>();
             if (ctOrder != null) {
-                Comparator<Plugin> comparator = comparing(plugin -> plugin.getMetadata().getCreationTimestamp());
+                Comparator<Plugin> comparator =
+                    comparing(plugin -> plugin.getMetadata().getCreationTimestamp());
                 if (ctOrder.isDescending()) {
                     comparator = comparator.reversed();
                 }

--- a/src/main/java/run/halo/app/extension/Comparators.java
+++ b/src/main/java/run/halo/app/extension/Comparators.java
@@ -1,0 +1,20 @@
+package run.halo.app.extension;
+
+import java.time.Instant;
+import java.util.Comparator;
+
+public enum Comparators {
+    ;
+
+    public static <E extends Extension> Comparator<E> compareCreationTimestamp(boolean asc) {
+        var comparator =
+            Comparator.<E, Instant>comparing(e -> e.getMetadata().getCreationTimestamp());
+        return asc ? comparator : comparator.reversed();
+    }
+
+    public static <E extends Extension> Comparator<E> compareName(boolean asc) {
+        var comparator = Comparator.<E, String>comparing(e -> e.getMetadata().getName());
+        return asc ? comparator : comparator.reversed();
+    }
+
+}

--- a/src/test/java/run/halo/app/extension/ComparatorsTest.java
+++ b/src/test/java/run/halo/app/extension/ComparatorsTest.java
@@ -1,0 +1,13 @@
+package run.halo.app.extension;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.Nested;
+
+class ComparatorsTest {
+
+    @Nested
+    class CompareCreationTimestamp {
+
+    }
+}

--- a/src/test/java/run/halo/app/extension/ComparatorsTest.java
+++ b/src/test/java/run/halo/app/extension/ComparatorsTest.java
@@ -1,13 +1,97 @@
 package run.halo.app.extension;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
 import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
 
 class ComparatorsTest {
 
     @Nested
     class CompareCreationTimestamp {
 
+        FakeExtension createFake(String name, Instant creationTimestamp) {
+            var metadata = new Metadata();
+            metadata.setName(name);
+            metadata.setCreationTimestamp(creationTimestamp);
+            var fake = new FakeExtension();
+            fake.setMetadata(metadata);
+            return fake;
+        }
+
+        @Test
+        void desc() {
+            var comparator = Comparators.compareCreationTimestamp(false);
+            var now = Instant.now();
+            var before = now.minusMillis(1);
+            var after = now.plusMillis(1);
+
+            var fakeNow = createFake("now", now);
+            var fakeBefore = createFake("before", before);
+            var fakeAfter = createFake("after", after);
+
+            var sortedFakes = new ArrayList<>(List.of(fakeNow, fakeAfter, fakeBefore));
+            sortedFakes.sort(comparator);
+
+            assertEquals(List.of(fakeAfter, fakeNow, fakeBefore), sortedFakes);
+        }
+
+        @Test
+        void asc() {
+            var comparator = Comparators.compareCreationTimestamp(true);
+            var now = Instant.now();
+            var before = now.minusMillis(1);
+            var after = now.plusMillis(1);
+
+            var fakeNow = createFake("now", now);
+            var fakeBefore = createFake("before", before);
+            var fakeAfter = createFake("after", after);
+
+            var sortedFakes = new ArrayList<>(List.of(fakeNow, fakeAfter, fakeBefore));
+            sortedFakes.sort(comparator);
+
+            assertEquals(List.of(fakeBefore, fakeNow, fakeAfter), sortedFakes);
+        }
+    }
+
+    @Nested
+    class CompareName {
+
+        FakeExtension createFake(String name) {
+            var metadata = new Metadata();
+            metadata.setName(name);
+            var fake = new FakeExtension();
+            fake.setMetadata(metadata);
+            return fake;
+        }
+
+        @Test
+        void desc() {
+            var comparator = Comparators.compareName(false);
+            var fake01 = createFake("fake01");
+            var fake02 = createFake("fake02");
+            var fake03 = createFake("fake03");
+
+            var sortedFakes = new ArrayList<>(List.of(fake02, fake01, fake03));
+            sortedFakes.sort(comparator);
+
+            assertEquals(List.of(fake03, fake02, fake01), sortedFakes);
+        }
+
+        @Test
+        void asc() {
+            var comparator = Comparators.compareName(true);
+            var fake01 = createFake("fake01");
+            var fake02 = createFake("fake02");
+            var fake03 = createFake("fake03");
+
+            var sortedFakes = new ArrayList<>(List.of(fake02, fake03, fake01));
+            sortedFakes.sort(comparator);
+
+            assertEquals(List.of(fake01, fake02, fake03), sortedFakes);
+        }
     }
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind feature
/area core
/milestone 2.0

#### What this PR does / why we need it:

Provide sort query param for sorting attachment. By default, we use creationTimestamp(desc) to sort the attachments.

Below is an example to sort with creationTimestamp(desc) and size(asc):

```bash
curl -X 'GET' \
  'http://localhost:8090/apis/api.console.halo.run/v1alpha1/attachments?sort=creationTimestamp%2Cdesc&sort=size%2Casc' \
  -H 'accept: */*'
```

#### Which issue(s) this PR fixes:

Fixes https://github.com/halo-dev/halo/issues/2627

#### Does this PR introduce a user-facing change?

```release-note
附件列表支持排序
```
