### PR TITLE
Set property server.forward-header-strategy to framework by default

### DIFF
--- a/application/src/main/resources/application.yaml
+++ b/application/src/main/resources/application.yaml
@@ -1,5 +1,6 @@
 server:
   port: 8090
+  forward-headers-strategy: framework
   compression:
     enabled: true
   error:

--- a/application/src/test/java/run/halo/app/XForwardHeaderTest.java
+++ b/application/src/test/java/run/halo/app/XForwardHeaderTest.java
@@ -1,0 +1,55 @@
+package run.halo.app;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDOM_PORT;
+import static org.springframework.web.reactive.function.server.RequestPredicates.GET;
+import static org.springframework.web.reactive.function.server.RouterFunctions.route;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.context.annotation.Bean;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.reactive.function.server.RouterFunction;
+import org.springframework.web.reactive.function.server.ServerResponse;
+import reactor.test.StepVerifier;
+
+@SpringBootTest(webEnvironment = RANDOM_PORT,
+    properties = "server.forward-headers-strategy=framework")
+class XForwardHeaderTest {
+
+    @LocalServerPort
+    int port;
+
+    @Test
+    void shouldGetCorrectProtoFromXForwardHeaders() {
+        var response = WebClient.create("http://localhost:" + port)
+            .get().uri("/print-uri")
+            .header("X-Forwarded-Proto", "https")
+            .header("X-Forwarded-Host", "halo.run")
+            .header("X-Forwarded-Port", "6666")
+            .retrieve()
+            .toEntity(String.class);
+        StepVerifier.create(response)
+            .assertNext(entity -> {
+                assertEquals(HttpStatus.OK, entity.getStatusCode());
+                assertEquals("\"https://halo.run:6666/print-uri\"", entity.getBody());
+            })
+            .verifyComplete();
+    }
+
+    @TestConfiguration
+    static class Configuration {
+
+        @Bean
+        RouterFunction<ServerResponse> printUri() {
+            return route(GET("/print-uri"),
+                request -> {
+                    var uri = request.exchange().getRequest().getURI();
+                    return ServerResponse.ok().bodyValue(uri);
+                });
+        }
+    }
+}


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/area core

#### What this PR does / why we need it:

Set property `server.forward-header-strategy` to `framework` to enable handling `X-Forwarded*` headers correctly.

By default, Spring won't handle `X-Forwarded*` headers. It doesn't work correctly if Halo is running back reverse proxy server.

Supported headers: <https://github.com/spring-projects/spring-framework/blob/310344cf615339ec330031da127737a41400b6cd/spring-web/src/main/java/org/springframework/web/server/adapter/ForwardedHeaderTransformer.java#L63-L69>.

#### Which issue(s) this PR fixes:

Fixes https://github.com/halo-dev/halo/issues/3670

#### Does this PR introduce a user-facing change?

```release-note
解决反向代理后无法正确获取当前请求 URI 的问题
```
