### PR TITLE
feat: support validate requires version for plugin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,6 +27,10 @@ configurations {
     }
 }
 
+springBoot {
+    buildInfo()
+}
+
 bootJar {
     manifest {
         attributes "Implementation-Title": "Halo Application",

--- a/src/main/java/run/halo/app/infra/utils/VersionUtils.java
+++ b/src/main/java/run/halo/app/infra/utils/VersionUtils.java
@@ -1,0 +1,49 @@
+package run.halo.app.infra.utils;
+
+import com.github.zafarkhaja.semver.Version;
+import com.github.zafarkhaja.semver.expr.Expression;
+import lombok.experimental.UtilityClass;
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.web.server.ServerWebInputException;
+
+@UtilityClass
+public class VersionUtils {
+
+    /**
+     * Check if this "requires" param satisfies for a given (system) version.
+     *
+     * @param version the version to check
+     * @return true if version satisfies the "requires" or if requires was left blank
+     */
+    public static boolean satisfiesRequires(String version, String requires) {
+        String requiresVersion = StringUtils.trim(requires);
+
+        // an exact version x.y.z will implicitly mean the same as >=x.y.z
+        if (requiresVersion.matches("^\\d+\\.\\d+\\.\\d+$")) {
+            // If exact versions are not allowed in requires, rewrite to >= expression
+            requiresVersion = ">=" + requiresVersion;
+        }
+        return version.equals("0.0.0") || checkVersionConstraint(version, requiresVersion);
+    }
+
+    /**
+     * Checks if a version satisfies the specified SemVer {@link Expression} string.
+     * If the constraint is empty or null then the method returns true.
+     * Constraint examples: {@code >2.0.0} (simple), {@code ">=1.4.0 & <1.6.0"} (range).
+     * See
+     * <a href="https://github.com/zafarkhaja/jsemver#semver-expressions-api-ranges">semver-expressions-api-ranges</a> for more info.
+     *
+     * @param version the version to check
+     * @param constraint the SemVer Expression string
+     * @return true if version satisfies the constraint or if constraint was left blank
+     */
+    public static boolean checkVersionConstraint(String version, String constraint) {
+        try {
+            return StringUtils.isBlank(constraint)
+                || "*".equals(constraint)
+                || Version.valueOf(version).satisfies(constraint);
+        } catch (Exception e) {
+            throw new ServerWebInputException("Illegal requires version expression.", null, e);
+        }
+    }
+}

--- a/src/main/java/run/halo/app/plugin/HaloPluginManager.java
+++ b/src/main/java/run/halo/app/plugin/HaloPluginManager.java
@@ -25,6 +25,7 @@ import org.springframework.beans.factory.InitializingBean;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.ApplicationContextAware;
 import org.springframework.lang.NonNull;
+import org.springframework.util.Assert;
 import run.halo.app.plugin.event.HaloPluginBeforeStopEvent;
 import run.halo.app.plugin.event.HaloPluginLoadedEvent;
 import run.halo.app.plugin.event.HaloPluginStartedEvent;
@@ -214,6 +215,11 @@ public class HaloPluginManager extends DefaultPluginManager
     @Override
     public void stopPlugins() {
         doStopPlugins();
+    }
+
+    public boolean validatePluginVersion(PluginWrapper pluginWrapper) {
+        Assert.notNull(pluginWrapper, "The pluginWrapper must not be null.");
+        return isPluginValid(pluginWrapper);
     }
 
     private PluginState doStartPlugin(String pluginId) {

--- a/src/main/java/run/halo/app/plugin/PluginProperties.java
+++ b/src/main/java/run/halo/app/plugin/PluginProperties.java
@@ -70,9 +70,4 @@ public class PluginProperties {
      * Allows providing custom plugin loaders.
      */
     private Class<PluginLoader> customPluginLoader;
-
-    /**
-     * The system version used for comparisons to the plugin requires attribute.
-     */
-    private String systemVersion = "0.0.0";
 }

--- a/src/test/java/run/halo/app/core/extension/reconciler/PluginReconcilerTest.java
+++ b/src/test/java/run/halo/app/core/extension/reconciler/PluginReconcilerTest.java
@@ -60,7 +60,8 @@ class PluginReconcilerTest {
     @BeforeEach
     void setUp() {
         pluginReconciler = new PluginReconciler(extensionClient, haloPluginManager);
-
+        lenient().when(haloPluginManager.validatePluginVersion(any())).thenReturn(true);
+        lenient().when(haloPluginManager.getSystemVersion()).thenReturn("0.0.0");
         lenient().when(haloPluginManager.getPlugin(any())).thenReturn(pluginWrapper);
         lenient().when(haloPluginManager.getUnresolvedPlugins()).thenReturn(List.of());
     }
@@ -127,7 +128,7 @@ class PluginReconcilerTest {
         when(pluginWrapper.getPluginState()).thenReturn(PluginState.STARTED);
 
         ArgumentCaptor<Plugin> pluginCaptor = doReconcileWithoutRequeue();
-        verify(extensionClient, times(3)).update(any(Plugin.class));
+        verify(extensionClient, times(4)).update(any(Plugin.class));
 
         Plugin updateArgs = pluginCaptor.getValue();
         assertThat(updateArgs).isNotNull();
@@ -162,7 +163,7 @@ class PluginReconcilerTest {
         when(pluginWrapper.getPluginState()).thenReturn(PluginState.STARTED);
 
         ArgumentCaptor<Plugin> pluginCaptor = doReconcileWithoutRequeue();
-        verify(extensionClient, times(3)).update(any(Plugin.class));
+        verify(extensionClient, times(4)).update(any(Plugin.class));
 
         Plugin updateArgs = pluginCaptor.getValue();
         assertThat(updateArgs).isNotNull();

--- a/src/test/java/run/halo/app/infra/utils/VersionUtilsTest.java
+++ b/src/test/java/run/halo/app/infra/utils/VersionUtilsTest.java
@@ -1,0 +1,51 @@
+package run.halo.app.infra.utils;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for {@link VersionUtils}.
+ *
+ * @author guqing
+ * @since 2.2.0
+ */
+class VersionUtilsTest {
+
+    @Test
+    void satisfiesRequires() {
+        // match all requires
+        String systemVersion = "0.0.0";
+        String requires = ">=2.2.0";
+        boolean result = VersionUtils.satisfiesRequires(systemVersion, requires);
+        assertThat(result).isTrue();
+
+        systemVersion = "2.0.0";
+        requires = "*";
+        result = VersionUtils.satisfiesRequires(systemVersion, requires);
+        assertThat(result).isTrue();
+
+        systemVersion = "2.0.0";
+        requires = "";
+        result = VersionUtils.satisfiesRequires(systemVersion, requires);
+        assertThat(result).isTrue();
+
+        // match exact version
+        systemVersion = "2.0.0";
+        requires = ">=2.0.0";
+        result = VersionUtils.satisfiesRequires(systemVersion, requires);
+        assertThat(result).isTrue();
+
+        systemVersion = "2.0.0";
+        requires = ">2.0.0";
+        result = VersionUtils.satisfiesRequires(systemVersion, requires);
+        assertThat(result).isFalse();
+
+        //an exact version x.y.z will implicitly mean the same as >=x.y.z
+        systemVersion = "2.1.0";
+        // means >=2.0.0
+        requires = "2.0.0";
+        result = VersionUtils.satisfiesRequires(systemVersion, requires);
+        assertThat(result).isTrue();
+    }
+}


### PR DESCRIPTION
#### What type of PR is this?
/kind feature
/area core
/milestone 2.2.x

#### What this PR does / why we need it:
插件安装和升级支持版本校验

参考文档：
- [semver-expressions-api-ranges](https://github.com/zafarkhaja/jsemver#semver-expressions-api-ranges)
- [integrating-with-actuator.build-info](https://docs.spring.io/spring-boot/docs/current/gradle-plugin/reference/htmlsingle/#integrating-with-actuator.build-info)

#### Which issue(s) this PR fixes:
Fixes #3089

#### Special notes for your reviewer:
how to test it?
- 开发模式下不会校验插件填写的 requires，但通过接口安装和升级都会统一校验。
- 在 deployment 模式下安装插件和升级插件会根据 halo 的版本校验插件的 spec.requires 是否符合要求，参考 [semver-expressions-api-ranges](https://github.com/zafarkhaja/jsemver#semver-expressions-api-ranges)。
- 如果 spec.requires 为 `*` 则表示允许所有，如果填写为具体的版本号，例如 requires: "2.2.0" 则隐式表示为 `>=2.2.0`。

可以测试这几种情况是否符合期望。

/cc @halo-dev/sig-halo 
#### Does this PR introduce a user-facing change?
```release-note
插件安装和升级支持版本校验
```
