### PR TITLE
fix: unable to login again after using oauth providers login

### DIFF
--- a/console/src/components/login/LoginForm.vue
+++ b/console/src/components/login/LoginForm.vue
@@ -70,8 +70,6 @@ const handleLogin = async () => {
 
     await userStore.fetchCurrentUser();
 
-    localStorage.setItem("logged_in", "true");
-
     emit("succeed");
   } catch (e: unknown) {
     console.error("Failed to login", e);

--- a/console/src/router/guards/auth-check.ts
+++ b/console/src/router/guards/auth-check.ts
@@ -10,7 +10,7 @@ export function setupAuthCheckGuard(router: Router) {
 
     const userStore = useUserStore();
 
-    if (localStorage.getItem("logged_in") !== "true" || userStore.isAnonymous) {
+    if (userStore.isAnonymous) {
       next({ name: "Login" });
       return;
     }

--- a/console/src/utils/api-client.ts
+++ b/console/src/utils/api-client.ts
@@ -94,7 +94,6 @@ axiosInstance.interceptors.response.use(
       const userStore = useUserStore();
       userStore.loginModalVisible = true;
       Toast.warning(i18n.global.t("core.common.toast.login_expired"));
-      localStorage.removeItem("logged_in");
     } else if (status === 403) {
       Toast.error(i18n.global.t("core.common.toast.forbidden"));
     } else if (status === 404) {


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/area console

#### What this PR does / why we need it:

修复使用非本地认证登录之后，无法重新登录的问题。此问题来源是三方登录方式登录之后没有在 localStorage 存入 `logged_in` 的 flag。并且在引入匿名用户之后，本身也不再需要这个 flag。

#### Which issue(s) this PR fixes:

Fixes #3569 

#### Special notes for your reviewer:

测试方式：

1. 使用 https://github.com/halo-sigs/plugin-oauth2/pull/3 插件配置 OAuth 2 的登录方式。
2. 在个人资料中绑定配置的登录方式。
3. 测试登录之后退出，再进行登录。

#### Does this PR introduce a user-facing change?

```release-note
None
```
