### PR TITLE
fix: repeated display of theme tabs.

### DIFF
--- a/console/src/modules/interface/themes/layouts/ThemeLayout.vue
+++ b/console/src/modules/interface/themes/layouts/ThemeLayout.vue
@@ -89,18 +89,21 @@ const { data: setting } = useQuery<Setting>({
   async onSuccess(data) {
     if (data) {
       const { forms } = data.spec;
-      tabs.value = forms.map((item: SettingForm) => {
-        return {
-          id: item.group,
-          label: item.label || "",
-          route: {
-            name: "ThemeSetting",
-            params: {
-              group: item.group,
+      tabs.value = [
+        ...initialTabs,
+        ...forms.map((item: SettingForm) => {
+          return {
+            id: item.group,
+            label: item.label || "",
+            route: {
+              name: "ThemeSetting",
+              params: {
+                group: item.group,
+              },
             },
-          },
-        };
-      });
+          };
+        }),
+      ] as ThemeTab[];
     }
 
     await nextTick();

--- a/console/src/modules/interface/themes/layouts/ThemeLayout.vue
+++ b/console/src/modules/interface/themes/layouts/ThemeLayout.vue
@@ -89,21 +89,18 @@ const { data: setting } = useQuery<Setting>({
   async onSuccess(data) {
     if (data) {
       const { forms } = data.spec;
-      tabs.value = [
-        ...tabs.value,
-        ...forms.map((item: SettingForm) => {
-          return {
-            id: item.group,
-            label: item.label || "",
-            route: {
-              name: "ThemeSetting",
-              params: {
-                group: item.group,
-              },
+      tabs.value = forms.map((item: SettingForm) => {
+        return {
+          id: item.group,
+          label: item.label || "",
+          route: {
+            name: "ThemeSetting",
+            params: {
+              group: item.group,
             },
-          };
-        }),
-      ] as ThemeTab[];
+          },
+        };
+      });
     }
 
     await nextTick();

--- a/console/src/modules/system/plugins/layouts/PluginLayout.vue
+++ b/console/src/modules/system/plugins/layouts/PluginLayout.vue
@@ -88,7 +88,7 @@ const { data: setting } = useQuery({
     if (data) {
       const { forms } = data.spec;
       tabs.value = [
-        ...tabs.value,
+        ...initialTabs,
         ...forms.map((item: SettingForm) => {
           return {
             id: item.group,


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/area console

#### What this PR does / why we need it:
获取主题配置时，重复添加了上次已经获取到的主题配置，导致重复显示。并同步修改了 plugin 中可能出现问题的位置。

#### Which issue(s) this PR fixes:

Fixes #3726 

#### Special notes for your reviewer:
1. 打开 Console 端主题页面
2. 点击右上角预览页面
3. 关闭预览页面，选项卡无重复即为正常。


#### Does this PR introduce a user-facing change?
```release-note
修复 Console 端主题设置中，选项卡会重复显示的问题
```
