### PR TITLE
fix: i18n unit test

### DIFF
--- a/src/test/java/run/halo/app/infra/exception/handlers/I18nExceptionTest.java
+++ b/src/test/java/run/halo/app/infra/exception/handlers/I18nExceptionTest.java
@@ -2,6 +2,9 @@ package run.halo.app.infra.exception.handlers;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import java.util.Locale;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.reactive.AutoConfigureWebTestClient;
@@ -25,6 +28,18 @@ class I18nExceptionTest {
     @Autowired
     WebTestClient webClient;
 
+    Locale currentLocale;
+
+    @BeforeEach
+    void setUp() {
+        currentLocale = Locale.getDefault();
+        Locale.setDefault(Locale.ENGLISH);
+    }
+
+    @AfterEach
+    void tearDown() {
+        Locale.setDefault(currentLocale);
+    }
 
     @Test
     void shouldBeOkForGreetingEndpoint() {


### PR DESCRIPTION
#### What type of PR is this?
/kind improvement
/area core

#### What this PR does / why we need it:
修复 i18n 的单元测试，在中文或其他除了英语之外的系统语言的环境下断言无法通过
<img width="883" alt="image" src="https://user-images.githubusercontent.com/38999863/221122828-b3cb2139-21ff-4e44-8ee8-62326aa249bc.png">

可以将系统语言设置为其他来测试此 PR 不会出现上述问题即可

#### Does this PR introduce a user-facing change?
```release-note
None
```
