### PR TITLE
Bump up springdoc-openapi

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -58,7 +58,7 @@ dependencies {
     implementation 'org.springframework.security:spring-security-oauth2-jose'
     implementation 'org.springframework.security:spring-security-oauth2-resource-server'
 
-    implementation 'org.springdoc:springdoc-openapi-starter-webflux-ui:2.0.0-RC1'
+    implementation 'org.springdoc:springdoc-openapi-starter-webflux-ui:2.0.0-RC2'
     implementation 'org.openapi4j:openapi-schema-validator:1.0.7'
     implementation "net.bytebuddy:byte-buddy"
 


### PR DESCRIPTION
#### What type of PR is this?

/kind improvement
/area core
/milestone 2.0.0

#### What this PR does / why we need it:

springdoc-openapi 2.0.0-RC2 fully supports Spring Boot 3.0.0-RC2 currently, please see https://github.com/springdoc/springdoc-openapi/releases/tag/v2.0.0-RC2 for more.

#### Does this PR introduce a user-facing change?

```release-note
升级依赖 SpringDoc OpenAPI 至 2.0.0-RC2
```
