### PR TITLE
chore: disable the visit log writer

### DIFF
--- a/src/main/java/run/halo/app/metrics/VisitLogWriter.java
+++ b/src/main/java/run/halo/app/metrics/VisitLogWriter.java
@@ -17,7 +17,6 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.springframework.beans.factory.DisposableBean;
 import org.springframework.beans.factory.InitializingBean;
-import org.springframework.stereotype.Component;
 import reactor.core.Disposable;
 import run.halo.app.infra.properties.HaloProperties;
 import run.halo.app.infra.utils.FileUtils;
@@ -29,7 +28,7 @@ import run.halo.app.infra.utils.FileUtils;
  * @since 2.0.0
  */
 @Slf4j
-@Component
+@Deprecated
 public class VisitLogWriter implements InitializingBean, DisposableBean {
     private static final String LOG_FILE_NAME = "visits.log";
     private static final String LOG_FILE_LOCATION = "logs";

--- a/src/test/java/run/halo/app/metrics/VisitLogWriterTest.java
+++ b/src/test/java/run/halo/app/metrics/VisitLogWriterTest.java
@@ -8,6 +8,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
@@ -21,6 +22,8 @@ import run.halo.app.infra.properties.HaloProperties;
  * @author guqing
  * @since 2.0.0
  */
+@Disabled
+@Deprecated
 @ExtendWith(MockitoExtension.class)
 class VisitLogWriterTest {
 


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup
/area core
/milestone 2.3.x

#### What this PR does / why we need it:
移除 VisitLogWriter 的使用，不再记录访问日志，后续由 httptrace 去暴露指标

#### Does this PR introduce a user-facing change?
```release-note
None
```
