### PR TITLE
Fix the problem that generateing OpenAPI defined in Plugin may not work

### DIFF
--- a/api/src/main/java/run/halo/app/extension/ListResult.java
+++ b/api/src/main/java/run/halo/app/extension/ListResult.java
@@ -9,8 +9,6 @@ import java.util.List;
 import java.util.function.Supplier;
 import java.util.stream.Stream;
 import lombok.Data;
-import net.bytebuddy.ByteBuddy;
-import net.bytebuddy.description.type.TypeDescription;
 import org.springframework.util.Assert;
 import run.halo.app.infra.utils.GenericClassUtils;
 
@@ -96,15 +94,12 @@ public class ListResult<T> implements Iterable<T>, Supplier<Stream<T>> {
      * @return generic ListResult class.
      */
     public static Class<?> generateGenericClass(Scheme scheme) {
-        var generic =
-            TypeDescription.Generic.Builder.parameterizedType(ListResult.class, scheme.type())
-                .build();
-        return new ByteBuddy()
-            .subclass(generic)
-            .name(scheme.groupVersionKind().kind() + "List")
-            .make()
-            .load(ListResult.class.getClassLoader())
-            .getLoaded();
+        return GenericClassUtils.generateConcreteClass(ListResult.class,
+            scheme.type(),
+            () -> {
+                var pkgName = scheme.type().getPackageName();
+                return pkgName + '.' + scheme.groupVersionKind().kind() + "List";
+            });
     }
 
     /**
@@ -116,7 +111,7 @@ public class ListResult<T> implements Iterable<T>, Supplier<Stream<T>> {
      */
     public static <T> Class<?> generateGenericClass(Class<T> type) {
         return GenericClassUtils.generateConcreteClass(ListResult.class, type,
-            () -> type.getSimpleName() + "List");
+            () -> type.getName() + "List");
     }
 
     public static <T> ListResult<T> emptyResult() {

--- a/api/src/main/java/run/halo/app/infra/utils/GenericClassUtils.java
+++ b/api/src/main/java/run/halo/app/infra/utils/GenericClassUtils.java
@@ -19,7 +19,7 @@ public enum GenericClassUtils {
      */
     public static <T> Class<?> generateConcreteClass(Class<?> rawClass, Class<T> parameterType) {
         return generateConcreteClass(rawClass, parameterType, () ->
-            parameterType.getSimpleName() + rawClass.getSimpleName());
+            parameterType.getName() + rawClass.getSimpleName());
     }
 
     /**
@@ -39,7 +39,7 @@ public enum GenericClassUtils {
             .subclass(concreteType)
             .name(nameGenerator.get())
             .make()) {
-            return unloaded.load(rawClass.getClassLoader()).getLoaded();
+            return unloaded.load(parameterType.getClassLoader()).getLoaded();
         } catch (IOException e) {
             // Should never happen
             throw Exceptions.propagate(e);

--- a/api/src/test/java/run/halo/app/infra/utils/GenericClassUtilsTest.java
+++ b/api/src/test/java/run/halo/app/infra/utils/GenericClassUtilsTest.java
@@ -1,0 +1,19 @@
+package run.halo.app.infra.utils;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+import run.halo.app.core.extension.content.Post;
+import run.halo.app.extension.ListResult;
+
+class GenericClassUtilsTest {
+
+    @Test
+    void generateConcreteClass() {
+        var clazz = GenericClassUtils.generateConcreteClass(ListResult.class, Post.class,
+            () -> Post.class.getName() + "List");
+        assertEquals("run.halo.app.core.extension.content.PostList", clazz.getName());
+        assertEquals("run.halo.app.core.extension.content", clazz.getPackageName());
+    }
+
+}


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/area core

#### What this PR does / why we need it:

- Use the class loader belonging to the parameter type when creating a generic class.
- Use full qualified class name when generating a generic class.

Before testing, you have to set property `springdoc.cache.disabled` to `true`.

#### Which issue(s) this PR fixes:

Fixes #3728 

#### Does this PR introduce a user-facing change?

```release-note
None
```
