### PR TITLE
fix: lost the activated theme settings when saving the system settings

### DIFF
--- a/console/src/composables/use-setting-form.ts
+++ b/console/src/composables/use-setting-form.ts
@@ -219,6 +219,14 @@ export function useSettingFormConvert(
           configMap.value?.data?.[form.group] || "{}"
         );
       });
+
+      Object.keys(configMap.value?.data || {}).forEach((key) => {
+        if (!forms?.find((item) => item.group === key)) {
+          configMapFormData.value[key] = JSON.parse(
+            configMap.value?.data?.[key] || "{}"
+          );
+        }
+      });
     },
     {
       immediate: true,
@@ -236,8 +244,16 @@ export function useSettingFormConvert(
       [key: string]: string;
     } = {};
 
-    setting.value?.spec.forms.forEach((item: SettingForm) => {
+    const { forms } = setting.value?.spec || {};
+
+    forms?.forEach((item: SettingForm) => {
       data[item.group] = JSON.stringify(configMapFormData?.value?.[item.group]);
+    });
+
+    Object.keys(configMap.value?.data || {}).forEach((key) => {
+      if (!forms?.find((item) => item.group === key)) {
+        data[key] = configMap.value?.data?.[key] || "{}";
+      }
     });
 
     configMapToUpdate.data = data;


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/area console
/milestone 2.5.x

#### What this PR does / why we need it:

修复保存系统设置之后，启用主题的设置丢失，恢复为了默认主题。原因是因为在 https://github.com/halo-dev/halo/pull/3606 中使用了新的 useSettingFormConvert 方法，但这个方法未考虑到某些 ConfigMap 的分组并未在表单中定义，也就是数据转换方法是以表单的定义为基准，所以丢失了 `theme.active` 设置。

#### Which issue(s) this PR fixes:

Fixes #3673 

#### Special notes for your reviewer:

测试方式：

1. 安装若干主题并启用。
2. 然后去系统设置修改任意数据并保存。
3. 检查主题是否被修改为默认主题。

#### Does this PR introduce a user-facing change?

```release-note
修复保存系统设置之后导致激活主题的设置值丢失，恢复为了默认主题的问题。
```
