### PR TITLE
Support command-line arguments running with Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,4 +20,4 @@ ENV JVM_OPTS="-Xmx256m -Xms256m" \
 RUN ln -sf /usr/share/zoneinfo/$TZ /etc/localtime \
     && echo $TZ > /etc/timezone
 
-ENTRYPOINT java ${JVM_OPTS} -Djava.security.egd=file:/dev/./urandom org.springframework.boot.loader.JarLauncher
+ENTRYPOINT ["sh", "-c", "java ${JVM_OPTS} org.springframework.boot.loader.JarLauncher ${0} ${@}"]


### PR DESCRIPTION
#### What type of PR is this?

/kind improvement
/area core

#### What this PR does / why we need it:

Now, we can pass command-line arguments while using Docker. Please refer to <https://github.com/halo-dev/halo/issues/2902>.

#### Which issue(s) this PR fixes:

Fixes https://github.com/halo-dev/halo/issues/2902

#### Special notes for your reviewer:

Steps to test:

1. Run Halo with command-line arguments:

    ```bash
    docker run --rm -it -p6666:6666 johnniang/halo:support-command-line-args --server.port=6666
    ```

1. Request <http://localhost:6666>

    ```bash
    curl -v http://localhost:6666
    ```

#### Does this PR introduce a user-facing change?

<!--
如果当前 Pull Request 的修改不会造成用户侧的任何变更，在 `release-note` 代码块儿中填写 `NONE`。
否则请填写用户侧能够理解的 Release Note。如果当前 Pull Request 包含破坏性更新（Break Change），
Release Note 需要以 `action required` 开头。
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->

```release-note
支持命令行参数启动 Halo
```
