### PR TITLE
Fix the problem of slug name with percent sign when publishing post

### DIFF
--- a/src/main/java/run/halo/app/theme/router/RadixRouterTree.java
+++ b/src/main/java/run/halo/app/theme/router/RadixRouterTree.java
@@ -31,9 +31,7 @@ public class RadixRouterTree extends RadixTree<HandlerFunction<ServerResponse>> 
     @Override
     public void insert(String key, HandlerFunction<ServerResponse> value)
         throws IllegalArgumentException {
-        // uri decode key to insert
-        String decodedKey = UriUtils.decode(key, StandardCharsets.UTF_8);
-        super.insert(decodedKey, value);
+        super.insert(key, value);
         if (log.isDebugEnabled()) {
             checkIndices();
         }

--- a/src/test/java/run/halo/app/theme/router/RadixRouterTreeTest.java
+++ b/src/test/java/run/halo/app/theme/router/RadixRouterTreeTest.java
@@ -7,6 +7,7 @@ import java.net.URISyntaxException;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpMethod;
 import org.springframework.mock.web.reactive.function.server.MockServerRequest;
+import org.springframework.web.reactive.function.server.ServerResponse;
 
 /**
  * Tests for {@link RadixRouterTree}.
@@ -40,5 +41,11 @@ class RadixRouterTreeTest {
             .queryParam("p", "fake-post")
             .method(HttpMethod.GET).build();
         assertThat(RadixRouterTree.pathToFind(request)).isEqualTo("/?p=fake-post");
+    }
+
+    @Test
+    void shouldInsertKeyWithPercentSign() {
+        var tree = new RadixRouterTree();
+        tree.insert("/1%1", request -> ServerResponse.ok().build());
     }
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/area core
/milestone 2.2.x

#### What this PR does / why we need it:

Remove URI decode operation while inserting key into RadixRouterTree to avoid repeat decode.

#### Which issue(s) this PR fixes:

Fixes #3178 

#### Special notes for your reviewer:

1. Set slug name to `1%1` when creating a post
2. Publish it
3. Browse the post

#### Does this PR introduce a user-facing change?

```release-note
修复因别名包含百分号导致无法正常访问的问题
```
