### PR TITLE
refactpr: add the creation time allowed for modification to be compatible with the migration order problem

### DIFF
--- a/src/main/java/run/halo/app/content/comment/CommentServiceImpl.java
+++ b/src/main/java/run/halo/app/content/comment/CommentServiceImpl.java
@@ -93,6 +93,9 @@ public class CommentServiceImpl implements CommentService {
                 if (comment.getSpec().getOwner() != null) {
                     return Mono.just(comment);
                 }
+                if (comment.getSpec().getCreationTime() == null) {
+                    comment.getSpec().setCreationTime(Instant.now());
+                }
                 // populate owner from current user
                 return fetchCurrentUser()
                     .map(this::toCommentOwner)

--- a/src/main/java/run/halo/app/content/comment/CommentSorter.java
+++ b/src/main/java/run/halo/app/content/comment/CommentSorter.java
@@ -30,12 +30,12 @@ public enum CommentSorter {
 
     static Comparator<Comment> from(CommentSorter sorter) {
         if (sorter == null) {
-            return defaultCommentComparator();
+            return lastReplyTimeComparator();
         }
         if (CREATE_TIME.equals(sorter)) {
             Function<Comment, Instant> comparatorFunc =
-                comment -> comment.getMetadata().getCreationTimestamp();
-            return Comparator.comparing(comparatorFunc)
+                comment -> comment.getSpec().getCreationTime();
+            return Comparator.comparing(comparatorFunc, Comparators.nullsLow())
                 .thenComparing(name);
         }
 
@@ -65,12 +65,12 @@ public enum CommentSorter {
         return null;
     }
 
-    static Comparator<Comment> defaultCommentComparator() {
+    static Comparator<Comment> lastReplyTimeComparator() {
         Function<Comment, Instant> comparatorFunc =
             comment -> {
                 Instant lastReplyTime = comment.getStatusOrDefault().getLastReplyTime();
-                return Optional.ofNullable(
-                    lastReplyTime).orElse(comment.getMetadata().getCreationTimestamp());
+                return Optional.ofNullable(lastReplyTime)
+                    .orElse(comment.getSpec().getCreationTime());
             };
         return Comparator.comparing(comparatorFunc, Comparators.nullsLow())
             .thenComparing(name);

--- a/src/main/java/run/halo/app/content/comment/ReplyService.java
+++ b/src/main/java/run/halo/app/content/comment/ReplyService.java
@@ -1,5 +1,9 @@
 package run.halo.app.content.comment;
 
+import java.time.Instant;
+import java.util.Comparator;
+import java.util.function.Function;
+import org.springframework.util.comparator.Comparators;
 import reactor.core.publisher.Mono;
 import run.halo.app.core.extension.content.Reply;
 import run.halo.app.extension.ListResult;
@@ -15,4 +19,20 @@ public interface ReplyService {
     Mono<Reply> create(String commentName, Reply reply);
 
     Mono<ListResult<ListedReply>> list(ReplyQuery query);
+
+    /**
+     * Ascending order by creation time.
+     *
+     * @return reply comparator
+     */
+    static Comparator<Reply> creationTimeAscComparator() {
+        Function<Reply, Instant> creationTime = reply -> reply.getSpec().getCreationTime();
+        Function<Reply, Instant> metadataCreationTime =
+            reply -> reply.getMetadata().getCreationTimestamp();
+        // ascending order by creation time
+        // asc nulls high will be placed at the end
+        return Comparator.comparing(creationTime, Comparators.nullsHigh())
+            .thenComparing(metadataCreationTime)
+            .thenComparing(reply -> reply.getMetadata().getName());
+    }
 }

--- a/src/main/java/run/halo/app/core/extension/content/Comment.java
+++ b/src/main/java/run/halo/app/core/extension/content/Comment.java
@@ -1,5 +1,7 @@
 package run.halo.app.core.extension.content;
 
+import static org.apache.commons.lang3.ObjectUtils.defaultIfNull;
+
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.Instant;
@@ -70,6 +72,11 @@ public class Comment extends AbstractExtension {
 
         private Instant approvedTime;
 
+        /**
+         * The user-defined creation time default is <code>metadata.creationTimestamp</code>.
+         */
+        private Instant creationTime;
+
         @Schema(required = true, defaultValue = "0")
         private Integer priority;
 
@@ -84,6 +91,15 @@ public class Comment extends AbstractExtension {
 
         @Schema(required = true, defaultValue = "false")
         private Boolean hidden;
+
+        /**
+         * If the creation time is null, use approvedTime.
+         *
+         * @return if creationTime is null returned approved time, otherwise creationTime.
+         */
+        public Instant getCreationTime() {
+            return defaultIfNull(creationTime, approvedTime);
+        }
     }
 
     @Data
@@ -130,8 +146,9 @@ public class Comment extends AbstractExtension {
                 if (lastReadTime == null) {
                     return true;
                 }
-                return existingReply.getMetadata().getCreationTimestamp()
-                    .isAfter(lastReadTime);
+                Instant creationTime = defaultIfNull(existingReply.getSpec().getCreationTime(),
+                    existingReply.getMetadata().getCreationTimestamp());
+                return creationTime.isAfter(lastReadTime);
             })
             .count();
         return (int) unreadReplyCount;

--- a/src/main/java/run/halo/app/core/extension/reconciler/CommentReconciler.java
+++ b/src/main/java/run/halo/app/core/extension/reconciler/CommentReconciler.java
@@ -1,16 +1,15 @@
 package run.halo.app.core.extension.reconciler;
 
 import java.time.Instant;
-import java.util.Comparator;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.function.Function;
 import org.apache.commons.lang3.BooleanUtils;
 import org.apache.commons.lang3.ObjectUtils;
 import org.springframework.lang.Nullable;
 import org.springframework.stereotype.Component;
+import run.halo.app.content.comment.ReplyService;
 import run.halo.app.core.extension.Counter;
 import run.halo.app.core.extension.content.Comment;
 import run.halo.app.core.extension.content.Constant;
@@ -110,7 +109,7 @@ public class CommentReconciler implements Reconciler<Reconciler.Request> {
         List<Reply> replies = client.list(Reply.class,
             reply -> commentName.equals(reply.getSpec().getCommentName())
                 && reply.getMetadata().getDeletionTimestamp() == null,
-            defaultReplyComparator());
+            ReplyService.creationTimeAscComparator());
 
         // calculate unread reply count
         comment.getStatusOrDefault()
@@ -180,12 +179,5 @@ public class CommentReconciler implements Reconciler<Reconciler.Request> {
             return null;
         }
         return new GroupVersionKind(ref.getGroup(), ref.getVersion(), ref.getKind());
-    }
-
-    Comparator<Reply> defaultReplyComparator() {
-        Function<Reply, Instant> createTime = reply -> reply.getMetadata().getCreationTimestamp();
-        return Comparator.comparing(createTime)
-            .thenComparing(reply -> reply.getMetadata().getName())
-            .reversed();
     }
 }

--- a/src/test/java/run/halo/app/content/comment/CommentServiceImplTest.java
+++ b/src/test/java/run/halo/app/content/comment/CommentServiceImplTest.java
@@ -127,6 +127,7 @@ class CommentServiceImplTest {
 
         verify(client, times(1)).create(captor.capture());
         Comment comment = captor.getValue();
+        comment.getSpec().setCreationTime(null);
         JSONAssert.assertEquals("""
                 {
                     "spec": {

--- a/src/test/java/run/halo/app/content/comment/CommentSorterTest.java
+++ b/src/test/java/run/halo/app/content/comment/CommentSorterTest.java
@@ -102,7 +102,7 @@ class CommentSorterTest {
 
     @Test
     void sortByDefaultDesc() {
-        Comparator<Comment> defaultComparator = CommentSorter.defaultCommentComparator().reversed();
+        Comparator<Comment> defaultComparator = CommentSorter.lastReplyTimeComparator().reversed();
         List<String> commentNames = comments().stream()
             .sorted(defaultComparator)
             .map(comment -> comment.getMetadata().getName())
@@ -124,8 +124,9 @@ class CommentSorterTest {
         commentA.getMetadata().setName("A");
         // create time
         commentA.getMetadata().setCreationTimestamp(now.plusSeconds(10));
-
         commentA.setSpec(new Comment.CommentSpec());
+        commentA.getSpec().setCreationTime(commentA.getMetadata().getCreationTimestamp());
+
         commentA.setStatus(new Comment.CommentStatus());
         // last reply time
         commentA.getStatus().setLastReplyTime(now.plusSeconds(5));
@@ -140,6 +141,7 @@ class CommentSorterTest {
         commentB.setStatus(new Comment.CommentStatus());
         commentB.getStatus().setLastReplyTime(now.plusSeconds(15));
         commentB.getStatus().setReplyCount(8);
+        commentB.getSpec().setCreationTime(commentB.getMetadata().getCreationTimestamp());
 
         Comment commentC = new Comment();
         commentC.setMetadata(new Metadata());
@@ -151,6 +153,7 @@ class CommentSorterTest {
         commentC.setStatus(new Comment.CommentStatus());
         commentC.getStatus().setLastReplyTime(now.plusSeconds(3));
         commentC.getStatus().setReplyCount(10);
+        commentC.getSpec().setCreationTime(commentC.getMetadata().getCreationTimestamp());
 
         return List.of(commentA, commentB, commentC);
     }
@@ -165,6 +168,7 @@ class CommentSorterTest {
         commentD.getMetadata().setCreationTimestamp(now.plusSeconds(50));
 
         commentD.setSpec(new Comment.CommentSpec());
+        commentD.getSpec().setCreationTime(commentD.getMetadata().getCreationTimestamp());
         commentD.setStatus(new Comment.CommentStatus());
 
         Comment commentE = new Comment();
@@ -172,8 +176,8 @@ class CommentSorterTest {
         commentE.getMetadata().setName("E");
 
         commentE.getMetadata().setCreationTimestamp(now.plusSeconds(20));
-
         commentE.setSpec(new Comment.CommentSpec());
+        commentE.getSpec().setCreationTime(commentE.getMetadata().getCreationTimestamp());
         commentE.setStatus(new Comment.CommentStatus());
 
         List<Comment> comments = new ArrayList<>(comments());

--- a/src/test/java/run/halo/app/content/comment/ReplyServiceTest.java
+++ b/src/test/java/run/halo/app/content/comment/ReplyServiceTest.java
@@ -1,0 +1,52 @@
+package run.halo.app.content.comment;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.Instant;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Test;
+import run.halo.app.core.extension.content.Reply;
+import run.halo.app.extension.Metadata;
+
+/**
+ * Tests for {@link ReplyService}.
+ *
+ * @author guqing
+ * @since 2.0.0
+ */
+class ReplyServiceTest {
+    private final Instant now = Instant.now();
+
+    @Test
+    void creationTimeAscComparator() {
+        // creation time:
+        // 1. now + 5s, name: 1
+        // 2. now + 3s, name: 2
+        // 3. now + 3s, name: 3
+        // 5. now + 1s, name: 4
+        // 6. now - 1s, name: 5
+        // 7. null, name: 6
+        Reply reply1 = createReply("1", now.plusSeconds(5));
+        Reply reply2 = createReply("2", now.plusSeconds(3));
+        Reply reply3 = createReply("3", now.plusSeconds(3));
+        Reply reply4 = createReply("4", now.plusSeconds(1));
+        Reply reply5 = createReply("5", now.minusSeconds(1));
+        Reply reply6 = createReply("6", null);
+        String result = Stream.of(reply1, reply2, reply3, reply4, reply5, reply6)
+            .sorted(ReplyService.creationTimeAscComparator())
+            .map(reply -> reply.getMetadata().getName())
+            .collect(Collectors.joining(", "));
+        assertThat(result).isEqualTo("5, 4, 2, 3, 1, 6");
+    }
+
+    Reply createReply(String name, Instant creationTime) {
+        Reply reply = new Reply();
+        reply.setMetadata(new Metadata());
+        reply.getMetadata().setName(name);
+        reply.getMetadata().setCreationTimestamp(now);
+        reply.setSpec(new Reply.ReplySpec());
+        reply.getSpec().setCreationTime(creationTime);
+        return reply;
+    }
+}


### PR DESCRIPTION
#### What type of PR is this?
/kind improvement
/area core
/milestone 2.3.x
/kind api-change

#### What this PR does / why we need it:
1. spec 中新增 creationTime
2. 旧数据的 spec.creationTime 默认等于 approvedTime
3. 按照 metadata.creationTimestamp 排序的使用 spec.creationTime 代替

how to test it?
1. 使用迁移插件迁移看评论和回复的排序是否正确
2. 使用评论插件创建评论和回复看顺序是否正确
#### Which issue(s) this PR fixes:
Fixes #3330

#### Special notes for your reviewer:
/cc @halo-dev/sig-halo 
#### Does this PR introduce a user-facing change?

```release-note
评论和回复新增创建时间以兼容迁移数据的排序
```
