### PR TITLE
feat: add reset config API for theme and plugin

### DIFF
--- a/src/main/java/run/halo/app/core/extension/endpoint/PluginEndpoint.java
+++ b/src/main/java/run/halo/app/core/extension/endpoint/PluginEndpoint.java
@@ -100,9 +100,9 @@ public class PluginEndpoint implements CustomEndpoint {
                         .content(contentBuilder().mediaType(MediaType.MULTIPART_FORM_DATA_VALUE)
                             .schema(schemaBuilder().implementation(InstallRequest.class))))
             )
-            .PUT("plugins/{name}/resetconfig", this::resetSettingConfig,
-                builder -> builder.operationId("ResetPluginSettingConfig")
-                    .description("Reset plugin setting configMap.")
+            .PUT("plugins/{name}/reset-config", this::resetSettingConfig,
+                builder -> builder.operationId("ResetPluginConfig")
+                    .description("Reset the configMap of plugin setting.")
                     .tag(tag)
                     .parameter(parameterBuilder()
                         .name("name")

--- a/src/main/java/run/halo/app/core/extension/endpoint/PluginEndpoint.java
+++ b/src/main/java/run/halo/app/core/extension/endpoint/PluginEndpoint.java
@@ -101,7 +101,7 @@ public class PluginEndpoint implements CustomEndpoint {
                             .schema(schemaBuilder().implementation(InstallRequest.class))))
             )
             .PUT("plugins/{name}/resetconfig", this::resetSettingConfig,
-                builder -> builder.operationId("ResetSettingConfig")
+                builder -> builder.operationId("ResetPluginSettingConfig")
                     .description("Reset plugin setting configMap.")
                     .tag(tag)
                     .parameter(parameterBuilder()

--- a/src/main/java/run/halo/app/core/extension/theme/SettingUtils.java
+++ b/src/main/java/run/halo/app/core/extension/theme/SettingUtils.java
@@ -1,0 +1,48 @@
+package run.halo.app.core.extension.theme;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import lombok.experimental.UtilityClass;
+import org.springframework.lang.NonNull;
+import org.springframework.util.CollectionUtils;
+import run.halo.app.core.extension.Setting;
+import run.halo.app.infra.utils.JsonUtils;
+
+@UtilityClass
+public class SettingUtils {
+    private static final String VALUE_FIELD = "value";
+    private static final String NAME_FIELD = "name";
+
+    /**
+     * Read setting default value from {@link Setting} forms.
+     *
+     * @param setting {@link Setting} extension
+     * @return a map of setting default value
+     */
+    @NonNull
+    public static Map<String, String> settingDefinedDefaultValueMap(Setting setting) {
+        List<Setting.SettingForm> forms = setting.getSpec().getForms();
+        if (CollectionUtils.isEmpty(forms)) {
+            return Map.of();
+        }
+        Map<String, String> data = new LinkedHashMap<>();
+        for (Setting.SettingForm form : forms) {
+            String group = form.getGroup();
+            Map<String, JsonNode> groupValue = form.getFormSchema().stream()
+                .map(o -> JsonUtils.DEFAULT_JSON_MAPPER.convertValue(o, JsonNode.class))
+                .filter(jsonNode -> jsonNode.isObject() && jsonNode.has(NAME_FIELD)
+                    && jsonNode.has(VALUE_FIELD))
+                .map(jsonNode -> {
+                    String name = jsonNode.get(NAME_FIELD).asText();
+                    JsonNode value = jsonNode.get(VALUE_FIELD);
+                    return Map.entry(name, value);
+                })
+                .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+            data.put(group, JsonUtils.objectToJson(groupValue));
+        }
+        return data;
+    }
+}

--- a/src/main/java/run/halo/app/core/extension/theme/ThemeEndpoint.java
+++ b/src/main/java/run/halo/app/core/extension/theme/ThemeEndpoint.java
@@ -103,7 +103,7 @@ public class ThemeEndpoint implements CustomEndpoint {
                         .implementation(Theme.class))
             )
             .PUT("themes/{name}/resetconfig", this::resetSettingConfig,
-                builder -> builder.operationId("ResetSettingConfig")
+                builder -> builder.operationId("ResetThemeSettingConfig")
                     .description("Reset theme setting configMap.")
                     .tag(tag)
                     .parameter(parameterBuilder()

--- a/src/main/java/run/halo/app/core/extension/theme/ThemeEndpoint.java
+++ b/src/main/java/run/halo/app/core/extension/theme/ThemeEndpoint.java
@@ -102,9 +102,9 @@ public class ThemeEndpoint implements CustomEndpoint {
                     .response(responseBuilder()
                         .implementation(Theme.class))
             )
-            .PUT("themes/{name}/resetconfig", this::resetSettingConfig,
-                builder -> builder.operationId("ResetThemeSettingConfig")
-                    .description("Reset theme setting configMap.")
+            .PUT("themes/{name}/reset-config", this::resetSettingConfig,
+                builder -> builder.operationId("ResetThemeConfig")
+                    .description("Reset the configMap of theme setting.")
                     .tag(tag)
                     .parameter(parameterBuilder()
                         .name("name")

--- a/src/main/java/run/halo/app/core/extension/theme/ThemeEndpoint.java
+++ b/src/main/java/run/halo/app/core/extension/theme/ThemeEndpoint.java
@@ -32,6 +32,7 @@ import reactor.core.Exceptions;
 import reactor.core.publisher.Mono;
 import run.halo.app.core.extension.Theme;
 import run.halo.app.core.extension.endpoint.CustomEndpoint;
+import run.halo.app.extension.ConfigMap;
 import run.halo.app.extension.ListResult;
 import run.halo.app.extension.ReactiveExtensionClient;
 import run.halo.app.extension.router.IListRequest;
@@ -100,6 +101,19 @@ public class ThemeEndpoint implements CustomEndpoint {
                     )
                     .response(responseBuilder()
                         .implementation(Theme.class))
+            )
+            .PUT("themes/{name}/resetconfig", this::resetSettingConfig,
+                builder -> builder.operationId("ResetSettingConfig")
+                    .description("Reset theme setting configMap.")
+                    .tag(tag)
+                    .parameter(parameterBuilder()
+                        .name("name")
+                        .in(ParameterIn.PATH)
+                        .required(true)
+                        .implementation(String.class)
+                    )
+                    .response(responseBuilder()
+                        .implementation(ConfigMap.class))
             )
             .GET("themes", this::listThemes,
                 builder -> {
@@ -210,6 +224,14 @@ public class ThemeEndpoint implements CustomEndpoint {
     Mono<ServerResponse> reloadTheme(ServerRequest request) {
         String name = request.pathVariable("name");
         return themeService.reloadTheme(name)
+            .flatMap(theme -> ServerResponse.ok()
+                .contentType(MediaType.APPLICATION_JSON)
+                .bodyValue(theme));
+    }
+
+    Mono<ServerResponse> resetSettingConfig(ServerRequest request) {
+        String name = request.pathVariable("name");
+        return themeService.resetSettingConfig(name)
             .flatMap(theme -> ServerResponse.ok()
                 .contentType(MediaType.APPLICATION_JSON)
                 .bodyValue(theme));

--- a/src/main/java/run/halo/app/core/extension/theme/ThemeService.java
+++ b/src/main/java/run/halo/app/core/extension/theme/ThemeService.java
@@ -3,6 +3,7 @@ package run.halo.app.core.extension.theme;
 import java.io.InputStream;
 import reactor.core.publisher.Mono;
 import run.halo.app.core.extension.Theme;
+import run.halo.app.extension.ConfigMap;
 
 public interface ThemeService {
 
@@ -11,6 +12,8 @@ public interface ThemeService {
     Mono<Theme> upgrade(String themeName, InputStream is);
 
     Mono<Theme> reloadTheme(String name);
+
+    Mono<ConfigMap> resetSettingConfig(String name);
     // TODO Migrate other useful methods in ThemeEndpoint in the future.
 
 }

--- a/src/main/resources/extensions/role-template-plugin.yaml
+++ b/src/main/resources/extensions/role-template-plugin.yaml
@@ -15,6 +15,9 @@ rules:
   - apiGroups: [ "plugin.halo.run" ]
     resources: [ "plugins" ]
     verbs: [ "create", "patch", "update", "delete", "deletecollection" ]
+  - apiGroups: [ "api.console.halo.run" ]
+    resources: [ "plugins/upgrade", "plugins/resetconfig" ]
+    verbs: [ "*" ]
   - nonResourceURLs: [ "/apis/api.console.halo.run/v1alpha1/plugins/*" ]
     verbs: [ "create" ]
 ---

--- a/src/main/resources/extensions/role-template-theme.yaml
+++ b/src/main/resources/extensions/role-template-theme.yaml
@@ -15,7 +15,7 @@ rules:
     resources: [ "themes" ]
     verbs: [ "*" ]
   - apiGroups: [ "api.console.halo.run" ]
-    resources: [ "themes", "themes/reload" ]
+    resources: [ "themes", "themes/reload", "themes/resetconfig" ]
     verbs: [ "*" ]
   - nonResourceURLs: [ "/apis/api.console.halo.run/themes/install" ]
     verbs: [ "create" ]

--- a/src/test/java/run/halo/app/core/extension/reconciler/ThemeReconcilerTest.java
+++ b/src/test/java/run/halo/app/core/extension/reconciler/ThemeReconcilerTest.java
@@ -173,21 +173,6 @@ class ThemeReconcilerTest {
             true);
     }
 
-    @Test
-    void settingDefinedDefaultValueMap() throws JSONException {
-        Setting setting = getFakeSetting();
-        when(haloProperties.getWorkDir()).thenReturn(tempDirectory);
-        Map<String, String> map = new ThemeReconciler(extensionClient, haloProperties)
-            .settingDefinedDefaultValueMap(setting);
-        JSONAssert.assertEquals("""
-            {
-                "sns": "{\\"email\\":\\"example@exmple.com\\"}"
-            }
-            """,
-            JsonUtils.objectToJson(map),
-            true);
-    }
-
     private static Setting getFakeSetting() {
         String settingJson = """
             {

--- a/src/test/java/run/halo/app/core/extension/theme/SettingUtilsTest.java
+++ b/src/test/java/run/halo/app/core/extension/theme/SettingUtilsTest.java
@@ -1,0 +1,67 @@
+package run.halo.app.core.extension.theme;
+
+import org.json.JSONException;
+import org.junit.jupiter.api.Test;
+import org.skyscreamer.jsonassert.JSONAssert;
+import run.halo.app.core.extension.Setting;
+import run.halo.app.infra.utils.JsonUtils;
+
+/**
+ * Tests for {@link SettingUtils}.
+ *
+ * @author guqing
+ * @since 2.0.1
+ */
+class SettingUtilsTest {
+
+    @Test
+    void settingDefinedDefaultValueMap() throws JSONException {
+        Setting setting = getFakeSetting();
+        var map = SettingUtils.settingDefinedDefaultValueMap(setting);
+        JSONAssert.assertEquals("""
+                {
+                    "sns": "{\\"email\\":\\"example@exmple.com\\"}"
+                }
+                """,
+            JsonUtils.objectToJson(map),
+            true);
+    }
+
+    private static Setting getFakeSetting() {
+        String settingJson = """
+            {
+                "apiVersion": "v1alpha1",
+                "kind": "Setting",
+                "metadata": {
+                    "name": "theme-default-setting"
+                },
+                "spec": {
+                    "forms": [{
+                        "formSchema": [
+                            {
+                                "$el": "h1",
+                                "children": "Register"
+                            },
+                            {
+                                "$formkit": "text",
+                                "label": "Email",
+                                "name": "email",
+                                "value": "example@exmple.com"
+                            },
+                            {
+                                "$formkit": "password",
+                                "label": "Password",
+                                "name": "password",
+                                "validation": "required|length:5,16",
+                                "value": null
+                            }
+                        ],
+                        "group": "sns",
+                        "label": "社交资料"
+                    }]
+                }
+            }
+            """;
+        return JsonUtils.jsonToObject(settingJson, Setting.class);
+    }
+}

--- a/src/test/java/run/halo/app/core/extension/theme/ThemeEndpointTest.java
+++ b/src/test/java/run/halo/app/core/extension/theme/ThemeEndpointTest.java
@@ -165,7 +165,7 @@ class ThemeEndpointTest {
     void resetSettingConfig() {
         when(themeService.resetSettingConfig(any())).thenReturn(Mono.empty());
         webTestClient.put()
-            .uri("/themes/fake/resetconfig")
+            .uri("/themes/fake/reset-config")
             .exchange()
             .expectStatus().isOk();
     }

--- a/src/test/java/run/halo/app/core/extension/theme/ThemeEndpointTest.java
+++ b/src/test/java/run/halo/app/core/extension/theme/ThemeEndpointTest.java
@@ -160,4 +160,13 @@ class ThemeEndpointTest {
             .exchange()
             .expectStatus().isOk();
     }
+
+    @Test
+    void resetSettingConfig() {
+        when(themeService.resetSettingConfig(any())).thenReturn(Mono.empty());
+        webTestClient.put()
+            .uri("/themes/fake/resetconfig")
+            .exchange()
+            .expectStatus().isOk();
+    }
 }


### PR DESCRIPTION
#### What type of PR is this?
/kind feature
/kind api-change
/area core

#### What this PR does / why we need it:
为主题和插件提供重置设置项 API

此 PR 会重新读取配置对应的 Setting 资源，从其中读取默认值后更新到现有的 ConfigMap 中替换其 data
see #2789 for more details
#### Which issue(s) this PR fixes:

Fixes #2789

#### Special notes for your reviewer:
how to test it?
1. 在主题设置或插件设置配置一些设置项后保存
2. 执行重置配置
3. 配置恢复为了 Setting 中指定的默认值

/cc @halo-dev/sig-halo 
#### Does this PR introduce a user-facing change?

```release-note
为主题和插件提供重置设置项 API
```
