### PR TITLE
fix: initializes a ghost user by default to replace that the users that has been deleted

### DIFF
--- a/src/main/java/run/halo/app/content/Contributor.java
+++ b/src/main/java/run/halo/app/content/Contributor.java
@@ -13,11 +13,4 @@ public class Contributor {
     private String displayName;
     private String avatar;
     private String name;
-
-    public static Contributor getGhost() {
-        Contributor contributor = new Contributor();
-        contributor.setName("ghost");
-        contributor.setDisplayName("已删除用户");
-        return contributor;
-    }
 }

--- a/src/main/java/run/halo/app/content/impl/PostServiceImpl.java
+++ b/src/main/java/run/halo/app/content/impl/PostServiceImpl.java
@@ -224,15 +224,15 @@ public class PostServiceImpl extends AbstractContentService implements PostServi
             return Flux.empty();
         }
         return Flux.fromIterable(usernames)
-            .flatMap(username -> client.fetch(User.class, username))
+            .flatMap(username -> client.fetch(User.class, username)
+                .switchIfEmpty(client.fetch(User.class, "ghost")))
             .map(user -> {
                 Contributor contributor = new Contributor();
                 contributor.setName(user.getMetadata().getName());
                 contributor.setDisplayName(user.getSpec().getDisplayName());
                 contributor.setAvatar(user.getSpec().getAvatar());
                 return contributor;
-            })
-            .defaultIfEmpty(Contributor.getGhost());
+            });
     }
 
     @Override

--- a/src/main/java/run/halo/app/content/impl/PostServiceImpl.java
+++ b/src/main/java/run/halo/app/content/impl/PostServiceImpl.java
@@ -225,7 +225,7 @@ public class PostServiceImpl extends AbstractContentService implements PostServi
         }
         return Flux.fromIterable(usernames)
             .flatMap(username -> client.fetch(User.class, username)
-                .switchIfEmpty(client.fetch(User.class, "ghost")))
+                .switchIfEmpty(Mono.defer(() -> client.fetch(User.class, "ghost"))))
             .map(user -> {
                 Contributor contributor = new Contributor();
                 contributor.setName(user.getMetadata().getName());

--- a/src/main/resources/extensions/user.yaml
+++ b/src/main/resources/extensions/user.yaml
@@ -6,3 +6,15 @@ spec:
   displayName: Anonymous User
   email: anonymous@example.com
   disabled: true
+
+---
+apiVersion: v1alpha1
+kind: User
+metadata:
+  name: ghost
+spec:
+  displayName: 已删除用户
+  email: ghost@example.com
+  disabled: true
+  bio: 该用户已被删除。
+


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

系统默认初始化一个 ghost 用户，用于表示用户已删除。

#### Which issue(s) this PR fixes:

Fixes #3317

```release-note
NONE
```
