### PR TITLE
feat: add target attribute for menu item

### DIFF
--- a/src/main/java/run/halo/app/core/extension/MenuItem.java
+++ b/src/main/java/run/halo/app/core/extension/MenuItem.java
@@ -1,5 +1,7 @@
 package run.halo.app.core.extension;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
 import io.swagger.v3.oas.annotations.media.ArraySchema;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.util.LinkedHashSet;
@@ -23,6 +25,25 @@ public class MenuItem extends AbstractExtension {
     @Schema(description = "The status of menu item.")
     private MenuItemStatus status;
 
+    public enum Target {
+        BLANK("_blank"),
+        SELF("_self"),
+        PARENT("_parent"),
+        TOP("_top");
+
+        private final String value;
+
+        @JsonCreator
+        Target(String value) {
+            this.value = value;
+        }
+
+        @JsonValue
+        public String getValue() {
+            return value;
+        }
+    }
+
     @Data
     public static class MenuItemSpec {
 
@@ -31,6 +52,9 @@ public class MenuItem extends AbstractExtension {
 
         @Schema(description = "The href of this menu item.")
         private String href;
+
+        @Schema(description = "The <a> target attribute of this menu item.")
+        private Target target;
 
         @Schema(description = "The priority is for ordering.")
         private Integer priority;


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

为 MenuItem 模型添加 a 标签的 target 属性设置。

#### Which issue(s) this PR fixes:

Fixes https://github.com/halo-dev/halo/issues/3063

#### Special notes for your reviewer:

测试方式请看：https://github.com/halo-dev/console/pull/805

#### Does this PR introduce a user-facing change?

```release-note
菜单项支持设置打开方式
```
