### PR TITLE
perf: add supports for force updating of post and single page settings

### DIFF
--- a/console/src/modules/contents/posts/components/__tests__/PostSettingModal.spec.ts
+++ b/console/src/modules/contents/posts/components/__tests__/PostSettingModal.spec.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it } from "vitest";
 import { mount } from "@vue/test-utils";
 import PostSettingModal from "../PostSettingModal.vue";
 import { createPinia, setActivePinia } from "pinia";
+import { VueQueryPlugin } from "@tanstack/vue-query";
 
 describe("PostSettingModal", () => {
   beforeEach(() => {
@@ -9,12 +10,19 @@ describe("PostSettingModal", () => {
   });
 
   it("should render", () => {
-    const wrapper = mount({
-      components: {
-        PostSettingModal,
+    const wrapper = mount(
+      {
+        components: {
+          PostSettingModal,
+        },
+        template: `<PostSettingModal></PostSettingModal>`,
       },
-      template: `<PostSettingModal></PostSettingModal>`,
-    });
+      {
+        global: {
+          plugins: [VueQueryPlugin],
+        },
+      }
+    );
     expect(wrapper).toBeDefined();
   });
 });


### PR DESCRIPTION
#### What type of PR is this?

/kind improvement

#### What this PR does / why we need it:

支持强制保存文章和单页面的设置，绕开后端 version 锁的机制，因为目前发现在后端 Reconcile 处理文章较慢时会影响文章的保存。

需要注意的是，这是一个不太合理的处理方式，但目前别无选择。

#### Which issue(s) this PR fixes:

Fixes https://github.com/halo-dev/halo/issues/3339

#### Special notes for your reviewer:

测试方式：

1. 同时打开多个同文章的编辑页面的窗口。
2. 编辑任意一个窗口的文章设置。
3. 然后再去其他窗口保存，观察是否有异常。

#### Does this PR introduce a user-facing change?

```release-note
支持强制保存文章和页面的设置，避免因为 Version 锁的机制导致保存失败。
```
