### PR TITLE
[WIP] refactor: snapshot attributes and post publish

### DIFF
--- a/src/main/java/run/halo/app/config/ExtensionConfiguration.java
+++ b/src/main/java/run/halo/app/config/ExtensionConfiguration.java
@@ -151,11 +151,11 @@ public class ExtensionConfiguration {
         @Bean
         Controller postController(ExtensionClient client, ContentService contentService,
             PostPermalinkPolicy postPermalinkPolicy, CounterService counterService,
-            PostService postService) {
+            PostService postService, ApplicationContext applicationContext) {
             return new ControllerBuilder("post-controller", client)
                 .reconciler(new PostReconciler(client, contentService, postService,
                     postPermalinkPolicy,
-                    counterService))
+                    counterService, applicationContext))
                 .extension(new Post())
                 .build();
         }

--- a/src/main/java/run/halo/app/config/ExtensionConfiguration.java
+++ b/src/main/java/run/halo/app/config/ExtensionConfiguration.java
@@ -9,7 +9,6 @@ import org.springframework.web.reactive.function.server.RouterFunction;
 import org.springframework.web.reactive.function.server.ServerResponse;
 import run.halo.app.content.ContentService;
 import run.halo.app.content.PostService;
-import run.halo.app.content.SinglePageService;
 import run.halo.app.content.permalinks.CategoryPermalinkPolicy;
 import run.halo.app.content.permalinks.PostPermalinkPolicy;
 import run.halo.app.content.permalinks.TagPermalinkPolicy;
@@ -202,10 +201,10 @@ public class ExtensionConfiguration {
         @Bean
         Controller singlePageController(ExtensionClient client, ContentService contentService,
             ApplicationContext applicationContext, CounterService counterService,
-            SinglePageService singlePageService, ExternalUrlSupplier externalUrlSupplier) {
+            ExternalUrlSupplier externalUrlSupplier) {
             return new ControllerBuilder("single-page-controller", client)
                 .reconciler(new SinglePageReconciler(client, contentService,
-                    applicationContext, singlePageService, counterService, externalUrlSupplier)
+                    applicationContext, counterService, externalUrlSupplier)
                 )
                 .extension(new SinglePage())
                 .build();

--- a/src/main/java/run/halo/app/content/ContentRequest.java
+++ b/src/main/java/run/halo/app/content/ContentRequest.java
@@ -1,6 +1,7 @@
 package run.halo.app.content;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.HashMap;
 import org.apache.commons.lang3.StringUtils;
 import run.halo.app.core.extension.Snapshot;
 import run.halo.app.extension.Metadata;
@@ -17,29 +18,21 @@ public record ContentRequest(@Schema(required = true) Ref subjectRef,
                              @Schema(required = true) String rawType) {
 
     public Snapshot toSnapshot() {
-        Snapshot snapshot = new Snapshot();
+        final Snapshot snapshot = new Snapshot();
 
         Metadata metadata = new Metadata();
-        metadata.setName(defaultName(subjectRef));
+        metadata.setAnnotations(new HashMap<>());
         snapshot.setMetadata(metadata);
 
         Snapshot.SnapShotSpec snapShotSpec = new Snapshot.SnapShotSpec();
         snapShotSpec.setSubjectRef(subjectRef);
-        snapShotSpec.setVersion(1);
+
         snapShotSpec.setRawType(rawType);
         snapShotSpec.setRawPatch(StringUtils.defaultString(raw()));
         snapShotSpec.setContentPatch(StringUtils.defaultString(content()));
-        String displayVersion = Snapshot.displayVersionFrom(snapShotSpec.getVersion());
-        snapShotSpec.setDisplayVersion(displayVersion);
 
         snapshot.setSpec(snapShotSpec);
         return snapshot;
-    }
-
-    private String defaultName(Ref subjectRef) {
-        // example: Post-apost-v1-snapshot
-        return String.join("-", subjectRef.getKind(),
-            subjectRef.getName(), "v1", "snapshot");
     }
 
     public String rawPatchFrom(String originalRaw) {

--- a/src/main/java/run/halo/app/content/ContentService.java
+++ b/src/main/java/run/halo/app/content/ContentService.java
@@ -19,8 +19,6 @@ public interface ContentService {
 
     Mono<ContentWrapper> updateContent(ContentRequest content);
 
-    Mono<ContentWrapper> publish(String headSnapshotName, Ref subjectRef);
-
     Mono<Snapshot> getBaseSnapshot(Ref subjectRef);
 
     Mono<Snapshot> latestSnapshotVersion(Ref subjectRef);

--- a/src/main/java/run/halo/app/content/ContentService.java
+++ b/src/main/java/run/halo/app/content/ContentService.java
@@ -17,13 +17,13 @@ public interface ContentService {
 
     Mono<ContentWrapper> draftContent(ContentRequest content);
 
+    Mono<ContentWrapper> draftContent(ContentRequest content, String parentName);
+
     Mono<ContentWrapper> updateContent(ContentRequest content);
 
     Mono<Snapshot> getBaseSnapshot(Ref subjectRef);
 
     Mono<Snapshot> latestSnapshotVersion(Ref subjectRef);
-
-    Mono<Snapshot> latestPublishedSnapshot(Ref subjectRef);
 
     Flux<Snapshot> listSnapshots(Ref subjectRef);
 }

--- a/src/main/java/run/halo/app/content/ContentWrapper.java
+++ b/src/main/java/run/halo/app/content/ContentWrapper.java
@@ -11,7 +11,6 @@ import lombok.Data;
 @Builder
 public class ContentWrapper {
     private String snapshotName;
-    private Integer version;
     private String raw;
     private String content;
     private String rawType;

--- a/src/main/java/run/halo/app/content/PostService.java
+++ b/src/main/java/run/halo/app/content/PostService.java
@@ -17,6 +17,4 @@ public interface PostService {
     Mono<Post> draftPost(PostRequest postRequest);
 
     Mono<Post> updatePost(PostRequest postRequest);
-
-    Mono<Boolean> publishPost(String postName, String releaseSnapshotName);
 }

--- a/src/main/java/run/halo/app/content/PostService.java
+++ b/src/main/java/run/halo/app/content/PostService.java
@@ -18,5 +18,5 @@ public interface PostService {
 
     Mono<Post> updatePost(PostRequest postRequest);
 
-    Mono<Post> publishPost(String postName);
+    Mono<Boolean> publishPost(String postName, String releaseSnapshotName);
 }

--- a/src/main/java/run/halo/app/content/SinglePageService.java
+++ b/src/main/java/run/halo/app/content/SinglePageService.java
@@ -18,5 +18,5 @@ public interface SinglePageService {
 
     Mono<SinglePage> update(SinglePageRequest pageRequest);
 
-    Mono<SinglePage> publish(String name);
+    Mono<Boolean> publish(String name, String releaseSnapshot);
 }

--- a/src/main/java/run/halo/app/content/SinglePageService.java
+++ b/src/main/java/run/halo/app/content/SinglePageService.java
@@ -17,6 +17,4 @@ public interface SinglePageService {
     Mono<SinglePage> draft(SinglePageRequest pageRequest);
 
     Mono<SinglePage> update(SinglePageRequest pageRequest);
-
-    Mono<Boolean> publish(String name, String releaseSnapshot);
 }

--- a/src/main/java/run/halo/app/content/impl/ContentServiceImpl.java
+++ b/src/main/java/run/halo/app/content/impl/ContentServiceImpl.java
@@ -1,19 +1,22 @@
 package run.halo.app.content.impl;
 
 import java.security.Principal;
+import java.time.Instant;
 import java.util.Comparator;
 import java.util.UUID;
-import org.apache.commons.lang3.StringUtils;
+import java.util.function.Function;
 import org.springframework.security.core.context.ReactiveSecurityContextHolder;
 import org.springframework.security.core.context.SecurityContext;
 import org.springframework.stereotype.Component;
 import org.springframework.util.Assert;
+import org.thymeleaf.util.StringUtils;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import run.halo.app.content.ContentRequest;
 import run.halo.app.content.ContentService;
 import run.halo.app.content.ContentWrapper;
 import run.halo.app.core.extension.Snapshot;
+import run.halo.app.extension.ExtensionUtil;
 import run.halo.app.extension.ReactiveExtensionClient;
 import run.halo.app.extension.Ref;
 
@@ -25,10 +28,6 @@ import run.halo.app.extension.Ref;
  */
 @Component
 public class ContentServiceImpl implements ContentService {
-    private static final Comparator<Snapshot> SNAPSHOT_COMPARATOR =
-        Comparator.comparing(Snapshot::getVersionAnno);
-    public static Comparator<Snapshot> LATEST_SNAPSHOT_COMPARATOR = SNAPSHOT_COMPARATOR.reversed();
-
     private final ReactiveExtensionClient client;
 
     public ContentServiceImpl(ReactiveExtensionClient client) {
@@ -43,36 +42,54 @@ public class ContentServiceImpl implements ContentService {
     }
 
     @Override
-    public Mono<ContentWrapper> draftContent(ContentRequest contentRequest) {
-        return getContextUsername()
-            .flatMap(username -> {
-                // create snapshot
-                Snapshot snapshot = contentRequest.toSnapshot();
-                snapshot.addContributor(username);
-                return client.create(snapshot)
-                    .flatMap(this::restoredContent);
-            });
+    public Mono<ContentWrapper> draftContent(ContentRequest content) {
+        return this.draftContent(content, content.headSnapshotName());
+    }
+
+    @Override
+    public Mono<ContentWrapper> draftContent(ContentRequest contentRequest, String parentName) {
+        return Mono.defer(
+                () -> {
+                    Snapshot snapshot = contentRequest.toSnapshot();
+                    snapshot.getMetadata().setName(UUID.randomUUID().toString());
+                    snapshot.getSpec().setParentSnapshotName(parentName);
+                    return getBaseSnapshot(contentRequest.subjectRef())
+                        .defaultIfEmpty(snapshot)
+                        .map(baseSnapshot -> determineRawAndContentPatch(snapshot, baseSnapshot,
+                            contentRequest))
+                        .flatMap(source -> getContextUsername()
+                            .map(username -> {
+                                Snapshot.addContributor(source, username);
+                                source.getSpec().setOwner(username);
+                                return source;
+                            })
+                            .defaultIfEmpty(source)
+                        );
+                })
+            .flatMap(snapshot -> client.create(snapshot)
+                .flatMap(this::restoredContent));
     }
 
     @Override
     public Mono<ContentWrapper> updateContent(ContentRequest contentRequest) {
         Assert.notNull(contentRequest, "The contentRequest must not be null");
         Assert.notNull(contentRequest.headSnapshotName(), "The headSnapshotName must not be null");
-        return Mono.zip(getContextUsername(),
-                client.fetch(Snapshot.class, contentRequest.headSnapshotName()))
-            .flatMap(tuple -> {
-                String username = tuple.getT1();
-                Snapshot headSnapShot = tuple.getT2();
-                return handleSnapshot(headSnapShot, contentRequest, username);
-            })
+        Ref subjectRef = contentRequest.subjectRef();
+        return client.fetch(Snapshot.class, contentRequest.headSnapshotName())
+            .flatMap(headSnapshot -> getBaseSnapshot(subjectRef)
+                .map(baseSnapshot -> determineRawAndContentPatch(headSnapshot, baseSnapshot,
+                    contentRequest)
+                )
+            )
+            .flatMap(headSnapshot -> getContextUsername()
+                .map(username -> {
+                    Snapshot.addContributor(headSnapshot, username);
+                    return headSnapshot;
+                })
+                .defaultIfEmpty(headSnapshot)
+            )
+            .flatMap(client::update)
             .flatMap(this::restoredContent);
-    }
-
-    private Mono<ContentWrapper> restoredContent(String snapshotName,
-        Ref subjectRef) {
-        return getBaseSnapshot(subjectRef)
-            .flatMap(baseSnapshot -> client.fetch(Snapshot.class, snapshotName)
-                .map(snapshot -> snapshot.applyPatch(baseSnapshot)));
     }
 
     private Mono<ContentWrapper> restoredContent(Snapshot headSnapshot) {
@@ -83,78 +100,17 @@ public class ContentServiceImpl implements ContentService {
     @Override
     public Mono<Snapshot> getBaseSnapshot(Ref subjectRef) {
         return listSnapshots(subjectRef)
-            .filter(snapshot -> Snapshot.getVersionAnno(snapshot) == 1)
+            .sort(createTimeReversedComparator().reversed())
+            .filter(p -> StringUtils.equals(Boolean.TRUE.toString(),
+                ExtensionUtil.nullSafeAnnotations(p).get(Snapshot.KEEP_RAW_ANNO)))
             .next();
-    }
-
-    private Mono<Snapshot> handleSnapshot(Snapshot headSnapshot, ContentRequest contentRequest,
-        String username) {
-        Ref subjectRef = contentRequest.subjectRef();
-        return getBaseSnapshot(subjectRef).flatMap(baseSnapshot -> {
-            String baseSnapshotName = baseSnapshot.getMetadata().getName();
-            return latestPublishedSnapshot(subjectRef)
-                .flatMap(latestReleasedSnapshot -> {
-                    Snapshot newSnapshot = contentRequest.toSnapshot();
-                    newSnapshot.getSpec().setSubjectRef(subjectRef);
-                    newSnapshot.addContributor(username);
-                    // has released snapshot, there are 3 assumptions:
-                    // if headPtr != releasePtr && head is not published, then update its content
-                    // directly
-                    // if headPtr != releasePtr && head is published, then create a new snapshot
-                    // if headPtr == releasePtr, then create a new snapshot too
-                    return latestSnapshotVersion(subjectRef)
-                        .flatMap(latestSnapshot -> {
-                            String headSnapshotName = contentRequest.headSnapshotName();
-                            newSnapshot.getSpec()
-                                .setVersion(latestSnapshot.getSpec().getVersion() + 1);
-                            newSnapshot.getSpec().setDisplayVersion(
-                                Snapshot.displayVersionFrom(newSnapshot.getSpec().getVersion()));
-                            newSnapshot.getSpec()
-                                .setParentSnapshotName(headSnapshotName);
-                            // head is published or headPtr == releasePtr
-                            String releasedSnapshotName =
-                                latestReleasedSnapshot.getMetadata().getName();
-                            if (headSnapshot.isPublished() || StringUtils.equals(headSnapshotName,
-                                releasedSnapshotName)) {
-                                String latestSnapshotName = latestSnapshot.getMetadata().getName();
-                                if (!headSnapshotName.equals(latestSnapshotName)
-                                    && !latestSnapshot.isPublished()) {
-                                    // publish it then create new one
-                                    return publish(latestSnapshotName, subjectRef)
-                                        .then(createNewSnapshot(newSnapshot, baseSnapshotName,
-                                            contentRequest));
-                                }
-                                // create a new snapshot,done
-                                return createNewSnapshot(newSnapshot, baseSnapshotName,
-                                    contentRequest);
-                            }
-
-                            // otherwise update its content directly
-                            return updateRawAndContentToHeadSnapshot(headSnapshot, baseSnapshotName,
-                                contentRequest);
-                        });
-                })
-                // no released snapshot, indicating v1 now, just update the content directly
-                .switchIfEmpty(Mono.defer(
-                    () -> updateRawAndContentToHeadSnapshot(headSnapshot, baseSnapshotName,
-                        contentRequest)));
-        });
     }
 
     @Override
     public Mono<Snapshot> latestSnapshotVersion(Ref subjectRef) {
         Assert.notNull(subjectRef, "The subjectRef must not be null.");
         return listSnapshots(subjectRef)
-            .sort(LATEST_SNAPSHOT_COMPARATOR)
-            .next();
-    }
-
-    @Override
-    public Mono<Snapshot> latestPublishedSnapshot(Ref subjectRef) {
-        Assert.notNull(subjectRef, "The subjectRef must not be null.");
-        return listSnapshots(subjectRef)
-            .filter(Snapshot::isPublished)
-            .sort(LATEST_SNAPSHOT_COMPARATOR)
+            .sort(createTimeReversedComparator())
             .next();
     }
 
@@ -171,41 +127,22 @@ public class ContentServiceImpl implements ContentService {
             .map(Principal::getName);
     }
 
-    private Mono<Snapshot> updateRawAndContentToHeadSnapshot(Snapshot snapshotToUpdate,
-        String baseSnapshotName,
+    private Snapshot determineRawAndContentPatch(Snapshot snapshotToUse, Snapshot baseSnapshot,
         ContentRequest contentRequest) {
-        return client.fetch(Snapshot.class, baseSnapshotName)
-            .flatMap(baseSnapshot -> {
-                determineRawAndContentPatch(snapshotToUpdate,
-                    baseSnapshot, contentRequest);
-                return client.update(snapshotToUpdate)
-                    .thenReturn(snapshotToUpdate);
-            });
-    }
-
-    private Mono<Snapshot> createNewSnapshot(Snapshot snapshotToCreate,
-        String baseSnapshotName,
-        ContentRequest contentRequest) {
-        return client.fetch(Snapshot.class, baseSnapshotName)
-            .flatMap(baseSnapshot -> {
-                determineRawAndContentPatch(snapshotToCreate,
-                    baseSnapshot, contentRequest);
-                snapshotToCreate.getMetadata().setName(UUID.randomUUID().toString());
-                snapshotToCreate.getSpec().setSubjectRef(contentRequest.subjectRef());
-                return client.create(snapshotToCreate)
-                    .thenReturn(snapshotToCreate);
-            });
-    }
-
-    private void determineRawAndContentPatch(Snapshot snapshotToUse, Snapshot baseSnapshot,
-        ContentRequest contentRequest) {
+        Assert.notNull(baseSnapshot, "The baseSnapshot must not be null.");
+        Assert.notNull(contentRequest, "The contentRequest must not be null.");
+        Assert.notNull(snapshotToUse, "The snapshotToUse not be null.");
         String originalRaw = baseSnapshot.getSpec().getRawPatch();
         String originalContent = baseSnapshot.getSpec().getContentPatch();
+        String baseSnapshotName = baseSnapshot.getMetadata().getName();
 
+        snapshotToUse.getSpec().setLastModifyTime(Instant.now());
         // it is the v1 snapshot, set the content directly
-        if (Snapshot.getVersionAnno(snapshotToUse) == 1) {
+        if (StringUtils.equals(baseSnapshotName, snapshotToUse.getMetadata().getName())) {
             snapshotToUse.getSpec().setRawPatch(contentRequest.raw());
             snapshotToUse.getSpec().setContentPatch(contentRequest.content());
+            ExtensionUtil.nullSafeAnnotations(snapshotToUse)
+                .put(Snapshot.KEEP_RAW_ANNO, Boolean.TRUE.toString());
         } else {
             // otherwise diff a patch based on the v1 snapshot
             String revisedRaw = contentRequest.rawPatchFrom(originalRaw);
@@ -213,5 +150,15 @@ public class ContentServiceImpl implements ContentService {
             snapshotToUse.getSpec().setRawPatch(revisedRaw);
             snapshotToUse.getSpec().setContentPatch(revisedContent);
         }
+        return snapshotToUse;
+    }
+
+    Comparator<Snapshot> createTimeReversedComparator() {
+        Function<Snapshot, String> name = snapshot -> snapshot.getMetadata().getName();
+        Function<Snapshot, Instant> createTime = snapshot -> snapshot.getMetadata()
+            .getCreationTimestamp();
+        return Comparator.comparing(createTime)
+            .thenComparing(name)
+            .reversed();
     }
 }

--- a/src/main/java/run/halo/app/core/extension/Post.java
+++ b/src/main/java/run/halo/app/core/extension/Post.java
@@ -5,7 +5,6 @@ import static java.lang.Boolean.parseBoolean;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.Instant;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -16,7 +15,7 @@ import run.halo.app.extension.AbstractExtension;
 import run.halo.app.extension.ExtensionUtil;
 import run.halo.app.extension.GVK;
 import run.halo.app.extension.MetadataOperator;
-import run.halo.app.infra.Condition;
+import run.halo.app.infra.ConditionList;
 
 /**
  * <p>Post extension.</p>
@@ -33,6 +32,7 @@ import run.halo.app.infra.Condition;
 public class Post extends AbstractExtension {
     public static final String KIND = "Post";
     public static final String CATEGORIES_ANNO = "content.halo.run/categories";
+    public static final String PUBLISHED_ANNO = "content.halo.run/published";
     public static final String TAGS_ANNO = "content.halo.run/tags";
     public static final String DELETED_LABEL = "content.halo.run/deleted";
     public static final String PUBLISHED_LABEL = "content.halo.run/published";
@@ -113,9 +113,6 @@ public class Post extends AbstractExtension {
         @Schema(required = true, defaultValue = "PUBLIC")
         private VisibleEnum visible;
 
-        @Schema(required = true, defaultValue = "1")
-        private Integer version;
-
         @Schema(required = true, defaultValue = "0")
         private Integer priority;
 
@@ -135,7 +132,7 @@ public class Post extends AbstractExtension {
         private String phase;
 
         @Schema
-        private List<Condition> conditions;
+        private ConditionList conditions;
 
         private String permalink;
 
@@ -147,12 +144,10 @@ public class Post extends AbstractExtension {
 
         private List<String> contributors;
 
-        private List<String> releasedSnapshots;
-
         @JsonIgnore
-        public List<Condition> getConditionsOrDefault() {
+        public ConditionList getConditionsOrDefault() {
             if (this.conditions == null) {
-                this.conditions = new ArrayList<>();
+                this.conditions = new ConditionList();
             }
             return conditions;
         }

--- a/src/main/java/run/halo/app/core/extension/Post.java
+++ b/src/main/java/run/halo/app/core/extension/Post.java
@@ -32,7 +32,8 @@ import run.halo.app.infra.ConditionList;
 public class Post extends AbstractExtension {
     public static final String KIND = "Post";
     public static final String CATEGORIES_ANNO = "content.halo.run/categories";
-    public static final String PUBLISHED_ANNO = "content.halo.run/published";
+    public static final String LAST_RELEASED_SNAPSHOT_ANNO =
+        "content.halo.run/last-released-snapshot";
     public static final String TAGS_ANNO = "content.halo.run/tags";
     public static final String DELETED_LABEL = "content.halo.run/deleted";
     public static final String PUBLISHED_LABEL = "content.halo.run/published";

--- a/src/main/java/run/halo/app/core/extension/SinglePage.java
+++ b/src/main/java/run/halo/app/core/extension/SinglePage.java
@@ -27,6 +27,7 @@ public class SinglePage extends AbstractExtension {
     public static final String KIND = "SinglePage";
     public static final String DELETED_LABEL = "content.halo.run/deleted";
     public static final String PUBLISHED_LABEL = "content.halo.run/published";
+    public static final String PUBLISHED_ANNO = "content.halo.run/published";
     public static final String OWNER_LABEL = "content.halo.run/owner";
     public static final String VISIBLE_LABEL = "content.halo.run/visible";
 
@@ -89,9 +90,6 @@ public class SinglePage extends AbstractExtension {
 
         @Schema(required = true, defaultValue = "PUBLIC")
         private Post.VisibleEnum visible;
-
-        @Schema(required = true, defaultValue = "1")
-        private Integer version;
 
         @Schema(required = true, defaultValue = "0")
         private Integer priority;

--- a/src/main/java/run/halo/app/core/extension/SinglePage.java
+++ b/src/main/java/run/halo/app/core/extension/SinglePage.java
@@ -27,7 +27,8 @@ public class SinglePage extends AbstractExtension {
     public static final String KIND = "SinglePage";
     public static final String DELETED_LABEL = "content.halo.run/deleted";
     public static final String PUBLISHED_LABEL = "content.halo.run/published";
-    public static final String PUBLISHED_ANNO = "content.halo.run/published";
+    public static final String LAST_RELEASED_SNAPSHOT_ANNO =
+        "content.halo.run/last-released-snapshot";
     public static final String OWNER_LABEL = "content.halo.run/owner";
     public static final String VISIBLE_LABEL = "content.halo.run/visible";
 

--- a/src/main/java/run/halo/app/core/extension/endpoint/SinglePageEndpoint.java
+++ b/src/main/java/run/halo/app/core/extension/endpoint/SinglePageEndpoint.java
@@ -115,10 +115,15 @@ public class SinglePageEndpoint implements CustomEndpoint {
             .flatMap(singlePage -> {
                 SinglePage.SinglePageSpec spec = singlePage.getSpec();
                 spec.setPublish(true);
+                if (spec.getHeadSnapshot() == null) {
+                    spec.setHeadSnapshot(spec.getBaseSnapshot());
+                }
                 spec.setReleaseSnapshot(spec.getHeadSnapshot());
                 return client.update(singlePage);
             })
-            .flatMap(singlePage -> singlePageService.publish(singlePage.getMetadata().getName()))
+            .flatMap(singlePage -> singlePageService.publish(name,
+                singlePage.getSpec().getReleaseSnapshot())
+            )
             .flatMap(page -> ServerResponse.ok().bodyValue(page));
     }
 

--- a/src/main/java/run/halo/app/extension/ExtensionUtil.java
+++ b/src/main/java/run/halo/app/extension/ExtensionUtil.java
@@ -71,7 +71,7 @@ public final class ExtensionUtil {
         Map<String, String> annotations = extension.getMetadata().getAnnotations();
         if (annotations == null) {
             annotations = new HashMap<>();
-            extension.getMetadata().setLabels(annotations);
+            extension.getMetadata().setAnnotations(annotations);
         }
         return annotations;
     }

--- a/src/main/java/run/halo/app/extension/ExtensionUtil.java
+++ b/src/main/java/run/halo/app/extension/ExtensionUtil.java
@@ -58,4 +58,21 @@ public final class ExtensionUtil {
         }
         return labels;
     }
+
+    /**
+     * Gets extension metadata annotations null safe.
+     *
+     * @param extension extension must not be null
+     * @return extension metadata annotations
+     */
+    public static Map<String, String> nullSafeAnnotations(AbstractExtension extension) {
+        Assert.notNull(extension, "The extension must not be null.");
+        Assert.notNull(extension.getMetadata(), "The extension metadata must not be null.");
+        Map<String, String> annotations = extension.getMetadata().getAnnotations();
+        if (annotations == null) {
+            annotations = new HashMap<>();
+            extension.getMetadata().setLabels(annotations);
+        }
+        return annotations;
+    }
 }

--- a/src/main/java/run/halo/app/infra/Condition.java
+++ b/src/main/java/run/halo/app/infra/Condition.java
@@ -2,7 +2,10 @@ package run.halo.app.infra;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.Instant;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 
 /**
  * @author guqing
@@ -11,6 +14,9 @@ import lombok.Data;
  * @since 2.0.0
  */
 @Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
 public class Condition {
     /**
      * type of condition in CamelCase or in foo.example.com/CamelCase.

--- a/src/main/java/run/halo/app/infra/ConditionList.java
+++ b/src/main/java/run/halo/app/infra/ConditionList.java
@@ -1,29 +1,38 @@
 package run.halo.app.infra;
 
+import java.util.AbstractCollection;
 import java.util.ArrayDeque;
 import java.util.Deque;
 import java.util.Iterator;
 import java.util.Objects;
-import java.util.Spliterator;
 import java.util.function.Consumer;
 import org.springframework.lang.NonNull;
 
 /**
  * <p>This {@link ConditionList} to stores multiple {@link Condition}.</p>
+ * <p>The element added after is always the first, the first to be removed is always the first to
+ * be added.</p>
+ * <p>The queue head is the one whose element index is 0</p>
  * Note that: this class is not thread-safe.
  *
  * @author guqing
  * @since 2.0.0
  */
-public class ConditionList implements Iterable<Condition> {
+public class ConditionList extends AbstractCollection<Condition> {
     private static final int EVICT_THRESHOLD = 20;
     private final Deque<Condition> conditions = new ArrayDeque<>();
 
-    public void add(@NonNull Condition condition) {
-        if (isSame(conditions.peek(), condition)) {
-            return;
+    @Override
+    public boolean add(@NonNull Condition condition) {
+        if (isSame(conditions.peekFirst(), condition)) {
+            return false;
         }
-        conditions.add(condition);
+        return conditions.add(condition);
+    }
+
+    public boolean addFirst(@NonNull Condition condition) {
+        conditions.addFirst(condition);
+        return true;
     }
 
     /**
@@ -32,11 +41,8 @@ public class ConditionList implements Iterable<Condition> {
      *
      * @param condition item to add
      */
-    public void addAndEvictFIFO(@NonNull Condition condition) {
-        this.add(condition);
-        if (conditions.size() > EVICT_THRESHOLD) {
-            conditions.removeFirst();
-        }
+    public boolean addAndEvictFIFO(@NonNull Condition condition) {
+        return addAndEvictFIFO(condition, EVICT_THRESHOLD);
     }
 
     /**
@@ -45,25 +51,41 @@ public class ConditionList implements Iterable<Condition> {
      *
      * @param condition item to add
      */
-    public void addAndEvictFIFO(@NonNull Condition condition, int evictThreshold) {
-        this.add(condition);
-        if (conditions.size() > evictThreshold) {
-            conditions.removeFirst();
+    public boolean addAndEvictFIFO(@NonNull Condition condition, int evictThreshold) {
+        boolean result = this.addFirst(condition);
+        while (conditions.size() > evictThreshold) {
+            removeLast();
         }
+        return result;
     }
 
     public void remove(Condition condition) {
         conditions.remove(condition);
     }
 
-    public void poll() {
-        conditions.poll();
-    }
-
+    /**
+     * Retrieves, but does not remove, the head of the queue represented by
+     * this deque (in other words, the first element of this deque), or
+     * returns {@code null} if this deque is empty.
+     *
+     * <p>This method is equivalent to {@link #peekFirst()}.
+     *
+     * @return the head of the queue represented by this deque, or
+     * {@code null} if this deque is empty
+     */
     public Condition peek() {
-        return conditions.peek();
+        return peekFirst();
     }
 
+    public Condition peekFirst() {
+        return conditions.peekFirst();
+    }
+
+    public Condition removeLast() {
+        return conditions.removeLast();
+    }
+
+    @Override
     public void clear() {
         conditions.clear();
     }
@@ -90,10 +112,5 @@ public class ConditionList implements Iterable<Condition> {
     @Override
     public void forEach(Consumer<? super Condition> action) {
         conditions.forEach(action);
-    }
-
-    @Override
-    public Spliterator<Condition> spliterator() {
-        return Iterable.super.spliterator();
     }
 }

--- a/src/main/java/run/halo/app/infra/ConditionList.java
+++ b/src/main/java/run/halo/app/infra/ConditionList.java
@@ -1,0 +1,99 @@
+package run.halo.app.infra;
+
+import java.util.ArrayDeque;
+import java.util.Deque;
+import java.util.Iterator;
+import java.util.Objects;
+import java.util.Spliterator;
+import java.util.function.Consumer;
+import org.springframework.lang.NonNull;
+
+/**
+ * <p>This {@link ConditionList} to stores multiple {@link Condition}.</p>
+ * Note that: this class is not thread-safe.
+ *
+ * @author guqing
+ * @since 2.0.0
+ */
+public class ConditionList implements Iterable<Condition> {
+    private static final int EVICT_THRESHOLD = 20;
+    private final Deque<Condition> conditions = new ArrayDeque<>();
+
+    public void add(@NonNull Condition condition) {
+        if (isSame(conditions.peek(), condition)) {
+            return;
+        }
+        conditions.add(condition);
+    }
+
+    /**
+     * Add {@param #condition} and evict the first item if the size of conditions is greater than
+     * {@link #EVICT_THRESHOLD}.
+     *
+     * @param condition item to add
+     */
+    public void addAndEvictFIFO(@NonNull Condition condition) {
+        this.add(condition);
+        if (conditions.size() > EVICT_THRESHOLD) {
+            conditions.removeFirst();
+        }
+    }
+
+    /**
+     * Add {@param #condition} and evict the first item if the size of conditions is greater than
+     * {@param evictThreshold}.
+     *
+     * @param condition item to add
+     */
+    public void addAndEvictFIFO(@NonNull Condition condition, int evictThreshold) {
+        this.add(condition);
+        if (conditions.size() > evictThreshold) {
+            conditions.removeFirst();
+        }
+    }
+
+    public void remove(Condition condition) {
+        conditions.remove(condition);
+    }
+
+    public void poll() {
+        conditions.poll();
+    }
+
+    public Condition peek() {
+        return conditions.peek();
+    }
+
+    public void clear() {
+        conditions.clear();
+    }
+
+    public int size() {
+        return conditions.size();
+    }
+
+    private boolean isSame(Condition a, Condition b) {
+        if (a == null || b == null) {
+            return false;
+        }
+        return Objects.equals(a.getType(), b.getType())
+            && Objects.equals(a.getStatus(), b.getStatus())
+            && Objects.equals(a.getReason(), b.getReason())
+            && Objects.equals(a.getMessage(), b.getMessage());
+    }
+
+    @Override
+    public Iterator<Condition> iterator() {
+        return conditions.iterator();
+    }
+
+    @Override
+    public void forEach(Consumer<? super Condition> action) {
+        conditions.forEach(action);
+    }
+
+    @Override
+    public Spliterator<Condition> spliterator() {
+        return Iterable.super.spliterator();
+    }
+}

--- a/src/test/java/run/halo/app/content/ContentRequestTest.java
+++ b/src/test/java/run/halo/app/content/ContentRequestTest.java
@@ -59,14 +59,13 @@ class ContentRequestTest {
                         },
                         "rawType": "MARKDOWN",
                         "rawPatch": "%s",
-                        "contentPatch": "%s",
-                        "displayVersion": "v1",
-                        "version": 1
+                        "contentPatch": "%s"
                     },
                     "apiVersion": "content.halo.run/v1alpha1",
                     "kind": "Snapshot",
                     "metadata": {
-                        "name": "7b149646-ac60-4a5c-98ee-78b2dd0631b2"
+                        "name": "7b149646-ac60-4a5c-98ee-78b2dd0631b2",
+                        "annotations": {}
                     }
                 }
                 """.formatted(expectedRawPatch, expectedContentPath),

--- a/src/test/java/run/halo/app/content/PostIntegrationTests.java
+++ b/src/test/java/run/halo/app/content/PostIntegrationTests.java
@@ -1,0 +1,144 @@
+package run.halo.app.content;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+import static org.springframework.security.test.web.reactive.server.SecurityMockServerConfigurers.csrf;
+
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.web.reactive.AutoConfigureWebTestClient;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.reactive.server.WebTestClient;
+import reactor.core.publisher.Mono;
+import run.halo.app.core.extension.Post;
+import run.halo.app.core.extension.Role;
+import run.halo.app.core.extension.service.RoleService;
+import run.halo.app.extension.MetadataOperator;
+import run.halo.app.extension.ReactiveExtensionClient;
+import run.halo.app.infra.utils.JsonUtils;
+
+/**
+ * Integration tests for {@link PostService}.
+ *
+ * @author guqing
+ * @since 2.0.0
+ */
+@SpringBootTest
+@AutoConfigureWebTestClient
+@AutoConfigureTestDatabase
+@WithMockUser(username = "fake-user", password = "fake-password", roles = "fake-super-role")
+public class PostIntegrationTests {
+
+    @Autowired
+    private WebTestClient webTestClient;
+
+    @MockBean
+    RoleService roleService;
+
+    @Autowired
+    ReactiveExtensionClient client;
+
+    @BeforeEach
+    void setUp() {
+        var rule = new Role.PolicyRule.Builder()
+            .apiGroups("*")
+            .resources("*")
+            .verbs("*")
+            .build();
+        var role = new Role();
+        role.setRules(List.of(rule));
+        when(roleService.getMonoRole("authenticated")).thenReturn(Mono.just(role));
+        webTestClient = webTestClient.mutateWith(csrf());
+    }
+
+    @Test
+    void draftPost() {
+        webTestClient.post()
+            .uri("/apis/api.console.halo.run/v1alpha1/posts")
+            .contentType(MediaType.APPLICATION_JSON)
+            .bodyValue(postDraftRequest())
+            .exchange()
+            .expectBody(Post.class)
+            .value(post -> {
+                MetadataOperator metadata = post.getMetadata();
+                Post.PostSpec spec = post.getSpec();
+                assertThat(spec.getTitle()).isEqualTo("无标题文章");
+                assertThat(metadata.getCreationTimestamp()).isNotNull();
+                assertThat(metadata.getName()).startsWith("post-");
+                assertThat(spec.getHeadSnapshot()).isNotNull();
+                assertThat(spec.getHeadSnapshot()).isEqualTo(spec.getBaseSnapshot());
+                assertThat(spec.getOwner()).isEqualTo("fake-user");
+
+                assertThat(post.getStatus()).isNotNull();
+                assertThat(post.getStatus().getPhase()).isEqualTo("DRAFT");
+                assertThat(post.getStatus().getConditions().peek().getType()).isEqualTo("DRAFT");
+            });
+    }
+
+    @Test
+    void draftPostAsPublish() {
+        PostRequest postRequest = postDraftRequest();
+        postRequest.post().getSpec().setPublish(true);
+        webTestClient.post()
+            .uri("/apis/api.console.halo.run/v1alpha1/posts")
+            .contentType(MediaType.APPLICATION_JSON)
+            .bodyValue(postRequest)
+            .exchange()
+            .expectBody(Post.class)
+            .value(post -> {
+                assertThat(post.getSpec().getReleaseSnapshot()).isNotNull();
+                assertThat(post.getSpec().getReleaseSnapshot())
+                    .isEqualTo(post.getSpec().getHeadSnapshot());
+                assertThat(post.getSpec().getHeadSnapshot())
+                    .isEqualTo(post.getSpec().getBaseSnapshot());
+            });
+    }
+
+    PostRequest postDraftRequest() {
+        String s = """
+            {
+                "post": {
+                    "spec": {
+                        "title": "无标题文章",
+                        "slug": "41c2ad39-21b4-45e4-a36b-5768245a0555",
+                        "template": "",
+                        "cover": "",
+                        "deleted": false,
+                        "publish": true,
+                        "publishTime": "",
+                        "pinned": false,
+                        "allowComment": true,
+                        "visible": "PUBLIC",
+                        "version": 1,
+                        "priority": 0,
+                        "excerpt": {
+                            "autoGenerate": true,
+                            "raw": ""
+                        },
+                        "categories": [],
+                        "tags": [],
+                        "htmlMetas": []
+                    },
+                    "apiVersion": "content.halo.run/v1alpha1",
+                    "kind": "Post",
+                    "metadata": {
+                        "name": "",
+                        "generateName": "post-"
+                    }
+                },
+                "content": {
+                    "raw": "<p>hello world</p>",
+                    "content": "<p>hello world</p>",
+                    "rawType": "HTML"
+                }
+            }
+            """;
+        return JsonUtils.jsonToObject(s, PostRequest.class);
+    }
+}

--- a/src/test/java/run/halo/app/content/TestPost.java
+++ b/src/test/java/run/halo/app/content/TestPost.java
@@ -1,8 +1,10 @@
 package run.halo.app.content;
 
+import java.time.Instant;
 import run.halo.app.core.extension.Post;
 import run.halo.app.core.extension.Snapshot;
 import run.halo.app.extension.AbstractExtension;
+import run.halo.app.extension.ExtensionUtil;
 import run.halo.app.extension.GVK;
 import run.halo.app.extension.Metadata;
 
@@ -23,7 +25,6 @@ public class TestPost {
         post.setSpec(postSpec);
 
         postSpec.setTitle("post-A");
-        postSpec.setVersion(1);
         postSpec.setBaseSnapshot(snapshotV1().getMetadata().getName());
         postSpec.setHeadSnapshot("base-snapshot");
         postSpec.setReleaseSnapshot(null);
@@ -37,13 +38,13 @@ public class TestPost {
         snapshot.setApiVersion(getApiVersion(Snapshot.class));
         Metadata metadata = new Metadata();
         metadata.setName("snapshot-A");
+        metadata.setCreationTimestamp(Instant.now());
         snapshot.setMetadata(metadata);
+        ExtensionUtil.nullSafeAnnotations(snapshot).put(Snapshot.KEEP_RAW_ANNO, "true");
         Snapshot.SnapShotSpec spec = new Snapshot.SnapShotSpec();
         snapshot.setSpec(spec);
 
-        spec.setDisplayVersion("v1");
-        spec.setVersion(1);
-        snapshot.addContributor("guqing");
+        Snapshot.addContributor(snapshot, "guqing");
         spec.setRawType("MARKDOWN");
         spec.setRawPatch("A");
         spec.setContentPatch("<p>A</p>");
@@ -56,14 +57,12 @@ public class TestPost {
         snapshot.setKind(Snapshot.KIND);
         snapshot.setApiVersion(getApiVersion(Snapshot.class));
         Metadata metadata = new Metadata();
+        metadata.setCreationTimestamp(Instant.now().plusSeconds(10));
         metadata.setName("snapshot-B");
         snapshot.setMetadata(metadata);
         Snapshot.SnapShotSpec spec = new Snapshot.SnapShotSpec();
         snapshot.setSpec(spec);
-
-        spec.setDisplayVersion("v2");
-        spec.setVersion(2);
-        snapshot.addContributor("guqing");
+        Snapshot.addContributor(snapshot, "guqing");
         spec.setRawType("MARKDOWN");
         spec.setRawPatch(PatchUtils.diffToJsonPatch("A", "B"));
         spec.setContentPatch(PatchUtils.diffToJsonPatch("<p>A</p>", "<p>B</p>"));
@@ -74,10 +73,9 @@ public class TestPost {
     public static Snapshot snapshotV3() {
         Snapshot snapshotV3 = snapshotV2();
         snapshotV3.getMetadata().setName("snapshot-C");
+        snapshotV3.getMetadata().setCreationTimestamp(Instant.now().plusSeconds(20));
         Snapshot.SnapShotSpec spec = snapshotV3.getSpec();
-        spec.setDisplayVersion("v3");
-        spec.setVersion(3);
-        snapshotV3.addContributor("guqing");
+        Snapshot.addContributor(snapshotV3, "guqing");
         spec.setRawType("MARKDOWN");
         spec.setRawPatch(PatchUtils.diffToJsonPatch("B", "C"));
         spec.setContentPatch(PatchUtils.diffToJsonPatch("<p>B</p>", "<p>C</p>"));

--- a/src/test/java/run/halo/app/content/comment/CommentServiceImplTest.java
+++ b/src/test/java/run/halo/app/content/comment/CommentServiceImplTest.java
@@ -285,8 +285,7 @@ class CommentServiceImplTest {
                             "spec": {
                                 "title": "post-A",
                                 "headSnapshot": "base-snapshot",
-                                "baseSnapshot": "snapshot-A",
-                                "version": 1
+                                "baseSnapshot": "snapshot-A"
                             },
                             "apiVersion": "content.halo.run/v1alpha1",
                             "kind": "Post",
@@ -330,8 +329,7 @@ class CommentServiceImplTest {
                             "spec": {
                                 "title": "post-A",
                                 "headSnapshot": "base-snapshot",
-                                "baseSnapshot": "snapshot-A",
-                                "version": 1
+                                "baseSnapshot": "snapshot-A"
                             },
                             "apiVersion": "content.halo.run/v1alpha1",
                             "kind": "Post",
@@ -374,8 +372,7 @@ class CommentServiceImplTest {
                             "spec": {
                                 "title": "post-A",
                                 "headSnapshot": "base-snapshot",
-                                "baseSnapshot": "snapshot-A",
-                                "version": 1
+                                "baseSnapshot": "snapshot-A"
                             },
                             "apiVersion": "content.halo.run/v1alpha1",
                             "kind": "Post",

--- a/src/test/java/run/halo/app/content/impl/ContentServiceImplTest.java
+++ b/src/test/java/run/halo/app/content/impl/ContentServiceImplTest.java
@@ -1,0 +1,73 @@
+package run.halo.app.content.impl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+
+import java.time.Instant;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import reactor.core.publisher.Flux;
+import reactor.test.StepVerifier;
+import run.halo.app.content.TestPost;
+import run.halo.app.core.extension.Snapshot;
+import run.halo.app.extension.ExtensionUtil;
+import run.halo.app.extension.ReactiveExtensionClient;
+import run.halo.app.extension.Ref;
+
+/**
+ * Tests for {@link ContentServiceImpl}.
+ *
+ * @author guqing
+ * @since 2.0.0
+ */
+@ExtendWith(MockitoExtension.class)
+class ContentServiceImplTest {
+
+    @Mock
+    private ReactiveExtensionClient client;
+
+    @InjectMocks
+    private ContentServiceImpl contentService;
+
+    @Test
+    void getBaseSnapshot() {
+        Snapshot snapshotV1 = TestPost.snapshotV1();
+        ExtensionUtil.nullSafeAnnotations(snapshotV1)
+            .put(Snapshot.KEEP_RAW_ANNO, "true");
+        when(client.list(eq(Snapshot.class), any(), any()))
+            .thenReturn(Flux.just(TestPost.snapshotV2(), snapshotV1, TestPost.snapshotV3()));
+        contentService.getBaseSnapshot(Ref.of("fake-post"))
+            .as(StepVerifier::create)
+            .consumeNextWith(
+                baseSnapshot -> assertThat(baseSnapshot.getMetadata().getName())
+                    .isEqualTo(snapshotV1.getMetadata().getName()))
+            .verifyComplete();
+    }
+
+    @Test
+    void latestSnapshotVersion() {
+        Snapshot snapshotV1 = TestPost.snapshotV1();
+        snapshotV1.getMetadata().setCreationTimestamp(Instant.now());
+
+        Snapshot snapshotV2 = TestPost.snapshotV2();
+        snapshotV2.getMetadata().setCreationTimestamp(Instant.now().plusSeconds(2));
+
+        Snapshot snapshotV3 = TestPost.snapshotV3();
+        snapshotV3.getMetadata().setCreationTimestamp(Instant.now().plusSeconds(3));
+
+        when(client.list(eq(Snapshot.class), any(), any()))
+            .thenReturn(Flux.just(snapshotV2, snapshotV1, snapshotV3));
+
+        contentService.latestSnapshotVersion(Ref.of("fake-post"))
+            .as(StepVerifier::create)
+            .consumeNextWith(s -> {
+                assertThat(s.getMetadata().getName()).isEqualTo(snapshotV3.getMetadata().getName());
+            })
+            .verifyComplete();
+    }
+}

--- a/src/test/java/run/halo/app/content/impl/PostServiceImplTest.java
+++ b/src/test/java/run/halo/app/content/impl/PostServiceImplTest.java
@@ -2,35 +2,21 @@ package run.halo.app.content.impl;
 
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.mockito.stubbing.Answer;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
-import reactor.core.publisher.Mono;
-import reactor.test.StepVerifier;
 import run.halo.app.content.ContentService;
 import run.halo.app.content.PostQuery;
 import run.halo.app.content.TestPost;
 import run.halo.app.core.extension.Post;
-import run.halo.app.core.extension.Snapshot;
-import run.halo.app.extension.ExtensionUtil;
 import run.halo.app.extension.ReactiveExtensionClient;
-import run.halo.app.infra.ConditionList;
-import run.halo.app.infra.ConditionStatus;
 
 /**
  * Tests for {@link PostServiceImpl}.
@@ -90,111 +76,7 @@ class PostServiceImplTest {
     }
 
     @Test
-    void publishWhenPostIsNonePublishedState() {
-        String postName = "fake-post";
-        String snapV1name = "fake-post-snapshot-v1";
-        Post post = TestPost.postV1();
-        post.getMetadata().setName(postName);
+    void draftPost() {
 
-        // v1 not published
-        Snapshot snapshotV1 = TestPost.snapshotV1();
-        snapshotV1.getMetadata().setName(snapV1name);
-        post.getSpec().setBaseSnapshot(snapshotV1.getMetadata().getName());
-
-        post.getSpec().setHeadSnapshot(null);
-        post.getSpec().setReleaseSnapshot(null);
-        when(client.fetch(eq(Post.class), eq(postName))).thenReturn(Mono.just(post));
-        verify(client, times(0)).fetch(eq(Snapshot.class), eq(snapV1name));
-
-        postService.publishPost(postName, post.getSpec().getReleaseSnapshot())
-            .as(StepVerifier::create)
-            .verifyComplete();
-    }
-
-    @Test
-    void publishWhenPostIsPublishedStateAndNotPublishedBefore() {
-        String postName = "fake-post";
-        String snapV1name = "fake-post-snapshot-v1";
-        Post post = TestPost.postV1();
-        post.getSpec().setPublish(true);
-        post.getSpec().setPublishTime(null);
-        post.getMetadata().setName(postName);
-        post.getSpec().setBaseSnapshot(snapV1name);
-        post.getSpec().setHeadSnapshot(null);
-        post.getSpec().setReleaseSnapshot(null);
-        when(client.fetch(eq(Post.class), eq(postName))).thenReturn(Mono.just(post));
-
-        // v1 not published
-        Snapshot snapshotV1 = TestPost.snapshotV1();
-        snapshotV1.getMetadata().setName(snapV1name);
-        when(client.fetch(eq(Snapshot.class), eq(snapV1name))).thenReturn(Mono.just(snapshotV1));
-
-        when(client.update(any(Post.class))).thenAnswer((Answer<Mono<Post>>) invocation -> {
-            Post updated = invocation.getArgument(0);
-            return Mono.just(updated);
-        });
-
-        postService.publishPost(postName, post.getSpec().getReleaseSnapshot())
-            .as(StepVerifier::create)
-            .consumeNextWith(expected -> {
-                ArgumentCaptor<Post> captor = ArgumentCaptor.forClass(Post.class);
-                verify(client, times(1)).update(captor.capture());
-                Post updated = captor.getValue();
-                assertThat(updated.getSpec().getReleaseSnapshot()).isEqualTo(snapV1name);
-                assertThat(updated.getSpec().getHeadSnapshot()).isEqualTo(snapV1name);
-                assertThat(updated.getSpec().getPublishTime()).isNotNull();
-                ConditionList conditions = updated.getStatus().getConditions();
-                assertThat(conditions).hasSize(1);
-                assertThat(conditions.peek().getType()).isEqualTo("PUBLISHED");
-                assertThat(conditions.peek().getStatus()).isEqualTo(ConditionStatus.TRUE);
-                assertThat(expected).isNotNull();
-            })
-            .verifyComplete();
-    }
-
-    @Test
-    void publishWhenPostIsPublishedStateAndPublishedBefore() {
-        String postName = "fake-post";
-        String snapV1name = "fake-post-snapshot-v1";
-        String snapV2name = "fake-post-snapshot-v2";
-        Post post = TestPost.postV1();
-        post.getSpec().setPublish(true);
-        post.getSpec().setPublishTime(null);
-        post.getMetadata().setName(postName);
-        post.getSpec().setBaseSnapshot(snapV1name);
-        post.getSpec().setHeadSnapshot(snapV2name);
-        post.getSpec().setReleaseSnapshot(snapV2name);
-        ExtensionUtil.nullSafeLabels(post).put(Post.PUBLISHED_LABEL, "true");
-        when(client.fetch(eq(Post.class), eq(postName))).thenReturn(Mono.just(post));
-
-        // v1 has been published
-        Snapshot snapshotV1 = TestPost.snapshotV1();
-        snapshotV1.getMetadata().setName(snapV1name);
-        snapshotV1.getMetadata().setLabels(new HashMap<>());
-        ExtensionUtil.nullSafeAnnotations(snapshotV1)
-            .put(Post.PUBLISHED_ANNO, Boolean.TRUE.toString());
-
-        // v1 not published
-        Snapshot snapshotV2 = TestPost.snapshotV2();
-        snapshotV2.getMetadata().setName(snapV2name);
-        when(client.fetch(eq(Snapshot.class), eq(snapV2name))).thenReturn(Mono.just(snapshotV2));
-
-        when(client.update(any(Post.class))).thenAnswer((Answer<Mono<Post>>) invocation -> {
-            Post updated = invocation.getArgument(0);
-            return Mono.just(updated);
-        });
-
-        postService.publishPost(postName, post.getSpec().getReleaseSnapshot())
-            .as(StepVerifier::create)
-            .consumeNextWith(expected -> {
-                assertThat(expected).isNotNull();
-                ArgumentCaptor<Post> captor = ArgumentCaptor.forClass(Post.class);
-                verify(client, times(1)).update(captor.capture());
-                Post updated = captor.getValue();
-                assertThat(updated.getSpec().getReleaseSnapshot()).isEqualTo(snapV2name);
-                assertThat(updated.getSpec().getHeadSnapshot()).isEqualTo(snapV2name);
-                assertThat(updated.getSpec().getPublishTime()).isNotNull();
-            })
-            .verifyComplete();
     }
 }

--- a/src/test/java/run/halo/app/core/extension/endpoint/PostEndpointTest.java
+++ b/src/test/java/run/halo/app/core/extension/endpoint/PostEndpointTest.java
@@ -2,7 +2,6 @@ package run.halo.app.core.extension.endpoint;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
 
 import org.junit.jupiter.api.BeforeEach;
@@ -74,24 +73,6 @@ class PostEndpointTest {
             .isOk()
             .expectBody(Post.class)
             .value(post -> assertThat(post).isEqualTo(TestPost.postV1()));
-    }
-
-    @Test
-    void publishPost() {
-        Post post = TestPost.postV1();
-        when(postService.publishPost(any(), any())).thenReturn(Mono.just(true));
-        when(client.get(eq(Post.class), eq(post.getMetadata().getName())))
-            .thenReturn(Mono.just(post));
-        when(client.update(any())).thenReturn(Mono.just(post));
-
-        webTestClient.put()
-            .uri("/posts/post-A/publish")
-            .bodyValue(postRequest(TestPost.postV1()))
-            .exchange()
-            .expectStatus()
-            .isOk()
-            .expectBody(Post.class)
-            .value(p -> assertThat(p).isEqualTo(post));
     }
 
     PostRequest postRequest(Post post) {

--- a/src/test/java/run/halo/app/core/extension/endpoint/PostEndpointTest.java
+++ b/src/test/java/run/halo/app/core/extension/endpoint/PostEndpointTest.java
@@ -3,8 +3,6 @@ package run.halo.app.core.extension.endpoint;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.ArgumentMatchers.isA;
-import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.when;
 
 import org.junit.jupiter.api.BeforeEach;
@@ -20,7 +18,6 @@ import run.halo.app.content.PostRequest;
 import run.halo.app.content.PostService;
 import run.halo.app.content.TestPost;
 import run.halo.app.core.extension.Post;
-import run.halo.app.event.post.PostPublishedEvent;
 import run.halo.app.extension.ReactiveExtensionClient;
 
 /**
@@ -82,11 +79,10 @@ class PostEndpointTest {
     @Test
     void publishPost() {
         Post post = TestPost.postV1();
-        when(postService.publishPost(any())).thenReturn(Mono.just(post));
+        when(postService.publishPost(any(), any())).thenReturn(Mono.just(true));
         when(client.get(eq(Post.class), eq(post.getMetadata().getName())))
             .thenReturn(Mono.just(post));
         when(client.update(any())).thenReturn(Mono.just(post));
-        doNothing().when(eventPublisher).publishEvent(isA(PostPublishedEvent.class));
 
         webTestClient.put()
             .uri("/posts/post-A/publish")

--- a/src/test/java/run/halo/app/core/extension/reconciler/PostReconcilerTest.java
+++ b/src/test/java/run/halo/app/core/extension/reconciler/PostReconcilerTest.java
@@ -7,8 +7,6 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import java.time.Instant;
-import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Optional;
@@ -29,8 +27,8 @@ import run.halo.app.content.permalinks.PostPermalinkPolicy;
 import run.halo.app.core.extension.Post;
 import run.halo.app.core.extension.Snapshot;
 import run.halo.app.extension.ExtensionClient;
+import run.halo.app.extension.ExtensionUtil;
 import run.halo.app.extension.controller.Reconciler;
-import run.halo.app.infra.Condition;
 
 /**
  * Tests for {@link PostReconciler}.
@@ -64,7 +62,7 @@ class PostReconcilerTest {
             .thenReturn(Optional.of(post));
         when(contentService.getContent(eq(post.getSpec().getReleaseSnapshot())))
             .thenReturn(Mono.empty());
-        when(postService.publishPost(eq(name))).thenReturn(Mono.empty());
+        when(postService.publishPost(eq(name), any())).thenReturn(Mono.empty());
 
         Snapshot snapshotV1 = TestPost.snapshotV1();
         Snapshot snapshotV2 = TestPost.snapshotV2();
@@ -108,8 +106,8 @@ class PostReconcilerTest {
 
         Snapshot snapshotV2 = TestPost.snapshotV2();
         snapshotV2.getMetadata().setLabels(new HashMap<>());
-        Snapshot.putPublishedLabel(snapshotV2.getMetadata().getLabels());
-        snapshotV2.getSpec().setPublishTime(Instant.now());
+        ExtensionUtil.nullSafeAnnotations(snapshotV2)
+            .put(Post.PUBLISHED_ANNO, Boolean.TRUE.toString());
         snapshotV2.getSpec().setContributors(Set.of("guqing", "zhangsan"));
 
         Snapshot snapshotV1 = TestPost.snapshotV1();
@@ -117,7 +115,7 @@ class PostReconcilerTest {
 
         when(contentService.listSnapshots(any()))
             .thenReturn(Flux.just(snapshotV1, snapshotV2));
-        when(postService.publishPost(eq(name))).thenReturn(Mono.empty());
+        when(postService.publishPost(eq(name), any())).thenReturn(Mono.empty());
 
         ArgumentCaptor<Post> captor = ArgumentCaptor.forClass(Post.class);
         postReconciler.reconcile(new Reconciler.Request(name));
@@ -125,28 +123,5 @@ class PostReconcilerTest {
         verify(client, times(3)).update(captor.capture());
         Post value = captor.getValue();
         assertThat(value.getStatus().getExcerpt()).isEqualTo("hello world");
-    }
-
-    @Test
-    void limitConditionSize() {
-        List<Condition> conditions = new ArrayList<>();
-        for (int i = 0; i < 10; i++) {
-            Condition condition = new Condition();
-            condition.setType("test-" + i);
-            conditions.add(condition);
-        }
-        List<Condition> subConditions = PostReconciler.limitConditionSize(conditions);
-        assertThat(subConditions.get(0).getType()).isEqualTo("test-0");
-        assertThat(subConditions.get(9).getType()).isEqualTo("test-9");
-
-        for (int i = 10; i < 15; i++) {
-            Condition condition = new Condition();
-            condition.setType("test-" + i);
-            conditions.add(condition);
-        }
-        subConditions = PostReconciler.limitConditionSize(conditions);
-        assertThat(subConditions.size()).isEqualTo(10);
-        assertThat(subConditions.get(0).getType()).isEqualTo("test-5");
-        assertThat(subConditions.get(9).getType()).isEqualTo("test-14");
     }
 }

--- a/src/test/java/run/halo/app/core/extension/reconciler/PostReconcilerTest.java
+++ b/src/test/java/run/halo/app/core/extension/reconciler/PostReconcilerTest.java
@@ -27,7 +27,6 @@ import run.halo.app.content.permalinks.PostPermalinkPolicy;
 import run.halo.app.core.extension.Post;
 import run.halo.app.core.extension.Snapshot;
 import run.halo.app.extension.ExtensionClient;
-import run.halo.app.extension.ExtensionUtil;
 import run.halo.app.extension.controller.Reconciler;
 
 /**
@@ -62,7 +61,6 @@ class PostReconcilerTest {
             .thenReturn(Optional.of(post));
         when(contentService.getContent(eq(post.getSpec().getReleaseSnapshot())))
             .thenReturn(Mono.empty());
-        when(postService.publishPost(eq(name), any())).thenReturn(Mono.empty());
 
         Snapshot snapshotV1 = TestPost.snapshotV1();
         Snapshot snapshotV2 = TestPost.snapshotV2();
@@ -106,8 +104,6 @@ class PostReconcilerTest {
 
         Snapshot snapshotV2 = TestPost.snapshotV2();
         snapshotV2.getMetadata().setLabels(new HashMap<>());
-        ExtensionUtil.nullSafeAnnotations(snapshotV2)
-            .put(Post.PUBLISHED_ANNO, Boolean.TRUE.toString());
         snapshotV2.getSpec().setContributors(Set.of("guqing", "zhangsan"));
 
         Snapshot snapshotV1 = TestPost.snapshotV1();
@@ -115,12 +111,11 @@ class PostReconcilerTest {
 
         when(contentService.listSnapshots(any()))
             .thenReturn(Flux.just(snapshotV1, snapshotV2));
-        when(postService.publishPost(eq(name), any())).thenReturn(Mono.empty());
 
         ArgumentCaptor<Post> captor = ArgumentCaptor.forClass(Post.class);
         postReconciler.reconcile(new Reconciler.Request(name));
 
-        verify(client, times(3)).update(captor.capture());
+        verify(client, times(4)).update(captor.capture());
         Post value = captor.getValue();
         assertThat(value.getStatus().getExcerpt()).isEqualTo("hello world");
     }

--- a/src/test/java/run/halo/app/core/extension/reconciler/SinglePageReconcilerTest.java
+++ b/src/test/java/run/halo/app/core/extension/reconciler/SinglePageReconcilerTest.java
@@ -89,8 +89,6 @@ class SinglePageReconcilerTest {
         when(contentService.listSnapshots(any()))
             .thenReturn(Flux.just(snapshotV1, snapshotV2));
         when(externalUrlSupplier.get()).thenReturn(URI.create(""));
-        when(singlePageService.publish(eq(name), eq(page.getSpec().getReleaseSnapshot())))
-            .thenReturn(Mono.empty());
 
         ArgumentCaptor<SinglePage> captor = ArgumentCaptor.forClass(SinglePage.class);
         singlePageReconciler.reconcile(new Reconciler.Request(name));

--- a/src/test/java/run/halo/app/core/extension/reconciler/SinglePageReconcilerTest.java
+++ b/src/test/java/run/halo/app/core/extension/reconciler/SinglePageReconcilerTest.java
@@ -89,7 +89,8 @@ class SinglePageReconcilerTest {
         when(contentService.listSnapshots(any()))
             .thenReturn(Flux.just(snapshotV1, snapshotV2));
         when(externalUrlSupplier.get()).thenReturn(URI.create(""));
-        when(singlePageService.publish(eq(name))).thenReturn(Mono.empty());
+        when(singlePageService.publish(eq(name), eq(page.getSpec().getReleaseSnapshot())))
+            .thenReturn(Mono.empty());
 
         ArgumentCaptor<SinglePage> captor = ArgumentCaptor.forClass(SinglePage.class);
         singlePageReconciler.reconcile(new Reconciler.Request(name));
@@ -138,7 +139,6 @@ class SinglePageReconcilerTest {
 
         spec.setTitle("page-A");
         spec.setSlug("page-slug");
-        spec.setVersion(1);
         spec.setBaseSnapshot(snapshotV1().getMetadata().getName());
         spec.setHeadSnapshot("base-snapshot");
         spec.setReleaseSnapshot(null);

--- a/src/test/java/run/halo/app/infra/ConditionListTest.java
+++ b/src/test/java/run/halo/app/infra/ConditionListTest.java
@@ -1,0 +1,43 @@
+package run.halo.app.infra;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for {@link ConditionList}.
+ *
+ * @author guqing
+ * @since 2.0.0
+ */
+class ConditionListTest {
+
+    @Test
+    void add() {
+        ConditionList conditionList = new ConditionList();
+        conditionList.add(condition("type", "message", "reason", ConditionStatus.FALSE));
+        conditionList.add(condition("type", "message", "reason", ConditionStatus.FALSE));
+
+        assertThat(conditionList.size()).isEqualTo(1);
+        conditionList.add(condition("type", "message", "reason", ConditionStatus.TRUE));
+        assertThat(conditionList.size()).isEqualTo(2);
+    }
+
+    @Test
+    void addAndEvictFIFO() {
+    }
+
+    @Test
+    void testAddAndEvictFIFO() {
+    }
+
+    private Condition condition(String type, String message, String reason,
+        ConditionStatus status) {
+        Condition condition = new Condition();
+        condition.setType(type);
+        condition.setMessage(message);
+        condition.setReason(reason);
+        condition.setStatus(status);
+        return condition;
+    }
+}

--- a/src/test/java/run/halo/app/infra/ConditionListTest.java
+++ b/src/test/java/run/halo/app/infra/ConditionListTest.java
@@ -2,7 +2,11 @@ package run.halo.app.infra;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.util.Iterator;
+import org.json.JSONException;
 import org.junit.jupiter.api.Test;
+import org.skyscreamer.jsonassert.JSONAssert;
+import run.halo.app.infra.utils.JsonUtils;
 
 /**
  * Tests for {@link ConditionList}.
@@ -24,11 +28,118 @@ class ConditionListTest {
     }
 
     @Test
-    void addAndEvictFIFO() {
+    void addAndEvictFIFO() throws JSONException {
+        ConditionList conditionList = new ConditionList();
+        conditionList.addFirst(condition("type", "message", "reason", ConditionStatus.FALSE));
+        conditionList.addFirst(condition("type2", "message2", "reason2", ConditionStatus.FALSE));
+        conditionList.addFirst(condition("type3", "message3", "reason3", ConditionStatus.FALSE));
+
+        JSONAssert.assertEquals("""
+                [
+                    {
+                        "type": "type3",
+                        "status": "FALSE",
+                        "message": "message3",
+                        "reason": "reason3"
+                    },
+                    {
+                        "type": "type2",
+                        "status": "FALSE",
+                        "message": "message2",
+                        "reason": "reason2"
+                    },
+                    {
+                        "type": "type",
+                        "status": "FALSE",
+                        "message": "message",
+                        "reason": "reason"
+                    }
+                ]
+                """,
+            JsonUtils.objectToJson(conditionList),
+            true);
+        assertThat(conditionList.size()).isEqualTo(3);
+
+        conditionList.addAndEvictFIFO(
+            condition("type4", "message4", "reason4", ConditionStatus.FALSE), 1);
+
+        assertThat(conditionList.size()).isEqualTo(1);
+
+        // json serialize test.
+        JSONAssert.assertEquals("""
+                [
+                    {
+                        "type": "type4",
+                        "status": "FALSE",
+                        "message": "message4",
+                        "reason": "reason4"
+                    }
+                ]
+                """,
+            JsonUtils.objectToJson(conditionList), true);
     }
 
     @Test
-    void testAddAndEvictFIFO() {
+    void peek() {
+        ConditionList conditionList = new ConditionList();
+        conditionList.addFirst(condition("type", "message", "reason", ConditionStatus.FALSE));
+        Condition condition = condition("type2", "message2", "reason2", ConditionStatus.FALSE);
+        conditionList.addFirst(condition);
+
+        Condition peek = conditionList.peek();
+        assertThat(peek).isEqualTo(condition);
+    }
+
+    @Test
+    void removeLast() {
+        ConditionList conditionList = new ConditionList();
+        Condition condition = condition("type", "message", "reason", ConditionStatus.FALSE);
+        conditionList.addFirst(condition);
+
+        conditionList.addFirst(condition("type2", "message2", "reason2", ConditionStatus.FALSE));
+
+        assertThat(conditionList.size()).isEqualTo(2);
+        assertThat(conditionList.removeLast()).isEqualTo(condition);
+        assertThat(conditionList.size()).isEqualTo(1);
+    }
+
+    @Test
+    void test() {
+        ConditionList conditionList = new ConditionList();
+        conditionList.addAndEvictFIFO(
+            condition("type", "message", "reason", ConditionStatus.FALSE));
+        conditionList.addAndEvictFIFO(
+            condition("type2", "message2", "reason2", ConditionStatus.FALSE));
+
+        Iterator<Condition> iterator = conditionList.iterator();
+        assertThat(iterator.next().getType()).isEqualTo("type2");
+        assertThat(iterator.next().getType()).isEqualTo("type");
+    }
+
+    @Test
+    void deserialization() {
+        String s = """
+            [{
+                "type": "type3",
+                "status": "FALSE",
+                "message": "message3",
+                "reason": "reason3"
+            },
+            {
+                "type": "type2",
+                "status": "FALSE",
+                "message": "message2",
+                "reason": "reason2"
+            },
+            {
+                "type": "type",
+                "status": "FALSE",
+                "message": "message",
+                "reason": "reason"
+            }]
+            """;
+        ConditionList conditions = JsonUtils.jsonToObject(s, ConditionList.class);
+        assertThat(conditions.peek().getType()).isEqualTo("type3");
     }
 
     private Condition condition(String type, String message, String reason,


### PR DESCRIPTION
#### What type of PR is this?
/kind improvement
/area core
/milestone 2.0
 
#### What this PR does / why we need it:
1. 简化 Snapshot 的指责，去除 Snapshot 中关于 version，publishTime 等与发布相关的东西，Snapshot本身没有发布概念
2. 对应修改文章和自定义页面，将版本的概念转移到拥有 Snapshot 的模型上，如 Post 和 SinglePage

#### Special notes for your reviewer:
/cc @halo-dev/sig-halo 
#### Does this PR introduce a user-facing change?

```release-note
简化 Snapshot 模型的指责，去除版本相关属性
```
