### PR TITLE
Fix invalid attachment role templates

### DIFF
--- a/src/main/resources/extensions/role-template-attachment.yaml
+++ b/src/main/resources/extensions/role-template-attachment.yaml
@@ -12,13 +12,13 @@ metadata:
       ["system:attachments:manage"]
 rules:
   - apiGroups: [ "storage.halo.run" ]
-    resources: [ "attachments" ]
+    resources: [ "attachments", "policies", "policytemplates", "groups" ]
     verbs: [ "*" ]
   - apiGroups: [ "api.console.halo.run" ]
     resources: [ "attachments" ]
     verbs: [ "*" ]
-  - nonResourceURLs: [ "/apis/api.console.halo.run/attachments/upload" ]
-    verbs: [ "post" ]
+  - nonResourceURLs: [ "/apis/api.console.halo.run/v1alpha1/attachments/upload" ]
+    verbs: [ "create" ]
 ---
 apiVersion: v1alpha1
 kind: "Role"
@@ -33,7 +33,7 @@ metadata:
       ["system:attachments:view"]
 rules:
   - apiGroups: [ "storage.halo.run" ]
-    resources: [ "attachments" ]
+    resources: [ "attachments", "policies", "policytemplates", "groups" ]
     verbs: [ "get", "list" ]
   - apiGroups: [ "api.console.halo.run" ]
     resources: [ "attachments" ]

--- a/src/main/resources/extensions/role-template-attachment.yaml
+++ b/src/main/resources/extensions/role-template-attachment.yaml
@@ -17,6 +17,9 @@ rules:
   - apiGroups: [ "api.console.halo.run" ]
     resources: [ "attachments" ]
     verbs: [ "*" ]
+  - apiGroups: [ "" ]
+    resources: [ "settings" ]
+    verbs: [ "get" ]
   - nonResourceURLs: [ "/apis/api.console.halo.run/v1alpha1/attachments/upload" ]
     verbs: [ "create" ]
 ---


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/area core
/milestone 2.1.x

#### What this PR does / why we need it:

- Add missing resources `"policies", "policytemplates", "groups"` in policy rules in attachment role templates.
- Correct `nonResourceURLs` and `verbs`

See https://github.com/halo-dev/halo/issues/3007 for more.

#### Which issue(s) this PR fixes:

Fixes https://github.com/halo-dev/halo/issues/3007

#### Special notes for your reviewer:

Steps to test:

1. Start Halo and login with `admin`
2. Create a Role with `Attachment Manage` permission only
3. Create an user and assign the role to the user
4. Set password for the user
5. Log out current user and log in as the user created just now
6. Try to do various operations in attachment tab
    - Create and list policy
    - Create and list group
    - Upload and list attachments

#### Does this PR introduce a user-facing change?

```release-note
修复附件权限定义的错误
```
