### PR TITLE
refactor: support chaining calls for flux and mono in javascript inline tag

### DIFF
--- a/src/main/java/run/halo/app/theme/ReactivePropertyAccessor.java
+++ b/src/main/java/run/halo/app/theme/ReactivePropertyAccessor.java
@@ -57,7 +57,7 @@ public class ReactivePropertyAccessor implements PropertyAccessor {
         if (Mono.class.isAssignableFrom(clazz)) {
             value = ((Mono<?>) target).block();
         } else if (Flux.class.isAssignableFrom(clazz)) {
-            value = ((Flux<?>) target).toIterable();
+            value = ((Flux<?>) target).collectList().block();
         }
 
         if (value == null) {

--- a/src/main/java/run/halo/app/theme/ReactiveSpelVariableExpressionEvaluator.java
+++ b/src/main/java/run/halo/app/theme/ReactiveSpelVariableExpressionEvaluator.java
@@ -37,7 +37,7 @@ public class ReactiveSpelVariableExpressionEvaluator
             return ((Mono<?>) returnValue).block();
         }
         if (Flux.class.isAssignableFrom(clazz)) {
-            return ((Flux<?>) returnValue).toIterable();
+            return ((Flux<?>) returnValue).collectList().block();
         }
         return returnValue;
     }

--- a/src/test/java/run/halo/app/theme/ReactiveFinderExpressionParserTests.java
+++ b/src/test/java/run/halo/app/theme/ReactiveFinderExpressionParserTests.java
@@ -1,0 +1,102 @@
+package run.halo.app.theme;
+
+import java.util.Map;
+import java.util.Set;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationContext;
+import org.thymeleaf.IEngineConfiguration;
+import org.thymeleaf.TemplateEngine;
+import org.thymeleaf.context.Context;
+import org.thymeleaf.spring6.dialect.SpringStandardDialect;
+import org.thymeleaf.spring6.expression.ThymeleafEvaluationContext;
+import org.thymeleaf.standard.expression.IStandardVariableExpressionEvaluator;
+import org.thymeleaf.templateresolver.StringTemplateResolver;
+import org.thymeleaf.templateresource.ITemplateResource;
+import org.thymeleaf.templateresource.StringTemplateResource;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+import run.halo.app.theme.dialect.HaloProcessorDialect;
+
+/**
+ * Tests expression parser for reactive return value.
+ *
+ * @author guqing
+ * @see ReactivePropertyAccessor
+ * @see ReactiveSpelVariableExpressionEvaluator
+ * @since 2.0.0
+ */
+@ExtendWith(MockitoExtension.class)
+public class ReactiveFinderExpressionParserTests {
+    @Mock
+    private ApplicationContext applicationContext;
+
+    private TemplateEngine templateEngine;
+
+    @BeforeEach
+    void setUp() {
+        HaloProcessorDialect haloProcessorDialect = new HaloProcessorDialect();
+        templateEngine = new TemplateEngine();
+        templateEngine.setDialects(Set.of(haloProcessorDialect, new SpringStandardDialect() {
+            @Override
+            public IStandardVariableExpressionEvaluator getVariableExpressionEvaluator() {
+                return new ReactiveSpelVariableExpressionEvaluator();
+            }
+        }));
+        templateEngine.addTemplateResolver(new TestTemplateResolver());
+    }
+
+    @Test
+    void javascriptInlineParser() {
+        Context context = getContext();
+        context.setVariable("testReactiveFinder", new TestReactiveFinder());
+        String result = templateEngine.process("javascriptInline", context);
+        System.out.println(result);
+    }
+
+    static class TestReactiveFinder {
+        public Mono<String> getName() {
+            return Mono.just("guqing");
+        }
+
+        public Flux<String> names() {
+            return Flux.just("guqing", "johnniang", "ruibaby");
+        }
+
+        public Flux<TestUser> users() {
+            return Flux.just(
+                new TestUser("guqing"), new TestUser("ruibaby"), new TestUser("johnniang")
+            );
+        }
+    }
+
+    record TestUser(String name) {
+    }
+
+    private Context getContext() {
+        Context context = new Context();
+        context.setVariable(
+            ThymeleafEvaluationContext.THYMELEAF_EVALUATION_CONTEXT_CONTEXT_VARIABLE_NAME,
+            new ThymeleafEvaluationContext(applicationContext, null));
+        return context;
+    }
+
+    static class TestTemplateResolver extends StringTemplateResolver {
+        @Override
+        protected ITemplateResource computeTemplateResource(IEngineConfiguration configuration,
+            String ownerTemplate, String template,
+            Map<String, Object> templateResolutionAttributes) {
+            return new StringTemplateResource("""
+                <script th:inline="javascript">
+                    var name = /*[[${testReactiveFinder.getName()}]]*/;
+                    var names = /*[[${testReactiveFinder.names()}]]*/;
+                    var users = /*[[${testReactiveFinder.users()}]]*/;
+                    var userListItem = /*[[${testReactiveFinder.users[0]}]]*/;
+                </script>
+                 """);
+        }
+    }
+}


### PR DESCRIPTION
#### What type of PR is this?
/kind improvement
/area core
/milestone 2.0

#### What this PR does / why we need it:
支持在 JavaScript 中对 Flux 或 Mono 的泛型类型属性链式调用
测试参考：
https://github.com/halo-dev/halo/blob/7e9bdec4923348b98df17b7e1071154ecec8ead1/src/test/java/run/halo/app/theme/ReactiveFinderExpressionParserTests.java#L131-L147
期望
https://github.com/halo-dev/halo/blob/7e9bdec4923348b98df17b7e1071154ecec8ead1/src/test/java/run/halo/app/theme/ReactiveFinderExpressionParserTests.java#L64-L79

#### Special notes for your reviewer:
/cc @halo-dev/sig-halo 
#### Does this PR introduce a user-facing change?

```release-note
支持在 JavaScript 中对 Flux 或 Mono 的泛型类型属性链式调用
```
