### PR TITLE
chore: bump console and packages version to 2.4.0-rc.1

### DIFF
--- a/console/package.json
+++ b/console/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@halo-dev/console",
-  "version": "2.3.0",
+  "version": "2.4.0-rc.1",
   "scripts": {
     "prepare": "cd .. && husky install console/.husky",
     "dev": "vite --host",

--- a/console/packages/api-client/package.json
+++ b/console/packages/api-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@halo-dev/api-client",
-  "version": "2.3.0",
+  "version": "2.4.0-rc.1",
   "description": "",
   "scripts": {
     "build": "unbuild",

--- a/console/packages/shared/package.json
+++ b/console/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@halo-dev/console-shared",
-  "version": "2.3.0",
+  "version": "2.4.0-rc.1",
   "description": "",
   "files": [
     "dist"


### PR DESCRIPTION
#### What type of PR is this?

/area console
/milestone 2.4.0

#### What this PR does / why we need it:

修改 Console 以及其下 packages 的版本为 2.4.0-rc.1

#### Does this PR introduce a user-facing change?

```release-note
None
```
