### PR TITLE
fix: plugin logo cannot be loaded when it is not enabled

### DIFF
--- a/src/main/java/run/halo/app/core/extension/reconciler/PluginReconciler.java
+++ b/src/main/java/run/halo/app/core/extension/reconciler/PluginReconciler.java
@@ -231,6 +231,9 @@ public class PluginReconciler implements Reconciler<Request> {
         // stop and unload plugin, see also PluginBeforeStopSyncListener
         haloPluginManager.stopPlugin(pluginWrapper.getPluginId());
         haloPluginManager.unloadPlugin(pluginWrapper.getPluginId());
+        // delete initial reverse proxy
+        client.fetch(ReverseProxy.class, initialReverseProxyName(pluginWrapper.getPluginId()))
+            .ifPresent(client::delete);
         // delete plugin resources
         if (RuntimeMode.DEPLOYMENT.equals(pluginWrapper.getRuntimeMode())) {
             // delete plugin file

--- a/src/main/java/run/halo/app/core/extension/reconciler/ReverseProxyReconciler.java
+++ b/src/main/java/run/halo/app/core/extension/reconciler/ReverseProxyReconciler.java
@@ -60,7 +60,7 @@ public class ReverseProxyReconciler implements Reconciler<Reconciler.Request> {
 
     private void cleanUpResources(ReverseProxy reverseProxy) {
         String pluginId = getPluginId(reverseProxy);
-        routerFunctionRegistry.remove(pluginId).block();
+        routerFunctionRegistry.remove(pluginId, reverseProxy.getMetadata().getName()).block();
     }
 
     private void addFinalizerIfNecessary(ReverseProxy oldReverseProxy) {

--- a/src/test/java/run/halo/app/core/extension/reconciler/ReverseProxyReconcilerTest.java
+++ b/src/test/java/run/halo/app/core/extension/reconciler/ReverseProxyReconcilerTest.java
@@ -1,0 +1,69 @@
+package run.halo.app.core.extension.reconciler;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import reactor.core.publisher.Mono;
+import run.halo.app.core.extension.ReverseProxy;
+import run.halo.app.extension.ExtensionClient;
+import run.halo.app.extension.Metadata;
+import run.halo.app.extension.controller.Reconciler;
+import run.halo.app.plugin.PluginConst;
+import run.halo.app.plugin.resources.ReverseProxyRouterFunctionRegistry;
+
+/**
+ * Tests for {@link ReverseProxyReconciler}.
+ *
+ * @author guqing
+ * @since 2.0.1
+ */
+@ExtendWith(MockitoExtension.class)
+class ReverseProxyReconcilerTest {
+
+    @Mock
+    private ExtensionClient client;
+
+    @Mock
+    private ReverseProxyRouterFunctionRegistry routerFunctionRegistry;
+
+    @InjectMocks
+    private ReverseProxyReconciler reverseProxyReconciler;
+
+    @Test
+    void reconcileRemoval() {
+        // fix gh-2937
+        ReverseProxy reverseProxy = new ReverseProxy();
+        reverseProxy.setMetadata(new Metadata());
+        reverseProxy.getMetadata().setName("fake-reverse-proxy");
+        reverseProxy.getMetadata().setDeletionTimestamp(Instant.now());
+        reverseProxy.getMetadata()
+            .setLabels(Map.of(PluginConst.PLUGIN_NAME_LABEL_NAME, "fake-plugin"));
+        reverseProxy.setRules(List.of());
+
+        when(routerFunctionRegistry.remove(anyString(), anyString())).thenReturn(Mono.empty());
+        when(client.fetch(ReverseProxy.class, "fake-reverse-proxy"))
+            .thenReturn(Optional.of(reverseProxy));
+
+        reverseProxyReconciler.reconcile(new Reconciler.Request("fake-reverse-proxy"));
+
+        verify(routerFunctionRegistry, never()).register(anyString(), any(ReverseProxy.class));
+
+        verify(routerFunctionRegistry, never()).remove(eq("fake-plugin"));
+        verify(routerFunctionRegistry, times(1))
+            .remove(eq("fake-plugin"), eq("fake-reverse-proxy"));
+    }
+}


### PR DESCRIPTION
#### What type of PR is this?
/kind bug
/area core

#### What this PR does / why we need it:
修复插件 logo 为相对路径时先启用再停后就无法加载 logo  的问题

原因是 reverse proxy reconciler 资源被删除要取消注册路由时没有确切指定名称，logo 这样的 ReverseProxy 是插件安装时初始化的这条初始化的规则要跟随插件的生命周期，只有插件卸载时才会被删除，而在此之前插件被停止时就被误取消注册了

see #2937 for more detail
#### Which issue(s) this PR fixes:

Fixes #2937

#### Special notes for your reviewer:
/cc @halo-dev/sig-halo 
#### Does this PR introduce a user-facing change?

```release-note
修复插件 logo 为相对路径时先启用再停后就无法加载 logo  的问题
```
