### PR TITLE
fix: publish time of the post cannot be displayed back

### DIFF
--- a/console/src/modules/contents/pages/SinglePageEditor.vue
+++ b/console/src/modules/contents/pages/SinglePageEditor.vue
@@ -62,7 +62,7 @@ const initialFormState: SinglePageRequest = {
       cover: "",
       deleted: false,
       publish: false,
-      publishTime: "",
+      publishTime: undefined,
       pinned: false,
       allowComment: true,
       visible: "PUBLIC",

--- a/console/src/modules/contents/pages/components/SinglePageSettingModal.vue
+++ b/console/src/modules/contents/pages/components/SinglePageSettingModal.vue
@@ -28,7 +28,7 @@ const initialFormState: SinglePage = {
     cover: "",
     deleted: false,
     publish: false,
-    publishTime: "",
+    publishTime: undefined,
     pinned: false,
     allowComment: true,
     visible: "PUBLIC",
@@ -286,17 +286,15 @@ watchEffect(() => {
 const { templates } = useThemeCustomTemplates("page");
 
 // publishTime
-const publishTime = computed(() => {
-  const { publishTime } = formState.value.spec;
-  if (publishTime) {
-    return toDatetimeLocal(publishTime);
-  }
-  return "";
+const publishTime = computed({
+  get() {
+    const { publishTime } = formState.value.spec;
+    return publishTime ? toDatetimeLocal(publishTime) : undefined;
+  },
+  set(value) {
+    formState.value.spec.publishTime = value ? toISOString(value) : undefined;
+  },
 });
-
-const onPublishTimeChange = (value: string) => {
-  formState.value.spec.publishTime = value ? toISOString(value) : undefined;
-};
 
 // slug
 const { handleGenerateSlug } = useSlugify(
@@ -443,11 +441,10 @@ const { handleGenerateSlug } = useSlugify(
               type="select"
             ></FormKit>
             <FormKit
-              :model-value="publishTime"
+              v-model="publishTime"
               :label="$t('core.page.settings.fields.publish_time.label')"
               type="datetime-local"
               name="publishTime"
-              @input="onPublishTimeChange"
             ></FormKit>
             <FormKit
               v-model="formState.spec.template"

--- a/console/src/modules/contents/posts/PostEditor.vue
+++ b/console/src/modules/contents/posts/PostEditor.vue
@@ -62,7 +62,7 @@ const initialFormState: PostRequest = {
       cover: "",
       deleted: false,
       publish: false,
-      publishTime: "",
+      publishTime: undefined,
       pinned: false,
       allowComment: true,
       visible: "PUBLIC",

--- a/console/src/modules/contents/posts/components/PostSettingModal.vue
+++ b/console/src/modules/contents/posts/components/PostSettingModal.vue
@@ -28,7 +28,7 @@ const initialFormState: Post = {
     cover: "",
     deleted: false,
     publish: false,
-    publishTime: "",
+    publishTime: undefined,
     pinned: false,
     allowComment: true,
     visible: "PUBLIC",
@@ -247,17 +247,15 @@ watchEffect(() => {
 const { templates } = useThemeCustomTemplates("post");
 
 // publishTime convert
-const publishTime = computed(() => {
-  const { publishTime } = formState.value.spec;
-  if (publishTime) {
-    return toDatetimeLocal(publishTime);
-  }
-  return "";
+const publishTime = computed({
+  get() {
+    const { publishTime } = formState.value.spec;
+    return publishTime ? toDatetimeLocal(publishTime) : undefined;
+  },
+  set(value) {
+    formState.value.spec.publishTime = value ? toISOString(value) : undefined;
+  },
 });
-
-const onPublishTimeChange = (value: string) => {
-  formState.value.spec.publishTime = value ? toISOString(value) : undefined;
-};
 
 const annotationsFormRef = ref<InstanceType<typeof AnnotationsForm>>();
 
@@ -418,10 +416,9 @@ const { handleGenerateSlug } = useSlugify(
               type="select"
             ></FormKit>
             <FormKit
-              :model-value="publishTime"
+              v-model="publishTime"
               :label="$t('core.post.settings.fields.publish_time.label')"
               type="datetime-local"
-              @input="onPublishTimeChange"
             ></FormKit>
             <FormKit
               v-model="formState.spec.template"


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/area console
/milestone 2.5.x
/cherry-pick release-2.4

#### What this PR does / why we need it:

修复文章设置中的发布时间无法回显导致重新保存时丢失发布时间的问题。

#### Which issue(s) this PR fixes:

Fixes #3669 

#### Special notes for your reviewer:

测试方式：

1. 新建或者修改已有文章的设置。
2. 检查时间输入框的时间是否显示正确。
3. 检查保存之后时间是否显示正确。

#### Does this PR introduce a user-facing change?

```release-note
修复 Console 端文章设置中的发布时间无法回显导致重新保存时丢失发布时间的问题。
```
