### PR TITLE
Support querying sub-categories of any level

### DIFF
--- a/src/main/java/run/halo/app/extension/controller/DefaultController.java
+++ b/src/main/java/run/halo/app/extension/controller/DefaultController.java
@@ -11,6 +11,7 @@ import java.util.function.Supplier;
 import java.util.stream.IntStream;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.concurrent.BasicThreadFactory;
+import org.springframework.dao.OptimisticLockingFailureException;
 import org.springframework.lang.Nullable;
 import org.springframework.util.Assert;
 import org.springframework.util.StopWatch;
@@ -167,9 +168,14 @@ public class DefaultController<R> implements Controller {
                             log.trace(watch.toString());
                         }
                     } catch (Throwable t) {
-                        log.error("Reconciler in " + this.name
-                                + " aborted with an error, re-enqueuing...",
-                            t);
+                        if (t instanceof OptimisticLockingFailureException) {
+                            log.warn("Optimistic locking failure when reconciling request: {}/{}",
+                                this.name, entry.getEntry());
+                        } else {
+                            log.error("Reconciler in " + this.name
+                                    + " aborted with an error, re-enqueuing...",
+                                t);
+                        }
                         result = new Reconciler.Result(true, null);
                     } finally {
                         queue.done(entry.getEntry());

--- a/src/main/java/run/halo/app/theme/finders/CategoryFinder.java
+++ b/src/main/java/run/halo/app/theme/finders/CategoryFinder.java
@@ -27,5 +27,5 @@ public interface CategoryFinder {
 
     Flux<CategoryTreeVo> listAsTree();
 
-    Flux<CategoryTreeVo> listAsTree(String nodeName);
+    Flux<CategoryTreeVo> listAsTree(String name);
 }

--- a/src/main/java/run/halo/app/theme/finders/CategoryFinder.java
+++ b/src/main/java/run/halo/app/theme/finders/CategoryFinder.java
@@ -26,4 +26,6 @@ public interface CategoryFinder {
     Flux<CategoryVo> listAll();
 
     Flux<CategoryTreeVo> listAsTree();
+
+    Flux<CategoryTreeVo> listSubTreeByName(String nodeName);
 }

--- a/src/main/java/run/halo/app/theme/finders/CategoryFinder.java
+++ b/src/main/java/run/halo/app/theme/finders/CategoryFinder.java
@@ -27,5 +27,5 @@ public interface CategoryFinder {
 
     Flux<CategoryTreeVo> listAsTree();
 
-    Flux<CategoryTreeVo> listSubTreeByName(String nodeName);
+    Flux<CategoryTreeVo> listAsTree(String nodeName);
 }

--- a/src/main/java/run/halo/app/theme/finders/impl/CategoryFinderImpl.java
+++ b/src/main/java/run/halo/app/theme/finders/impl/CategoryFinderImpl.java
@@ -122,7 +122,7 @@ public class CategoryFinderImpl implements CategoryFinder {
         });
         return list.stream()
             .filter(v -> StringUtils.isEmpty(nodeName) ? v.getParentName() == null
-                : StringUtils.equalsIgnoreCase(v.getMetadata().getName(), nodeName))
+                : StringUtils.equals(v.getMetadata().getName(), nodeName))
             .sorted(defaultTreeNodeComparator())
             .collect(Collectors.toList());
     }

--- a/src/main/java/run/halo/app/theme/finders/impl/CategoryFinderImpl.java
+++ b/src/main/java/run/halo/app/theme/finders/impl/CategoryFinderImpl.java
@@ -77,7 +77,7 @@ public class CategoryFinderImpl implements CategoryFinder {
     }
 
     @Override
-    public Flux<CategoryTreeVo> listSubTreeByName(String nodeName) {
+    public Flux<CategoryTreeVo> listAsTree(String nodeName) {
         return this.toCategoryTreeVoFlux(nodeName);
     }
 

--- a/src/main/java/run/halo/app/theme/finders/impl/CategoryFinderImpl.java
+++ b/src/main/java/run/halo/app/theme/finders/impl/CategoryFinderImpl.java
@@ -54,7 +54,7 @@ public class CategoryFinderImpl implements CategoryFinder {
     @Override
     public Mono<ListResult<CategoryVo>> list(Integer page, Integer size) {
         return client.list(Category.class, null,
-            defaultComparator(), pageNullSafe(page), sizeNullSafe(size))
+                defaultComparator(), pageNullSafe(page), sizeNullSafe(size))
             .map(list -> {
                 List<CategoryVo> categoryVos = list.stream()
                     .map(CategoryVo::from)

--- a/src/main/java/run/halo/app/theme/finders/impl/CategoryFinderImpl.java
+++ b/src/main/java/run/halo/app/theme/finders/impl/CategoryFinderImpl.java
@@ -77,11 +77,11 @@ public class CategoryFinderImpl implements CategoryFinder {
     }
 
     @Override
-    public Flux<CategoryTreeVo> listAsTree(String nodeName) {
-        return this.toCategoryTreeVoFlux(nodeName);
+    public Flux<CategoryTreeVo> listAsTree(String name) {
+        return this.toCategoryTreeVoFlux(name);
     }
 
-    Flux<CategoryTreeVo> toCategoryTreeVoFlux(String nodeName) {
+    Flux<CategoryTreeVo> toCategoryTreeVoFlux(String name) {
         return listAll()
             .collectList()
             .flatMapIterable(categoryVos -> {
@@ -90,7 +90,7 @@ public class CategoryFinderImpl implements CategoryFinder {
                     .collect(Collectors.toMap(categoryVo -> categoryVo.getMetadata().getName(),
                         Function.identity()));
 
-                nameIdentityMap.forEach((name, value) -> {
+                nameIdentityMap.forEach((nameKey, value) -> {
                     List<String> children = value.getSpec().getChildren();
                     if (children == null) {
                         return;
@@ -98,15 +98,15 @@ public class CategoryFinderImpl implements CategoryFinder {
                     for (String child : children) {
                         CategoryTreeVo childNode = nameIdentityMap.get(child);
                         if (childNode != null) {
-                            childNode.setParentName(name);
+                            childNode.setParentName(nameKey);
                         }
                     }
                 });
-                return listToTree(nameIdentityMap.values(), nodeName);
+                return listToTree(nameIdentityMap.values(), name);
             });
     }
 
-    static List<CategoryTreeVo> listToTree(Collection<CategoryTreeVo> list, String nodeName) {
+    static List<CategoryTreeVo> listToTree(Collection<CategoryTreeVo> list, String name) {
         Map<String, List<CategoryTreeVo>> parentNameIdentityMap = list.stream()
             .filter(categoryTreeVo -> categoryTreeVo.getParentName() != null)
             .collect(Collectors.groupingBy(CategoryTreeVo::getParentName));
@@ -121,8 +121,8 @@ public class CategoryFinderImpl implements CategoryFinder {
             node.setChildren(children);
         });
         return list.stream()
-            .filter(v -> StringUtils.isEmpty(nodeName) ? v.getParentName() == null
-                : StringUtils.equals(v.getMetadata().getName(), nodeName))
+            .filter(v -> StringUtils.isEmpty(name) ? v.getParentName() == null
+                : StringUtils.equals(v.getMetadata().getName(), name))
             .sorted(defaultTreeNodeComparator())
             .collect(Collectors.toList());
     }

--- a/src/test/java/run/halo/app/theme/finders/impl/CategoryFinderImplTest.java
+++ b/src/test/java/run/halo/app/theme/finders/impl/CategoryFinderImplTest.java
@@ -105,7 +105,7 @@ class CategoryFinderImplTest {
     void listSubTreeByName() {
         when(client.list(eq(Category.class), eq(null), any()))
             .thenReturn(Flux.fromIterable(categoriesForTree()));
-        List<CategoryTreeVo> treeVos = categoryFinder.listSubTreeByName("E").collectList().block();
+        List<CategoryTreeVo> treeVos = categoryFinder.listAsTree("E").collectList().block();
         assertThat(treeVos).hasSize(1);
     }
 

--- a/src/test/java/run/halo/app/theme/finders/impl/CategoryFinderImplTest.java
+++ b/src/test/java/run/halo/app/theme/finders/impl/CategoryFinderImplTest.java
@@ -107,7 +107,9 @@ class CategoryFinderImplTest {
             .thenReturn(Flux.fromIterable(categoriesForTree()));
         List<CategoryTreeVo> treeVos = categoryFinder.listAsTree("E").collectList().block();
         assertThat(treeVos.get(0).getMetadata().getName()).isEqualTo("E");
+        assertThat(treeVos.get(0).getChildren()).hasSize(2);
         assertThat(treeVos.get(0).getChildren().get(0).getMetadata().getName()).isEqualTo("A");
+        assertThat(treeVos.get(0).getChildren().get(1).getMetadata().getName()).isEqualTo("C");
     }
 
     /**

--- a/src/test/java/run/halo/app/theme/finders/impl/CategoryFinderImplTest.java
+++ b/src/test/java/run/halo/app/theme/finders/impl/CategoryFinderImplTest.java
@@ -107,6 +107,7 @@ class CategoryFinderImplTest {
             .thenReturn(Flux.fromIterable(categoriesForTree()));
         List<CategoryTreeVo> treeVos = categoryFinder.listAsTree("E").collectList().block();
         assertThat(treeVos.get(0).getMetadata().getName()).isEqualTo("E");
+        assertThat(treeVos.get(0).getChildren().get(0).getMetadata().getName()).isEqualTo("A");
     }
 
     /**

--- a/src/test/java/run/halo/app/theme/finders/impl/CategoryFinderImplTest.java
+++ b/src/test/java/run/halo/app/theme/finders/impl/CategoryFinderImplTest.java
@@ -101,6 +101,14 @@ class CategoryFinderImplTest {
         assertThat(treeVos).hasSize(1);
     }
 
+    @Test
+    void listSubTreeByName() {
+        when(client.list(eq(Category.class), eq(null), any()))
+            .thenReturn(Flux.fromIterable(categoriesForTree()));
+        List<CategoryTreeVo> treeVos = categoryFinder.listSubTreeByName("E").collectList().block();
+        assertThat(treeVos).hasSize(1);
+    }
+
     /**
      * Test for {@link CategoryFinderImpl#listAsTree()}.
      *

--- a/src/test/java/run/halo/app/theme/finders/impl/CategoryFinderImplTest.java
+++ b/src/test/java/run/halo/app/theme/finders/impl/CategoryFinderImplTest.java
@@ -106,7 +106,7 @@ class CategoryFinderImplTest {
         when(client.list(eq(Category.class), eq(null), any()))
             .thenReturn(Flux.fromIterable(categoriesForTree()));
         List<CategoryTreeVo> treeVos = categoryFinder.listAsTree("E").collectList().block();
-        assertThat(treeVos).hasSize(1);
+        assertThat(treeVos.get(0).getMetadata().getName()).isEqualTo("E");
     }
 
     /**


### PR DESCRIPTION
What type of PR is this?

/kind feature
/kind api-change

What this PR does / why we need it:

添加一个方法可以根据分类树的任意一层级的名称查询子树

Which issue(s) this PR fixes:

Fixes https://github.com/halo-dev/halo/issues/2960

Special notes for your reviewer:

None

Does this PR introduce a user-facing change?

```release-note
CategoryFinder 添加根据分类查询子分类树结构的方法
```