### PR TITLE
Support configuring Halo in working directory

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,8 @@ COPY --from=builder application/snapshot-dependencies/ ./
 COPY --from=builder application/application/ ./
 
 ENV JVM_OPTS="-Xmx256m -Xms256m" \
+    HALO_WORK_DIR="/root/.halo2" \
+    SPRING_CONFIG_LOCATION="optional:classpath:/;optional:file:/root/.halo2/" \
     TZ=Asia/Shanghai
 
 RUN ln -sf /usr/share/zoneinfo/$TZ /etc/localtime \


### PR DESCRIPTION
#### What type of PR is this?

/kind improvement
/area core
/milestone 2.1.x

#### What this PR does / why we need it:

Force to add environment variables `HALO_WORK_DIR` and `SPRING_CONFIG_LOCATION` into Dockerfile. After that, we can configure `application.yaml` in working directory as we want.

Please note that we can not configure Halo working directory in `/root/.halo2/application.yaml` directly. Use environment variable `HALO_WORK_DIR` instead.

#### Which issue(s) this PR fixes:

Fixes https://github.com/halo-dev/halo/issues/2812

#### Special notes for your reviewer:

Steps to test:

1. Prepare custom configuration

    ```bash
    mkdir -p halo2

    cat <<EOF > halo2/application.yaml
    server:
      port: 12345
    EOF
    ```

2. Start up Halo using Docker
    
    ```bash
    docker run -it --rm -p12345:12345 -v `pwd`/halo2:/root/.halo2  johnniang/halo:configure-halo-in-work-dir
    ```

3. Request http://localhost:12345

    ```bash
    curl -v localhost:12345
    ```

#### Does this PR introduce a user-facing change?

```release-note
支持在工作目录添加自定义配置
```
