### PR TITLE
Provide an endpoint to update user profile

### DIFF
--- a/src/main/resources/extensions/role-template-authenticated.yaml
+++ b/src/main/resources/extensions/role-template-authenticated.yaml
@@ -31,7 +31,7 @@ rules:
   - apiGroups: [ "api.console.halo.run" ]
     resources: [ "users" ]
     resourceNames: [ "-" ]
-    verbs: [ "list", "get" ]
+    verbs: [ "get", "update" ]
 ---
 apiVersion: v1alpha1
 kind: "Role"

--- a/src/test/java/run/halo/app/core/extension/endpoint/UserEndpointTest.java
+++ b/src/test/java/run/halo/app/core/extension/endpoint/UserEndpointTest.java
@@ -99,6 +99,65 @@ class UserEndpointTest {
     }
 
     @Nested
+    @DisplayName("UpdateProfile")
+    class UpdateProfileTest {
+
+        @Test
+        void shouldUpdateProfileCorrectly() {
+            var currentUser = createUser("fake-user");
+            var updatedUser = createUser("fake-user");
+            var requestUser = createUser("fake-user");
+
+            when(client.get(User.class, "fake-user")).thenReturn(Mono.just(currentUser));
+            when(client.update(currentUser)).thenReturn(Mono.just(updatedUser));
+
+            webClient.put().uri("/apis/api.console.halo.run/v1alpha1/users/-")
+                .bodyValue(requestUser)
+                .exchange()
+                .expectStatus().isOk()
+                .expectBody(User.class)
+                .isEqualTo(updatedUser);
+
+            verify(client).get(User.class, "fake-user");
+            verify(client).update(currentUser);
+        }
+
+        @Test
+        void shouldGetErrorIfUsernameMismatch() {
+            var currentUser = createUser("fake-user");
+            var updatedUser = createUser("fake-user");
+            var requestUser = createUser("another-fake-user");
+
+            when(client.get(User.class, "fake-user")).thenReturn(Mono.just(currentUser));
+            when(client.update(currentUser)).thenReturn(Mono.just(updatedUser));
+
+            webClient.put().uri("/apis/api.console.halo.run/v1alpha1/users/-")
+                .bodyValue(requestUser)
+                .exchange()
+                .expectStatus().isBadRequest();
+
+            verify(client).get(User.class, "fake-user");
+            verify(client, never()).update(currentUser);
+        }
+
+        User createUser(String name) {
+            var spec = new User.UserSpec();
+            spec.setEmail("hi@halo.run");
+            spec.setBio("Fake bio");
+            spec.setDisplayName("Faker");
+            spec.setPassword("fake-password");
+
+            var metadata = new Metadata();
+            metadata.setName(name);
+
+            var user = new User();
+            user.setSpec(spec);
+            user.setMetadata(metadata);
+            return user;
+        }
+    }
+
+    @Nested
     @DisplayName("ChangePassword")
     class ChangePasswordTest {
 


### PR DESCRIPTION
#### What type of PR is this?

/kind feature
/area core
/milestone 2.1.x

#### What this PR does / why we need it:

Provide an endpoint to update current user profile instead of whole user data.

##### Request example

```bash
curl -X 'PUT' \
  'http://localhost:8090/apis/api.console.halo.run/v1alpha1/users/-' \
  -H 'accept: */*' \
  -H 'Content-Type: */*' \
  -d '{
  "spec": {
    "displayName": "JohnNiang",
    "email": "johnniang@halo.run",
    "password": "xxx",
    "registeredAt": "2022-12-19T03:46:54.809770900Z",
    "twoFactorAuthEnabled": false,
    "disabled": false
  },
  "status": {
    "permalink": "http://localhost:8090/authors/admin"
  },
  "apiVersion": "v1alpha1",
  "kind": "User",
  "metadata": {
    "finalizers": [
      "user-protection"
    ],
    "name": "admin",
    "annotations": {
      "rbac.authorization.halo.run/role-names": "[\"super-role\"]"
    },
    "version": 3,
    "creationTimestamp": "2022-12-19T03:46:54.911951800Z"
  }
}'
```

##### Response example

```json
{
  "spec": {
    "displayName": "JohnNiang",
    "email": "johnniang@halo.run",
    "password": "{bcrypt}$2a$10$IBV8/q7Q6Fj78Ls5AG1eBO0bCQ.rM6vli5pAVexf/gqu.hNfjJxaq",
    "registeredAt": "2022-12-19T03:46:54.809770900Z",
    "twoFactorAuthEnabled": false,
    "disabled": false
  },
  "status": {
    "permalink": "http://localhost:8090/authors/admin"
  },
  "apiVersion": "v1alpha1",
  "kind": "User",
  "metadata": {
    "finalizers": [
      "user-protection"
    ],
    "name": "admin",
    "annotations": {
      "rbac.authorization.halo.run/role-names": "[\"super-role\"]"
    },
    "version": 5,
    "creationTimestamp": "2022-12-19T03:46:54.911951800Z"
  }
}
```

#### Which issue(s) this PR fixes:

Fixes https://github.com/halo-dev/halo/issues/3035

#### Does this PR introduce a user-facing change?

```release-note
提供更新当前登录用户信息功能
```
