### PR TITLE
feat: add the lastModifyTime attribute for post and single page

### DIFF
--- a/src/main/java/run/halo/app/core/extension/content/Post.java
+++ b/src/main/java/run/halo/app/core/extension/content/Post.java
@@ -150,6 +150,8 @@ public class Post extends AbstractExtension {
 
         private List<String> contributors;
 
+        private Instant lastModifyTime;
+
         @JsonIgnore
         public ConditionList getConditionsOrDefault() {
             if (this.conditions == null) {

--- a/src/main/java/run/halo/app/core/extension/reconciler/PostReconciler.java
+++ b/src/main/java/run/halo/app/core/extension/reconciler/PostReconciler.java
@@ -303,6 +303,12 @@ public class PostReconciler implements Reconciler<Reconciler.Request> {
                         !StringUtils.equals(headSnapshot, post.getSpec().getReleaseSnapshot()));
                 });
 
+            if (post.isPublished() && status.getLastModifyTime() == null) {
+                client.fetch(Snapshot.class, post.getSpec().getReleaseSnapshot())
+                    .ifPresent(releasedSnapshot ->
+                        status.setLastModifyTime(releasedSnapshot.getSpec().getLastModifyTime()));
+            }
+
             if (!oldPost.equals(post)) {
                 client.update(post);
             }

--- a/src/main/java/run/halo/app/core/extension/reconciler/PostReconciler.java
+++ b/src/main/java/run/halo/app/core/extension/reconciler/PostReconciler.java
@@ -5,6 +5,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
 import lombok.AllArgsConstructor;
 import org.apache.commons.lang3.StringUtils;
@@ -13,7 +14,6 @@ import org.springframework.context.ApplicationContext;
 import org.springframework.stereotype.Component;
 import org.springframework.util.Assert;
 import run.halo.app.content.ContentService;
-import run.halo.app.content.PostService;
 import run.halo.app.content.permalinks.PostPermalinkPolicy;
 import run.halo.app.core.extension.content.Comment;
 import run.halo.app.core.extension.content.Post;
@@ -53,7 +53,6 @@ public class PostReconciler implements Reconciler<Reconciler.Request> {
     private static final String FINALIZER_NAME = "post-protection";
     private final ExtensionClient client;
     private final ContentService contentService;
-    private final PostService postService;
     private final PostPermalinkPolicy postPermalinkPolicy;
     private final CounterService counterService;
 
@@ -126,9 +125,9 @@ public class PostReconciler implements Reconciler<Reconciler.Request> {
                 Post.PostStatus status = post.getStatusOrDefault();
 
                 // validate release snapshot
-                boolean present = client.fetch(Snapshot.class, releaseSnapshot)
-                    .isPresent();
-                if (!present) {
+                Optional<Snapshot> releasedSnapshotOpt =
+                    client.fetch(Snapshot.class, releaseSnapshot);
+                if (releasedSnapshotOpt.isEmpty()) {
                     Condition condition = Condition.builder()
                         .type(Post.PostPhase.FAILED.name())
                         .reason("SnapshotNotFound")
@@ -158,6 +157,9 @@ public class PostReconciler implements Reconciler<Reconciler.Request> {
                 if (post.getSpec().getPublishTime() == null) {
                     post.getSpec().setPublishTime(Instant.now());
                 }
+
+                // populate lastModifyTime
+                status.setLastModifyTime(releasedSnapshotOpt.get().getSpec().getLastModifyTime());
 
                 client.update(post);
                 applicationContext.publishEvent(new PostPublishedEvent(this, name));

--- a/src/main/java/run/halo/app/core/extension/reconciler/SinglePageReconciler.java
+++ b/src/main/java/run/halo/app/core/extension/reconciler/SinglePageReconciler.java
@@ -369,6 +369,12 @@ public class SinglePageReconciler implements Reconciler<Reconciler.Request> {
                     status.setInProgress(!StringUtils.equals(releaseSnapshot, headSnapshot));
                 });
 
+            if (singlePage.isPublished() && status.getLastModifyTime() == null) {
+                client.fetch(Snapshot.class, singlePage.getSpec().getReleaseSnapshot())
+                    .ifPresent(releasedSnapshot ->
+                        status.setLastModifyTime(releasedSnapshot.getSpec().getLastModifyTime()));
+            }
+
             if (!oldPage.equals(singlePage)) {
                 client.update(singlePage);
             }


### PR DESCRIPTION
#### What type of PR is this?
/kind improvement
/milestone 2.2.x

#### What this PR does / why we need it:
文章和自定义页面支持展示最后修改时间
- 文章发布后会同步 post.spec.releasedSnapshot 记录的最后修改时间到 post.status.lastModifyTime，自定义页面亦如是。
- 主题端可以通过 `${item.status.lastModifyTime}` 获取（item表示文章或自定义页面 Vo）。
#### Which issue(s) this PR fixes:

Fixes #3090 

#### Special notes for your reviewer:
/cc @halo-dev/sig-halo 
#### Does this PR introduce a user-facing change?

```release-note
文章和自定义页面支持展示最后修改时间
```
