### PR TITLE
fix: route title i18n in global search is not compatible

### DIFF
--- a/console/src/components/global-search/GlobalSearchModal.vue
+++ b/console/src/components/global-search/GlobalSearchModal.vue
@@ -76,7 +76,7 @@ const handleBuildSearchIndex = () => {
 
   routes.forEach((route) => {
     fuse.add({
-      title: route.meta?.title as string,
+      title: t(route.meta?.title as string),
       icon: {
         component: markRaw(IconLink),
       },


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/area console
/cherry-pick release-2.4

#### What this PR does / why we need it:

修复后台全局搜索中关于 Console 路由的文字没有适配 i18n 的问题。

#### Which issue(s) this PR fixes:

Fixes #3664 

#### Special notes for your reviewer:

<img width="741" alt="image" src="https://user-images.githubusercontent.com/21301288/229279243-4b727cc7-1790-41b3-a170-4958ce1f65a8.png">

#### Does this PR introduce a user-facing change?

```release-note
修复后台全局搜索中关于 Console 路由的文字没有适配 i18n 的问题。
```
