### PR TITLE
fix: the issue of failing to unbind third-party login

### DIFF
--- a/console/src/modules/system/users/UserDetail.vue
+++ b/console/src/modules/system/users/UserDetail.vue
@@ -35,7 +35,7 @@ const handleUnbindAuth = (authProvider: ListedAuthProvider) => {
     confirmText: t("core.common.buttons.confirm"),
     cancelText: t("core.common.buttons.cancel"),
     onConfirm: async () => {
-      await axios.post(
+      await axios.put(
         `${import.meta.env.VITE_API_URL}${authProvider.unbindingUrl}`,
         {
           withCredentials: true,


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/area console
/milestone 2.4.x

#### What this PR does / why we need it:

修复解绑三方登录失败的问题，原因是解绑接口是 put 请求，但请求接口时用了 post 请求。

#### Special notes for your reviewer:

测试方式：

1. 安装 OAuth2 插件：https://github.com/halo-sigs/plugin-oauth2/pull/3
2. 配置某个三方的 OAuth 登录。
3. 测试在个人资料中的绑定和解绑三方登录。

#### Does this PR introduce a user-facing change?

```release-note
None
```
