### PR TITLE
feat: add role information for user-related custom endpoint

### DIFF
--- a/src/main/java/run/halo/app/core/extension/endpoint/UserEndpoint.java
+++ b/src/main/java/run/halo/app/core/extension/endpoint/UserEndpoint.java
@@ -73,6 +73,12 @@ public class UserEndpoint implements CustomEndpoint {
                 builder -> builder.operationId("GetUserDetail")
                     .description("Get user detail by name")
                     .tag(tag)
+                    .parameter(parameterBuilder()
+                        .in(ParameterIn.PATH)
+                        .name("name")
+                        .description("User name")
+                        .required(true)
+                    )
                     .response(responseBuilder().implementation(DetailedUser.class)))
             .PUT("/users/-", this::updateProfile,
                 builder -> builder.operationId("UpdateCurrentUser")

--- a/src/main/java/run/halo/app/core/extension/endpoint/UserEndpoint.java
+++ b/src/main/java/run/halo/app/core/extension/endpoint/UserEndpoint.java
@@ -5,6 +5,7 @@ import static java.util.Comparator.comparing;
 import static org.springdoc.core.fn.builders.apiresponse.Builder.responseBuilder;
 import static org.springdoc.core.fn.builders.parameter.Builder.parameterBuilder;
 import static org.springdoc.core.fn.builders.requestbody.Builder.requestBodyBuilder;
+import static run.halo.app.extension.ListResult.generateGenericClass;
 import static run.halo.app.extension.router.QueryParamBuildUtil.buildParametersFromType;
 import static run.halo.app.extension.router.selector.SelectorUtil.labelAndFieldSelectorToPredicate;
 
@@ -124,7 +125,8 @@ public class UserEndpoint implements CustomEndpoint {
                 builder.operationId("ListUsers")
                     .tag(tag)
                     .description("List users")
-                    .response(responseBuilder().implementation(ListedUser.class));
+                    .response(responseBuilder()
+                        .implementation(generateGenericClass(ListedUser.class)));
                 buildParametersFromType(builder, ListRequest.class);
             })
             .build();
@@ -221,7 +223,7 @@ public class UserEndpoint implements CustomEndpoint {
     }
 
     record DetailedUser(@Schema(requiredMode = REQUIRED) User user,
-                        @Schema(requiredMode = REQUIRED) List<Role> role) {
+                        @Schema(requiredMode = REQUIRED) List<Role> roles) {
 
     }
 

--- a/src/main/java/run/halo/app/core/extension/service/DefaultRoleService.java
+++ b/src/main/java/run/halo/app/core/extension/service/DefaultRoleService.java
@@ -10,6 +10,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.ObjectUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.lang.NonNull;
 import org.springframework.stereotype.Service;
@@ -86,6 +87,12 @@ public class DefaultRoleService implements RoleService {
                 });
         }
         return result;
+    }
+
+    @Override
+    public Flux<Role> list(Set<String> roleNames) {
+        return Flux.fromIterable(ObjectUtils.defaultIfNull(roleNames, Set.of()))
+            .flatMap(roleName -> extensionClient.fetch(Role.class, roleName));
     }
 
     @NonNull

--- a/src/main/java/run/halo/app/core/extension/service/RoleService.java
+++ b/src/main/java/run/halo/app/core/extension/service/RoleService.java
@@ -24,4 +24,6 @@ public interface RoleService {
     Flux<RoleRef> listRoleRefs(Subject subject);
 
     List<Role> listDependencies(Set<String> names);
+
+    Flux<Role> list(Set<String> roleNames);
 }

--- a/src/main/java/run/halo/app/core/extension/service/UserServiceImpl.java
+++ b/src/main/java/run/halo/app/core/extension/service/UserServiceImpl.java
@@ -16,6 +16,8 @@ import run.halo.app.core.extension.Role;
 import run.halo.app.core.extension.RoleBinding;
 import run.halo.app.core.extension.User;
 import run.halo.app.extension.ReactiveExtensionClient;
+import run.halo.app.extension.exception.ExtensionNotFoundException;
+import run.halo.app.infra.exception.UserNotFoundException;
 
 @Service
 public class UserServiceImpl implements UserService {
@@ -31,7 +33,9 @@ public class UserServiceImpl implements UserService {
 
     @Override
     public Mono<User> getUser(String username) {
-        return client.get(User.class, username);
+        return client.get(User.class, username)
+            .onErrorMap(ExtensionNotFoundException.class,
+                e -> new UserNotFoundException(username));
     }
 
     @Override

--- a/src/main/resources/extensions/role-template-user.yaml
+++ b/src/main/resources/extensions/role-template-user.yaml
@@ -33,7 +33,7 @@ rules:
     verbs: [ "get", "list" ]
   - apiGroups: [ "api.console.halo.run" ]
     resources: [ "users" ]
-    verbs: [ "get" ]
+    verbs: [ "get", "list" ]
 ---
 apiVersion: v1alpha1
 kind: "Role"

--- a/src/main/resources/extensions/role-template-user.yaml
+++ b/src/main/resources/extensions/role-template-user.yaml
@@ -31,6 +31,9 @@ rules:
   - apiGroups: [ "" ]
     resources: [ "users" ]
     verbs: [ "get", "list" ]
+  - apiGroups: [ "api.console.halo.run" ]
+    resources: [ "users" ]
+    verbs: [ "get" ]
 ---
 apiVersion: v1alpha1
 kind: "Role"

--- a/src/test/java/run/halo/app/core/extension/endpoint/UserEndpointTest.java
+++ b/src/test/java/run/halo/app/core/extension/endpoint/UserEndpointTest.java
@@ -105,6 +105,7 @@ class UserEndpointTest {
                 createUser("fake-user-3")
             );
             var expectResult = new ListResult<>(users);
+            when(roleService.list(anySet())).thenReturn(Flux.empty());
             when(client.list(same(User.class), any(), any(), anyInt(), anyInt()))
                 .thenReturn(Mono.just(expectResult));
 
@@ -132,6 +133,7 @@ class UserEndpointTest {
             var expectResult = new ListResult<>(users);
             when(client.list(same(User.class), any(), any(), anyInt(), anyInt()))
                 .thenReturn(Mono.just(expectResult));
+            when(roleService.list(anySet())).thenReturn(Flux.empty());
 
             bindToRouterFunction(endpoint.endpoint())
                 .build()
@@ -191,6 +193,7 @@ class UserEndpointTest {
             var expectResult = new ListResult<>(users);
             when(client.list(same(User.class), any(), any(), anyInt(), anyInt()))
                 .thenReturn(Mono.just(expectResult));
+            when(roleService.list(anySet())).thenReturn(Flux.empty());
 
             bindToRouterFunction(endpoint.endpoint())
                 .build()
@@ -216,6 +219,7 @@ class UserEndpointTest {
             var expectResult = new ListResult<>(List.of(expectUser));
             when(client.list(same(User.class), any(), any(), anyInt(), anyInt()))
                 .thenReturn(Mono.just(expectResult));
+            when(roleService.list(anySet())).thenReturn(Flux.empty());
 
             bindToRouterFunction(endpoint.endpoint())
                 .build()

--- a/src/test/java/run/halo/app/core/extension/service/UserServiceImplTest.java
+++ b/src/test/java/run/halo/app/core/extension/service/UserServiceImplTest.java
@@ -35,6 +35,7 @@ import run.halo.app.core.extension.User;
 import run.halo.app.extension.Metadata;
 import run.halo.app.extension.ReactiveExtensionClient;
 import run.halo.app.extension.exception.ExtensionNotFoundException;
+import run.halo.app.infra.exception.UserNotFoundException;
 import run.halo.app.infra.utils.JsonUtils;
 
 @ExtendWith(MockitoExtension.class)
@@ -51,11 +52,10 @@ class UserServiceImplTest {
 
     @Test
     void shouldThrowExceptionIfUserNotFoundInExtension() {
-        when(client.get(User.class, "faker")).thenReturn(
+        when(client.get(eq(User.class), eq("faker"))).thenReturn(
             Mono.error(new ExtensionNotFoundException(fromExtension(User.class), "faker")));
-
         StepVerifier.create(userService.getUser("faker"))
-            .verifyError(ExtensionNotFoundException.class);
+            .verifyError(UserNotFoundException.class);
 
         verify(client, times(1)).get(eq(User.class), eq("faker"));
     }
@@ -275,12 +275,12 @@ class UserServiceImplTest {
 
         @Test
         void shouldThrowExceptionIfUserNotFound() {
-            when(client.get(User.class, "fake-user"))
+            when(client.get(eq(User.class), eq("fake-user")))
                 .thenReturn(Mono.error(
                     new ExtensionNotFoundException(fromExtension(User.class), "fake-user")));
 
             StepVerifier.create(userService.updateWithRawPassword("fake-user", "new-password"))
-                .verifyError(ExtensionNotFoundException.class);
+                .verifyError(UserNotFoundException.class);
 
             verify(passwordEncoder, never()).matches(anyString(), anyString());
             verify(passwordEncoder, never()).encode(anyString());


### PR DESCRIPTION
#### What type of PR is this?
/kind feature
/kind api-change
/area core
/milestone 2.3.x

#### What this PR does / why we need it:
获取用户信息的 API 响应体包含关联角色信息

- 新增 API `/apis/api.console.halo.run/v1alpha1/users/{name}`
- 修改了 API 的返回值类型 `/apis/api.console.halo.run/v1alpha1/users/-`

由于 API 响应体结构的改变，需要 Console 适配
#### Which issue(s) this PR fixes:

Fixes #3342

#### Special notes for your reviewer:
/cc @halo-dev/sig-halo 
#### Does this PR introduce a user-facing change?

```release-note
获取用户信息的 API 响应体包含关联角色信息
```
