### PR TITLE
Fix the problem of ServerHttpResponse already committed after logging in

### DIFF
--- a/application/src/main/java/run/halo/app/security/authentication/login/UsernamePasswordAuthenticator.java
+++ b/application/src/main/java/run/halo/app/security/authentication/login/UsernamePasswordAuthenticator.java
@@ -113,6 +113,10 @@ public class UsernamePasswordAuthenticator implements AdditionalWebFilter {
             return ignoringMediaTypeAll(MediaType.APPLICATION_JSON)
                 .matches(webFilterExchange.getExchange())
                 .filter(ServerWebExchangeMatcher.MatchResult::isMatch)
+                .switchIfEmpty(
+                    defaultHandler.onAuthenticationSuccess(webFilterExchange, authentication)
+                        .then(Mono.empty())
+                )
                 .flatMap(matchResult -> {
                     var principal = authentication.getPrincipal();
                     if (principal instanceof CredentialsContainer credentialsContainer) {
@@ -124,10 +128,7 @@ public class UsernamePasswordAuthenticator implements AdditionalWebFilter {
                         .bodyValue(principal)
                         .flatMap(serverResponse ->
                             serverResponse.writeTo(webFilterExchange.getExchange(), context));
-                })
-                .switchIfEmpty(
-                    defaultHandler.onAuthenticationSuccess(webFilterExchange, authentication)
-                );
+                });
         }
     }
 


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/area core

#### What this PR does / why we need it:

Move `defaultHandler#onAuthenticationSuccess` up to response write, or it will be executed always.

#### Which issue(s) this PR fixes:

Fixes https://github.com/halo-dev/halo/issues/3553

#### Special notes for your reviewer:

Try to login and see the log detail.

#### Does this PR introduce a user-facing change?

```release-note
修复登录成功或失败后报错的问题
```
