### PR TITLE
Refine exception message of duplicate key

### DIFF
--- a/src/main/java/run/halo/app/extension/store/ReactiveExtensionStoreClientImpl.java
+++ b/src/main/java/run/halo/app/extension/store/ReactiveExtensionStoreClientImpl.java
@@ -1,9 +1,11 @@
 package run.halo.app.extension.store;
 
+import org.springframework.dao.DuplicateKeyException;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
+import run.halo.app.infra.exception.DuplicateNameException;
 
 @Component
 public class ReactiveExtensionStoreClientImpl implements ReactiveExtensionStoreClient {
@@ -26,7 +28,9 @@ public class ReactiveExtensionStoreClientImpl implements ReactiveExtensionStoreC
 
     @Override
     public Mono<ExtensionStore> create(String name, byte[] data) {
-        return repository.save(new ExtensionStore(name, data));
+        return repository.save(new ExtensionStore(name, data))
+            .onErrorMap(DuplicateKeyException.class,
+                t -> new DuplicateNameException("Duplicate name detected.", t));
     }
 
     @Override

--- a/src/main/java/run/halo/app/infra/exception/DuplicateNameException.java
+++ b/src/main/java/run/halo/app/infra/exception/DuplicateNameException.java
@@ -1,0 +1,24 @@
+package run.halo.app.infra.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.server.ResponseStatusException;
+
+public class DuplicateNameException extends ResponseStatusException {
+
+    public DuplicateNameException() {
+        this("Duplicate name detected");
+    }
+
+    public DuplicateNameException(String reason) {
+        this(reason, null);
+    }
+
+    public DuplicateNameException(String reason, Throwable cause) {
+        this(reason, cause, null, null);
+    }
+
+    public DuplicateNameException(String reason, Throwable cause, String messageDetailCode,
+        Object[] messageDetailArguments) {
+        super(HttpStatus.BAD_REQUEST, reason, cause, messageDetailCode, messageDetailArguments);
+    }
+}

--- a/src/main/resources/config/i18n/messages.properties
+++ b/src/main/resources/config/i18n/messages.properties
@@ -15,6 +15,7 @@ problemDetail.title.reactor.core.Exceptions.RetryExhaustedException=Retry Exhaus
 problemDetail.title.run.halo.app.infra.exception.ThemeInstallationException=Theme Install Error
 problemDetail.title.run.halo.app.infra.exception.ThemeUpgradeException=Theme Upgrade Error
 problemDetail.title.run.halo.app.infra.exception.PluginInstallationException=Plugin Install Error
+problemDetail.title.run.halo.app.infra.exception.DuplicateNameException=Duplicate Name Error
 
 # Detail definitions
 problemDetail.org.springframework.web.server.UnsupportedMediaTypeStatusException=Content type {0} is not supported. Supported media types: {1}.
@@ -28,6 +29,7 @@ problemDetail.org.springframework.web.server.ServerErrorException={0}.
 problemDetail.org.springframework.web.server.MethodNotAllowedException=Request method {0} is not supported. Supported methods: {1}.
 problemDetail.run.halo.app.extension.exception.SchemaViolationException={1} of schema {0}.
 problemDetail.run.halo.app.infra.exception.AttachmentAlreadyExistsException=File {0} already exists, please rename it and try again.
+problemDetail.run.halo.app.infra.exception.DuplicateNameException=Duplicate name detected, please rename it and retry.
 
 problemDetail.comment.turnedOff=The comment function has been turned off.
 problemDetail.comment.systemUsersOnly=Allow only system users to comment

--- a/src/main/resources/config/i18n/messages_zh.properties
+++ b/src/main/resources/config/i18n/messages_zh.properties
@@ -2,8 +2,10 @@ problemDetail.title.org.springframework.web.server.ServerWebInputException=请�
 problemDetail.title.run.halo.app.infra.exception.UnsatisfiedAttributeValueException=请求参数属性值不满足要求
 problemDetail.title.run.halo.app.infra.exception.PluginInstallationException=插件安装失败
 problemDetail.title.run.halo.app.infra.exception.AttachmentAlreadyExistsException=附件已存在
+problemDetail.title.run.halo.app.infra.exception.DuplicateNameException=名称重复
 
 problemDetail.run.halo.app.infra.exception.AttachmentAlreadyExistsException=文件 {0} 已存在，建议更名后重试。
+problemDetail.run.halo.app.infra.exception.DuplicateNameException=检测到有重复的名称，请重命名后重试。
 
 problemDetail.plugin.version.unsatisfied.requires=插件要求一个最小的系统版本为 {0}, 但当前版本为 {1}。
 problemDetail.plugin.install.alreadyInstalled=插件 {0} 已经被安装。


### PR DESCRIPTION
#### What type of PR is this?

/kind improvement
/area core
/milestone 2.3.x

#### What this PR does / why we need it:

I create another exception `DuplicateNameException` to map `org.springframework.dao.DuplicateKeyException` when creating extensions.

See https://github.com/halo-dev/halo/issues/3180 for more.

#### Which issue(s) this PR fixes:

Fixes https://github.com/halo-dev/halo/issues/3180

#### Special notes for your reviewer:

1. Try to create an user which name has already exist
2. See the error

#### Does this PR introduce a user-facing change?

```release-note
优化名称重复的错误提示
```
