### PR TITLE
chore: add FloatingDropdown to solve compatibility issues

### DIFF
--- a/console/package.json
+++ b/console/package.json
@@ -66,6 +66,7 @@
     "dayjs": "^1.11.6",
     "emoji-mart": "^5.3.3",
     "fastq": "^1.15.0",
+    "floating-vue": "2.0.0-beta.20",
     "fuse.js": "^6.6.2",
     "jsencrypt": "^3.3.2",
     "lodash.clonedeep": "^4.5.0",

--- a/console/pnpm-lock.yaml
+++ b/console/pnpm-lock.yaml
@@ -65,6 +65,7 @@ importers:
       eslint-plugin-cypress: ^2.12.1
       eslint-plugin-vue: ^9.8.0
       fastq: ^1.15.0
+      floating-vue: 2.0.0-beta.20
       fuse.js: ^6.6.2
       husky: ^8.0.2
       jsdom: ^20.0.3
@@ -140,6 +141,7 @@ importers:
       dayjs: 1.11.6
       emoji-mart: 5.3.3
       fastq: 1.15.0
+      floating-vue: 2.0.0-beta.20_vue@3.2.45
       fuse.js: 6.6.2
       jsencrypt: 3.3.2
       lodash.clonedeep: 4.5.0
@@ -3645,6 +3647,7 @@ packages:
 
   /@tiptap/prosemirror-tables/1.1.4_jdrte4nkwfesllz53h6f6dfkhi:
     resolution: {integrity: sha512-O2XnDhZV7xTHSFxMMl8Ei3UVeCxuMlbGYZ+J2QG8CzkK8mxDpBa66kFr5DdyAhvdi1ptpcH9u7/GMwItQpN4sA==}
+    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
     peerDependencies:
       prosemirror-keymap: ^1.1.2
       prosemirror-model: ^1.8.1

--- a/console/src/setup/setupComponents.ts
+++ b/console/src/setup/setupComponents.ts
@@ -1,5 +1,7 @@
 import type { App } from "vue";
 import { VClosePopper, VTooltip } from "@halo-dev/components";
+import { Dropdown } from "floating-vue";
+import "floating-vue/dist/style.css";
 // @ts-ignore
 import VueGridLayout from "vue-grid-layout";
 import { defaultConfig, plugin as FormKit } from "@formkit/vue";
@@ -16,4 +18,7 @@ export function setupComponents(app: App) {
 
   app.directive("tooltip", VTooltip);
   app.directive("close-popper", VClosePopper);
+  // @deprecated
+  // Will be removed in the future, please use the VDropdown component from @halo-dev/components.
+  app.component("FloatingDropdown", Dropdown);
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind improvement
/area console
/milestone 2.4.x

#### What this PR does / why we need it:

重新在全局注册 FloatingDropdown 组件，因为在 https://github.com/halo-dev/halo/pull/3576 中移除之后，会导致插件无法正常加载 FloatingDropdown 组件，从而带来破坏更新。

#### Which issue(s) this PR fixes:

Fixes #3621 

#### Does this PR introduce a user-facing change?

```release-note
None
```
