### PR TITLE
Add forgotten label for system-reserved roles

### DIFF
--- a/src/main/java/run/halo/app/core/extension/Role.java
+++ b/src/main/java/run/halo/app/core/extension/Role.java
@@ -32,6 +32,9 @@ public class Role extends AbstractExtension {
         "rbac.authorization.halo.run/dependency-rules";
     public static final String ROLE_DEPENDENCIES_ANNO = "rbac.authorization.halo.run/dependencies";
     public static final String UI_PERMISSIONS_ANNO = "rbac.authorization.halo.run/ui-permissions";
+
+    public static final String SYSTEM_RESERVED_LABELS =
+        "rbac.authorization.halo.run/system-reserved";
     public static final String UI_PERMISSIONS_AGGREGATED_ANNO =
         "rbac.authorization.halo.run/ui-permissions-aggregated";
 

--- a/src/main/resources/extensions/system-default-role.yaml
+++ b/src/main/resources/extensions/system-default-role.yaml
@@ -1,5 +1,23 @@
 apiVersion: v1alpha1
-kind: "Role"
+kind: Role
 metadata:
   name: guest
+  labels:
+    rbac.authorization.halo.run/system-reserved: "true"
 rules: [ ]
+
+---
+apiVersion: v1alpha1
+kind: Role
+metadata:
+  name: super-role
+  labels:
+    rbac.authorization.halo.run/system-reserved: "true"
+  annotations:
+    rbac.authorization.halo.run/ui-permissions: |
+      ["*"]
+rules:
+  - apiGroups: ["*"]
+    resources: ["*"]
+    nonResourceURLs: ["*"]
+    verbs: ["*"]


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/area core

#### What this PR does / why we need it:

Add forgotten label `rbac.authorization.halo.run/system-reserved` for system-reserved roles. See the screenshot below:

![image](https://user-images.githubusercontent.com/16865714/205936031-8a49d4ef-9d10-4c72-a125-973cd361771e.png)

#### Which issue(s) this PR fixes:

Fixes https://github.com/halo-dev/halo/issues/2844

#### Special notes for your reviewer:

For @halo-dev/sig-halo-console : We have to determine whether the role is system-reserved by checking if label `rbac.authorization.halo.run/system-reserved` is equal to `true`.

#### Does this PR introduce a user-facing change?

<!--
如果当前 Pull Request 的修改不会造成用户侧的任何变更，在 `release-note` 代码块儿中填写 `NONE`。
否则请填写用户侧能够理解的 Release Note。如果当前 Pull Request 包含破坏性更新（Break Change），
Release Note 需要以 `action required` 开头。
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->

```release-note
修复每个角色都显示系统保留标签的问题
```
