### PR TITLE
Prevent H2 from closing on exit to allow destruction

### DIFF
--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -7,7 +7,7 @@ spring:
     ansi:
       enabled: detect
   r2dbc:
-    url: r2dbc:h2:file:///${halo.work-dir}/db/halo-next?options=AUTO_SERVER=TRUE;MODE=MySQL
+    url: r2dbc:h2:file:///${halo.work-dir}/db/halo-next?MODE=MySQL&DB_CLOSE_ON_EXIT=FALSE
     username: admin
     password: 123456
   sql:


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/area core

#### What this PR does / why we need it:

Before this, `CounterMeterHandler#stop` will encounter an error when Halo is graceful shutdown due to database closed before.

```java
2022-11-16T15:52:17.904+08:00 DEBUG 21324 --- [ionShutdownHook] r.halo.app.metrics.CounterMeterHandler   : Persist counter meters to database before destroy...
2022-11-16T15:52:17.910+08:00 ERROR 21324 --- [ionShutdownHook] r.halo.app.metrics.CounterMeterHandler   : Persist counter meters to database failed.

org.springframework.dao.DataAccessResourceFailureException: Failed to obtain R2DBC Connection
	at org.springframework.r2dbc.connection.ConnectionFactoryUtils.lambda$getConnection$0(ConnectionFactoryUtils.java:88) ~[spring-r2dbc-6.0.0-RC4.jar:6.0.0-RC4]
	Suppressed: reactor.core.publisher.FluxOnAssembly$OnAssemblyException: 
```

#### Special notes for your reviewer:

Steps to test:

1. Start Halo and then stop it
2. See the log detail

#### Does this PR introduce a user-facing change?

```release-note
None
```
