### PR TITLE
fix: unapproved replies are included in the reply count of comments

### DIFF
--- a/api/src/main/java/run/halo/app/core/extension/content/Comment.java
+++ b/api/src/main/java/run/halo/app/core/extension/content/Comment.java
@@ -123,6 +123,8 @@ public class Comment extends AbstractExtension {
 
         private Integer replyCount;
 
+        private Integer visibleReplyCount;
+
         private Integer unreadReplyCount;
 
         private Boolean hasNewReply;

--- a/application/src/main/java/run/halo/app/event/post/ReplyChangedEvent.java
+++ b/application/src/main/java/run/halo/app/event/post/ReplyChangedEvent.java
@@ -6,9 +6,9 @@ import run.halo.app.core.extension.content.Reply;
  * @author guqing
  * @since 2.0.0
  */
-public class ReplyCreatedEvent extends ReplyEvent {
+public class ReplyChangedEvent extends ReplyEvent {
 
-    public ReplyCreatedEvent(Object source, Reply reply) {
+    public ReplyChangedEvent(Object source, Reply reply) {
         super(source, reply);
     }
 }


### PR DESCRIPTION
#### What type of PR is this?
/kind improvement
/area core
/milestone 2.4.x
/kind api-change

#### What this PR does / why we need it:
修复未审核过的回复包含在了评论的回复数量中的问题

此改动需要评论组件修改回复数量取值为 `status.visibleReplyCount`

how to test it?
1. 创建评论，并在评论下回复
2. 评论的所有回复被计数在 `status.replyCount` 中
3. 而 `status.visibleReplyCount` 数量不包含 `spec.hiden=true` 或 `spec.approved = false` 的

#### Which issue(s) this PR fixes:
Fixes #3165

#### Does this PR introduce a user-facing change?

```release-note
修复未审核过的回复包含在了评论的回复数量中的问题
```
