### PR TITLE
fix: the loading status is not displayed when loading auth providers

### DIFF
--- a/console/src/modules/system/auth-providers/AuthProviders.vue
+++ b/console/src/modules/system/auth-providers/AuthProviders.vue
@@ -1,5 +1,10 @@
 <script lang="ts" setup>
-import { VPageHeader, IconLockPasswordLine, VCard } from "@halo-dev/components";
+import {
+  VPageHeader,
+  IconLockPasswordLine,
+  VCard,
+  VLoading,
+} from "@halo-dev/components";
 import { useQuery } from "@tanstack/vue-query";
 import { apiClient } from "@/utils/api-client";
 import type { ListedAuthProvider } from "@halo-dev/api-client";


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/area console
/milestone 2.4.x

#### What this PR does / why we need it:

修复认证方式管理页面在加载时不显示加载状态的问题。

#### Does this PR introduce a user-facing change?

```release-note
None
```
