### PR TITLE
Configure default external-url as slash

### DIFF
--- a/application/src/main/resources/application.yaml
+++ b/application/src/main/resources/application.yaml
@@ -28,7 +28,7 @@ spring:
           max-age: 365d
 
 halo:
-  external-url: "http://${server.address:localhost}:${server.port}"
+  external-url: "/"
   work-dir: ${user.home}/.halo2
   plugin:
     plugins-root: ${halo.work-dir}/plugins

--- a/console/.env.development
+++ b/console/.env.development
@@ -1,2 +1,2 @@
-VITE_API_URL=http://localhost:8090
+VITE_API_URL=
 VITE_BASE_URL=/console/


### PR DESCRIPTION
#### What type of PR is this?

/kind improvement
/area core

#### What this PR does / why we need it:

Configure default external-url as slash. So that system will generate relative links for all permalinks.

See https://github.com/halo-dev/halo/issues/3654 for more.

#### Which issue(s) this PR fixes:

Fixes https://github.com/halo-dev/halo/issues/3654

#### Does this PR introduce a user-facing change?

```release-note
None
```
