### PR TITLE
Change type of SettingFetcher from interface into abstract class

### DIFF
--- a/api/src/main/java/run/halo/app/plugin/SettingFetcher.java
+++ b/api/src/main/java/run/halo/app/plugin/SettingFetcher.java
@@ -4,12 +4,17 @@ import com.fasterxml.jackson.databind.JsonNode;
 import java.util.Map;
 import java.util.Optional;
 
-public interface SettingFetcher {
+/**
+ * SettingFetcher must be a class instead of an interface due to backward compatibility.
+ *
+ * @author johnniang
+ */
+public abstract class SettingFetcher {
 
-    <T> Optional<T> fetch(String group, Class<T> clazz);
+    public abstract <T> Optional<T> fetch(String group, Class<T> clazz);
 
-    JsonNode get(String group);
+    public abstract JsonNode get(String group);
 
-    Map<String, JsonNode> getValues();
+    public abstract Map<String, JsonNode> getValues();
 
 }

--- a/application/src/main/java/run/halo/app/plugin/DefaultSettingFetcher.java
+++ b/application/src/main/java/run/halo/app/plugin/DefaultSettingFetcher.java
@@ -21,7 +21,7 @@ import run.halo.app.infra.utils.JsonUtils;
  * @author guqing
  * @since 2.0.0
  */
-public class DefaultSettingFetcher implements SettingFetcher {
+public class DefaultSettingFetcher extends SettingFetcher {
 
     private final ExtensionClient extensionClient;
 


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/area core

#### What this PR does / why we need it:

Change type of SettingFetcher from interface into abstract class for backward compatibility. See https://github.com/halo-dev/halo/issues/3592 for more.

#### Which issue(s) this PR fixes:

Fixes https://github.com/halo-dev/halo/issues/3592

#### Special notes for your reviewer:

Please use [plugin-search-widget](https://github.com/halo-sigs/plugin-search-widget) to test.

#### Does this PR introduce a user-facing change?

```release-note
None
```
