### PR TITLE
perf: improve styles of bottom menu in mobile devices

### DIFF
--- a/console/src/layouts/BasicLayout.vue
+++ b/console/src/layouts/BasicLayout.vue
@@ -327,14 +327,9 @@ onMounted(() => {
         <div
           class="flex w-full cursor-pointer items-center justify-center p-1 text-white"
         >
-          <div
-            class="is-active is-active0 flex h-10 w-10 flex-col items-center justify-center"
-          >
+          <div class="flex h-10 w-10 flex-col items-center justify-center">
             <div class="text-base">
               <Component :is="menu?.icon" />
-            </div>
-            <div class="mt-0.5 text-xs">
-              {{ menu?.name }}
             </div>
           </div>
         </div>
@@ -343,14 +338,9 @@ onMounted(() => {
         <div
           class="flex w-full cursor-pointer items-center justify-center p-1 text-white"
         >
-          <div
-            class="is-active is-active0 flex h-10 w-10 flex-col items-center justify-center"
-          >
+          <div class="flex h-10 w-10 flex-col items-center justify-center">
             <div class="text-base">
               <IconMore />
-            </div>
-            <div class="mt-0.5 text-xs">
-              {{ $t("core.sidebar.operations.more.button") }}
             </div>
           </div>
         </div>

--- a/console/src/locales/en.yaml
+++ b/console/src/locales/en.yaml
@@ -38,8 +38,6 @@ core:
         settings: Settings
         actuator: Actuator
     operations:
-      more:
-        button: More
       logout:
         button: Logout
         title: Are you sure you want to log out?

--- a/console/src/locales/zh-CN.yaml
+++ b/console/src/locales/zh-CN.yaml
@@ -38,8 +38,6 @@ core:
         settings: 设置
         actuator: 概览
     operations:
-      more:
-        button: 更多
       logout:
         button: 退出登录
         title: 确定要退出登录吗？

--- a/console/src/modules/contents/pages/module.ts
+++ b/console/src/modules/contents/pages/module.ts
@@ -29,7 +29,6 @@ export default definePlugin({
               group: "content",
               icon: markRaw(IconPages),
               priority: 1,
-              mobile: true,
             },
           },
         },

--- a/console/src/modules/system/actuator/module.ts
+++ b/console/src/modules/system/actuator/module.ts
@@ -22,7 +22,6 @@ export default definePlugin({
               group: "system",
               icon: markRaw(IconTerminalBoxLine),
               priority: 3,
-              mobile: true,
             },
           },
         },


### PR DESCRIPTION
#### What type of PR is this?

/kind improvement
/area console
/milestone 2.4.x

#### What this PR does / why we need it:

优化移动端底部菜单栏的布局和样式。

before:

<img width="349" alt="image" src="https://user-images.githubusercontent.com/21301288/227410375-87e7b6bb-1528-425e-ac58-fdba809c2bf3.png">

after:

<img width="394" alt="image" src="https://user-images.githubusercontent.com/21301288/227410199-9fb04304-0ff3-4a8f-9a9f-38a5031b0c05.png">

#### Which issue(s) this PR fixes:

Fixes #3575 

#### Does this PR introduce a user-facing change?

```release-note
优化 Console 在移动端下底部菜单栏的布局和样式。
```
