### PR TITLE
Refine problem detail when plugin is already installed

### DIFF
--- a/src/main/java/run/halo/app/core/extension/endpoint/PluginEndpoint.java
+++ b/src/main/java/run/halo/app/core/extension/endpoint/PluginEndpoint.java
@@ -62,7 +62,7 @@ import run.halo.app.extension.ConfigMap;
 import run.halo.app.extension.ReactiveExtensionClient;
 import run.halo.app.extension.router.IListRequest.QueryListRequest;
 import run.halo.app.infra.SystemVersionSupplier;
-import run.halo.app.infra.exception.PluginInstallationException;
+import run.halo.app.infra.exception.PluginAlreadyExistsException;
 import run.halo.app.infra.exception.UnsatisfiedAttributeValueException;
 import run.halo.app.infra.utils.FileUtils;
 import run.halo.app.infra.utils.VersionUtils;
@@ -458,11 +458,7 @@ public class PluginEndpoint implements CustomEndpoint {
                 plugin.getSpec().setEnabled(false);
                 return client.fetch(Plugin.class, plugin.getMetadata().getName())
                     .doOnNext(oldPlugin -> {
-                        String pluginName = oldPlugin.getMetadata().getName();
-                        throw new PluginInstallationException(
-                            "Plugin [" + pluginName + "] already installed",
-                            "problemDetail.plugin.install.alreadyInstalled",
-                            new Object[] {pluginName});
+                        throw new PluginAlreadyExistsException(oldPlugin.getMetadata().getName());
                     })
                     .then(client.create(plugin))
                     .publishOn(Schedulers.boundedElastic())

--- a/src/main/java/run/halo/app/infra/exception/PluginAlreadyExistsException.java
+++ b/src/main/java/run/halo/app/infra/exception/PluginAlreadyExistsException.java
@@ -1,0 +1,21 @@
+package run.halo.app.infra.exception;
+
+import java.net.URI;
+import org.springframework.web.server.ServerWebInputException;
+
+/**
+ * PluginAlreadyExistsException indicates the provided plugin has already installed before.
+ *
+ * @author johnniang
+ */
+public class PluginAlreadyExistsException extends ServerWebInputException {
+
+    public static final String PLUGIN_ALREADY_EXISTS_TYPE =
+        "https://halo.run/probs/plugin-alreay-exists";
+
+    public PluginAlreadyExistsException(String pluginName) {
+        super("Plugin already exists.", null, null, null, new Object[] {pluginName});
+        setType(URI.create(PLUGIN_ALREADY_EXISTS_TYPE));
+        getBody().setProperty("pluginName", pluginName);
+    }
+}

--- a/src/main/resources/config/i18n/messages.properties
+++ b/src/main/resources/config/i18n/messages.properties
@@ -15,6 +15,7 @@ problemDetail.title.reactor.core.Exceptions.RetryExhaustedException=Retry Exhaus
 problemDetail.title.run.halo.app.infra.exception.ThemeInstallationException=Theme Install Error
 problemDetail.title.run.halo.app.infra.exception.ThemeUpgradeException=Theme Upgrade Error
 problemDetail.title.run.halo.app.infra.exception.PluginInstallationException=Plugin Install Error
+problemDetail.title.run.halo.app.infra.exception.PluginAlreadyExistsException=Plugin Already Exists Error
 problemDetail.title.run.halo.app.infra.exception.DuplicateNameException=Duplicate Name Error
 
 # Detail definitions
@@ -30,6 +31,7 @@ problemDetail.org.springframework.web.server.MethodNotAllowedException=Request m
 problemDetail.run.halo.app.extension.exception.SchemaViolationException={1} of schema {0}.
 problemDetail.run.halo.app.infra.exception.AttachmentAlreadyExistsException=File {0} already exists, please rename it and try again.
 problemDetail.run.halo.app.infra.exception.DuplicateNameException=Duplicate name detected, please rename it and retry.
+problemDetail.run.halo.app.infra.exception.PluginAlreadyExistsException=Plugin {0} already exists.
 
 problemDetail.comment.turnedOff=The comment function has been turned off.
 problemDetail.comment.systemUsersOnly=Allow only system users to comment
@@ -41,4 +43,3 @@ problemDetail.theme.version.unsatisfied.requires=The theme requires a minimum sy
 problemDetail.directoryTraversal=Directory traversal detected. Base path is {0}, but real path is {1}.
 
 problemDetail.plugin.version.unsatisfied.requires=Plugin requires a minimum system version of {0}, but the current version is {1}.
-problemDetail.plugin.install.alreadyInstalled=Plugin {0} already installed.

--- a/src/main/resources/config/i18n/messages_zh.properties
+++ b/src/main/resources/config/i18n/messages_zh.properties
@@ -3,11 +3,12 @@ problemDetail.title.run.halo.app.infra.exception.UnsatisfiedAttributeValueExcept
 problemDetail.title.run.halo.app.infra.exception.PluginInstallationException=插件安装失败
 problemDetail.title.run.halo.app.infra.exception.AttachmentAlreadyExistsException=附件已存在
 problemDetail.title.run.halo.app.infra.exception.DuplicateNameException=名称重复
+problemDetail.title.run.halo.app.infra.exception.PluginAlreadyExistsException=插件已存在
 
 problemDetail.run.halo.app.infra.exception.AttachmentAlreadyExistsException=文件 {0} 已存在，建议更名后重试。
 problemDetail.run.halo.app.infra.exception.DuplicateNameException=检测到有重复的名称，请重命名后重试。
+problemDetail.run.halo.app.infra.exception.PluginAlreadyExistsException=插件 {0} 已经存。
 
 problemDetail.plugin.version.unsatisfied.requires=插件要求一个最小的系统版本为 {0}, 但当前版本为 {1}。
-problemDetail.plugin.install.alreadyInstalled=插件 {0} 已经被安装。
 
 problemDetail.theme.version.unsatisfied.requires=主题要求一个最小的系统版本为 {0}, 但当前版本为 {1}。


### PR DESCRIPTION
#### What type of PR is this?

/kind improvement
/area core

#### What this PR does / why we need it:

This PR refines problem detail of PluginAlreadyExistsException. Please note the new type `https://halo.run/probs/plugin-alreay-exists` and additional property `pluginName` of problem detail.

Meanwhile 

- Before

    ```json
    {
      "type": "about:blank",
      "title": "Plugin Already Exists Error",
      "status": 400,
      "detail": "Plugin PluginCommentWidget already exists.",
      "instance": "/apis/api.console.halo.run/v1alpha1/plugins/install",
      "requestId": "880fe8cd-5",
      "timestamp": "2023-02-20T10:17:21.541104Z"
    }
    ```

- After

    ```json
    {
      "type": "https://halo.run/probs/plugin-alreay-exists",
      "title": "Plugin Already Exists Error",
      "status": 400,
      "detail": "Plugin PluginCommentWidget already exists.",
      "instance": "/apis/api.console.halo.run/v1alpha1/plugins/install",
      "pluginName": "PluginCommentWidget",
      "requestId": "880fe8cd-5",
      "timestamp": "2023-02-20T10:17:21.541104Z"
    }
    ```
#### Which issue(s) this PR fixes:

Fixes https://github.com/halo-dev/halo/issues/3164

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
优化插件重复安装错误提示。
```
