### PR TITLE
refactor: remove get root application context method from halo plugin manager

### DIFF
--- a/src/main/java/run/halo/app/plugin/BasePlugin.java
+++ b/src/main/java/run/halo/app/plugin/BasePlugin.java
@@ -2,6 +2,7 @@ package run.halo.app.plugin;
 
 import lombok.extern.slf4j.Slf4j;
 import org.pf4j.Plugin;
+import org.pf4j.PluginManager;
 import org.pf4j.PluginWrapper;
 
 /**
@@ -18,7 +19,7 @@ public class BasePlugin extends Plugin {
         super(wrapper);
     }
 
-    private HaloPluginManager getPluginManager() {
-        return (HaloPluginManager) getWrapper().getPluginManager();
+    private PluginManager getPluginManager() {
+        return getWrapper().getPluginManager();
     }
 }

--- a/src/main/java/run/halo/app/plugin/HaloPluginManager.java
+++ b/src/main/java/run/halo/app/plugin/HaloPluginManager.java
@@ -68,17 +68,13 @@ public class HaloPluginManager extends DefaultPluginManager
         return new SpringComponentsFinder(this);
     }
 
-    public ApplicationContext getRootApplicationContext() {
-        return this.rootApplicationContext;
-    }
-
     @Override
-    public void setApplicationContext(@NonNull ApplicationContext rootApplicationContext)
+    public final void setApplicationContext(@NonNull ApplicationContext rootApplicationContext)
         throws BeansException {
         this.rootApplicationContext = rootApplicationContext;
     }
 
-    public PluginApplicationContext getPluginApplicationContext(String pluginId) {
+    final PluginApplicationContext getPluginApplicationContext(String pluginId) {
         return pluginApplicationInitializer.getPluginApplicationContext(pluginId);
     }
 
@@ -88,8 +84,9 @@ public class HaloPluginManager extends DefaultPluginManager
     }
 
     @Override
-    public void afterPropertiesSet() {
-        this.pluginApplicationInitializer = new PluginApplicationInitializer(this);
+    public final void afterPropertiesSet() {
+        this.pluginApplicationInitializer =
+            new PluginApplicationInitializer(this, rootApplicationContext);
 
         this.requestMappingManager =
             rootApplicationContext.getBean(PluginRequestMappingManager.class);

--- a/src/main/java/run/halo/app/plugin/PluginApplicationInitializer.java
+++ b/src/main/java/run/halo/app/plugin/PluginApplicationInitializer.java
@@ -26,15 +26,16 @@ public class PluginApplicationInitializer {
 
     private final ExtensionContextRegistry contextRegistry = ExtensionContextRegistry.getInstance();
     private final SharedApplicationContextHolder sharedApplicationContextHolder;
+    private final ApplicationContext rootApplicationContext;
 
-    public PluginApplicationInitializer(HaloPluginManager springPluginManager) {
-        this.haloPluginManager = springPluginManager;
-        sharedApplicationContextHolder = springPluginManager.getRootApplicationContext()
+    public PluginApplicationInitializer(HaloPluginManager haloPluginManager,
+        ApplicationContext rootApplicationContext) {
+        Assert.notNull(haloPluginManager, "The haloPluginManager must not be null");
+        Assert.notNull(rootApplicationContext, "The rootApplicationContext must not be null");
+        this.haloPluginManager = haloPluginManager;
+        this.rootApplicationContext = rootApplicationContext;
+        sharedApplicationContextHolder = rootApplicationContext
             .getBean(SharedApplicationContextHolder.class);
-    }
-
-    public ApplicationContext getRootApplicationContext() {
-        return this.haloPluginManager.getRootApplicationContext();
     }
 
     private PluginApplicationContext createPluginApplicationContext(String pluginId) {
@@ -111,7 +112,7 @@ public class PluginApplicationInitializer {
     private void populateSettingFetcher(String pluginName,
         DefaultListableBeanFactory listableBeanFactory) {
         ExtensionClient extensionClient =
-            getRootApplicationContext().getBean(ExtensionClient.class);
+            rootApplicationContext.getBean(ExtensionClient.class);
         SettingFetcher settingFetcher = new SettingFetcher(pluginName, extensionClient);
         listableBeanFactory.registerSingleton("settingFetcher", settingFetcher);
     }


### PR DESCRIPTION

#### What type of PR is this?
/kind improvement
/area core
#### What this PR does / why we need it:
HaloPluginManager 移除 getRootApplicationContext 方法

#### Which issue(s) this PR fixes:

Fixes #2943

#### Special notes for your reviewer:
/cc @halo-dev/sig-halo 
#### Does this PR introduce a user-facing change?

```release-note
HaloPluginManager 移除 getRootApplicationContext 方法
```
