### PR TITLE
refactor: APIs returns ghost users when user is deleted

### DIFF
--- a/src/main/java/run/halo/app/content/comment/CommentServiceImpl.java
+++ b/src/main/java/run/halo/app/content/comment/CommentServiceImpl.java
@@ -150,6 +150,7 @@ public class CommentServiceImpl implements CommentService {
 
     private Mono<OwnerInfo> getCommentOwnerInfo(Comment.CommentOwner owner) {
         if (User.KIND.equals(owner.getKind())) {
+
             return client.fetch(User.class, owner.getName())
                 .map(OwnerInfo::from)
                 .switchIfEmpty(Mono.just(OwnerInfo.ghostUser()));

--- a/src/main/java/run/halo/app/content/comment/CommentServiceImpl.java
+++ b/src/main/java/run/halo/app/content/comment/CommentServiceImpl.java
@@ -153,7 +153,6 @@ public class CommentServiceImpl implements CommentService {
 
     private Mono<OwnerInfo> getCommentOwnerInfo(Comment.CommentOwner owner) {
         if (User.KIND.equals(owner.getKind())) {
-
             return client.fetch(User.class, owner.getName())
                 .map(OwnerInfo::from)
                 .switchIfEmpty(Mono.just(OwnerInfo.ghostUser()));

--- a/src/main/java/run/halo/app/content/comment/OwnerInfo.java
+++ b/src/main/java/run/halo/app/content/comment/OwnerInfo.java
@@ -2,7 +2,6 @@ package run.halo.app.content.comment;
 
 import lombok.Builder;
 import lombok.Value;
-import org.apache.commons.lang3.StringUtils;
 import run.halo.app.core.extension.User;
 import run.halo.app.core.extension.content.Comment;
 
@@ -58,20 +57,6 @@ public class OwnerInfo {
             .email(user.getSpec().getEmail())
             .avatar(user.getSpec().getAvatar())
             .displayName(user.getSpec().getDisplayName())
-            .build();
-    }
-
-    /**
-     * Obtain a ghost owner info when user not found.
-     *
-     * @return a ghost user if user not found.
-     */
-    public static OwnerInfo ghostUser() {
-        return OwnerInfo.builder()
-            .kind(User.KIND)
-            .name("ghost")
-            .email(StringUtils.EMPTY)
-            .displayName("Ghost")
             .build();
     }
 }

--- a/src/main/java/run/halo/app/content/comment/ReplyServiceImpl.java
+++ b/src/main/java/run/halo/app/content/comment/ReplyServiceImpl.java
@@ -6,6 +6,7 @@ import java.time.Instant;
 import java.util.Comparator;
 import java.util.function.Function;
 import java.util.function.Predicate;
+import lombok.RequiredArgsConstructor;
 import org.apache.commons.lang3.BooleanUtils;
 import org.springframework.security.core.context.ReactiveSecurityContextHolder;
 import org.springframework.stereotype.Service;
@@ -14,6 +15,7 @@ import reactor.core.publisher.Mono;
 import run.halo.app.core.extension.User;
 import run.halo.app.core.extension.content.Comment;
 import run.halo.app.core.extension.content.Reply;
+import run.halo.app.core.extension.service.UserService;
 import run.halo.app.extension.Extension;
 import run.halo.app.extension.ListResult;
 import run.halo.app.extension.ReactiveExtensionClient;
@@ -27,16 +29,12 @@ import run.halo.app.infra.exception.AccessDeniedException;
  * @since 2.0.0
  */
 @Service
+@RequiredArgsConstructor
 public class ReplyServiceImpl implements ReplyService {
 
     private final ReactiveExtensionClient client;
     private final SystemConfigurableEnvironmentFetcher environmentFetcher;
-
-    public ReplyServiceImpl(ReactiveExtensionClient client,
-        SystemConfigurableEnvironmentFetcher environmentFetcher) {
-        this.client = client;
-        this.environmentFetcher = environmentFetcher;
-    }
+    private final UserService userService;
 
     @Override
     public Mono<Reply> create(String commentName, Reply reply) {
@@ -129,7 +127,7 @@ public class ReplyServiceImpl implements ReplyService {
     private Mono<OwnerInfo> getOwnerInfo(Reply reply) {
         Comment.CommentOwner owner = reply.getSpec().getOwner();
         if (User.KIND.equals(owner.getKind())) {
-            return client.fetch(User.class, owner.getName())
+            return userService.userOrGhost(owner.getName())
                 .map(OwnerInfo::from)
                 .switchIfEmpty(Mono.just(OwnerInfo.ghostUser()));
         }

--- a/src/main/java/run/halo/app/content/comment/ReplyServiceImpl.java
+++ b/src/main/java/run/halo/app/content/comment/ReplyServiceImpl.java
@@ -130,7 +130,7 @@ public class ReplyServiceImpl implements ReplyService {
     private Mono<OwnerInfo> getOwnerInfo(Reply reply) {
         Comment.CommentOwner owner = reply.getSpec().getOwner();
         if (User.KIND.equals(owner.getKind())) {
-            return userService.userOrGhost(owner.getName())
+            return userService.getUserOrGhost(owner.getName())
                 .map(OwnerInfo::from)
                 .switchIfEmpty(Mono.just(OwnerInfo.ghostUser()));
         }

--- a/src/main/java/run/halo/app/content/comment/ReplyServiceImpl.java
+++ b/src/main/java/run/halo/app/content/comment/ReplyServiceImpl.java
@@ -131,8 +131,7 @@ public class ReplyServiceImpl implements ReplyService {
         Comment.CommentOwner owner = reply.getSpec().getOwner();
         if (User.KIND.equals(owner.getKind())) {
             return userService.getUserOrGhost(owner.getName())
-                .map(OwnerInfo::from)
-                .switchIfEmpty(Mono.just(OwnerInfo.ghostUser()));
+                .map(OwnerInfo::from);
         }
         if (Comment.CommentOwner.KIND_EMAIL.equals(owner.getKind())) {
             return Mono.just(OwnerInfo.from(owner));

--- a/src/main/java/run/halo/app/content/impl/PostServiceImpl.java
+++ b/src/main/java/run/halo/app/content/impl/PostServiceImpl.java
@@ -194,7 +194,7 @@ public class PostServiceImpl extends AbstractContentService implements PostServi
     }
 
     private Mono<ListedPost> setOwner(String ownerName, ListedPost post) {
-        return userService.userOrGhost(ownerName)
+        return userService.getUserOrGhost(ownerName)
             .map(user -> {
                 Contributor contributor = new Contributor();
                 contributor.setName(user.getMetadata().getName());
@@ -227,7 +227,7 @@ public class PostServiceImpl extends AbstractContentService implements PostServi
             return Flux.empty();
         }
         return Flux.fromIterable(usernames)
-            .flatMap(userService::userOrGhost)
+            .flatMap(userService::getUserOrGhost)
             .map(user -> {
                 Contributor contributor = new Contributor();
                 contributor.setName(user.getMetadata().getName());

--- a/src/main/java/run/halo/app/content/impl/PostServiceImpl.java
+++ b/src/main/java/run/halo/app/content/impl/PostServiceImpl.java
@@ -28,10 +28,10 @@ import run.halo.app.content.PostRequest;
 import run.halo.app.content.PostService;
 import run.halo.app.content.PostSorter;
 import run.halo.app.content.Stats;
-import run.halo.app.core.extension.User;
 import run.halo.app.core.extension.content.Category;
 import run.halo.app.core.extension.content.Post;
 import run.halo.app.core.extension.content.Tag;
+import run.halo.app.core.extension.service.UserService;
 import run.halo.app.extension.ListResult;
 import run.halo.app.extension.ReactiveExtensionClient;
 import run.halo.app.extension.Ref;
@@ -51,11 +51,14 @@ import run.halo.app.metrics.MeterUtils;
 public class PostServiceImpl extends AbstractContentService implements PostService {
     private final ReactiveExtensionClient client;
     private final CounterService counterService;
+    private final UserService userService;
 
-    public PostServiceImpl(ReactiveExtensionClient client, CounterService counterService) {
+    public PostServiceImpl(ReactiveExtensionClient client, CounterService counterService,
+        UserService userService) {
         super(client);
         this.client = client;
         this.counterService = counterService;
+        this.userService = userService;
     }
 
     @Override
@@ -191,7 +194,7 @@ public class PostServiceImpl extends AbstractContentService implements PostServi
     }
 
     private Mono<ListedPost> setOwner(String ownerName, ListedPost post) {
-        return client.fetch(User.class, ownerName)
+        return userService.userOrGhost(ownerName)
             .map(user -> {
                 Contributor contributor = new Contributor();
                 contributor.setName(user.getMetadata().getName());
@@ -224,8 +227,7 @@ public class PostServiceImpl extends AbstractContentService implements PostServi
             return Flux.empty();
         }
         return Flux.fromIterable(usernames)
-            .flatMap(username -> client.fetch(User.class, username)
-                .switchIfEmpty(Mono.defer(() -> client.fetch(User.class, "ghost"))))
+            .flatMap(userService::userOrGhost)
             .map(user -> {
                 Contributor contributor = new Contributor();
                 contributor.setName(user.getMetadata().getName());

--- a/src/main/java/run/halo/app/content/impl/SinglePageServiceImpl.java
+++ b/src/main/java/run/halo/app/content/impl/SinglePageServiceImpl.java
@@ -245,7 +245,7 @@ public class SinglePageServiceImpl extends AbstractContentService implements Sin
     }
 
     private Mono<ListedSinglePage> setOwner(String ownerName, ListedSinglePage page) {
-        return userService.userOrGhost(ownerName)
+        return userService.getUserOrGhost(ownerName)
             .map(user -> {
                 Contributor contributor = new Contributor();
                 contributor.setName(user.getMetadata().getName());
@@ -276,7 +276,7 @@ public class SinglePageServiceImpl extends AbstractContentService implements Sin
             return Flux.empty();
         }
         return Flux.fromIterable(usernames)
-            .flatMap(userService::userOrGhost)
+            .flatMap(userService::getUserOrGhost)
             .map(user -> {
                 Contributor contributor = new Contributor();
                 contributor.setName(user.getMetadata().getName());

--- a/src/main/java/run/halo/app/content/impl/SinglePageServiceImpl.java
+++ b/src/main/java/run/halo/app/content/impl/SinglePageServiceImpl.java
@@ -28,9 +28,9 @@ import run.halo.app.content.SinglePageRequest;
 import run.halo.app.content.SinglePageService;
 import run.halo.app.content.SinglePageSorter;
 import run.halo.app.content.Stats;
-import run.halo.app.core.extension.User;
 import run.halo.app.core.extension.content.Post;
 import run.halo.app.core.extension.content.SinglePage;
+import run.halo.app.core.extension.service.UserService;
 import run.halo.app.extension.ListResult;
 import run.halo.app.extension.ReactiveExtensionClient;
 import run.halo.app.extension.Ref;
@@ -51,11 +51,14 @@ public class SinglePageServiceImpl extends AbstractContentService implements Sin
 
     private final ReactiveExtensionClient client;
     private final CounterService counterService;
+    private final UserService userService;
 
-    public SinglePageServiceImpl(ReactiveExtensionClient client, CounterService counterService) {
+    public SinglePageServiceImpl(ReactiveExtensionClient client, CounterService counterService,
+        UserService userService) {
         super(client);
         this.client = client;
         this.counterService = counterService;
+        this.userService = userService;
     }
 
     @Override
@@ -242,7 +245,7 @@ public class SinglePageServiceImpl extends AbstractContentService implements Sin
     }
 
     private Mono<ListedSinglePage> setOwner(String ownerName, ListedSinglePage page) {
-        return client.fetch(User.class, ownerName)
+        return userService.userOrGhost(ownerName)
             .map(user -> {
                 Contributor contributor = new Contributor();
                 contributor.setName(user.getMetadata().getName());
@@ -273,7 +276,7 @@ public class SinglePageServiceImpl extends AbstractContentService implements Sin
             return Flux.empty();
         }
         return Flux.fromIterable(usernames)
-            .flatMap(username -> client.fetch(User.class, username))
+            .flatMap(userService::userOrGhost)
             .map(user -> {
                 Contributor contributor = new Contributor();
                 contributor.setName(user.getMetadata().getName());

--- a/src/main/java/run/halo/app/core/extension/service/UserService.java
+++ b/src/main/java/run/halo/app/core/extension/service/UserService.java
@@ -10,6 +10,8 @@ public interface UserService {
 
     Mono<User> getUser(String username);
 
+    Mono<User> userOrGhost(String username);
+
     Mono<User> updatePassword(String username, String newPassword);
 
     Mono<User> updateWithRawPassword(String username, String rawPassword);

--- a/src/main/java/run/halo/app/core/extension/service/UserService.java
+++ b/src/main/java/run/halo/app/core/extension/service/UserService.java
@@ -10,7 +10,7 @@ public interface UserService {
 
     Mono<User> getUser(String username);
 
-    Mono<User> userOrGhost(String username);
+    Mono<User> getUserOrGhost(String username);
 
     Mono<User> updatePassword(String username, String newPassword);
 

--- a/src/main/java/run/halo/app/core/extension/service/UserServiceImpl.java
+++ b/src/main/java/run/halo/app/core/extension/service/UserServiceImpl.java
@@ -19,6 +19,7 @@ import run.halo.app.extension.ReactiveExtensionClient;
 
 @Service
 public class UserServiceImpl implements UserService {
+    public static final String GHOST_USER_NAME = "ghost";
 
     private final ReactiveExtensionClient client;
 
@@ -32,6 +33,12 @@ public class UserServiceImpl implements UserService {
     @Override
     public Mono<User> getUser(String username) {
         return client.get(User.class, username);
+    }
+
+    @Override
+    public Mono<User> userOrGhost(String username) {
+        return client.fetch(User.class, username)
+            .switchIfEmpty(Mono.defer(() -> client.fetch(User.class, GHOST_USER_NAME)));
     }
 
     @Override

--- a/src/main/java/run/halo/app/core/extension/service/UserServiceImpl.java
+++ b/src/main/java/run/halo/app/core/extension/service/UserServiceImpl.java
@@ -36,7 +36,7 @@ public class UserServiceImpl implements UserService {
     }
 
     @Override
-    public Mono<User> userOrGhost(String username) {
+    public Mono<User> getUserOrGhost(String username) {
         return client.fetch(User.class, username)
             .switchIfEmpty(Mono.defer(() -> client.fetch(User.class, GHOST_USER_NAME)));
     }

--- a/src/main/java/run/halo/app/core/extension/service/UserServiceImpl.java
+++ b/src/main/java/run/halo/app/core/extension/service/UserServiceImpl.java
@@ -38,7 +38,7 @@ public class UserServiceImpl implements UserService {
     @Override
     public Mono<User> getUserOrGhost(String username) {
         return client.fetch(User.class, username)
-            .switchIfEmpty(Mono.defer(() -> client.fetch(User.class, GHOST_USER_NAME)));
+            .switchIfEmpty(Mono.defer(() -> client.get(User.class, GHOST_USER_NAME)));
     }
 
     @Override

--- a/src/main/java/run/halo/app/theme/finders/impl/CommentFinderImpl.java
+++ b/src/main/java/run/halo/app/theme/finders/impl/CommentFinderImpl.java
@@ -17,7 +17,6 @@ import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import run.halo.app.content.comment.OwnerInfo;
 import run.halo.app.content.comment.ReplyService;
-import run.halo.app.core.extension.User;
 import run.halo.app.core.extension.content.Comment;
 import run.halo.app.core.extension.content.Reply;
 import run.halo.app.core.extension.service.UserService;
@@ -107,7 +106,7 @@ public class CommentFinderImpl implements CommentFinder {
         if (Comment.CommentOwner.KIND_EMAIL.equals(owner.getKind())) {
             return Mono.just(OwnerInfo.from(owner));
         }
-        return userService.userOrGhost(owner.getName())
+        return userService.getUserOrGhost(owner.getName())
             .map(OwnerInfo::from)
             .defaultIfEmpty(OwnerInfo.ghostUser());
     }

--- a/src/main/java/run/halo/app/theme/finders/impl/CommentFinderImpl.java
+++ b/src/main/java/run/halo/app/theme/finders/impl/CommentFinderImpl.java
@@ -107,8 +107,7 @@ public class CommentFinderImpl implements CommentFinder {
             return Mono.just(OwnerInfo.from(owner));
         }
         return userService.getUserOrGhost(owner.getName())
-            .map(OwnerInfo::from)
-            .defaultIfEmpty(OwnerInfo.ghostUser());
+            .map(OwnerInfo::from);
     }
 
     private Mono<Predicate<Comment>> fixedCommentPredicate(Ref ref) {

--- a/src/main/java/run/halo/app/theme/finders/impl/CommentFinderImpl.java
+++ b/src/main/java/run/halo/app/theme/finders/impl/CommentFinderImpl.java
@@ -7,6 +7,7 @@ import java.util.List;
 import java.util.Objects;
 import java.util.function.Function;
 import java.util.function.Predicate;
+import lombok.RequiredArgsConstructor;
 import org.apache.commons.lang3.BooleanUtils;
 import org.apache.commons.lang3.ObjectUtils;
 import org.apache.commons.lang3.StringUtils;
@@ -16,9 +17,9 @@ import org.springframework.util.Assert;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import run.halo.app.content.comment.OwnerInfo;
-import run.halo.app.core.extension.User;
 import run.halo.app.core.extension.content.Comment;
 import run.halo.app.core.extension.content.Reply;
+import run.halo.app.core.extension.service.UserService;
 import run.halo.app.extension.ListResult;
 import run.halo.app.extension.ReactiveExtensionClient;
 import run.halo.app.extension.Ref;
@@ -35,13 +36,11 @@ import run.halo.app.theme.finders.vo.ReplyVo;
  * @since 2.0.0
  */
 @Finder("commentFinder")
+@RequiredArgsConstructor
 public class CommentFinderImpl implements CommentFinder {
 
     private final ReactiveExtensionClient client;
-
-    public CommentFinderImpl(ReactiveExtensionClient client) {
-        this.client = client;
-    }
+    private final UserService userService;
 
     @Override
     public Mono<CommentVo> getByName(String name) {
@@ -108,7 +107,7 @@ public class CommentFinderImpl implements CommentFinder {
         if (Comment.CommentOwner.KIND_EMAIL.equals(owner.getKind())) {
             return Mono.just(OwnerInfo.from(owner));
         }
-        return client.fetch(User.class, owner.getName())
+        return userService.userOrGhost(owner.getName())
             .map(OwnerInfo::from)
             .defaultIfEmpty(OwnerInfo.ghostUser());
     }

--- a/src/main/java/run/halo/app/theme/finders/impl/ContributorFinderImpl.java
+++ b/src/main/java/run/halo/app/theme/finders/impl/ContributorFinderImpl.java
@@ -1,10 +1,10 @@
 package run.halo.app.theme.finders.impl;
 
 import java.util.List;
+import lombok.RequiredArgsConstructor;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
-import run.halo.app.core.extension.User;
-import run.halo.app.extension.ReactiveExtensionClient;
+import run.halo.app.core.extension.service.UserService;
 import run.halo.app.theme.finders.ContributorFinder;
 import run.halo.app.theme.finders.Finder;
 import run.halo.app.theme.finders.vo.ContributorVo;
@@ -16,17 +16,14 @@ import run.halo.app.theme.finders.vo.ContributorVo;
  * @since 2.0.0
  */
 @Finder("contributorFinder")
+@RequiredArgsConstructor
 public class ContributorFinderImpl implements ContributorFinder {
 
-    private final ReactiveExtensionClient client;
-
-    public ContributorFinderImpl(ReactiveExtensionClient client) {
-        this.client = client;
-    }
+    private final UserService userService;
 
     @Override
     public Mono<ContributorVo> getContributor(String name) {
-        return client.fetch(User.class, name)
+        return userService.getUserOrGhost(name)
             .map(ContributorVo::from);
     }
 

--- a/src/test/java/run/halo/app/theme/finders/impl/CommentFinderImplTest.java
+++ b/src/test/java/run/halo/app/theme/finders/impl/CommentFinderImplTest.java
@@ -55,8 +55,8 @@ class CommentFinderImplTest {
     void setUp() {
         User ghost = createUser();
         ghost.getMetadata().setName("ghost");
-        when(userService.userOrGhost(eq("ghost"))).thenReturn(Mono.just(ghost));
-        when(userService.userOrGhost(eq("fake-user"))).thenReturn(Mono.just(createUser()));
+        when(userService.getUserOrGhost(eq("ghost"))).thenReturn(Mono.just(ghost));
+        when(userService.getUserOrGhost(eq("fake-user"))).thenReturn(Mono.just(createUser()));
     }
 
     @Nested
@@ -379,13 +379,13 @@ class CommentFinderImplTest {
     private void extractedUser() {
         User another = createUser();
         another.getMetadata().setName("another");
-        when(userService.userOrGhost(eq("another"))).thenReturn(Mono.just(another));
+        when(userService.getUserOrGhost(eq("another"))).thenReturn(Mono.just(another));
 
         User ghost = createUser();
         ghost.getMetadata().setName("ghost");
-        when(userService.userOrGhost(eq("ghost"))).thenReturn(Mono.just(ghost));
-        when(userService.userOrGhost(eq("fake-user"))).thenReturn(Mono.just(createUser()));
-        when(userService.userOrGhost(any())).thenReturn(Mono.just(ghost));
+        when(userService.getUserOrGhost(eq("ghost"))).thenReturn(Mono.just(ghost));
+        when(userService.getUserOrGhost(eq("fake-user"))).thenReturn(Mono.just(createUser()));
+        when(userService.getUserOrGhost(any())).thenReturn(Mono.just(ghost));
     }
 
     User createUser() {


### PR DESCRIPTION
#### What type of PR is this?
/kind improvement
/area core
/milestone 2.3.x

#### What this PR does / why we need it:
用户被删除时关联到的用户返回 ghost 用户信息

#### Which issue(s) this PR fixes:

Fixes #3356

#### Special notes for your reviewer:
/cc @halo-dev/sig-halo 
#### Does this PR introduce a user-facing change?
```release-note
用户被删除时关联到的用户返回 ghost 用户信息
```
