### PR TITLE
feat: role binding extension supports binding to other roles

### DIFF
--- a/application/src/main/java/run/halo/app/security/authorization/RbacRequestEvaluation.java
+++ b/application/src/main/java/run/halo/app/security/authorization/RbacRequestEvaluation.java
@@ -109,12 +109,37 @@ public class RbacRequestEvaluation {
         if (ArrayUtils.isEmpty(rule.getResourceNames())) {
             return true;
         }
+        String[] requestedNameParts = ArrayUtils.nullToEmpty(StringUtils.split(requestedName, "/"));
         for (String ruleName : rule.getResourceNames()) {
-            if (Objects.equals(ruleName, requestedName)) {
-                return true;
+            String[] patternParts = StringUtils.split(ruleName, "/");
+
+            for (int i = 0; i < patternParts.length; i++) {
+                String patternPart = patternParts[i];
+                String textPart = StringUtils.EMPTY;
+                if (requestedNameParts.length > i) {
+                    textPart = requestedNameParts[i];
+                }
+
+                if (!matchPart(patternPart, textPart)) {
+                    return false;
+                }
             }
+
+            return true;
         }
         return false;
+    }
+
+    private static boolean matchPart(String patternPart, String textPart) {
+        if (patternPart.equals("*")) {
+            return true;
+        } else if (patternPart.startsWith("*")) {
+            return textPart.endsWith(patternPart.substring(1));
+        } else if (patternPart.endsWith("*")) {
+            return textPart.startsWith(patternPart.substring(0, patternPart.length() - 1));
+        } else {
+            return patternPart.equals(textPart);
+        }
     }
 
     protected boolean nonResourceURLMatches(Role.PolicyRule rule, String requestedURL) {

--- a/application/src/test/java/run/halo/app/security/authorization/RbacRequestEvaluationTest.java
+++ b/application/src/test/java/run/halo/app/security/authorization/RbacRequestEvaluationTest.java
@@ -1,0 +1,47 @@
+package run.halo.app.security.authorization;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+import org.junit.jupiter.api.Test;
+import run.halo.app.core.extension.Role;
+
+/**
+ * Tests for {@link RbacRequestEvaluation}.
+ *
+ * @author guqing
+ * @since 2.4.0
+ */
+class RbacRequestEvaluationTest {
+
+    @Test
+    void resourceNameMatches() {
+        RbacRequestEvaluation rbacRequestEvaluation = new RbacRequestEvaluation();
+        assertThat(matchResourceName(rbacRequestEvaluation, "", "fake/test")).isTrue();
+        assertThat(matchResourceName(rbacRequestEvaluation, "", "fake")).isTrue();
+        assertThat(matchResourceName(rbacRequestEvaluation, "", "")).isTrue();
+        assertThat(matchResourceName(rbacRequestEvaluation, "*", null)).isTrue();
+
+        assertThat(matchResourceName(rbacRequestEvaluation, "*/test", "fake/test")).isTrue();
+
+        assertThat(matchResourceName(rbacRequestEvaluation, "*/test", "hello/test")).isTrue();
+        assertThat(matchResourceName(rbacRequestEvaluation, "*/test", "hello/fake")).isFalse();
+
+        assertThat(matchResourceName(rbacRequestEvaluation, "test/*", "hello/fake")).isFalse();
+        assertThat(matchResourceName(rbacRequestEvaluation, "test/*", "test/fake")).isTrue();
+        assertThat(matchResourceName(rbacRequestEvaluation, "test/*", "test")).isTrue();
+        assertThat(matchResourceName(rbacRequestEvaluation, "test/*", "hello")).isFalse();
+
+        assertThat(matchResourceName(rbacRequestEvaluation, "*/*", "test/fake")).isTrue();
+        assertThat(matchResourceName(rbacRequestEvaluation, "*/*", "test")).isTrue();
+
+        assertThat(matchResourceName(rbacRequestEvaluation, "*", "test")).isTrue();
+        assertThat(matchResourceName(rbacRequestEvaluation, "*", "hello")).isTrue();
+    }
+
+    boolean matchResourceName(RbacRequestEvaluation rbacRequestEvaluation, String rule,
+        String requestedName) {
+        return rbacRequestEvaluation.resourceNameMatches(new Role.PolicyRule.Builder()
+            .resourceNames(rule)
+            .build(), requestedName);
+    }
+}


### PR DESCRIPTION
#### What type of PR is this?
/kind feature
/milestone 2.4.x
/area core

#### What this PR does / why we need it:
RoleBinding 自定义模型支持绑定到其他角色

see #3560 for more details.

how to test it?
创建一个测试角色和和一个 RoleBinding 将此角色的绑定到其他角色，在不修改用户权限的情况下，用户将拥有新创建的测试角色的权限。

#### Which issue(s) this PR fixes:

Fixes #3560

#### Does this PR introduce a user-facing change?

```release-note
RoleBinding 自定义模型支持绑定到其他角色
```
