### PR TITLE
refactor: status update when setting not found

### DIFF
--- a/src/main/java/run/halo/app/core/extension/reconciler/PluginReconciler.java
+++ b/src/main/java/run/halo/app/core/extension/reconciler/PluginReconciler.java
@@ -381,9 +381,11 @@ public class PluginReconciler implements Reconciler<Request> {
                     Plugin.PluginStatus status = newPlugin.statusNonNull();
                     status.setPhase(PluginState.FAILED);
                     status.setReason("ResourceNotReady");
-                    status.setMessage("Setting for " + settingName + " is not ready, retrying...");
+                    status.setMessage(
+                        "Setting named " + settingName + " is not ready, retrying...");
                     status.setLastTransitionTime(Instant.now());
-                    if (!oldStatus.equals(status)) {
+                    if (!oldStatus.equals(status)
+                        && !StringUtils.equals(oldStatus.getReason(), status.getReason())) {
                         client.update(newPlugin);
                     }
                     throw new IllegalStateException(status.getMessage());


### PR DESCRIPTION
#### What type of PR is this?
/kind improvement
/area core
/milestone 2.3.x
#### What this PR does / why we need it:
状态更新时检查是否与之前状态相同，目前先这样解决后续等 status 的 update 出来以后再重构一下 plugin 的 status 结构。

测试：
测试插件在开发模式和生产模式下填写 settingName 后有/无对应 settingName 资源的插件启动情况，看 PluginReconciler 出错时是否很快
步骤：
1. 开发模式下，插件的 plugin.yaml 配置了 settingName 但没有创建名称为 settingName 对应的 Setting 资源看插件启动时控制台是否出现很快的错误日志，期望出现错误的时间间隔会逐渐变长。
2. 与步骤一相同，但 settingName 对应有 Setting 模型的 yaml，期望插件正常启动且能保存配置
3. 生产模式启动插件重复步骤 1 和 2

#### Special notes for your reviewer:
/cc @halo-dev/sig-halo 
#### Does this PR introduce a user-facing change?
```release-note
None
```
