### PR TITLE
Add downloadPluginPresets task

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,6 +5,7 @@ plugins {
     id "checkstyle"
     id 'java'
     id 'jacoco'
+    id "de.undercouch.download" version "5.3.1"
 }
 
 group = "run.halo.app"
@@ -126,4 +127,17 @@ jacocoTestReport {
         xml.enabled true
         html.enabled false
     }
+}
+
+tasks.register('downloadPluginPresets', Download) {
+    doFirst {
+        delete 'src/main/resources/presets/plugins'
+    }
+    src([
+            'https://github.com/halo-sigs/plugin-comment-widget/releases/download/v1.2.0/plugin-comment-widget-1.2.0.jar',
+            'https://github.com/halo-sigs/plugin-search-widget/releases/download/v1.0.0/plugin-search-widget-1.0.0.jar',
+            'https://github.com/halo-sigs/plugin-sitemap/releases/download/v1.0.1/plugin-sitemap-1.0.1.jar',
+            'https://github.com/halo-sigs/plugin-feed/releases/download/v1.1.0-beta.1/plugin-feed-1.1.0-beta.1.jar'
+    ])
+    dest 'src/main/resources/presets/plugins'
 }

--- a/build.gradle
+++ b/build.gradle
@@ -134,7 +134,7 @@ tasks.register('downloadPluginPresets', Download) {
         delete 'src/main/resources/presets/plugins'
     }
     src([
-            'https://github.com/halo-sigs/plugin-comment-widget/releases/download/v1.2.0/plugin-comment-widget-1.2.0.jar',
+            'https://github.com/halo-sigs/plugin-comment-widget/releases/download/v1.3.0/plugin-comment-widget-1.3.0.jar',
             'https://github.com/halo-sigs/plugin-search-widget/releases/download/v1.0.0/plugin-search-widget-1.0.0.jar',
             'https://github.com/halo-sigs/plugin-sitemap/releases/download/v1.0.1/plugin-sitemap-1.0.1.jar',
             'https://github.com/halo-sigs/plugin-feed/releases/download/v1.1.0-beta.1/plugin-feed-1.1.0-beta.1.jar'


### PR DESCRIPTION
#### What type of PR is this?

/kind feature
/area core

#### What this PR does / why we need it:

Add downloadPluginPresets task to download plugin presets from GitHub release.

```bash
> Task :downloadPluginPresets
Download https://github.com/halo-sigs/plugin-comment-widget/releases/download/v1.2.0/plugin-comment-widget-1.2.0.jar
Download https://github.com/halo-sigs/plugin-sitemap/releases/download/v1.0.1/plugin-sitemap-1.0.1.jar
Download https://github.com/halo-sigs/plugin-feed/releases/download/v1.1.0-beta.1/plugin-feed-1.1.0-beta.1.jar
Download https://github.com/halo-sigs/plugin-search-widget/releases/download/v1.0.0/plugin-search-widget-1.0.0.jar

Deprecated Gradle features were used in this build, making it incompatible with Gradle 8.0.

You can use '--warning-mode all' to show the individual deprecation warnings and determine if they come from your own scripts or plugins.

See https://docs.gradle.org/7.4/userguide/command_line_interface.html#sec:command_line_warnings

BUILD SUCCESSFUL in 1s
1 actionable task: 1 executed
10:47:59 AM: Execution finished 'downloadPluginPresets'.
```

#### Which issue(s) this PR fixes:

Fixes https://github.com/halo-dev/halo/issues/3120

#### Special notes for your reviewer:

Try to download plugin presets and check theme by using following commands:

```bash
./gradlew downloadPluginPresets

ls -lah src/main/resources/presets/plugins 
```

#### Does this PR introduce a user-facing change?

```release-note
None
```
