### PR TITLE
fix: not clearing the template engine cache after upgrading the theme

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -4,7 +4,7 @@ reviewers:
 - JohnNiang
 - lan-yonghui
 - wan92hen
-- mainliacom
+- minliacom
 
 approvers:
 - ruibaby

--- a/OWNERS
+++ b/OWNERS
@@ -4,7 +4,7 @@ reviewers:
 - JohnNiang
 - lan-yonghui
 - wan92hen
-- minliacom
+- mainliacom
 
 approvers:
 - ruibaby

--- a/src/main/java/run/halo/app/core/extension/theme/ThemeEndpoint.java
+++ b/src/main/java/run/halo/app/core/extension/theme/ThemeEndpoint.java
@@ -37,6 +37,7 @@ import run.halo.app.extension.ReactiveExtensionClient;
 import run.halo.app.extension.router.IListRequest;
 import run.halo.app.extension.router.QueryParamBuildUtil;
 import run.halo.app.infra.ThemeRootGetter;
+import run.halo.app.theme.TemplateEngineManager;
 
 /**
  * Endpoint for managing themes.
@@ -54,11 +55,14 @@ public class ThemeEndpoint implements CustomEndpoint {
 
     private final ThemeService themeService;
 
+    private final TemplateEngineManager templateEngineManager;
+
     public ThemeEndpoint(ReactiveExtensionClient client, ThemeRootGetter themeRoot,
-        ThemeService themeService) {
+        ThemeService themeService, TemplateEngineManager templateEngineManager) {
         this.client = client;
         this.themeRoot = themeRoot;
         this.themeService = themeService;
+        this.templateEngineManager = templateEngineManager;
     }
 
     @Override
@@ -180,6 +184,9 @@ public class ThemeEndpoint implements CustomEndpoint {
                     return Mono.error(e);
                 }
             })
+            .flatMap((updatedTheme) -> templateEngineManager.clearCache(
+                    updatedTheme.getMetadata().getName())
+                .thenReturn(updatedTheme))
             .flatMap(updatedTheme -> ServerResponse.ok()
                 .bodyValue(updatedTheme));
     }

--- a/src/test/java/run/halo/app/core/extension/reconciler/ThemeReconcilerTest.java
+++ b/src/test/java/run/halo/app/core/extension/reconciler/ThemeReconcilerTest.java
@@ -51,6 +51,7 @@ class ThemeReconcilerTest {
     @Mock
     private HaloProperties haloProperties;
 
+    @Mock
     private File defaultTheme;
 
     private Path tempDirectory;

--- a/src/test/java/run/halo/app/core/extension/theme/ThemeEndpointTest.java
+++ b/src/test/java/run/halo/app/core/extension/theme/ThemeEndpointTest.java
@@ -4,6 +4,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isA;
 import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.springframework.web.reactive.function.BodyInserters.fromMultipartData;
@@ -32,6 +33,7 @@ import reactor.core.publisher.Mono;
 import run.halo.app.core.extension.Theme;
 import run.halo.app.extension.Metadata;
 import run.halo.app.infra.ThemeRootGetter;
+import run.halo.app.theme.TemplateEngineManager;
 
 /**
  * Tests for {@link ThemeEndpoint}.
@@ -47,6 +49,9 @@ class ThemeEndpointTest {
 
     @Mock
     ThemeService themeService;
+
+    @Mock
+    TemplateEngineManager templateEngineManager;
 
     @InjectMocks
     ThemeEndpoint themeEndpoint;
@@ -108,6 +113,9 @@ class ThemeEndpointTest {
             when(themeService.upgrade(eq("default"), isA(InputStream.class)))
                 .thenReturn(Mono.just(newTheme));
 
+            when(templateEngineManager.clearCache(eq("default")))
+                .thenReturn(Mono.empty());
+
             webTestClient.post()
                 .uri("/themes/default/upgrade")
                 .body(fromMultipartData(bodyBuilder.build()))
@@ -115,6 +123,8 @@ class ThemeEndpointTest {
                 .expectStatus().isOk();
 
             verify(themeService).upgrade(eq("default"), isA(InputStream.class));
+
+            verify(templateEngineManager, times(1)).clearCache(eq("default"));
         }
 
     }


### PR DESCRIPTION
#### What type of PR is this?

/kind improvement

#### What this PR does / why we need it:

通过在模板引擎管理器里添加clearCache方法，在升级主题后进行缓存刷新，让新模板内容生效。

#### Which issue(s) this PR fixes:

Fixes #2953 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
