### PR TITLE
feat: plugin supports configuration when not started

### DIFF
--- a/src/main/java/run/halo/app/core/extension/Plugin.java
+++ b/src/main/java/run/halo/app/core/extension/Plugin.java
@@ -13,8 +13,10 @@ import lombok.EqualsAndHashCode;
 import lombok.ToString;
 import org.pf4j.PluginState;
 import org.springframework.lang.NonNull;
+import org.springframework.util.Assert;
 import run.halo.app.extension.AbstractExtension;
 import run.halo.app.extension.GVK;
+import run.halo.app.infra.ConditionList;
 
 /**
  * A custom resource for Plugin.
@@ -102,19 +104,23 @@ public class Plugin extends AbstractExtension {
 
         private PluginState phase;
 
-        private String reason;
-
-        private String message;
+        private ConditionList conditions;
 
         private Instant lastStartTime;
-
-        private Instant lastTransitionTime;
 
         private String entry;
 
         private String stylesheet;
 
         private String logo;
+
+        public static ConditionList nullSafeConditions(@NonNull PluginStatus status) {
+            Assert.notNull(status, "The status must not be null.");
+            if (status.getConditions() == null) {
+                status.setConditions(new ConditionList());
+            }
+            return status.getConditions();
+        }
     }
 
     @Data

--- a/src/main/java/run/halo/app/infra/Condition.java
+++ b/src/main/java/run/halo/app/infra/Condition.java
@@ -5,9 +5,13 @@ import java.time.Instant;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
+import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
 
 /**
+ * EqualsAndHashCode 排除了lastTransitionTime否则失败时，lastTransitionTime 会被更新
+ * 导致 equals 为 false，一直被加入队列.
+ *
  * @author guqing
  * @see
  * <a href="https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#pod-conditions">pod-conditions</a>
@@ -17,6 +21,7 @@ import lombok.NoArgsConstructor;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
+@EqualsAndHashCode(exclude = "lastTransitionTime")
 public class Condition {
     /**
      * type of condition in CamelCase or in foo.example.com/CamelCase.

--- a/src/main/java/run/halo/app/infra/ConditionList.java
+++ b/src/main/java/run/halo/app/infra/ConditionList.java
@@ -31,6 +31,9 @@ public class ConditionList extends AbstractCollection<Condition> {
     }
 
     public boolean addFirst(@NonNull Condition condition) {
+        if (isSame(conditions.peekFirst(), condition)) {
+            return false;
+        }
         conditions.addFirst(condition);
         return true;
     }

--- a/src/main/java/run/halo/app/plugin/PluginBeforeStopSyncListener.java
+++ b/src/main/java/run/halo/app/plugin/PluginBeforeStopSyncListener.java
@@ -1,5 +1,6 @@
 package run.halo.app.plugin;
 
+import java.util.Map;
 import org.springframework.context.event.EventListener;
 import org.springframework.lang.NonNull;
 import org.springframework.stereotype.Component;
@@ -39,6 +40,14 @@ public class PluginBeforeStopSyncListener {
         return Flux.fromIterable(gvkExtensionNames.entrySet())
             .flatMap(entry -> Flux.fromIterable(entry.getValue())
                 .flatMap(extensionName -> client.fetch(entry.getKey(), extensionName))
+                .filter(unstructured -> {
+                    Map<String, String> annotations = unstructured.getMetadata().getAnnotations();
+                    if (annotations == null) {
+                        return true;
+                    }
+                    String stage = PluginConst.DeleteStage.STOP.name();
+                    return stage.equals(annotations.getOrDefault(PluginConst.DELETE_STAGE, stage));
+                })
                 .flatMap(client::delete))
             .then();
     }

--- a/src/main/java/run/halo/app/plugin/PluginConst.java
+++ b/src/main/java/run/halo/app/plugin/PluginConst.java
@@ -12,9 +12,16 @@ public interface PluginConst {
      */
     String PLUGIN_NAME_LABEL_NAME = "plugin.halo.run/plugin-name";
 
+    String DELETE_STAGE = "delete-stage";
+
     String SYSTEM_PLUGIN_NAME = "system";
 
     static String assertsRoutePrefix(String pluginName) {
         return "/plugins/" + pluginName + "/assets/";
+    }
+
+    enum DeleteStage {
+        STOP,
+        UNINSTALL
     }
 }

--- a/src/main/java/run/halo/app/plugin/PluginExtensionLoaderUtils.java
+++ b/src/main/java/run/halo/app/plugin/PluginExtensionLoaderUtils.java
@@ -1,0 +1,82 @@
+package run.halo.app.plugin;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.jar.JarFile;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import java.util.zip.ZipEntry;
+import lombok.extern.slf4j.Slf4j;
+import org.pf4j.DevelopmentPluginClasspath;
+import org.pf4j.PluginRuntimeException;
+import org.pf4j.RuntimeMode;
+
+@Slf4j
+public class PluginExtensionLoaderUtils {
+    static final String EXTENSION_LOCATION = "extensions";
+    static final DevelopmentPluginClasspath PLUGIN_CLASSPATH = new DevelopmentPluginClasspath();
+
+    public static Set<String> lookupExtensions(Path pluginPath, RuntimeMode runtimeMode) {
+        if (RuntimeMode.DEVELOPMENT.equals(runtimeMode)) {
+            return lookupFromClasses(pluginPath);
+        } else {
+            return lookupFromJar(pluginPath);
+        }
+    }
+
+    public static Set<String> lookupFromClasses(Path pluginPath) {
+        Set<String> result = new HashSet<>();
+        for (String directory : PLUGIN_CLASSPATH.getClassesDirectories()) {
+            File file = pluginPath.resolve(directory).resolve(EXTENSION_LOCATION).toFile();
+            if (file.exists() && file.isDirectory()) {
+                result.addAll(walkExtensionFiles(file.toPath()));
+            }
+        }
+        return result;
+    }
+
+    private static Set<String> walkExtensionFiles(Path location) {
+        try (Stream<Path> stream = Files.walk(location)) {
+            return stream.map(Path::normalize)
+                .filter(Files::isRegularFile)
+                .filter(path -> isYamlFile(path.getFileName().toString()))
+                .map(path -> location.getParent().relativize(path).toString())
+                .collect(Collectors.toSet());
+        } catch (IOException e) {
+            log.debug("Failed to walk extension files from [{}]", location);
+            return Collections.emptySet();
+        }
+    }
+
+    static boolean isYamlFile(String path) {
+        return path.endsWith(".yaml") || path.endsWith(".yml");
+    }
+
+    /**
+     * <p>Lists the path of the unstructured yaml configuration file from the plugin jar.</p>
+     *
+     * @param pluginJarPath plugin jar path
+     * @return Unstructured file paths relative to plugin classpath
+     * @throws PluginRuntimeException If loading the file fails
+     */
+    static Set<String> lookupFromJar(Path pluginJarPath) {
+        try (JarFile jarFile = new JarFile(pluginJarPath.toFile())) {
+            return jarFile.stream()
+                .filter(jarEntry -> {
+                    String name = jarEntry.getName();
+                    return name.startsWith(EXTENSION_LOCATION)
+                        && !jarEntry.isDirectory()
+                        && isYamlFile(name);
+                })
+                .map(ZipEntry::getName)
+                .collect(Collectors.toSet());
+        } catch (IOException e) {
+            throw new PluginRuntimeException(e);
+        }
+    }
+}

--- a/src/main/java/run/halo/app/plugin/PluginStartedListener.java
+++ b/src/main/java/run/halo/app/plugin/PluginStartedListener.java
@@ -1,22 +1,9 @@
 package run.halo.app.plugin;
 
-import java.io.File;
-import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.util.Collections;
+import static run.halo.app.plugin.PluginExtensionLoaderUtils.lookupExtensions;
+
 import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Set;
-import java.util.jar.JarFile;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
-import java.util.zip.ZipEntry;
-import lombok.extern.slf4j.Slf4j;
-import org.pf4j.DevelopmentPluginClasspath;
-import org.pf4j.PluginRuntimeException;
 import org.pf4j.PluginWrapper;
-import org.pf4j.RuntimeMode;
 import org.springframework.context.event.EventListener;
 import org.springframework.core.io.DefaultResourceLoader;
 import org.springframework.core.io.Resource;
@@ -84,70 +71,5 @@ public class PluginStartedListener {
                             .switchIfEmpty(Mono.defer(() -> client.create(unstructured)));
                     }).then();
             }).then();
-    }
-
-    Set<String> lookupExtensions(Path pluginPath, RuntimeMode runtimeMode) {
-        if (RuntimeMode.DEVELOPMENT.equals(runtimeMode)) {
-            return PluginExtensionLoaderUtils.lookupFromClasses(pluginPath);
-        } else {
-            return PluginExtensionLoaderUtils.lookupFromJar(pluginPath);
-        }
-    }
-
-    @Slf4j
-    static class PluginExtensionLoaderUtils {
-        static final String EXTENSION_LOCATION = "extensions";
-        static final DevelopmentPluginClasspath PLUGIN_CLASSPATH = new DevelopmentPluginClasspath();
-
-        static Set<String> lookupFromClasses(Path pluginPath) {
-            Set<String> result = new HashSet<>();
-            for (String directory : PLUGIN_CLASSPATH.getClassesDirectories()) {
-                File file = pluginPath.resolve(directory).resolve(EXTENSION_LOCATION).toFile();
-                if (file.exists() && file.isDirectory()) {
-                    result.addAll(walkExtensionFiles(file.toPath()));
-                }
-            }
-            return result;
-        }
-
-        private static Set<String> walkExtensionFiles(Path location) {
-            try (Stream<Path> stream = Files.walk(location)) {
-                return stream.map(Path::normalize)
-                    .filter(Files::isRegularFile)
-                    .filter(path -> isYamlFile(path.getFileName().toString()))
-                    .map(path -> location.getParent().relativize(path).toString())
-                    .collect(Collectors.toSet());
-            } catch (IOException e) {
-                log.debug("Failed to walk extension files from [{}]", location);
-                return Collections.emptySet();
-            }
-        }
-
-        static boolean isYamlFile(String path) {
-            return path.endsWith(".yaml") || path.endsWith(".yml");
-        }
-
-        /**
-         * <p>Lists the path of the unstructured yaml configuration file from the plugin jar.</p>
-         *
-         * @param pluginJarPath plugin jar path
-         * @return Unstructured file paths relative to plugin classpath
-         * @throws PluginRuntimeException If loading the file fails
-         */
-        static Set<String> lookupFromJar(Path pluginJarPath) {
-            try (JarFile jarFile = new JarFile(pluginJarPath.toFile())) {
-                return jarFile.stream()
-                    .filter(jarEntry -> {
-                        String name = jarEntry.getName();
-                        return name.startsWith(EXTENSION_LOCATION)
-                            && !jarEntry.isDirectory()
-                            && isYamlFile(name);
-                    })
-                    .map(ZipEntry::getName)
-                    .collect(Collectors.toSet());
-            } catch (IOException e) {
-                throw new PluginRuntimeException(e);
-            }
-        }
     }
 }

--- a/src/test/java/run/halo/app/core/extension/reconciler/PluginReconcilerTest.java
+++ b/src/test/java/run/halo/app/core/extension/reconciler/PluginReconcilerTest.java
@@ -24,7 +24,6 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.stubbing.Answer;
-import org.pf4j.PluginRuntimeException;
 import org.pf4j.PluginState;
 import org.pf4j.PluginWrapper;
 import org.pf4j.RuntimeMode;
@@ -84,9 +83,9 @@ class PluginReconcilerTest {
         });
 
         ArgumentCaptor<Plugin> pluginCaptor = doReconcileWithoutRequeue();
-        verify(extensionClient, times(3)).update(isA(Plugin.class));
+        verify(extensionClient, times(2)).update(isA(Plugin.class));
 
-        Plugin updateArgs = pluginCaptor.getAllValues().get(2);
+        Plugin updateArgs = pluginCaptor.getAllValues().get(1);
         assertThat(updateArgs).isNotNull();
         assertThat(updateArgs.getSpec().getEnabled()).isTrue();
         assertThat(updateArgs.getStatus().getPhase()).isEqualTo(PluginState.STARTED);
@@ -97,10 +96,15 @@ class PluginReconcilerTest {
     @DisplayName("Reconcile to start failed")
     void reconcileOkWhenPluginManagerStartFailed() {
         Plugin plugin = need2ReconcileForStartupState();
-        when(extensionClient.fetch(eq(Plugin.class), eq("apples"))).thenReturn(Optional.of(plugin));
 
         // mock start plugin failed
-        when(haloPluginManager.startPlugin(any())).thenReturn(PluginState.FAILED);
+        when(extensionClient.fetch(eq(Plugin.class), eq("apples"))).thenReturn(Optional.of(plugin));
+        when(haloPluginManager.startPlugin(any())).thenAnswer((Answer<PluginState>) invocation -> {
+            // mock plugin real state is started
+            when(pluginWrapper.getPluginState()).thenReturn(PluginState.FAILED);
+            return PluginState.FAILED;
+        });
+
         // mock plugin real state is started
         when(pluginWrapper.getPluginState()).thenReturn(PluginState.STOPPED);
 
@@ -121,7 +125,7 @@ class PluginReconcilerTest {
             assertThat(status.getConditions().peek().getReason()).isEqualTo("error message");
             assertThat(status.getConditions().peek().getMessage()).isEqualTo("dev message");
             assertThat(status.getLastStartTime()).isNull();
-        }).isInstanceOf(PluginRuntimeException.class)
+        }).isInstanceOf(IllegalStateException.class)
             .hasMessage("error message");
 
     }
@@ -131,12 +135,15 @@ class PluginReconcilerTest {
     void shouldReconcileStopWhenEnabledIsFalseAndPhaseIsStarted() {
         Plugin plugin = need2ReconcileForStopState();
         when(extensionClient.fetch(eq(Plugin.class), eq("apples"))).thenReturn(Optional.of(plugin));
-        when(haloPluginManager.stopPlugin(any())).thenReturn(PluginState.STOPPED);
+        when(haloPluginManager.stopPlugin(any())).thenAnswer((Answer<PluginState>) invocation -> {
+            when(pluginWrapper.getPluginState()).thenReturn(PluginState.STOPPED);
+            return PluginState.STOPPED;
+        });
         // mock plugin real state is started
         when(pluginWrapper.getPluginState()).thenReturn(PluginState.STARTED);
 
         ArgumentCaptor<Plugin> pluginCaptor = doReconcileWithoutRequeue();
-        verify(extensionClient, times(4)).update(any(Plugin.class));
+        verify(extensionClient, times(2)).update(any(Plugin.class));
 
         Plugin updateArgs = pluginCaptor.getValue();
         assertThat(updateArgs).isNotNull();
@@ -166,12 +173,15 @@ class PluginReconcilerTest {
             }
             """, Plugin.class);
         when(extensionClient.fetch(eq(Plugin.class), eq("apples"))).thenReturn(Optional.of(plugin));
-        when(haloPluginManager.stopPlugin(any())).thenReturn(PluginState.STOPPED);
+        when(haloPluginManager.stopPlugin(any())).thenAnswer((Answer<PluginState>) invocation -> {
+            when(pluginWrapper.getPluginState()).thenReturn(PluginState.STOPPED);
+            return PluginState.STOPPED;
+        });
         // mock plugin real state is started
         when(pluginWrapper.getPluginState()).thenReturn(PluginState.STARTED);
 
         ArgumentCaptor<Plugin> pluginCaptor = doReconcileWithoutRequeue();
-        verify(extensionClient, times(4)).update(any(Plugin.class));
+        verify(extensionClient, times(2)).update(any(Plugin.class));
 
         Plugin updateArgs = pluginCaptor.getValue();
         assertThat(updateArgs).isNotNull();
@@ -190,11 +200,6 @@ class PluginReconcilerTest {
         // mock plugin real state is started
         when(pluginWrapper.getPluginState()).thenReturn(PluginState.STARTED);
 
-        // mock stop failed message
-        PluginStartingError pluginStartingError =
-            PluginStartingError.of("apples", "error message", "dev message");
-        when(haloPluginManager.getPluginStartingError(any())).thenReturn(pluginStartingError);
-
         assertThatThrownBy(() -> {
             ArgumentCaptor<Plugin> pluginCaptor = doReconcileNeedRequeue();
 
@@ -205,7 +210,7 @@ class PluginReconcilerTest {
             Plugin.PluginStatus status = updateArgs.getStatus();
             assertThat(status.getPhase()).isEqualTo(PluginState.FAILED);
         }).isInstanceOf(IllegalStateException.class)
-            .hasMessage("error message");
+            .hasMessage("Failed to stop plugin: apples");
     }
 
     @Test

--- a/src/test/java/run/halo/app/plugin/PluginStartedListenerTest.java
+++ b/src/test/java/run/halo/app/plugin/PluginStartedListenerTest.java
@@ -35,7 +35,7 @@ class PluginStartedListenerTest {
             Files.createFile(extensions.resolve("roles.yaml"));
 
             Set<String> extensionResources =
-                PluginStartedListener.PluginExtensionLoaderUtils.lookupFromClasses(tempPluginPath);
+                PluginExtensionLoaderUtils.lookupFromClasses(tempPluginPath);
             assertThat(extensionResources)
                 .containsAll(Set.of(Path.of("extensions/roles.yaml").toString()));
         }
@@ -50,7 +50,7 @@ class PluginStartedListenerTest {
                 Path targetJarPath = tempDirectory.resolve("plugin-0.0.1.jar");
                 FileUtils.jar(Paths.get(plugin001Uri), targetJarPath);
                 Set<String> unstructuredFilePathFromJar =
-                    PluginStartedListener.PluginExtensionLoaderUtils.lookupFromJar(targetJarPath);
+                    PluginExtensionLoaderUtils.lookupFromJar(targetJarPath);
                 assertThat(unstructuredFilePathFromJar).hasSize(3);
                 assertThat(unstructuredFilePathFromJar).containsAll(Set.of(
                     Path.of("extensions/roles.yaml").toString(),


### PR DESCRIPTION
#### What type of PR is this?
/kind feature
/milestone 2.3.x
/area core
/area plugin

#### What this PR does / why we need it:
顺便重构了一下插件 Reconciler ，否则经常容易出 bug，刚好一起测试一下免得反复整体测试这一块。
1. 插件 status 里的 message 和 reason 之前是直接放在 status 里的，现在改为一个 ConditionList， 最新的始终在 ConditionList 的第一个，这可以避免插件启动成功时还能在 message 上看到错误信息会很奇怪
2. 插件的 Setting 只会在卸载时删除，停止时不进行删除
3. 插件启动和停止状态的调和能从 CREATED、DISABLED、RESOLVED、STARTED、STOPPED、FAILED 这些状态之间进行循环过渡，如插件当前状态为 CREATED 期望达到 STARTED 则可能会经历 CREATED -> RESOLVED -> STARTED( -> FAILED) 这些过渡, 逻辑更清晰

Console 需要适配：
1. 需要去掉插件启动时才加载 Setting 的判断，让其在插件停用时也能加载
2. 需要修改发生错误时的字段取值，显示 conditons[0] 
#### Which issue(s) this PR fixes:

Fixes #3352

#### Special notes for your reviewer:
how to test it?
1. 测试在开发模式和生产模式下插件启用/设置/配置是否正常
2. 测试开发模式下插件启动失败后修复问题重启 halo 后能否正常启用
3. 测试插件卸载后 setting 是否被正确删除
4. 测试插件 logo 相对路径和 url 是否都能正常显示
5. 测试评论插件启动成功后主题端是否能显示评论列表（验证扩展点加载是否正常）
6. 测试插件配置了 settingName 但没有对应的 Setting 时的情况看 Reconciler 重试时间是否增长

/cc @halo-dev/sig-halo 
#### Does this PR introduce a user-facing change?

```release-note
允许插件在未启动时更改设置
```
