### PR TITLE
feat: theme templates support global seo settings

### DIFF
--- a/src/main/java/run/halo/app/theme/dialect/GlobalSeoProcessor.java
+++ b/src/main/java/run/halo/app/theme/dialect/GlobalSeoProcessor.java
@@ -1,0 +1,59 @@
+package run.halo.app.theme.dialect;
+
+import lombok.AllArgsConstructor;
+import org.apache.commons.lang3.BooleanUtils;
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.core.annotation.Order;
+import org.springframework.stereotype.Component;
+import org.thymeleaf.context.ITemplateContext;
+import org.thymeleaf.model.IModel;
+import org.thymeleaf.model.IModelFactory;
+import org.thymeleaf.processor.element.IElementModelStructureHandler;
+import reactor.core.publisher.Mono;
+import run.halo.app.infra.SystemConfigurableEnvironmentFetcher;
+import run.halo.app.infra.SystemSetting;
+
+/**
+ * Inject code to the template head tag according to the global seo settings.
+ *
+ * @author guqing
+ * @see SystemSetting.Seo
+ * @since 2.0.0
+ */
+@Order
+@Component
+@AllArgsConstructor
+public class GlobalSeoProcessor implements TemplateHeadProcessor {
+
+    private final SystemConfigurableEnvironmentFetcher environmentFetcher;
+
+    @Override
+    public Mono<Void> process(ITemplateContext context, IModel model,
+        IElementModelStructureHandler structureHandler) {
+        return environmentFetcher.fetch(SystemSetting.Seo.GROUP, SystemSetting.Seo.class)
+            .map(seo -> {
+                boolean blockSpiders = BooleanUtils.isTrue(seo.getBlockSpiders());
+                IModelFactory modelFactory = context.getModelFactory();
+                if (blockSpiders) {
+                    String noIndexMeta = "<meta name=\"robots\" content=\"noindex\" />\n";
+                    model.add(modelFactory.createText(noIndexMeta));
+                    return model;
+                }
+
+                String keywords = seo.getKeywords();
+                if (StringUtils.isNotBlank(keywords)) {
+                    String keywordsMeta =
+                        "<meta name=\"keywords\" content=\"" + keywords + "\" />\n";
+                    model.add(modelFactory.createText(keywordsMeta));
+                }
+
+                if (StringUtils.isNotBlank(seo.getDescription())) {
+                    String descriptionMeta =
+                        "<meta name=\"description\" content=\"" + seo.getDescription() + "\" />\n";
+                    model.add(modelFactory.createText(descriptionMeta));
+                }
+                return model;
+            })
+            .then();
+    }
+}


### PR DESCRIPTION
#### What type of PR is this?
/kind improvement
/area core
/milestone 2.0.0-rc.2

#### What this PR does / why we need it:
适配 SEO 系统设置，此功能之前遗漏

#### Which issue(s) this PR fixes:

Fixes #2797

#### Special notes for your reviewer:
how to test it?
1. seo 设置禁用搜索引擎，会在所有页面的 head 添加 `<meta name="robots" content="noindex" />`
2. seo 设置填写`关键词`和`描述`会在所有页面的 head 标签填充 `<meta name="xxx> content="xxx" />` 

/cc @halo-dev/sig-halo
#### Does this PR introduce a user-facing change?

```release-note
支持 SEO 全局系统设置
```
