### PR TITLE
Correct console ref while building on branch release-2.1

### DIFF
--- a/.github/workflows/halo.yaml
+++ b/.github/workflows/halo.yaml
@@ -61,4 +61,4 @@ jobs:
           dockerhub-user: ${{ secrets.DOCKER_USERNAME }}
           dockerhub-token: ${{ secrets.DOCKER_TOKEN }}
           push: ${{ github.event_name == 'push' || github.event_name == 'release' }} # we only push to GHCR if the push is to the next branch
-          console-ref: ${{ github.event_name == 'release' &&  github.ref || 'main' }}
+          console-ref: ${{ github.event_name == 'release' &&  github.ref || 'release-2.1' }}


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup
/area core

#### What this PR does / why we need it:

Correct console ref while building on branch release-2.1. After that, we can build Halo and console on same branch(release-2.1) instead of main branch of console.

#### Does this PR introduce a user-facing change?

```release-note
None
```
