### PR TITLE
feat: provides authentication and authorization expression dialects

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -76,6 +76,7 @@ dependencies {
     implementation "io.github.java-diff-utils:java-diff-utils:$javaDiffUtils"
     implementation "org.springframework.integration:spring-integration-core"
     implementation "com.github.java-json-tools:json-patch:$jsonPatch"
+    implementation "org.thymeleaf.extras:thymeleaf-extras-springsecurity6"
 
     compileOnly 'org.projectlombok:lombok'
     testCompileOnly 'org.projectlombok:lombok'

--- a/src/main/java/run/halo/app/config/WebServerSecurityConfig.java
+++ b/src/main/java/run/halo/app/config/WebServerSecurityConfig.java
@@ -1,7 +1,6 @@
 package run.halo.app.config;
 
 import static org.springframework.security.config.Customizer.withDefaults;
-import static org.springframework.security.web.server.util.matcher.ServerWebExchangeMatchers.pathMatchers;
 
 import com.nimbusds.jose.JWSAlgorithm;
 import com.nimbusds.jose.jwk.JWKSet;
@@ -56,9 +55,11 @@ public class WebServerSecurityConfig {
         RoleService roleService,
         ObjectProvider<SecurityConfigurer> securityConfigurers) {
 
-        http.securityMatcher(pathMatchers("/api/**", "/apis/**", "/login", "/logout"))
-            .authorizeExchange(exchanges ->
-                exchanges.anyExchange().access(new RequestInfoAuthorizationManager(roleService)))
+        http.authorizeExchange()
+            .pathMatchers("/**").permitAll()
+            .pathMatchers("/api/**", "/apis/**", "/login", "/logout")
+            .access(new RequestInfoAuthorizationManager(roleService))
+            .and()
             .anonymous(anonymousSpec -> {
                 anonymousSpec.authorities(AnonymousUserConst.Role);
                 anonymousSpec.principal(AnonymousUserConst.PRINCIPAL);

--- a/src/main/resources/extensions/user.yaml
+++ b/src/main/resources/extensions/user.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1alpha1
+kind: User
+metadata:
+  name: anonymousUser
+spec:
+  displayName: Anonymous User
+  email: anonymous@example.com
+  disabled: true


### PR DESCRIPTION
#### What type of PR is this?
/kind feature
/milestone 2.0
/area core

#### What this PR does / why we need it:
主题端支持使用表达式方言获取登录状态和判断权限，例如：
```html
<div th:text="${#authentication.name}">
  The value of the "name" property of the authentication object should appear here.
</div>
```
更多请参考：
https://github.com/thymeleaf/thymeleaf-extras-springsecurity

Console 端判断是否登录需要改一下，目前所有未登录状态都属于一个叫 anonymousUser 的用户
#### Which issue(s) this PR fixes:

Fixes #2676

#### Special notes for your reviewer:
/cc @halo-dev/sig-halo 
#### Does this PR introduce a user-facing change?
```release-note
主题端支持使用表达式方言获取登录状态和判断权限
```
