### PR TITLE
refactor: do not disable when auth provider deleted

### DIFF
--- a/application/src/main/java/run/halo/app/core/extension/reconciler/AuthProviderReconciler.java
+++ b/application/src/main/java/run/halo/app/core/extension/reconciler/AuthProviderReconciler.java
@@ -1,7 +1,5 @@
 package run.halo.app.core.extension.reconciler;
 
-import java.util.HashSet;
-import java.util.Set;
 import lombok.RequiredArgsConstructor;
 import org.apache.commons.lang3.BooleanUtils;
 import org.springframework.stereotype.Component;
@@ -22,21 +20,13 @@ import run.halo.app.security.AuthProviderService;
 @Component
 @RequiredArgsConstructor
 public class AuthProviderReconciler implements Reconciler<Reconciler.Request> {
-    private static final String FINALIZER_NAME = "auth-provider-protection";
     private final ExtensionClient client;
     private final AuthProviderService authProviderService;
 
     @Override
     public Result reconcile(Request request) {
         client.fetch(AuthProvider.class, request.name())
-            .ifPresent(authProvider -> {
-                if (authProvider.getMetadata().getDeletionTimestamp() != null) {
-                    removeFinalizer(request.name());
-                    return;
-                }
-                addFinalizerIfNecessary(authProvider);
-                handlePrivileged(authProvider);
-            });
+            .ifPresent(this::handlePrivileged);
         return Result.doNotRetry();
     }
 
@@ -51,36 +41,6 @@ public class AuthProviderReconciler implements Reconciler<Reconciler.Request> {
         if (privileged(authProvider)) {
             authProviderService.enable(authProvider.getMetadata().getName()).block();
         }
-    }
-
-    private void addFinalizerIfNecessary(AuthProvider oldAuthProvider) {
-        Set<String> finalizers = oldAuthProvider.getMetadata().getFinalizers();
-        if (finalizers != null && finalizers.contains(FINALIZER_NAME)) {
-            return;
-        }
-        client.fetch(AuthProvider.class, oldAuthProvider.getMetadata().getName())
-            .ifPresent(authProvider -> {
-                Set<String> newFinalizers = authProvider.getMetadata().getFinalizers();
-                if (newFinalizers == null) {
-                    newFinalizers = new HashSet<>();
-                    authProvider.getMetadata().setFinalizers(newFinalizers);
-                }
-                newFinalizers.add(FINALIZER_NAME);
-                client.update(authProvider);
-            });
-    }
-
-    private void removeFinalizer(String authProviderName) {
-        client.fetch(AuthProvider.class, authProviderName)
-            .ifPresent(authProvider -> {
-                // Disable auth provider
-                authProviderService.disable(authProviderName).block();
-
-                if (authProvider.getMetadata().getFinalizers() != null) {
-                    authProvider.getMetadata().getFinalizers().remove(FINALIZER_NAME);
-                }
-                client.update(authProvider);
-            });
     }
 
     private boolean privileged(AuthProvider authProvider) {


### PR DESCRIPTION
#### What type of PR is this?
/kind improvement
/area core
/milestone 2.4.0

#### What this PR does / why we need it:
移除 AuthProviderReconciler 中关于 authProvier 数据被删除时禁用它提供的登录方式的逻辑
当第三方登录插件如 plugin-oauth2 被停止时不应该从已启用的登录配置中移除 auth provider name，这会导致插件被停用在启用后需要重新启用登录方式。
之前之所以如此是想着去掉 system configmap 中的配置残余，虽然现在去掉了 Reconciler 但为了确保数据干净或许还得想其他办法来解决它，但目前不是重点也没有一个很好的办法，或许可以在插件中去做，比如当插件被卸载的生命周期方法中去更新 ConfigMap 中关于此项的配置。

#### Does this PR introduce a user-facing change?
```release-note
None
```
