### PR TITLE
fix: compartor exception in post list

### DIFF
--- a/src/main/java/run/halo/app/content/impl/PostServiceImpl.java
+++ b/src/main/java/run/halo/app/content/impl/PostServiceImpl.java
@@ -165,7 +165,7 @@ public class PostServiceImpl implements PostService {
 
     private Mono<ListedPost> setTags(List<String> tagNames, ListedPost post) {
         return listTags(tagNames)
-            .collectSortedList()
+            .collectList()
             .doOnNext(post::setTags)
             .map(tags -> post)
             .switchIfEmpty(Mono.defer(() -> Mono.just(post)));
@@ -173,7 +173,7 @@ public class PostServiceImpl implements PostService {
 
     private Mono<ListedPost> setCategories(List<String> categoryNames, ListedPost post) {
         return listCategories(categoryNames)
-            .collectSortedList()
+            .collectList()
             .doOnNext(post::setCategories)
             .map(categories -> post)
             .switchIfEmpty(Mono.defer(() -> Mono.just(post)));
@@ -181,7 +181,7 @@ public class PostServiceImpl implements PostService {
 
     private Mono<ListedPost> setContributors(List<String> contributorNames, ListedPost post) {
         return listContributors(contributorNames)
-            .collectSortedList()
+            .collectList()
             .doOnNext(post::setContributors)
             .map(contributors -> post)
             .switchIfEmpty(Mono.defer(() -> Mono.just(post)));


### PR DESCRIPTION
#### What type of PR is this?
/kind bugfix
/area core

#### What this PR does / why we need it:
修复文章列表查询时的类型转换错误

文章列表查询将 collectList 错写为 collectSortedList 导致此 `Contributor cannot be cast to class java.lang.Comparable`，
collectSortedList 会使用  `Arrays.sort(a, (Comparator) c)`，这需要目标类实现 Comparable 才行，而此处并不需要自然排序。

#### Which issue(s) this PR fixes:

Fixes #2830

#### Special notes for your reviewer:
/cc @halo-dev/sig-halo 
#### Does this PR introduce a user-facing change?

```release-note
修复文章列表查询时的类型转换错误
```
