### PR TITLE
refactor: support extending jar directories for plugin class loader

### DIFF
--- a/src/main/java/run/halo/app/plugin/PluginAutoConfiguration.java
+++ b/src/main/java/run/halo/app/plugin/PluginAutoConfiguration.java
@@ -107,17 +107,30 @@ public class PluginAutoConfiguration {
                     } else {
                         return new CompoundPluginLoader()
                             .add(new DevelopmentPluginLoader(this) {
+
+                                @Override
+                                protected PluginClassLoader createPluginClassLoader(Path pluginPath,
+                                    PluginDescriptor pluginDescriptor) {
+                                    return new PluginClassLoader(pluginManager, pluginDescriptor,
+                                        getClass().getClassLoader(), ClassLoadingStrategy.APD);
+                                }
+
                                 @Override
                                 public ClassLoader loadPlugin(Path pluginPath,
                                     PluginDescriptor pluginDescriptor) {
-                                    PluginClassLoader pluginClassLoader =
-                                        new PluginClassLoader(pluginManager, pluginDescriptor,
-                                            getClass().getClassLoader(), ClassLoadingStrategy.APD);
-
-                                    loadClasses(pluginPath, pluginClassLoader);
-                                    loadJars(pluginPath, pluginClassLoader);
-
-                                    return pluginClassLoader;
+                                    if (pluginProperties.getClassesDirectories() != null) {
+                                        for (String classesDirectory :
+                                            pluginProperties.getClassesDirectories()) {
+                                            pluginClasspath.addClassesDirectories(classesDirectory);
+                                        }
+                                    }
+                                    if (pluginProperties.getLibDirectories() != null) {
+                                        for (String libDirectory :
+                                            pluginProperties.getLibDirectories()) {
+                                            pluginClasspath.addJarsDirectories(libDirectory);
+                                        }
+                                    }
+                                    return super.loadPlugin(pluginPath, pluginDescriptor);
                                 }
                             }, this::isDevelopment)
                             .add(new JarPluginLoader(this) {

--- a/src/main/java/run/halo/app/plugin/PluginProperties.java
+++ b/src/main/java/run/halo/app/plugin/PluginProperties.java
@@ -17,6 +17,7 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 @Data
 @ConfigurationProperties(prefix = "halo.plugin")
 public class PluginProperties {
+    public static final String GRADLE_LIBS_DIR = "build/libs";
 
     /**
      * Auto start plugin when main app is ready.
@@ -53,7 +54,7 @@ public class PluginProperties {
     /**
      * Extended Plugin Jar Directory.
      */
-    private List<String> libDirectories = new ArrayList<>();
+    private List<String> libDirectories = new ArrayList<>(List.of(GRADLE_LIBS_DIR));
 
     /**
      * Runtime Mode：development/deployment.

--- a/src/main/resources/application-dev.yaml
+++ b/src/main/resources/application-dev.yaml
@@ -19,11 +19,7 @@ halo:
       super-admin-password: admin
   plugin:
     runtime-mode: development # development, deployment
-    classes-directories:
-      - "build/classes"
-      - "build/resources"
-    lib-directories:
-      - "libs"
+    plugins-root: ${halo.work-dir}/plugins
   work-dir: ${user.home}/halo2-dev
 logging:
   level:

--- a/src/main/resources/application-dev.yaml
+++ b/src/main/resources/application-dev.yaml
@@ -19,7 +19,6 @@ halo:
       super-admin-password: admin
   plugin:
     runtime-mode: development # development, deployment
-    plugins-root: ${halo.work-dir}/plugins
   work-dir: ${user.home}/halo2-dev
 logging:
   level:


### PR DESCRIPTION
#### What type of PR is this?
/kind improvement
/area core
/milestone 2.2.x

#### What this PR does / why we need it:
修复引入外部依赖的插件以开发模式启动时会出现 NoClassDefFoundError 的问题
see #3107 for more detail.

#### Which issue(s) this PR fixes:
Fixes #3107

#### Special notes for your reviewer:
how to test it?
以插件 development 模式启动以下两个插件观察是否正常启动：
- https://github.com/halo-sigs/plugin-s3
- https://github.com/halo-sigs/plugin-alioss

期望没有 `Caused by: java. lang. NoClassDefFoundEenon` 错误，且插件正确启动。

/cc @halo-dev/sig-halo 
#### Does this PR introduce a user-facing change?
```release-note
修复引入外部依赖的插件以开发模式启动时会出现 NoClassDefFoundError 的问题
```
