### PR TITLE
Clean up unnecessary code in GlobalErrorWebExceptionHandler

### DIFF
--- a/src/main/java/run/halo/app/infra/exception/handlers/GlobalErrorWebExceptionHandler.java
+++ b/src/main/java/run/halo/app/infra/exception/handlers/GlobalErrorWebExceptionHandler.java
@@ -18,7 +18,6 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.HttpStatusCode;
 import org.springframework.http.MediaType;
 import org.springframework.http.ProblemDetail;
-import org.springframework.util.StringUtils;
 import org.springframework.web.ErrorResponse;
 import org.springframework.web.method.annotation.ExceptionHandlerMethodResolver;
 import org.springframework.web.reactive.BindingContext;
@@ -125,29 +124,6 @@ public class GlobalErrorWebExceptionHandler extends DefaultErrorWebExceptionHand
             .switchIfEmpty(this.errorProperties.getWhitelabel().isEnabled()
                 ? renderDefaultErrorView(responseBody, error) : Mono.error(getError(request)))
             .next();
-    }
-
-    protected void logError(ServerRequest request, ServerResponse response, Throwable throwable) {
-        if (log.isDebugEnabled()) {
-            log.debug(request.exchange().getLogPrefix() + formatError(throwable, request),
-                throwable);
-        }
-        if (HttpStatus.resolve(response.statusCode().value()) != null
-            && response.statusCode().equals(HttpStatus.INTERNAL_SERVER_ERROR)) {
-            log.error("{} 500 Server Error for {}",
-                request.exchange().getLogPrefix(), formatRequest(request), throwable);
-        }
-    }
-
-    private String formatRequest(ServerRequest request) {
-        String rawQuery = request.uri().getRawQuery();
-        String query = StringUtils.hasText(rawQuery) ? "?" + rawQuery : "";
-        return "HTTP " + request.method() + " \"" + request.path() + query + "\"";
-    }
-
-    private String formatError(Throwable ex, ServerRequest request) {
-        String reason = ex.getClass().getSimpleName() + ": " + ex.getMessage();
-        return "Resolved [" + reason + "] for HTTP " + request.method() + " " + request.path();
     }
 
     private Mono<ServerResponse> renderErrorViewBy(ServerRequest request, String viewName,


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup
/area core

#### What this PR does / why we need it:

Because these code has already defined in [here](https://github.com/spring-projects/spring-boot/blob/28f9f20d39325985ea79868bbf85a51fffa76c8f/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/web/reactive/error/AbstractErrorWebExceptionHandler.java#L310-L339). Printing error twice in development mode is completely unnecessary.

#### Does this PR introduce a user-facing change?

```release-note
None
```
