### PR TITLE
feat: support obtaining the configuration of halo.external-url for themes and plugins

### DIFF
--- a/src/main/java/run/halo/app/plugin/SharedApplicationContextHolder.java
+++ b/src/main/java/run/halo/app/plugin/SharedApplicationContextHolder.java
@@ -6,6 +6,7 @@ import org.springframework.stereotype.Component;
 import run.halo.app.extension.DefaultSchemeManager;
 import run.halo.app.extension.ExtensionClient;
 import run.halo.app.extension.ReactiveExtensionClient;
+import run.halo.app.infra.ExternalUrlSupplier;
 
 /**
  * <p>This {@link SharedApplicationContextHolder} class is used to hold a singleton instance of
@@ -61,6 +62,8 @@ public class SharedApplicationContextHolder {
         DefaultSchemeManager defaultSchemeManager =
             rootApplicationContext.getBean(DefaultSchemeManager.class);
         beanFactory.registerSingleton("schemeManager", defaultSchemeManager);
+        beanFactory.registerSingleton("externalUrlSupplier",
+            rootApplicationContext.getBean(ExternalUrlSupplier.class));
         // TODO add more shared instance here
 
         return sharedApplicationContext;

--- a/src/main/java/run/halo/app/theme/SiteSettingVariablesAcquirer.java
+++ b/src/main/java/run/halo/app/theme/SiteSettingVariablesAcquirer.java
@@ -1,9 +1,11 @@
 package run.halo.app.theme;
 
 import java.util.Map;
+import lombok.AllArgsConstructor;
 import org.springframework.stereotype.Component;
 import org.springframework.web.server.ServerWebExchange;
 import reactor.core.publisher.Mono;
+import run.halo.app.infra.ExternalUrlSupplier;
 import run.halo.app.infra.SystemConfigurableEnvironmentFetcher;
 import run.halo.app.theme.finders.vo.SiteSettingVo;
 
@@ -14,20 +16,19 @@ import run.halo.app.theme.finders.vo.SiteSettingVo;
  * @since 2.0.0
  */
 @Component
+@AllArgsConstructor
 public class SiteSettingVariablesAcquirer implements ViewContextBasedVariablesAcquirer {
 
     private final SystemConfigurableEnvironmentFetcher environmentFetcher;
-
-    public SiteSettingVariablesAcquirer(SystemConfigurableEnvironmentFetcher environmentFetcher) {
-        this.environmentFetcher = environmentFetcher;
-    }
+    private final ExternalUrlSupplier externalUrlSupplier;
 
     @Override
     public Mono<Map<String, Object>> acquire(ServerWebExchange exchange) {
         return environmentFetcher.getConfigMap()
             .filter(configMap -> configMap.getData() != null)
             .map(configMap -> {
-                SiteSettingVo siteSettingVo = SiteSettingVo.from(configMap);
+                SiteSettingVo siteSettingVo = SiteSettingVo.from(configMap)
+                    .withUrl(externalUrlSupplier.get());
                 return Map.of("site", siteSettingVo);
             });
     }

--- a/src/main/java/run/halo/app/theme/finders/vo/SiteSettingVo.java
+++ b/src/main/java/run/halo/app/theme/finders/vo/SiteSettingVo.java
@@ -1,8 +1,10 @@
 package run.halo.app.theme.finders.vo;
 
+import java.net.URI;
 import java.util.Map;
 import lombok.Builder;
 import lombok.Value;
+import lombok.With;
 import org.springframework.util.Assert;
 import run.halo.app.extension.ConfigMap;
 import run.halo.app.infra.SystemSetting;
@@ -19,6 +21,9 @@ import run.halo.app.infra.utils.JsonUtils;
 public class SiteSettingVo {
 
     String title;
+
+    @With
+    URI url;
 
     String subtitle;
 

--- a/src/test/java/run/halo/app/theme/SiteSettingVariablesAcquirerTest.java
+++ b/src/test/java/run/halo/app/theme/SiteSettingVariablesAcquirerTest.java
@@ -1,0 +1,59 @@
+package run.halo.app.theme;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.web.server.ServerWebExchange;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+import run.halo.app.extension.ConfigMap;
+import run.halo.app.infra.ExternalUrlSupplier;
+import run.halo.app.infra.SystemConfigurableEnvironmentFetcher;
+import run.halo.app.theme.finders.vo.SiteSettingVo;
+
+/**
+ * Tests for {@link SiteSettingVariablesAcquirer}.
+ *
+ * @author guqing
+ * @since 2.0.0
+ */
+@ExtendWith(MockitoExtension.class)
+public class SiteSettingVariablesAcquirerTest {
+    @Mock
+    private ExternalUrlSupplier externalUrlSupplier;
+    @Mock
+    private SystemConfigurableEnvironmentFetcher environmentFetcher;
+
+    @InjectMocks
+    private SiteSettingVariablesAcquirer siteSettingVariablesAcquirer;
+
+    @Test
+    void acquire() throws URISyntaxException {
+        ConfigMap configMap = new ConfigMap();
+        configMap.setData(Map.of());
+
+        URI uri = new URI("https://halo.run");
+        when(externalUrlSupplier.get()).thenReturn(uri);
+        when(environmentFetcher.getConfigMap()).thenReturn(Mono.just(configMap));
+
+        siteSettingVariablesAcquirer.acquire(Mockito.mock(ServerWebExchange.class))
+            .as(StepVerifier::create)
+            .consumeNextWith(result -> {
+                assertThat(result).containsKey("site");
+                assertThat(result.get("site")).isInstanceOf(SiteSettingVo.class);
+                assertThat((SiteSettingVo) result.get("site"))
+                    .extracting(SiteSettingVo::getUrl)
+                    .isEqualTo(uri);
+            })
+            .verifyComplete();
+    }
+}


### PR DESCRIPTION
#### What type of PR is this?
/kind improvement
/area core
/milestone 2.0

#### What this PR does / why we need it:
主题和插件支持获取 `halo.external-url` 配置信息

#### Which issue(s) this PR fixes:

Fixes #2711
#### Special notes for your reviewer:
how to test it?
1. 在主题中使用`<p th:text="${site.url}"></p>` 可以正确显示
2. 在插件中可以依赖注入 ExternalUrlSupplier

/cc @halo-dev/sig-halo 
#### Does this PR introduce a user-facing change?

```release-note
主题和插件支持获取外部访问地址配置
```
