### PR TITLE
refactor: extension update when reload from yaml

### DIFF
--- a/src/main/java/run/halo/app/core/extension/reconciler/PluginReconciler.java
+++ b/src/main/java/run/halo/app/core/extension/reconciler/PluginReconciler.java
@@ -253,8 +253,7 @@ public class PluginReconciler implements Reconciler<Request> {
         client.fetch(ReverseProxy.class, reverseProxyName)
             .ifPresentOrElse(persisted -> {
                 if (isDevelopmentMode(pluginName)) {
-                    reverseProxy.getMetadata()
-                        .setVersion(persisted.getMetadata().getVersion());
+                    reverseProxy.setMetadata(persisted.getMetadata());
                     client.update(reverseProxy);
                 }
             }, () -> client.create(reverseProxy));

--- a/src/main/java/run/halo/app/infra/ExtensionResourceInitializer.java
+++ b/src/main/java/run/halo/app/infra/ExtensionResourceInitializer.java
@@ -88,7 +88,7 @@ public class ExtensionResourceInitializer {
             .flatMap(ext -> extensionClient.fetch(extension.groupVersionKind(),
                 extension.getMetadata().getName()))
             .flatMap(existingExt -> {
-                extension.getMetadata().setVersion(existingExt.getMetadata().getVersion());
+                extension.setMetadata(existingExt.getMetadata());
                 return extensionClient.update(extension);
             })
             .switchIfEmpty(Mono.defer(() -> extensionClient.create(extension)))

--- a/src/main/java/run/halo/app/plugin/PluginDevelopmentInitializer.java
+++ b/src/main/java/run/halo/app/plugin/PluginDevelopmentInitializer.java
@@ -47,7 +47,7 @@ public class PluginDevelopmentInitializer implements ApplicationListener<Applica
             Plugin plugin = new YamlPluginFinder().find(pluginWrapper.getPluginPath());
             extensionClient.fetch(Plugin.class, plugin.getMetadata().getName())
                 .ifPresentOrElse(persistent -> {
-                    plugin.getMetadata().setVersion(persistent.getMetadata().getVersion());
+                    plugin.setMetadata(persistent.getMetadata());
                     extensionClient.update(plugin);
                 }, () -> extensionClient.create(plugin));
         }

--- a/src/main/java/run/halo/app/plugin/PluginStartedListener.java
+++ b/src/main/java/run/halo/app/plugin/PluginStartedListener.java
@@ -77,8 +77,7 @@ public class PluginStartedListener {
 
                         return client.fetch(unstructured.groupVersionKind(), metadata.getName())
                             .flatMap(extension -> {
-                                unstructured.getMetadata()
-                                    .setVersion(extension.getMetadata().getVersion());
+                                unstructured.setMetadata(extension.getMetadata());
                                 return client.update(unstructured);
                             })
                             .switchIfEmpty(Mono.defer(() -> client.create(unstructured)));


### PR DESCRIPTION
#### What type of PR is this?
/kind improvement
/area core
/milestone 2.0.0-rc.1

#### What this PR does / why we need it:
自定义模型资源在 Halo 启动时创建到数据库，当重启时数据库已经有记录要去更新它，此时不能只更新 重新 load yaml 得到extension 的 version 而要覆盖整个 metadata 否则会导致 metadata 里有的数据为空例如 creationTimeStamp，假如后续有 ownerReference 引用等也应该携带而不丢失

#### Special notes for your reviewer:
/cc @halo-dev/sig-halo 
#### Does this PR introduce a user-facing change?
```release-note
修复插件的创建时间会丢失问题
```
