### PR TITLE
Fix the problem of upgrading theme due to pipe closed

### DIFF
--- a/src/main/java/run/halo/app/core/extension/theme/ThemeEndpoint.java
+++ b/src/main/java/run/halo/app/core/extension/theme/ThemeEndpoint.java
@@ -178,8 +178,8 @@ public class ThemeEndpoint implements CustomEndpoint {
             .map(UpgradeRequest::new)
             .map(UpgradeRequest::getFile)
             .flatMap(file -> {
-                try (var inputStream = toInputStream(file.content())) {
-                    return themeService.upgrade(themeNameInPath, inputStream);
+                try {
+                    return themeService.upgrade(themeNameInPath, toInputStream(file.content()));
                 } catch (IOException e) {
                     return Mono.error(e);
                 }
@@ -261,8 +261,7 @@ public class ThemeEndpoint implements CustomEndpoint {
             .flatMap(this::getZipFilePart)
             .flatMap(file -> {
                 try {
-                    var is = toInputStream(file.content());
-                    return themeService.install(is);
+                    return themeService.install(toInputStream(file.content()));
                 } catch (IOException e) {
                     return Mono.error(Exceptions.propagate(e));
                 }


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/kind regression
/area core
/milestone 2.0

#### What this PR does / why we need it:

When we try to upgrade a theme, error will appear like below:

```java
2022-11-18T15:45:35.130+08:00 ERROR 18136 --- [oundedElastic-1] a.w.r.e.AbstractErrorWebExceptionHandler : [26de12d5-51]  500 Server Error for HTTP POST "/apis/api.console.halo.run/v1alpha1/themes/theme-earth/upgrade"

java.io.IOException: Pipe closed
	at java.base/java.io.PipedInputStream.read(PipedInputStream.java:307) ~[na:na]
	Suppressed: reactor.core.publisher.FluxOnAssembly$OnAssemblyException: 
Assembly trace from producer [reactor.core.publisher.MonoFlatMap] :
	reactor.core.publisher.Mono.flatMap(Mono.java:3080)
	run.halo.app.core.extension.theme.ThemeServiceImpl.upgrade(ThemeServiceImpl.java:72)
Error has been observed at the following site(s):
	*____________Mono.flatMap ⇢ at run.halo.app.core.extension.theme.ThemeServiceImpl.upgrade(ThemeServiceImpl.java:72)
	|_          Mono.doOnNext ⇢ at run.halo.app.core.extension.theme.ThemeServiceImpl.upgrade(ThemeServiceImpl.java:82)
	|_               Mono.map ⇢ at run.halo.app.core.extension.theme.ThemeServiceImpl.upgrade(ThemeServiceImpl.java:88)
	|_          Mono.doOnNext ⇢ at run.halo.app.core.extension.theme.ThemeServiceImpl.upgrade(ThemeServiceImpl.java:89)
	|_           Mono.flatMap ⇢ at run.halo.app.core.extension.theme.ThemeServiceImpl.upgrade(ThemeServiceImpl.java:98)
	|_          Mono.doOnNext ⇢ at run.halo.app.core.extension.theme.ThemeServiceImpl.upgrade(ThemeServiceImpl.java:103)
	|_           Mono.flatMap ⇢ at run.halo.app.core.extension.theme.ThemeServiceImpl.upgrade(ThemeServiceImpl.java:112)
	|_         Mono.doFinally ⇢ at run.halo.app.core.extension.theme.ThemeServiceImpl.upgrade(ThemeServiceImpl.java:113)
	*____________Mono.flatMap ⇢ at run.halo.app.core.extension.theme.ThemeEndpoint.upgrade(ThemeEndpoint.java:180)
	|_           Mono.flatMap ⇢ at run.halo.app.core.extension.theme.ThemeEndpoint.upgrade(ThemeEndpoint.java:187)
```

This might be caused by PR <https://github.com/halo-dev/halo/pull/2704>.

#### Special notes for your reviewer:

Steps to test:

1. Upgrade any theme

#### Does this PR introduce a user-facing change?

```release-note
None
```
