### PR TITLE
Update console ref to release-2.0 for current branch

### DIFF
--- a/.github/workflows/halo.yaml
+++ b/.github/workflows/halo.yaml
@@ -61,4 +61,4 @@ jobs:
           dockerhub-user: ${{ secrets.DOCKER_USERNAME }}
           dockerhub-token: ${{ secrets.DOCKER_TOKEN }}
           push: ${{ github.event_name == 'push' || github.event_name == 'release' }} # we only push to GHCR if the push is to the next branch
-          console-ref: ${{ github.event_name == 'release' &&  github.ref || 'main' }}
+          console-ref: ${{ github.event_name == 'release' &&  github.ref || 'release-2.0' }}


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup
/area core

#### What this PR does / why we need it:

We should build console project on branch `release-2.0` instead of `main` when building Halo on branch release-2.0. 

So that we can test latest Halo 2.0.x using `docker pull ghcr.io/halo-dev/halo-dev:release-2.0`

#### Does this PR introduce a user-facing change?

```release-note
None
```
