### PR TITLE
Avoid NPE problems when querying the list of posts in the console

### DIFF
--- a/src/main/java/run/halo/app/content/impl/PostServiceImpl.java
+++ b/src/main/java/run/halo/app/content/impl/PostServiceImpl.java
@@ -93,7 +93,7 @@ public class PostServiceImpl implements PostService {
         Predicate<Post> paramPredicate = post ->
             contains(query.getCategories(), post.getSpec().getCategories())
                 && contains(query.getTags(), post.getSpec().getTags())
-                && contains(query.getContributors(), post.getStatus().getContributors());
+                && contains(query.getContributors(), post.getStatusOrDefault().getContributors());
 
         String keyword = query.getKeyword();
         if (keyword != null) {
@@ -162,7 +162,7 @@ public class PostServiceImpl implements PostService {
             )
             .flatMap(lp -> setTags(post.getSpec().getTags(), lp))
             .flatMap(lp -> setCategories(post.getSpec().getCategories(), lp))
-            .flatMap(lp -> setContributors(post.getStatus().getContributors(), lp))
+            .flatMap(lp -> setContributors(post.getStatusOrDefault().getContributors(), lp))
             .flatMap(lp -> setOwner(post.getSpec().getOwner(), lp));
     }
 

--- a/src/main/java/run/halo/app/content/impl/SinglePageServiceImpl.java
+++ b/src/main/java/run/halo/app/content/impl/SinglePageServiceImpl.java
@@ -14,7 +14,6 @@ import java.util.function.Predicate;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
-import org.springframework.context.ApplicationContext;
 import org.springframework.dao.OptimisticLockingFailureException;
 import org.springframework.security.core.context.ReactiveSecurityContextHolder;
 import org.springframework.security.core.context.SecurityContext;
@@ -59,8 +58,6 @@ public class SinglePageServiceImpl implements SinglePageService {
     private final ReactiveExtensionClient client;
 
     private final CounterService counterService;
-
-    private final ApplicationContext applicationContext;
 
     @Override
     public Mono<ListResult<ListedSinglePage>> list(SinglePageQuery query) {


### PR DESCRIPTION
#### What type of PR is this?
/kind improvement
/area core
/milestone 2.1.x

#### What this PR does / why we need it:
迁移后文章过多，当文章的 Reconciler 还没有执行完时访问 Console 端文章列表会因为 post.status  为 Null 出现 NPE 问题
使用文章的 status 时需要对其进行判空

/cherry-pick release-2.0
#### Which issue(s) this PR fixes:

Fixes #3066

#### Special notes for your reviewer:
/cc @halo-dev/sig-halo 
#### Does this PR introduce a user-facing change?

```release-note
None
```
