### PR TITLE
perf: associate ghost user with posts on user deletion.

### DIFF
--- a/src/main/java/run/halo/app/content/Contributor.java
+++ b/src/main/java/run/halo/app/content/Contributor.java
@@ -17,7 +17,7 @@ public class Contributor {
     public static Contributor getGhost() {
         Contributor contributor = new Contributor();
         contributor.setName("ghost");
-        contributor.setDisplayName("Ghost");
+        contributor.setDisplayName("已删除用户");
         return contributor;
     }
 }

--- a/src/main/java/run/halo/app/content/Contributor.java
+++ b/src/main/java/run/halo/app/content/Contributor.java
@@ -13,4 +13,11 @@ public class Contributor {
     private String displayName;
     private String avatar;
     private String name;
+
+    public static Contributor getGhost() {
+        Contributor contributor = new Contributor();
+        contributor.setName("ghost");
+        contributor.setDisplayName("Ghost");
+        return contributor;
+    }
 }

--- a/src/main/java/run/halo/app/content/impl/PostServiceImpl.java
+++ b/src/main/java/run/halo/app/content/impl/PostServiceImpl.java
@@ -232,12 +232,7 @@ public class PostServiceImpl extends AbstractContentService implements PostServi
                 contributor.setAvatar(user.getSpec().getAvatar());
                 return contributor;
             })
-            .switchIfEmpty(Mono.fromCallable(() -> {
-                var contributor = new Contributor();
-                contributor.setName("ghost");
-                contributor.setDisplayName("Ghost");
-                return contributor;
-            }));
+            .defaultIfEmpty(Contributor.getGhost());
     }
 
     @Override

--- a/src/main/java/run/halo/app/content/impl/PostServiceImpl.java
+++ b/src/main/java/run/halo/app/content/impl/PostServiceImpl.java
@@ -231,7 +231,13 @@ public class PostServiceImpl extends AbstractContentService implements PostServi
                 contributor.setDisplayName(user.getSpec().getDisplayName());
                 contributor.setAvatar(user.getSpec().getAvatar());
                 return contributor;
-            });
+            })
+            .switchIfEmpty(Mono.fromCallable(() -> {
+                var contributor = new Contributor();
+                contributor.setName("ghost");
+                contributor.setDisplayName("Ghost");
+                return contributor;
+            }));
     }
 
     @Override

--- a/src/main/resources/extensions/system-default-role.yaml
+++ b/src/main/resources/extensions/system-default-role.yaml
@@ -4,6 +4,8 @@ metadata:
   name: guest
   labels:
     rbac.authorization.halo.run/system-reserved: "true"
+  annotations:
+    rbac.authorization.halo.run/display-name: "访客"
 rules: [ ]
 
 ---
@@ -14,6 +16,7 @@ metadata:
   labels:
     rbac.authorization.halo.run/system-reserved: "true"
   annotations:
+    rbac.authorization.halo.run/display-name: "超级管理员"
     rbac.authorization.halo.run/ui-permissions: |
       ["*"]
 rules:


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

文章发布用户被删除后，设置这篇文章的发布人为Ghost

#### Which issue(s) this PR fixes:

Fixes #3265

```release-note
NONE
```
