### PR TITLE
Bump up checkout and setup-java actions

### DIFF
--- a/.github/workflows/halo.yaml
+++ b/.github/workflows/halo.yaml
@@ -24,11 +24,11 @@ jobs:
     runs-on: ubuntu-latest
     # Default steps
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           submodules: true
       - name: Set up JDK 17
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v3
         with:
           distribution: 'temurin'
           cache: 'gradle'
@@ -38,11 +38,11 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           submodules: true
       - name: Set up JDK 17
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v3
         with:
           distribution: 'temurin'
           cache: 'gradle'
@@ -53,7 +53,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: test
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: halo-sigs/actions/halo-next-docker-build@main # change the version to specific ref or release tag while the action is stable.
         with:
           image-name: ${{ github.event_name == 'release' && 'halo' || 'halo-dev' }}


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

This PR aims to resolve GitHub workflow warnings which are deprecated by GitHub Action. See https://github.com/halo-dev/halo/issues/3200 for more.

Please note that workflow will always fail before https://github.com/halo-sigs/actions/pull/15 being merged.

#### Which issue(s) this PR fixes:

Fixes https://github.com/halo-dev/halo/issues/3200

#### Does this PR introduce a user-facing change?

```release-note
None
```
