### PR TITLE
Reduce the number of queries to resolve theme

### DIFF
--- a/src/main/java/run/halo/app/infra/exception/handlers/HaloErrorWebExceptionHandler.java
+++ b/src/main/java/run/halo/app/infra/exception/handlers/HaloErrorWebExceptionHandler.java
@@ -12,6 +12,7 @@ import org.springframework.http.ProblemDetail;
 import org.springframework.web.reactive.function.server.ServerRequest;
 import org.springframework.web.reactive.function.server.ServerResponse;
 import reactor.core.publisher.Mono;
+import reactor.util.context.Context;
 import run.halo.app.theme.ThemeContext;
 import run.halo.app.theme.ThemeResolver;
 import run.halo.app.theme.engine.ThemeTemplateAvailabilityProvider;
@@ -59,9 +60,9 @@ public class HaloErrorWebExceptionHandler extends DefaultErrorWebExceptionHandle
 
     @Override
     protected Mono<ServerResponse> renderErrorView(ServerRequest request) {
-        return themeResolver.getTheme(request.exchange().getRequest())
+        return themeResolver.getTheme(request.exchange())
             .flatMap(themeContext -> super.renderErrorView(request)
-                .contextWrite(context -> context.put(ThemeContext.class, themeContext)));
+                .contextWrite(Context.of(ThemeContext.class, themeContext)));
     }
 
     @Override

--- a/src/main/java/run/halo/app/theme/HaloViewResolver.java
+++ b/src/main/java/run/halo/app/theme/HaloViewResolver.java
@@ -50,7 +50,7 @@ public class HaloViewResolver extends ThymeleafReactiveViewResolver {
         @Override
         public Mono<Void> render(Map<String, ?> model, MediaType contentType,
             ServerWebExchange exchange) {
-            return themeResolver.getTheme(exchange.getRequest()).flatMap(theme -> {
+            return themeResolver.getTheme(exchange).flatMap(theme -> {
                 // calculate the engine before rendering
                 setTemplateEngine(engineManager.getTemplateEngine(theme));
                 return super.render(model, contentType, exchange)

--- a/src/main/java/run/halo/app/theme/ThemeContextBasedVariablesAcquirer.java
+++ b/src/main/java/run/halo/app/theme/ThemeContextBasedVariablesAcquirer.java
@@ -25,7 +25,7 @@ public class ThemeContextBasedVariablesAcquirer implements ViewContextBasedVaria
 
     @Override
     public Mono<Map<String, Object>> acquire(ServerWebExchange exchange) {
-        return themeResolver.getTheme(exchange.getRequest())
+        return themeResolver.getTheme(exchange)
             .flatMap(themeContext -> {
                 String name = themeContext.getName();
                 return themeFinder.getByName(name);

--- a/src/test/java/run/halo/app/theme/message/ThemeMessageResolverIntegrationTest.java
+++ b/src/test/java/run/halo/app/theme/message/ThemeMessageResolverIntegrationTest.java
@@ -1,12 +1,14 @@
 package run.halo.app.theme.message;
 
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
 import java.io.FileNotFoundException;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.nio.file.Path;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.reactive.AutoConfigureWebTestClient;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -14,13 +16,13 @@ import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.boot.test.mock.mockito.SpyBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.http.MediaType;
-import org.springframework.http.server.reactive.ServerHttpRequest;
 import org.springframework.test.web.reactive.server.WebTestClient;
 import org.springframework.util.ResourceUtils;
 import org.springframework.web.reactive.function.server.RequestPredicates;
 import org.springframework.web.reactive.function.server.RouterFunction;
 import org.springframework.web.reactive.function.server.RouterFunctions;
 import org.springframework.web.reactive.function.server.ServerResponse;
+import org.springframework.web.server.ServerWebExchange;
 import reactor.core.publisher.Mono;
 import run.halo.app.theme.ThemeContext;
 import run.halo.app.theme.ThemeResolver;
@@ -50,7 +52,7 @@ public class ThemeMessageResolverIntegrationTest {
         defaultThemeUrl = ResourceUtils.getURL("classpath:themes/default");
         otherThemeUrl = ResourceUtils.getURL("classpath:themes/other");
 
-        Mockito.when(themeResolver.getTheme(Mockito.any(ServerHttpRequest.class)))
+        when(themeResolver.getTheme(any(ServerWebExchange.class)))
             .thenReturn(Mono.just(createDefaultContext()));
     }
 
@@ -150,7 +152,7 @@ public class ThemeMessageResolverIntegrationTest {
                 """);
 
         // For other theme
-        Mockito.when(themeResolver.getTheme(Mockito.any(ServerHttpRequest.class)))
+        when(themeResolver.getTheme(any(ServerWebExchange.class)))
             .thenReturn(Mono.just(createOtherContext()));
         webTestClient.get()
             .uri("/index?language=zh")


### PR DESCRIPTION
#### What type of PR is this?

/kind improvement
/area core

#### What this PR does / why we need it:

Save ThemeContext into ServerWebExchange to reduce the number of queries to resolve theme from 2(or 3) to 1.

#### Which issue(s) this PR fixes:

Fixes https://github.com/halo-dev/halo/issues/3162

#### Does this PR introduce a user-facing change?

```release-note
优化查询主题的查询次数
```
