### PR TITLE
fix: the rawType of Content was not updated when switching editors

### DIFF
--- a/console/src/modules/contents/pages/SinglePageEditor.vue
+++ b/console/src/modules/contents/pages/SinglePageEditor.vue
@@ -48,7 +48,7 @@ const handleChangeEditorProvider = (provider: EditorProvider) => {
   formState.value.page.metadata.annotations = {
     "content.halo.run/preferred-editor": provider.name,
   };
-  formState.value.content.rawType = provider.rawType
+  formState.value.content.rawType = provider.rawType;
 };
 
 // SinglePage form

--- a/console/src/modules/contents/pages/SinglePageEditor.vue
+++ b/console/src/modules/contents/pages/SinglePageEditor.vue
@@ -48,6 +48,7 @@ const handleChangeEditorProvider = (provider: EditorProvider) => {
   formState.value.page.metadata.annotations = {
     "content.halo.run/preferred-editor": provider.name,
   };
+  formState.value.content.rawType = provider.rawType
 };
 
 // SinglePage form

--- a/console/src/modules/contents/posts/PostEditor.vue
+++ b/console/src/modules/contents/posts/PostEditor.vue
@@ -48,6 +48,7 @@ const handleChangeEditorProvider = (provider: EditorProvider) => {
   formState.value.post.metadata.annotations = {
     "content.halo.run/preferred-editor": provider.name,
   };
+  formState.value.content.rawType = provider.rawType
 };
 
 // Post form

--- a/console/src/modules/contents/posts/PostEditor.vue
+++ b/console/src/modules/contents/posts/PostEditor.vue
@@ -48,7 +48,7 @@ const handleChangeEditorProvider = (provider: EditorProvider) => {
   formState.value.post.metadata.annotations = {
     "content.halo.run/preferred-editor": provider.name,
   };
-  formState.value.content.rawType = provider.rawType
+  formState.value.content.rawType = provider.rawType;
 };
 
 // Post form


### PR DESCRIPTION

#### What type of PR is this?

/kind bug


#### What this PR does / why we need it:

修复在新建文章时，首次切换编辑器后没有设置内容 rawType 资源为对应编辑器类型的问题。

#### Which issue(s) this PR fixes:

Fixes #3512 

#### Special notes for your reviewer:

测试方式：

1. 安装任意一个编辑器插件，比如：https://github.com/halo-sigs/plugin-stackedit
1. 新建文章，选择安装的编辑器。
1. 发布文章。
1. 卸载或者停止编辑器。
1. 重新编辑刚刚创建的文章，如果提示 `未找到符合 markdown 格式的编辑器，请检查是否已安装编辑器插件` 则代表正常。

#### Does this PR introduce a user-facing change?

```release-note
修复在新建文章时，首次切换编辑器后没有设置内容 rawType 资源为对应编辑器类型的问题。
```
