### PR TITLE
fix: NPE when stopping the plugin after the plugin startup fails

### DIFF
--- a/application/src/main/java/run/halo/app/plugin/HaloPluginManager.java
+++ b/application/src/main/java/run/halo/app/plugin/HaloPluginManager.java
@@ -142,7 +142,9 @@ public class HaloPluginManager extends DefaultPluginManager
         }
         try {
             log.info("Stop plugin '{}'", getPluginLabel(pluginDescriptor));
-            pluginWrapper.getPlugin().stop();
+            if (pluginWrapper.getPlugin() != null) {
+                pluginWrapper.getPlugin().stop();
+            }
             pluginWrapper.setPluginState(PluginState.STOPPED);
             // release plugin resources
             releaseAdditionalResources(pluginId);
@@ -304,7 +306,9 @@ public class HaloPluginManager extends DefaultPluginManager
                     rootApplicationContext.publishEvent(
                         new HaloPluginBeforeStopEvent(this, pluginWrapper));
                     log.info("Stop plugin '{}'", getPluginLabel(pluginWrapper.getDescriptor()));
-                    pluginWrapper.getPlugin().stop();
+                    if (pluginWrapper.getPlugin() != null) {
+                        pluginWrapper.getPlugin().stop();
+                    }
                     pluginWrapper.setPluginState(PluginState.STOPPED);
                     itr.remove();
                     releaseAdditionalResources(pluginWrapper.getPluginId());


### PR DESCRIPTION
#### What type of PR is this?
/kind improvement
/area core
/milestone 2.4.x

#### What this PR does / why we need it:
修复插件启动失败后停止插件时出现的 NPE 问题

how to test it?
见 #3579，先使用 issue 描述步骤复现问题，在切换到此 PR 尝试相同步骤

#### Which issue(s) this PR fixes:

Fixes #3579

#### Does this PR introduce a user-facing change?
```release-note
修复插件启动失败后停止插件时出现的 NPE 问题
```
