### PR TITLE
chore: bump console version to 2.4.0

### DIFF
--- a/console/package.json
+++ b/console/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@halo-dev/console",
-  "version": "2.4.0-rc.1",
+  "version": "2.4.0",
   "scripts": {
     "prepare": "cd .. && husky install console/.husky",
     "dev": "vite --host",

--- a/console/packages/api-client/package.json
+++ b/console/packages/api-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@halo-dev/api-client",
-  "version": "2.4.0-rc.1",
+  "version": "2.4.0",
   "description": "",
   "scripts": {
     "build": "unbuild",

--- a/console/packages/components/package.json
+++ b/console/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@halo-dev/components",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "",
   "files": [
     "dist"

--- a/console/packages/shared/package.json
+++ b/console/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@halo-dev/console-shared",
-  "version": "2.4.0-rc.1",
+  "version": "2.4.0",
   "description": "",
   "files": [
     "dist"


### PR DESCRIPTION
#### What type of PR is this?

/kind improvement
/area console
/milestone 2.4.0

#### What this PR does / why we need it:

修改 Console 的版本号为 2.4.0。

修改 `@halo-dev/components` 的版本为 1.3.0

#### Does this PR introduce a user-facing change?

```release-note
None
```
