### PR TITLE
Fix the problem of not initializing default theme correctly

### DIFF
--- a/src/main/java/run/halo/app/core/extension/Theme.java
+++ b/src/main/java/run/halo/app/core/extension/Theme.java
@@ -1,5 +1,7 @@
 package run.halo.app.core.extension;
 
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.NOT_REQUIRED;
+
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.util.List;
 import lombok.Data;
@@ -60,6 +62,7 @@ public class Theme extends AbstractExtension {
         @Schema(description = "Deprecated, use `requires` instead.")
         private String require;
 
+        @Schema(requiredMode = NOT_REQUIRED)
         private String requires;
 
         private String settingName;


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/area core
/milestone 2.2.x

#### What this PR does / why we need it:

Make requires field of Theme not required.

#### Which issue(s) this PR fixes:

Fixes https://github.com/halo-dev/halo/issues/3177

#### Special notes for your reviewer:

1. Clear Halo working directory
2. Start Halo freshly

#### Does this PR introduce a user-facing change?

```release-note
None
```
