### PR TITLE
Discard watch when extension status is changed only

### DIFF
--- a/src/main/java/run/halo/app/extension/JSONExtensionConverter.java
+++ b/src/main/java/run/halo/app/extension/JSONExtensionConverter.java
@@ -53,8 +53,6 @@ public class JSONExtensionConverter implements ExtensionConverter {
         var scheme = schemeManager.get(gvk);
 
         try {
-            var data = objectMapper.writeValueAsBytes(extension);
-
             var validation = new ValidationData<>(extension);
             var extensionJsonNode = objectMapper.valueToTree(extension);
             var validator = getValidator(scheme);
@@ -68,6 +66,7 @@ public class JSONExtensionConverter implements ExtensionConverter {
 
             var version = extension.getMetadata().getVersion();
             var storeName = ExtensionUtil.buildStoreName(scheme, extension.getMetadata().getName());
+            var data = objectMapper.writeValueAsBytes(extensionJsonNode);
             return new ExtensionStore(storeName, data, version);
         } catch (IOException e) {
             throw new ExtensionConvertException("Failed write Extension as bytes", e);

--- a/src/main/java/run/halo/app/extension/JsonExtension.java
+++ b/src/main/java/run/halo/app/extension/JsonExtension.java
@@ -1,0 +1,232 @@
+package run.halo.app.extension;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.databind.node.LongNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.fasterxml.jackson.databind.node.TextNode;
+import java.io.IOException;
+import java.time.Instant;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * JsonExtension is representation an extension using ObjectNode. This extension is preparing for
+ * patching in the future.
+ *
+ * @author johnniang
+ */
+@JsonSerialize(using = JsonExtension.ObjectNodeExtensionSerializer.class)
+@JsonDeserialize(using = JsonExtension.ObjectNodeExtensionDeSerializer.class)
+class JsonExtension implements Extension {
+
+    private final ObjectMapper objectMapper;
+
+    private final ObjectNode objectNode;
+
+    public JsonExtension(ObjectMapper objectMapper) {
+        this(objectMapper, objectMapper.createObjectNode());
+    }
+
+    public JsonExtension(ObjectMapper objectMapper, ObjectNode objectNode) {
+        this.objectMapper = objectMapper;
+        this.objectNode = objectNode;
+    }
+
+    public JsonExtension(ObjectMapper objectMapper, Extension e) {
+        this(objectMapper, (ObjectNode) objectMapper.valueToTree(e));
+    }
+
+    @Override
+    public MetadataOperator getMetadata() {
+        var metadataNode = objectNode.get("metadata");
+        if (metadataNode == null) {
+            return null;
+        }
+        return new ObjectNodeMetadata((ObjectNode) metadataNode);
+    }
+
+    @Override
+    public String getApiVersion() {
+        var apiVersionNode = objectNode.get("apiVersion");
+        return apiVersionNode == null ? null : apiVersionNode.asText();
+    }
+
+    @Override
+    public String getKind() {
+        return objectNode.get("kind").asText();
+    }
+
+    @Override
+    public void setApiVersion(String apiVersion) {
+        objectNode.set("apiVersion", new TextNode(apiVersion));
+    }
+
+    @Override
+    public void setKind(String kind) {
+        objectNode.set("kind", new TextNode(kind));
+    }
+
+    @Override
+    public void setMetadata(MetadataOperator metadata) {
+        objectNode.set("metadata", objectMapper.valueToTree(metadata));
+    }
+
+    public static class ObjectNodeExtensionSerializer extends JsonSerializer<JsonExtension> {
+
+        @Override
+        public void serialize(JsonExtension value, JsonGenerator gen,
+            SerializerProvider serializers) throws IOException {
+            gen.writeTree(value.objectNode);
+        }
+    }
+
+    public static class ObjectNodeExtensionDeSerializer
+        extends JsonDeserializer<JsonExtension> {
+
+        @Override
+        public JsonExtension deserialize(JsonParser p, DeserializationContext ctxt)
+            throws IOException {
+            var mapper = (ObjectMapper) p.getCodec();
+            var treeNode = mapper.readTree(p);
+            return new JsonExtension(mapper, (ObjectNode) treeNode);
+        }
+    }
+
+    /**
+     * Get internal representation.
+     *
+     * @return internal representation
+     */
+    public ObjectNode getInternal() {
+        return objectNode;
+    }
+
+    public MetadataOperator getMetadataOrCreate() {
+        var metadataNode = objectMapper.createObjectNode();
+        objectNode.set("metadata", metadataNode);
+        return new ObjectNodeMetadata(metadataNode);
+    }
+
+    class ObjectNodeMetadata implements MetadataOperator {
+
+        private final ObjectNode objectNode;
+
+        public ObjectNodeMetadata(ObjectNode objectNode) {
+            this.objectNode = objectNode;
+        }
+
+        @Override
+        public String getName() {
+            var nameNode = objectNode.get("name");
+            return objectMapper.convertValue(nameNode, String.class);
+        }
+
+        @Override
+        public String getGenerateName() {
+            var generateNameNode = objectNode.get("generateName");
+            return objectMapper.convertValue(generateNameNode, String.class);
+        }
+
+        @Override
+        public Map<String, String> getLabels() {
+            var labelsNode = objectNode.get("labels");
+            return objectMapper.convertValue(labelsNode, new TypeReference<>() {
+            });
+        }
+
+        @Override
+        public Map<String, String> getAnnotations() {
+            var annotationsNode = objectNode.get("annotations");
+            return objectMapper.convertValue(annotationsNode, new TypeReference<>() {
+            });
+        }
+
+        @Override
+        public Long getVersion() {
+            JsonNode versionNode = objectNode.get("version");
+            return objectMapper.convertValue(versionNode, Long.class);
+        }
+
+        @Override
+        public Instant getCreationTimestamp() {
+            return objectMapper.convertValue(objectNode.get("creationTimestamp"), Instant.class);
+        }
+
+        @Override
+        public Instant getDeletionTimestamp() {
+            return objectMapper.convertValue(objectNode.get("deletionTimestamp"), Instant.class);
+        }
+
+        @Override
+        public Set<String> getFinalizers() {
+            return objectMapper.convertValue(objectNode.get("finalizers"), new TypeReference<>() {
+            });
+        }
+
+        @Override
+        public void setName(String name) {
+            if (name != null) {
+                objectNode.set("name", TextNode.valueOf(name));
+            }
+        }
+
+        @Override
+        public void setGenerateName(String generateName) {
+            if (generateName != null) {
+                objectNode.set("generateName", TextNode.valueOf(generateName));
+            }
+        }
+
+        @Override
+        public void setLabels(Map<String, String> labels) {
+            if (labels != null) {
+                objectNode.set("labels", objectMapper.valueToTree(labels));
+            }
+        }
+
+        @Override
+        public void setAnnotations(Map<String, String> annotations) {
+            if (annotations != null) {
+                objectNode.set("annotations", objectMapper.valueToTree(annotations));
+            }
+        }
+
+        @Override
+        public void setVersion(Long version) {
+            if (version != null) {
+                objectNode.set("version", LongNode.valueOf(version));
+            }
+        }
+
+        @Override
+        public void setCreationTimestamp(Instant creationTimestamp) {
+            if (creationTimestamp != null) {
+                objectNode.set("creationTimestamp", objectMapper.valueToTree(creationTimestamp));
+            }
+        }
+
+        @Override
+        public void setDeletionTimestamp(Instant deletionTimestamp) {
+            if (deletionTimestamp != null) {
+                objectNode.set("deletionTimestamp", objectMapper.valueToTree(deletionTimestamp));
+            }
+        }
+
+        @Override
+        public void setFinalizers(Set<String> finalizers) {
+            if (finalizers != null) {
+                objectNode.set("finalizers", objectMapper.valueToTree(finalizers));
+            }
+        }
+    }
+}

--- a/src/test/java/run/halo/app/extension/JsonExtensionTest.java
+++ b/src/test/java/run/halo/app/extension/JsonExtensionTest.java
@@ -1,0 +1,80 @@
+package run.halo.app.extension;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.json.JsonMapper;
+import com.fasterxml.jackson.databind.node.TextNode;
+import org.json.JSONException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.skyscreamer.jsonassert.JSONAssert;
+
+class JsonExtensionTest {
+
+    ObjectMapper objectMapper;
+
+    @BeforeEach
+    void setUp() {
+        objectMapper = JsonMapper.builder().build();
+    }
+
+    @Test
+    void serializeEmptyExt() throws JsonProcessingException, JSONException {
+        var ext = new JsonExtension(objectMapper);
+        var json = objectMapper.writeValueAsString(ext);
+        JSONAssert.assertEquals("{}", json, true);
+    }
+
+    @Test
+    void serializeExt() throws JsonProcessingException, JSONException {
+        var ext = new JsonExtension(objectMapper);
+        ext.setApiVersion("fake.halo.run/v1alpha");
+        ext.setKind("Fake");
+        var metadata = ext.getMetadataOrCreate();
+        metadata.setName("fake-name");
+
+        ext.getInternal().set("data", TextNode.valueOf("halo"));
+
+        JSONAssert.assertEquals("""
+            {
+              "apiVersion": "fake.halo.run/v1alpha",
+              "kind": "Fake",
+              "metadata": {
+                "name": "fake-name"
+              },
+              "data": "halo"
+            }""", objectMapper.writeValueAsString(ext), true);
+    }
+
+    @Test
+    void deserialize() throws JsonProcessingException {
+        var json = """
+            {
+              "apiVersion": "fake.halo.run/v1alpha1",
+              "kind": "Fake",
+              "metadata": {
+                "name": "faker"
+              },
+              "otherProperty": "otherPropertyValue"
+            }""";
+
+        var ext = objectMapper.readValue(json, JsonExtension.class);
+
+        assertEquals("fake.halo.run/v1alpha1", ext.getApiVersion());
+        assertEquals("Fake", ext.getKind());
+        assertNotNull(ext.getMetadata());
+        assertEquals("faker", ext.getMetadata().getName());
+        assertNull(ext.getMetadata().getVersion());
+        assertNull(ext.getMetadata().getFinalizers());
+        assertNull(ext.getMetadata().getAnnotations());
+        assertNull(ext.getMetadata().getLabels());
+        assertNull(ext.getMetadata().getGenerateName());
+        assertNull(ext.getMetadata().getCreationTimestamp());
+        assertNull(ext.getMetadata().getDeletionTimestamp());
+        assertEquals("otherPropertyValue", ext.getInternal().get("otherProperty").asText());
+    }
+}


### PR DESCRIPTION
#### What type of PR is this?

/kind improvement
/area core

#### What this PR does / why we need it:

This PR mainly creates two things:

1. Create JsonExtension to represent any extension and make extension modification more convenient
2. Discard watch when we detect that the extension status is changed only. It's useful to prevent infinite loop of reconciler.

#### Which issue(s) this PR fixes:

Fixes https://github.com/halo-dev/halo/issues/3273

#### Special notes for your reviewer:

Try to install test plugin from [plugin-comment-widget.zip](https://github.com/halo-dev/halo/files/10799875/plugin-comment-widget.zip) before checking out this PR. You will get a infinite reconciliation loop.

Then, stop the process and checkout this PR and see the result.

#### Does this PR introduce a user-facing change?

```release-note
None
```
