### PR TITLE
Set docker image name properly when releasing

### DIFF
--- a/.github/workflows/halo.yaml
+++ b/.github/workflows/halo.yaml
@@ -56,7 +56,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: halo-sigs/actions/halo-next-docker-build@main # change the version to specific ref or release tag while the action is stable.
         with:
-          image-name: halo-dev
+          image-name: ${{ github.event_name == 'release' && 'halo' || 'halo-dev' }}
           ghcr-token: ${{ secrets.GHCR_TOKEN }}
           dockerhub-user: ${{ secrets.DOCKER_USERNAME }}
           dockerhub-token: ${{ secrets.DOCKER_TOKEN }}


### PR DESCRIPTION
#### What type of PR is this?

/kind improvement
/area core

#### What this PR does / why we need it:

Set docker image name to `halo` instead of `halo-dev` when releasing.

#### Special notes for your reviewer:

Please refer to a real test at <https://github.com/JohnNiang/halo/actions/runs/3636780100/jobs/6137100454>

#### Does this PR introduce a user-facing change?

```release-note
None
```
