### PR TITLE
Enable CI on release branches

### DIFF
--- a/.github/workflows/halo.yaml
+++ b/.github/workflows/halo.yaml
@@ -3,15 +3,15 @@ name: Halo CI
 on:
   pull_request:
     branches:
-      - next
       - main
+      - release-*
     paths:
       - "**"
       - "!**.md"
   push:
     branches:
-      - next
       - main
+      - release-*
     paths:
       - "**"
       - "!**.md"


### PR DESCRIPTION
#### What type of PR is this?

/kind improvement
/area core
/cherry-pick release-2.0

#### What this PR does / why we need it:

Enable CI on release branches.

- Before

    ![image](https://user-images.githubusercontent.com/16865714/206140215-8425e15b-2a66-4f6f-9783-68967900ec40.png)

- After

    ![image](https://user-images.githubusercontent.com/16865714/206140366-4f4b7482-33bb-466b-aa6c-6f8869f79f7d.png)

#### Does this PR introduce a user-facing change?

```release-note
None
```
