### PR TITLE
perf: change the default role in user settings to select input type

### DIFF
--- a/application/src/main/resources/extensions/system-setting.yaml
+++ b/application/src/main/resources/extensions/system-setting.yaml
@@ -71,7 +71,7 @@ spec:
           name: allowRegistration
           label: "开放注册"
           value: false
-        - $formkit: text
+        - $formkit: roleSelect
           name: defaultRole
           label: "默认角色"
     - group: comment


### PR DESCRIPTION
#### What type of PR is this?

/area core
/kind improvement
/milestone 2.4.0

#### What this PR does / why we need it:

将系统设置中的用户注册的默认角色输入框改为选择框。

<img width="575" alt="image" src="https://user-images.githubusercontent.com/21301288/228888394-8355b71e-7d18-46bf-b177-569fa7b311d6.png">

#### Special notes for your reviewer:

测试 `系统设置 -> 用户设置` 中的默认角色是否可以正常设置即可。

#### Does this PR introduce a user-facing change?

```release-note
None
```
