### PR TITLE
Apply specific headers for portal endpoints

### DIFF
--- a/src/main/java/run/halo/app/config/WebServerSecurityConfig.java
+++ b/src/main/java/run/halo/app/config/WebServerSecurityConfig.java
@@ -1,20 +1,27 @@
 package run.halo.app.config;
 
 import static org.springframework.security.config.Customizer.withDefaults;
+import static org.springframework.security.web.server.header.ReferrerPolicyServerHttpHeadersWriter.ReferrerPolicy.STRICT_ORIGIN_WHEN_CROSS_ORIGIN;
 import static org.springframework.security.web.server.header.XFrameOptionsServerHttpHeadersWriter.Mode.SAMEORIGIN;
+import static org.springframework.security.web.server.util.matcher.ServerWebExchangeMatchers.pathMatchers;
 
+import java.util.Set;
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.Ordered;
 import org.springframework.core.annotation.Order;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
 import org.springframework.security.config.annotation.web.reactive.EnableWebFluxSecurity;
 import org.springframework.security.config.web.server.ServerHttpSecurity;
 import org.springframework.security.core.userdetails.ReactiveUserDetailsService;
 import org.springframework.security.crypto.factory.PasswordEncoderFactories;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.server.SecurityWebFilterChain;
+import org.springframework.security.web.server.util.matcher.AndServerWebExchangeMatcher;
+import org.springframework.security.web.server.util.matcher.MediaTypeServerWebExchangeMatcher;
 import run.halo.app.core.extension.service.RoleService;
 import run.halo.app.core.extension.service.UserService;
 import run.halo.app.extension.ReactiveExtensionClient;
@@ -40,24 +47,40 @@ public class WebServerSecurityConfig {
         RoleService roleService,
         ObjectProvider<SecurityConfigurer> securityConfigurers) {
 
-        http.authorizeExchange()
-            .pathMatchers("/api/**", "/apis/**", "/login", "/logout")
-            .access(new RequestInfoAuthorizationManager(roleService))
-            .pathMatchers("/**").permitAll()
-            .and()
-            .headers()
-            .frameOptions().mode(SAMEORIGIN)
-            .and()
-            .anonymous(anonymousSpec -> {
-                anonymousSpec.authorities(AnonymousUserConst.Role);
-                anonymousSpec.principal(AnonymousUserConst.PRINCIPAL);
+        http.securityMatcher(pathMatchers("/api/**", "/apis/**", "/login", "/logout"))
+            .authorizeExchange().anyExchange()
+            .access(new RequestInfoAuthorizationManager(roleService)).and()
+            .anonymous(spec -> {
+                spec.authorities(AnonymousUserConst.Role);
+                spec.principal(AnonymousUserConst.PRINCIPAL);
             })
+            .formLogin(withDefaults())
+            .logout(withDefaults())
             .httpBasic(withDefaults());
 
         // Integrate with other configurers separately
         securityConfigurers.orderedStream()
             .forEach(securityConfigurer -> securityConfigurer.configure(http));
 
+        return http.build();
+    }
+
+    @Bean
+    @Order(Ordered.HIGHEST_PRECEDENCE + 1)
+    SecurityWebFilterChain portalFilterChain(ServerHttpSecurity http) {
+        var pathMatcher = pathMatchers(HttpMethod.GET, "/**");
+        var mediaTypeMatcher = new MediaTypeServerWebExchangeMatcher(MediaType.TEXT_HTML);
+        mediaTypeMatcher.setIgnoredMediaTypes(Set.of(MediaType.ALL));
+        http.securityMatcher(new AndServerWebExchangeMatcher(pathMatcher, mediaTypeMatcher))
+            .authorizeExchange().anyExchange().permitAll().and()
+            .headers()
+            .frameOptions().mode(SAMEORIGIN)
+            .referrerPolicy().policy(STRICT_ORIGIN_WHEN_CROSS_ORIGIN).and()
+            .cache().disable().and()
+            .anonymous(spec -> {
+                spec.authorities(AnonymousUserConst.Role);
+                spec.principal(AnonymousUserConst.PRINCIPAL);
+            });
         return http.build();
     }
 


### PR DESCRIPTION
#### What type of PR is this?

/kind improvement
/area core

#### What this PR does / why we need it:

This PR separates security configuration of RESTful APIs and portal pages to configure specific headers for portal pages, such as `Referrer-Policy` and `X-Frame-Options`.

#### Which issue(s) this PR fixes:

Fixes https://github.com/halo-dev/halo/issues/2900

#### Special notes for your reviewer:

You can see the response headers of index page:

```bash
HTTP/1.1 200 OK
Content-Type: text/html
Content-Language: en-US
X-Content-Type-Options: nosniff
X-Frame-Options: SAMEORIGIN
X-XSS-Protection: 0
Referrer-Policy: strict-origin-when-cross-origin
content-encoding: gzip
content-length: 4285
```

#### Does this PR introduce a user-facing change?

```release-note
解决访问分析工具无法显示 referer 的问题
```
