### PR TITLE
Fix the problem that MySQL complains "Data too long for column 'data' at row 1"

### DIFF
--- a/src/main/resources/schema-mysql.sql
+++ b/src/main/resources/schema-mysql.sql
@@ -1,7 +1,7 @@
 create table if not exists extensions
 (
     name    varchar(255) not null,
-    data    blob,
+    data    longblob,
     version bigint,
     primary key (name)
 );


### PR DESCRIPTION
#### What type of PR is this?

/kind improvement
/area core
/milestone 2.0.1

#### What this PR does / why we need it:

See https://github.com/halo-dev/halo/issues/2832 and https://github.com/halo-dev/halo/issues/2832#issuecomment-1336616901 for more.

For a workaround, please refer to:
- https://github.com/halo-dev/halo/issues/2832#issuecomment-1336610679

But, there are still limitations here:
- For MySQL: ~4GB
- For PosgreSQL: ~1GB

#### Which issue(s) this PR fixes:

Fixes https://github.com/halo-dev/halo/issues/2832

#### Does this PR introduce a user-facing change?

```release-note
修复因文章过长导致无法保存数据的问题
```
