### PR TITLE
refactor: check whether plugin has been loaded when startup

### DIFF
--- a/src/main/java/run/halo/app/plugin/PluginDevelopmentInitializer.java
+++ b/src/main/java/run/halo/app/plugin/PluginDevelopmentInitializer.java
@@ -39,6 +39,10 @@ public class PluginDevelopmentInitializer implements ApplicationListener<Applica
 
     private void createFixedPluginIfNecessary(HaloPluginManager pluginManager) {
         for (Path path : pluginProperties.getFixedPluginPath()) {
+            // already loaded
+            if (idForPath(path) != null) {
+                continue;
+            }
             String pluginId = pluginManager.loadPlugin(path);
             PluginWrapper pluginWrapper = pluginManager.getPlugin(pluginId);
             if (pluginWrapper == null) {
@@ -51,5 +55,14 @@ public class PluginDevelopmentInitializer implements ApplicationListener<Applica
                     extensionClient.update(plugin);
                 }, () -> extensionClient.create(plugin));
         }
+    }
+
+    protected String idForPath(Path pluginPath) {
+        for (PluginWrapper plugin : haloPluginManager.getPlugins()) {
+            if (plugin.getPluginPath().equals(pluginPath)) {
+                return plugin.getPluginId();
+            }
+        }
+        return null;
     }
 }


### PR DESCRIPTION
#### What type of PR is this?
/kind improvement
/area core
/milestone 2.0.0-rc.1

#### What this PR does / why we need it:
插件以开发模式启动时加载插件需判断是否已经加载过

#### Which issue(s) this PR fixes:

Fixes #2758

#### Special notes for your reviewer:
how to test it?
1. 配置 `halo.plugin.fixed-plugin-path`
2. 以开发模式启动后重启几次不会出现  #2758 中描述的异常

/cc @halo-dev/sig-halo 
#### Does this PR introduce a user-facing change?

```release-note
修复插件以开发模式启动时会出现插件已经加载过的异常
```
