### PR TITLE
Fix the problem of getting authentication while rendering error page

### DIFF
--- a/src/main/java/run/halo/app/config/HaloAnonymousAuthenticationWebFilter.java
+++ b/src/main/java/run/halo/app/config/HaloAnonymousAuthenticationWebFilter.java
@@ -1,0 +1,43 @@
+package run.halo.app.config;
+
+import static org.springframework.security.core.context.ReactiveSecurityContextHolder.withSecurityContext;
+
+import java.util.List;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.context.ReactiveSecurityContextHolder;
+import org.springframework.security.core.context.SecurityContextImpl;
+import org.springframework.security.web.server.authentication.AnonymousAuthenticationWebFilter;
+import org.springframework.security.web.server.context.ServerSecurityContextRepository;
+import org.springframework.web.server.ServerWebExchange;
+import org.springframework.web.server.WebFilterChain;
+import reactor.core.publisher.Mono;
+
+/**
+ * HaloAnonymousAuthenticationWebFilter will save SecurityContext into SecurityContextRepository
+ * when AnonymousAuthenticationToken is created.
+ *
+ * @author johnniang
+ */
+public class HaloAnonymousAuthenticationWebFilter extends AnonymousAuthenticationWebFilter {
+
+    private final ServerSecurityContextRepository securityContextRepository;
+
+    public HaloAnonymousAuthenticationWebFilter(String key, Object principal,
+        List<GrantedAuthority> authorities,
+        ServerSecurityContextRepository securityContextRepository) {
+        super(key, principal, authorities);
+        this.securityContextRepository = securityContextRepository;
+    }
+
+    @Override
+    public Mono<Void> filter(ServerWebExchange exchange, WebFilterChain chain) {
+        return ReactiveSecurityContextHolder.getContext().switchIfEmpty(Mono.defer(() -> {
+            var authentication = createAuthentication(exchange);
+            var securityContext = new SecurityContextImpl(authentication);
+            return securityContextRepository.save(exchange, securityContext)
+                .then(Mono.defer(() -> chain.filter(exchange)
+                    .contextWrite(withSecurityContext(Mono.just(securityContext)))
+                    .then(Mono.empty())));
+        })).flatMap(securityContext -> chain.filter(exchange));
+    }
+}

--- a/src/main/java/run/halo/app/theme/ThemeConfiguration.java
+++ b/src/main/java/run/halo/app/theme/ThemeConfiguration.java
@@ -12,12 +12,15 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.io.FileSystemResource;
 import org.springframework.http.MediaType;
+import org.springframework.security.web.server.context.ServerSecurityContextRepository;
 import org.springframework.web.reactive.function.BodyInserters;
 import org.springframework.web.reactive.function.server.RouterFunction;
 import org.springframework.web.reactive.function.server.ServerResponse;
+import org.thymeleaf.extras.springsecurity6.dialect.SpringSecurityDialect;
 import reactor.core.publisher.Mono;
 import run.halo.app.infra.properties.HaloProperties;
 import run.halo.app.infra.utils.FilePathUtils;
+import run.halo.app.theme.dialect.HaloSpringSecurityDialect;
 import run.halo.app.theme.dialect.LinkExpressionObjectDialect;
 
 /**
@@ -65,5 +68,11 @@ public class ThemeConfiguration {
     @Bean
     LinkExpressionObjectDialect linkExpressionObjectDialect() {
         return new LinkExpressionObjectDialect();
+    }
+
+    @Bean
+    SpringSecurityDialect springSecurityDialect(
+        ServerSecurityContextRepository securityContextRepository) {
+        return new HaloSpringSecurityDialect(securityContextRepository);
     }
 }

--- a/src/main/java/run/halo/app/theme/dialect/HaloSpringSecurityDialect.java
+++ b/src/main/java/run/halo/app/theme/dialect/HaloSpringSecurityDialect.java
@@ -1,0 +1,65 @@
+package run.halo.app.theme.dialect;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.Function;
+import org.springframework.security.web.reactive.result.view.CsrfRequestDataValueProcessor;
+import org.springframework.security.web.server.context.ServerSecurityContextRepository;
+import org.springframework.security.web.server.csrf.CsrfToken;
+import org.springframework.web.server.ServerWebExchange;
+import org.thymeleaf.extras.springsecurity6.dialect.SpringSecurityDialect;
+import org.thymeleaf.extras.springsecurity6.util.SpringSecurityContextUtils;
+import org.thymeleaf.extras.springsecurity6.util.SpringVersionUtils;
+import reactor.core.publisher.Mono;
+
+/**
+ * HaloSpringSecurityDialect overwrites value of thymeleafSpringSecurityContext.
+ *
+ * @author johnniang
+ */
+public class HaloSpringSecurityDialect extends SpringSecurityDialect {
+
+    private static final String SECURITY_CONTEXT_EXECUTION_ATTRIBUTE_NAME =
+        "ThymeleafReactiveModelAdditions:"
+            + SpringSecurityContextUtils.SECURITY_CONTEXT_MODEL_ATTRIBUTE_NAME;
+    private static final String CSRF_EXECUTION_ATTRIBUTE_NAME =
+        "ThymeleafReactiveModelAdditions:" + CsrfRequestDataValueProcessor.DEFAULT_CSRF_ATTR_NAME;
+
+    private final Map<String, Object> executionAttributes;
+
+    private final ServerSecurityContextRepository securityContextRepository;
+
+    public HaloSpringSecurityDialect(ServerSecurityContextRepository securityContextRepository) {
+        this.securityContextRepository = securityContextRepository;
+        executionAttributes = new HashMap<>(3, 1.0f);
+        initExecutionAttributes();
+    }
+
+    private void initExecutionAttributes() {
+        if (!SpringVersionUtils.isSpringWebFluxPresent()) {
+            return;
+        }
+
+        final Function<ServerWebExchange, Object> secCtxInitializer =
+            (exchange) -> securityContextRepository.load(exchange);
+
+        final Function<ServerWebExchange, Object> csrfTokenInitializer =
+            (exchange) -> {
+                final Mono<CsrfToken> csrfToken = exchange.getAttribute(CsrfToken.class.getName());
+                if (csrfToken == null) {
+                    return Mono.empty();
+                }
+                return csrfToken.doOnSuccess(
+                    token -> exchange.getAttributes()
+                        .put(CsrfRequestDataValueProcessor.DEFAULT_CSRF_ATTR_NAME, token));
+            };
+
+        executionAttributes.put(SECURITY_CONTEXT_EXECUTION_ATTRIBUTE_NAME, secCtxInitializer);
+        executionAttributes.put(CSRF_EXECUTION_ATTRIBUTE_NAME, csrfTokenInitializer);
+    }
+
+    @Override
+    public Map<String, Object> getExecutionAttributes() {
+        return executionAttributes;
+    }
+}


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/area core
/milestone 2.2.x

#### What this PR does / why we need it:

This PR mainly customizes AnonymousAuthenticationWebFilter and SpringSecurityDialect to make authentication visible in exception web handler. So that we can get SecurityContext while rendering error page.

#### Which issue(s) this PR fixes:

Fixes https://github.com/halo-dev/halo/issues/3133

#### Test steps

1. Start Halo
2. Request a page which is not found
3. See upper right corner icon
    ![image](https://user-images.githubusercontent.com/16865714/212372504-b489507a-2d85-4f1a-a210-9653ad2fa8c2.png)

#### Does this PR introduce a user-facing change?

```release-note
修复错误模板渲染无法获取登录信息的问题
```
