### PR TITLE
Enable mapper feature: accept case-insensitive enums

### DIFF
--- a/application/src/main/java/run/halo/app/config/HaloConfiguration.java
+++ b/application/src/main/java/run/halo/app/config/HaloConfiguration.java
@@ -1,6 +1,7 @@
 package run.halo.app.config;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.databind.MapperFeature;
 import org.springframework.boot.autoconfigure.jackson.Jackson2ObjectMapperBuilderCustomizer;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -14,6 +15,7 @@ public class HaloConfiguration {
     Jackson2ObjectMapperBuilderCustomizer objectMapperCustomizer() {
         return builder -> {
             builder.serializationInclusion(JsonInclude.Include.NON_NULL);
+            builder.featuresToEnable(MapperFeature.ACCEPT_CASE_INSENSITIVE_ENUMS);
         };
     }
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind improvement
/area core

#### What this PR does / why we need it:

After enabling this mapper feature, we could pass a enum value with any case in request body(JSON format).

See https://github.com/FasterXML/jackson-databind/blob/39fdb63607a0e7a6dbf9d6be84fe7e380e661dcb/src/test/java/com/fasterxml/jackson/databind/deser/enums/EnumDeserializationTest.java#L22 for more.

#### Does this PR introduce a user-facing change?

```release-note
None
```
