### PR TITLE
fix: attachment policy editing modal crashes when opened

### DIFF
--- a/console/src/modules/contents/attachments/components/AttachmentPolicyEditingModal.vue
+++ b/console/src/modules/contents/attachments/components/AttachmentPolicyEditingModal.vue
@@ -207,32 +207,34 @@ const onVisibleChange = (visible: boolean) => {
     :width="600"
     @update:visible="onVisibleChange"
   >
-    <FormKit
-      v-if="formSchema && configMapFormData"
-      id="attachment-policy-form"
-      v-model="configMapFormData['default']"
-      name="attachment-policy-form"
-      :actions="false"
-      :preserve="true"
-      type="form"
-      :config="{ validationVisibility: 'submit' }"
-      @submit="handleSave"
-    >
+    <div>
       <FormKit
-        id="displayNameInput"
-        v-model="formState.spec.displayName"
-        :label="
-          $t('core.attachment.policy_editing_modal.fields.display_name.label')
-        "
-        type="text"
-        name="displayName"
-        validation="required|length:0,50"
-      ></FormKit>
-      <FormKitSchema
-        :schema="formSchema"
-        :data="configMapFormData['default']"
-      />
-    </FormKit>
+        v-if="formSchema && configMapFormData"
+        id="attachment-policy-form"
+        v-model="configMapFormData['default']"
+        name="attachment-policy-form"
+        :actions="false"
+        :preserve="true"
+        type="form"
+        :config="{ validationVisibility: 'submit' }"
+        @submit="handleSave"
+      >
+        <FormKit
+          id="displayNameInput"
+          v-model="formState.spec.displayName"
+          :label="
+            $t('core.attachment.policy_editing_modal.fields.display_name.label')
+          "
+          type="text"
+          name="displayName"
+          validation="required|length:0,50"
+        ></FormKit>
+        <FormKitSchema
+          :schema="formSchema"
+          :data="configMapFormData['default']"
+        />
+      </FormKit>
+    </div>
 
     <template #footer>
       <VSpace>


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/area console
/milestone 2.5.x

#### What this PR does / why we need it:

修复附件存储策略编辑表单无法正常渲染的问题。此问题原因为 Modal 组件使用了 OverlayScrollbars 库来模拟滚动条，但在初始化的时候由于 Body 没有任何子元素，所以导致异常。

#### Which issue(s) this PR fixes:

Fixes #3662 

#### Special notes for your reviewer:

测试是否能够正常打开附件存储策略编辑表单即可。

#### Does this PR introduce a user-facing change?

```release-note
修复 Console 端附件存储策略编辑表单无法正常渲染的问题
```
