### PR TITLE
Make referrer-policy configurable

### DIFF
--- a/application/src/main/java/run/halo/app/config/WebServerSecurityConfig.java
+++ b/application/src/main/java/run/halo/app/config/WebServerSecurityConfig.java
@@ -1,7 +1,6 @@
 package run.halo.app.config;
 
 import static org.springframework.security.config.Customizer.withDefaults;
-import static org.springframework.security.web.server.header.ReferrerPolicyServerHttpHeadersWriter.ReferrerPolicy.STRICT_ORIGIN_WHEN_CROSS_ORIGIN;
 import static org.springframework.security.web.server.header.XFrameOptionsServerHttpHeadersWriter.Mode.SAMEORIGIN;
 import static org.springframework.security.web.server.util.matcher.ServerWebExchangeMatchers.pathMatchers;
 
@@ -81,7 +80,8 @@ public class WebServerSecurityConfig {
     @Bean
     @Order(Ordered.HIGHEST_PRECEDENCE + 1)
     SecurityWebFilterChain portalFilterChain(ServerHttpSecurity http,
-        ServerSecurityContextRepository securityContextRepository) {
+        ServerSecurityContextRepository securityContextRepository,
+        HaloProperties haloProperties) {
         var pathMatcher = pathMatchers(HttpMethod.GET, "/**");
         var mediaTypeMatcher = new MediaTypeServerWebExchangeMatcher(MediaType.TEXT_HTML);
         mediaTypeMatcher.setIgnoredMediaTypes(Set.of(MediaType.ALL));
@@ -90,7 +90,8 @@ public class WebServerSecurityConfig {
             .securityContextRepository(securityContextRepository)
             .headers()
             .frameOptions().mode(SAMEORIGIN)
-            .referrerPolicy().policy(STRICT_ORIGIN_WHEN_CROSS_ORIGIN).and()
+            .referrerPolicy(
+                spec -> spec.policy(haloProperties.getSecurity().getReferrerOptions().getPolicy()))
             .cache().disable().and()
             .anonymous(spec -> spec.authenticationFilter(
                 new HaloAnonymousAuthenticationWebFilter("portal", AnonymousUserConst.PRINCIPAL,

--- a/application/src/main/java/run/halo/app/infra/properties/SecurityProperties.java
+++ b/application/src/main/java/run/halo/app/infra/properties/SecurityProperties.java
@@ -1,11 +1,23 @@
 package run.halo.app.infra.properties;
 
+import static org.springframework.security.web.server.header.ReferrerPolicyServerHttpHeadersWriter.ReferrerPolicy.STRICT_ORIGIN_WHEN_CROSS_ORIGIN;
+
 import lombok.Data;
+import org.springframework.security.web.server.header.ReferrerPolicyServerHttpHeadersWriter.ReferrerPolicy;
 
 @Data
 public class SecurityProperties {
 
     private final Initializer initializer = new Initializer();
+
+    private final ReferrerOptions referrerOptions = new ReferrerOptions();
+
+    @Data
+    public static class ReferrerOptions {
+
+        private ReferrerPolicy policy = STRICT_ORIGIN_WHEN_CROSS_ORIGIN;
+
+    }
 
     @Data
     public static class Initializer {


### PR DESCRIPTION
#### What type of PR is this?

/kind feature
/area core

#### What this PR does / why we need it:

This PR provides a configuration item to control referrer-policy header. Default is `strict-origin-when-cross-origin`.

```yaml
halo:
  security:
    referrer-options:
      policy: no-referrer
```

#### Which issue(s) this PR fixes:

Fixes https://github.com/halo-dev/halo/issues/3064

#### Does this PR introduce a user-facing change?

```release-note
提供配置以控制站点引用策略（Referrer-Policy）
```
