### PR TITLE
Auto rename attachment if it exists

### DIFF
--- a/src/main/java/run/halo/app/infra/utils/FileNameUtils.java
+++ b/src/main/java/run/halo/app/infra/utils/FileNameUtils.java
@@ -1,5 +1,9 @@
 package run.halo.app.infra.utils;
 
+import com.google.common.io.Files;
+import org.apache.commons.lang3.RandomStringUtils;
+import org.apache.commons.lang3.StringUtils;
+
 public final class FileNameUtils {
 
     private FileNameUtils() {
@@ -11,5 +15,30 @@ public final class FileNameUtils {
         }
         var extPattern = "(?<!^)[.]" + (removeAllExtensions ? ".*" : "[^.]*$");
         return filename.replaceAll(extPattern, "");
+    }
+
+    /**
+     * Append random string after file name.
+     * <pre>
+     * Case 1: halo.run -> halo-xyz.run
+     * Case 2: .run -> xyz.run
+     * Case 3: halo -> halo-xyz
+     * </pre>
+     *
+     * @param filename is name of file.
+     * @param length is for generating random string with specific length.
+     * @return File name with random string.
+     */
+    public static String randomFileName(String filename, int length) {
+        var nameWithoutExt = Files.getNameWithoutExtension(filename);
+        var ext = Files.getFileExtension(filename);
+        var random = RandomStringUtils.randomAlphabetic(length).toLowerCase();
+        if (StringUtils.isBlank(nameWithoutExt)) {
+            return random + "." + ext;
+        }
+        if (StringUtils.isBlank(ext)) {
+            return nameWithoutExt + "-" + random;
+        }
+        return nameWithoutExt + "-" + random + "." + ext;
     }
 }

--- a/src/test/java/run/halo/app/infra/utils/FileNameUtilsTest.java
+++ b/src/test/java/run/halo/app/infra/utils/FileNameUtilsTest.java
@@ -2,50 +2,77 @@ package run.halo.app.infra.utils;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static run.halo.app.infra.utils.FileNameUtils.randomFileName;
+import static run.halo.app.infra.utils.FileNameUtils.removeFileExtension;
 
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 class FileNameUtilsTest {
 
-    @Test
-    public void shouldNotRemoveExtIfNoExt() {
-        assertEquals("halo", FileNameUtils.removeFileExtension("halo", true));
-        assertEquals("halo", FileNameUtils.removeFileExtension("halo", false));
+    @Nested
+    class RemoveFileExtensionTest {
+
+        @Test
+        public void shouldNotRemoveExtIfNoExt() {
+            assertEquals("halo", removeFileExtension("halo", true));
+            assertEquals("halo", removeFileExtension("halo", false));
+        }
+
+        @Test
+        public void shouldRemoveExtIfHasOnlyOneExt() {
+            assertEquals("halo", removeFileExtension("halo.run", true));
+            assertEquals("halo", removeFileExtension("halo.run", false));
+        }
+
+        @Test
+        public void shouldNotRemoveExtIfDotfile() {
+            assertEquals(".halo", removeFileExtension(".halo", true));
+            assertEquals(".halo", removeFileExtension(".halo", false));
+        }
+
+        @Test
+        public void shouldRemoveExtIfDotfileHasOneExt() {
+            assertEquals(".halo", removeFileExtension(".halo.run", true));
+            assertEquals(".halo", removeFileExtension(".halo.run", false));
+        }
+
+        @Test
+        public void shouldRemoveExtIfHasTwoExt() {
+            assertEquals("halo", removeFileExtension("halo.tar.gz", true));
+            assertEquals("halo.tar", removeFileExtension("halo.tar.gz", false));
+        }
+
+        @Test
+        public void shouldRemoveExtIfDotfileHasTwoExt() {
+            assertEquals(".halo", removeFileExtension(".halo.tar.gz", true));
+            assertEquals(".halo.tar", removeFileExtension(".halo.tar.gz", false));
+        }
+
+        @Test
+        void shouldReturnNullIfFilenameIsNull() {
+            assertNull(removeFileExtension(null, true));
+            assertNull(removeFileExtension(null, false));
+        }
     }
 
-    @Test
-    public void shouldRemoveExtIfHasOnlyOneExt() {
-        assertEquals("halo", FileNameUtils.removeFileExtension("halo.run", true));
-        assertEquals("halo", FileNameUtils.removeFileExtension("halo.run", false));
-    }
+    @Nested
+    class AppendRandomFileNameTest {
+        @Test
+        void normalFileName() {
+            String randomFileName = randomFileName("halo.run", 3);
+            assertEquals(12, randomFileName.length());
+            assertTrue(randomFileName.startsWith("halo-"));
+            assertTrue(randomFileName.endsWith(".run"));
 
-    @Test
-    public void shouldNotRemoveExtIfDotfile() {
-        assertEquals(".halo", FileNameUtils.removeFileExtension(".halo", true));
-        assertEquals(".halo", FileNameUtils.removeFileExtension(".halo", false));
-    }
+            randomFileName = randomFileName(".run", 3);
+            assertEquals(7, randomFileName.length());
+            assertTrue(randomFileName.endsWith(".run"));
 
-    @Test
-    public void shouldRemoveExtIfDotfileHasOneExt() {
-        assertEquals(".halo", FileNameUtils.removeFileExtension(".halo.run", true));
-        assertEquals(".halo", FileNameUtils.removeFileExtension(".halo.run", false));
-    }
-
-    @Test
-    public void shouldRemoveExtIfHasTwoExt() {
-        assertEquals("halo", FileNameUtils.removeFileExtension("halo.tar.gz", true));
-        assertEquals("halo.tar", FileNameUtils.removeFileExtension("halo.tar.gz", false));
-    }
-
-    @Test
-    public void shouldRemoveExtIfDotfileHasTwoExt() {
-        assertEquals(".halo", FileNameUtils.removeFileExtension(".halo.tar.gz", true));
-        assertEquals(".halo.tar", FileNameUtils.removeFileExtension(".halo.tar.gz", false));
-    }
-
-    @Test
-    void shouldReturnNullIfFilenameIsNull() {
-        assertNull(FileNameUtils.removeFileExtension(null, true));
-        assertNull(FileNameUtils.removeFileExtension(null, false));
+            randomFileName = randomFileName("halo", 3);
+            assertEquals(8, randomFileName.length());
+            assertTrue(randomFileName.startsWith("halo-"));
+        }
     }
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind improvement
/area core
/milestone 2.3.x

#### What this PR does / why we need it:

Before this PR, halo will throw an FileAlreadyExists exception if users upload file which already exists.

But now, we will rename the attachment automatically on filename conflict. e.g.:

```bash
halo.run -> halo-xyz.run
.run -> xyz.run
halo -> halo-xyz
```

#### Which issue(s) this PR fixes:

Fixes https://github.com/halo-dev/halo/issues/3218

#### Special notes for your reviewer:

![image](https://user-images.githubusercontent.com/16865714/218670068-87389289-1248-48e8-82a4-1bcf939e64e3.png)

#### Does this PR introduce a user-facing change?

```release-note
附件已存在时自动重命名
```
