### PR TITLE
Expose attachment service to plugin

### DIFF
--- a/api/src/main/java/run/halo/app/core/extension/attachment/Attachment.java
+++ b/api/src/main/java/run/halo/app/core/extension/attachment/Attachment.java
@@ -56,7 +56,11 @@ public class Attachment extends AbstractExtension {
     @Data
     public static class AttachmentStatus {
 
-        @Schema(description = "Permalink of attachment")
+        @Schema(description = """
+            Permalink of attachment.
+            If it is in local storage, the public URL will be set.
+            If it is in s3 storage, the Object URL will be set.
+            """)
         private String permalink;
 
     }

--- a/api/src/main/java/run/halo/app/core/extension/attachment/Constant.java
+++ b/api/src/main/java/run/halo/app/core/extension/attachment/Constant.java
@@ -1,5 +1,7 @@
 package run.halo.app.core.extension.attachment;
 
+import run.halo.app.core.extension.attachment.endpoint.AttachmentHandler;
+
 public enum Constant {
     ;
 
@@ -14,6 +16,13 @@ public enum Constant {
      */
     public static final String URI_ANNO_KEY = GROUP + "/uri";
 
+    /**
+     * Do not use this key to set external link. You could implement
+     * {@link AttachmentHandler#getPermalink(Attachment)} by your self.
+     * <p>
+     *
+     * @deprecated Use your own group instead.
+     */
     public static final String EXTERNAL_LINK_ANNO_KEY = GROUP + "/external-link";
 
     public static final String FINALIZER_NAME = "attachment-manager";

--- a/api/src/main/java/run/halo/app/core/extension/attachment/Constant.java
+++ b/api/src/main/java/run/halo/app/core/extension/attachment/Constant.java
@@ -18,7 +18,7 @@ public enum Constant {
 
     /**
      * Do not use this key to set external link. You could implement
-     * {@link AttachmentHandler#getPermalink(Attachment)} by your self.
+     * {@link AttachmentHandler#getPermalink} by your self.
      * <p>
      *
      * @deprecated Use your own group instead.

--- a/api/src/main/java/run/halo/app/core/extension/attachment/endpoint/AttachmentHandler.java
+++ b/api/src/main/java/run/halo/app/core/extension/attachment/endpoint/AttachmentHandler.java
@@ -1,5 +1,7 @@
 package run.halo.app.core.extension.attachment.endpoint;
 
+import java.net.URI;
+import java.time.Duration;
 import org.pf4j.ExtensionPoint;
 import org.springframework.http.codec.multipart.FilePart;
 import reactor.core.publisher.Mono;
@@ -12,6 +14,44 @@ public interface AttachmentHandler extends ExtensionPoint {
     Mono<Attachment> upload(UploadContext context);
 
     Mono<Attachment> delete(DeleteContext context);
+
+    /**
+     * Gets a shared URL which could be accessed publicly.
+     * 1. If the attachment is in local storage, the permalink will be returned.
+     * 2. If the attachment is in s3 storage, the Presigned URL will be returned.
+     * <p>
+     * Please note that the default implementation is only for back compatibility.
+     *
+     * @param attachment contains detail of attachment.
+     * @param policy is storage policy.
+     * @param configMap contains configuration needed by handler.
+     * @param ttl indicates how long the URL is alive.
+     * @return shared URL which could be accessed publicly. Might be relative URL.
+     */
+    default Mono<URI> getSharedURL(Attachment attachment,
+        Policy policy,
+        ConfigMap configMap,
+        Duration ttl) {
+        return Mono.empty();
+    }
+
+    /**
+     * Gets a permalink representing a unique attachment.
+     * If the attachment is in local storage, the permalink will be returned.
+     * If the attachment is in s3 storage, the Object URL will be returned.
+     * <p>
+     * Please note that the default implementation is only for back compatibility.
+     *
+     * @param attachment contains detail of attachment.
+     * @param policy is storage policy.
+     * @param configMap contains configuration needed by handler.
+     * @return permalink representing a unique attachment. Might be relative URL.
+     */
+    default Mono<URI> getPermalink(Attachment attachment,
+        Policy policy,
+        ConfigMap configMap) {
+        return Mono.empty();
+    }
 
     interface UploadContext {
 

--- a/api/src/main/java/run/halo/app/core/extension/attachment/endpoint/AttachmentHandler.java
+++ b/api/src/main/java/run/halo/app/core/extension/attachment/endpoint/AttachmentHandler.java
@@ -31,12 +31,4 @@ public interface AttachmentHandler extends ExtensionPoint {
         ConfigMap configMap();
     }
 
-    record UploadOption(FilePart file,
-                        Policy policy,
-                        ConfigMap configMap) implements UploadContext {
-    }
-
-    record DeleteOption(Attachment attachment, Policy policy, ConfigMap configMap)
-        implements DeleteContext {
-    }
 }

--- a/api/src/main/java/run/halo/app/core/extension/attachment/endpoint/DeleteOption.java
+++ b/api/src/main/java/run/halo/app/core/extension/attachment/endpoint/DeleteOption.java
@@ -1,0 +1,9 @@
+package run.halo.app.core.extension.attachment.endpoint;
+
+import run.halo.app.core.extension.attachment.Attachment;
+import run.halo.app.core.extension.attachment.Policy;
+import run.halo.app.extension.ConfigMap;
+
+public record DeleteOption(Attachment attachment, Policy policy, ConfigMap configMap)
+    implements AttachmentHandler.DeleteContext {
+}

--- a/api/src/main/java/run/halo/app/core/extension/attachment/endpoint/SimpleFilePart.java
+++ b/api/src/main/java/run/halo/app/core/extension/attachment/endpoint/SimpleFilePart.java
@@ -1,0 +1,40 @@
+package run.halo.app.core.extension.attachment.endpoint;
+
+import java.nio.file.Path;
+import org.springframework.core.io.buffer.DataBuffer;
+import org.springframework.core.io.buffer.DataBufferUtils;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.http.codec.multipart.FilePart;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+/**
+ * SimpleFilePart is an adapter of simple data for uploading.
+ *
+ * @param filename is name of the attachment file.
+ * @param content is binary data of the attachment file.
+ * @param mediaType is media type of the attachment file.
+ */
+record SimpleFilePart(
+    String filename,
+    Flux<DataBuffer> content,
+    MediaType mediaType
+) implements FilePart {
+    @Override
+    public Mono<Void> transferTo(Path dest) {
+        return DataBufferUtils.write(content(), dest);
+    }
+
+    @Override
+    public String name() {
+        return filename();
+    }
+
+    @Override
+    public HttpHeaders headers() {
+        var headers = new HttpHeaders();
+        headers.setContentType(mediaType);
+        return HttpHeaders.readOnlyHttpHeaders(headers);
+    }
+}

--- a/api/src/main/java/run/halo/app/core/extension/attachment/endpoint/UploadOption.java
+++ b/api/src/main/java/run/halo/app/core/extension/attachment/endpoint/UploadOption.java
@@ -1,0 +1,23 @@
+package run.halo.app.core.extension.attachment.endpoint;
+
+import org.springframework.core.io.buffer.DataBuffer;
+import org.springframework.http.MediaType;
+import org.springframework.http.codec.multipart.FilePart;
+import reactor.core.publisher.Flux;
+import run.halo.app.core.extension.attachment.Policy;
+import run.halo.app.extension.ConfigMap;
+
+public record UploadOption(FilePart file,
+                           Policy policy,
+                           ConfigMap configMap) implements AttachmentHandler.UploadContext {
+
+    public static UploadOption from(String filename,
+        Flux<DataBuffer> content,
+        MediaType mediaType,
+        Policy policy,
+        ConfigMap configMap) {
+        var filePart = new SimpleFilePart(filename, content, mediaType);
+        return new UploadOption(filePart, policy, configMap);
+    }
+
+}

--- a/api/src/main/java/run/halo/app/core/extension/service/AttachmentService.java
+++ b/api/src/main/java/run/halo/app/core/extension/service/AttachmentService.java
@@ -1,5 +1,7 @@
 package run.halo.app.core.extension.service;
 
+import java.net.URI;
+import java.time.Duration;
 import org.springframework.core.io.buffer.DataBuffer;
 import org.springframework.http.MediaType;
 import org.springframework.lang.NonNull;
@@ -17,8 +19,14 @@ import run.halo.app.core.extension.attachment.Attachment;
 public interface AttachmentService {
 
     /**
-     * Upload binary data as attachment. Please note that we will make sure the request is
+     * Uploads the given attachment to specific storage using handlers in plugins. Please note
+     * that we will make
+     * sure the
+     * request is
      * authenticated, or an unauthorized exception throws.
+     * <p>
+     * If no handler can be found to upload the given attachment, ServerError exception will be
+     * thrown.
      *
      * @param policyName is attachment policy name.
      * @param groupName is group name the attachment belongs.
@@ -32,5 +40,37 @@ public interface AttachmentService {
         @NonNull String filename,
         @NonNull Flux<DataBuffer> content,
         @Nullable MediaType mediaType);
+
+    /**
+     * Deletes an attachment using handlers in plugins.
+     * <p>
+     * If no handler can be found to delete the given attachment, Mono.empty() will return.
+     *
+     * @param attachment is to be deleted.
+     * @return deleted attachment.
+     */
+    Mono<Attachment> delete(Attachment attachment);
+
+    /**
+     * Gets permalink using handlers in plugins.
+     * <p>
+     * If no handler can be found to delete the given attachment, Mono.empty() will return.
+     *
+     * @param attachment is created attachment.
+     * @return permalink
+     */
+    Mono<URI> getPermalink(Attachment attachment);
+
+    /**
+     * Gets shared URL using handlers in plugins.
+     * <p>
+     * If no handler can be found to delete the given attachment, Mono.empty() will return.
+     *
+     * @param attachment is created attachment.
+     * @param ttl is time to live of the shared URL.
+     * @return time-to-live shared URL. Please note that, if the attachment is stored in local, the
+     * shared URL is equal to permalink.
+     */
+    Mono<URI> getSharedURL(Attachment attachment, Duration ttl);
 
 }

--- a/api/src/main/java/run/halo/app/core/extension/service/AttachmentService.java
+++ b/api/src/main/java/run/halo/app/core/extension/service/AttachmentService.java
@@ -1,0 +1,36 @@
+package run.halo.app.core.extension.service;
+
+import org.springframework.core.io.buffer.DataBuffer;
+import org.springframework.http.MediaType;
+import org.springframework.lang.NonNull;
+import org.springframework.lang.Nullable;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+import run.halo.app.core.extension.attachment.Attachment;
+
+/**
+ * AttachmentService
+ *
+ * @author johnniang
+ * @since 2.5.0
+ */
+public interface AttachmentService {
+
+    /**
+     * Upload binary data as attachment. Please note that we will make sure the request is
+     * authenticated, or an unauthorized exception throws.
+     *
+     * @param policyName is attachment policy name.
+     * @param groupName is group name the attachment belongs.
+     * @param filename is filename of the attachment.
+     * @param content is binary data of the attachment.
+     * @param mediaType is media type of the attachment.
+     * @return attachment.
+     */
+    Mono<Attachment> upload(@NonNull String policyName,
+        @Nullable String groupName,
+        @NonNull String filename,
+        @NonNull Flux<DataBuffer> content,
+        @Nullable MediaType mediaType);
+
+}

--- a/api/src/main/java/run/halo/app/core/extension/service/AttachmentService.java
+++ b/api/src/main/java/run/halo/app/core/extension/service/AttachmentService.java
@@ -20,10 +20,7 @@ public interface AttachmentService {
 
     /**
      * Uploads the given attachment to specific storage using handlers in plugins. Please note
-     * that we will make
-     * sure the
-     * request is
-     * authenticated, or an unauthorized exception throws.
+     * that we will make sure the request is authenticated, or an unauthorized exception throws.
      * <p>
      * If no handler can be found to upload the given attachment, ServerError exception will be
      * thrown.

--- a/application/src/main/java/run/halo/app/core/extension/attachment/endpoint/LocalAttachmentUploadHandler.java
+++ b/application/src/main/java/run/halo/app/core/extension/attachment/endpoint/LocalAttachmentUploadHandler.java
@@ -24,6 +24,7 @@ import org.springframework.http.MediaType;
 import org.springframework.stereotype.Component;
 import org.springframework.util.StringUtils;
 import org.springframework.web.util.UriComponentsBuilder;
+import org.springframework.web.util.UriUtils;
 import reactor.core.Exceptions;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
@@ -172,6 +173,8 @@ class LocalAttachmentUploadHandler implements AttachmentHandler {
             return Mono.empty();
         }
         var uriStr = annotations.get(Constant.URI_ANNO_KEY);
+        // the uriStr is encoded before.
+        uriStr = UriUtils.decode(uriStr, StandardCharsets.UTF_8);
         var uri = UriComponentsBuilder.fromUri(externalUrl.get())
             // The URI has been encoded before, so there is no need to encode it again.
             .path(uriStr)

--- a/application/src/main/java/run/halo/app/core/extension/attachment/endpoint/LocalAttachmentUploadHandler.java
+++ b/application/src/main/java/run/halo/app/core/extension/attachment/endpoint/LocalAttachmentUploadHandler.java
@@ -5,10 +5,12 @@ import static run.halo.app.infra.utils.FileNameUtils.randomFileName;
 import static run.halo.app.infra.utils.FileUtils.checkDirectoryTraversal;
 
 import java.io.IOException;
+import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.FileAlreadyExistsException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Map;
 import java.util.Optional;
@@ -31,7 +33,9 @@ import run.halo.app.core.extension.attachment.Attachment;
 import run.halo.app.core.extension.attachment.Attachment.AttachmentSpec;
 import run.halo.app.core.extension.attachment.Constant;
 import run.halo.app.core.extension.attachment.Policy;
+import run.halo.app.extension.ConfigMap;
 import run.halo.app.extension.Metadata;
+import run.halo.app.infra.ExternalUrlSupplier;
 import run.halo.app.infra.exception.AttachmentAlreadyExistsException;
 import run.halo.app.infra.properties.HaloProperties;
 import run.halo.app.infra.utils.JsonUtils;
@@ -42,8 +46,12 @@ class LocalAttachmentUploadHandler implements AttachmentHandler {
 
     private final HaloProperties haloProp;
 
-    public LocalAttachmentUploadHandler(HaloProperties haloProp) {
+    private final ExternalUrlSupplier externalUrl;
+
+    public LocalAttachmentUploadHandler(HaloProperties haloProp,
+        ExternalUrlSupplier externalUrl) {
         this.haloProp = haloProp;
+        this.externalUrl = externalUrl;
     }
 
     Path getAttachmentsRoot() {
@@ -151,6 +159,33 @@ class LocalAttachmentUploadHandler implements AttachmentHandler {
                 }
             })
             .map(DeleteContext::attachment);
+    }
+
+    @Override
+    public Mono<URI> getPermalink(Attachment attachment, Policy policy, ConfigMap configMap) {
+        if (!this.shouldHandle(policy)) {
+            return Mono.empty();
+        }
+        var annotations = attachment.getMetadata().getAnnotations();
+        if (annotations == null
+            || !annotations.containsKey(Constant.URI_ANNO_KEY)) {
+            return Mono.empty();
+        }
+        var uriStr = annotations.get(Constant.URI_ANNO_KEY);
+        var uri = UriComponentsBuilder.fromUri(externalUrl.get())
+            // The URI has been encoded before, so there is no need to encode it again.
+            .path(uriStr)
+            .build()
+            .toUri();
+        return Mono.just(uri);
+    }
+
+    @Override
+    public Mono<URI> getSharedURL(Attachment attachment,
+        Policy policy,
+        ConfigMap configMap,
+        Duration ttl) {
+        return getPermalink(attachment, policy, configMap);
     }
 
     private boolean shouldHandle(Policy policy) {

--- a/application/src/main/java/run/halo/app/core/extension/reconciler/attachment/AttachmentReconciler.java
+++ b/application/src/main/java/run/halo/app/core/extension/reconciler/attachment/AttachmentReconciler.java
@@ -1,28 +1,22 @@
 package run.halo.app.core.extension.reconciler.attachment;
 
+import java.net.URI;
 import java.util.HashSet;
 import java.util.Objects;
 import java.util.Set;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
-import org.springframework.web.util.UriComponentsBuilder;
-import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import run.halo.app.core.extension.attachment.Attachment;
 import run.halo.app.core.extension.attachment.Attachment.AttachmentStatus;
 import run.halo.app.core.extension.attachment.Constant;
-import run.halo.app.core.extension.attachment.Policy;
-import run.halo.app.core.extension.attachment.endpoint.AttachmentHandler;
-import run.halo.app.core.extension.attachment.endpoint.DeleteOption;
-import run.halo.app.extension.ConfigMap;
+import run.halo.app.core.extension.service.AttachmentService;
 import run.halo.app.extension.ExtensionClient;
 import run.halo.app.extension.controller.Controller;
 import run.halo.app.extension.controller.ControllerBuilder;
 import run.halo.app.extension.controller.Reconciler;
 import run.halo.app.extension.controller.Reconciler.Request;
 import run.halo.app.infra.ExternalUrlSupplier;
-import run.halo.app.infra.exception.NotFoundException;
-import run.halo.app.plugin.ExtensionComponentsFinder;
 
 @Slf4j
 @Component
@@ -30,16 +24,15 @@ public class AttachmentReconciler implements Reconciler<Request> {
 
     private final ExtensionClient client;
 
-    private final ExtensionComponentsFinder extensionComponentsFinder;
-
     private final ExternalUrlSupplier externalUrl;
 
+    private final AttachmentService attachmentService;
+
     public AttachmentReconciler(ExtensionClient client,
-        ExtensionComponentsFinder extensionComponentsFinder,
-        ExternalUrlSupplier externalUrl) {
+        ExternalUrlSupplier externalUrl, AttachmentService attachmentService) {
         this.client = client;
-        this.extensionComponentsFinder = extensionComponentsFinder;
         this.externalUrl = externalUrl;
+        this.attachmentService = attachmentService;
     }
 
     @Override
@@ -47,46 +40,33 @@ public class AttachmentReconciler implements Reconciler<Request> {
         client.fetch(Attachment.class, request.name()).ifPresent(attachment -> {
             // TODO Handle the finalizer
             if (attachment.getMetadata().getDeletionTimestamp() != null) {
-                Policy policy = client.fetch(Policy.class, attachment.getSpec().getPolicyName())
-                    .orElseThrow();
-                var configMap = client.fetch(ConfigMap.class, policy.getSpec().getConfigMapName())
-                    .orElseThrow();
-                var deleteOption = new DeleteOption(attachment, policy, configMap);
-                Flux.fromIterable(extensionComponentsFinder.getExtensions(AttachmentHandler.class))
-                    .concatMap(handler -> handler.delete(deleteOption)).next().switchIfEmpty(
-                        Mono.error(() -> new NotFoundException(
-                            "No suitable handler found to delete the attachment")))
-                    .doOnNext(deleted -> removeFinalizer(deleted.getMetadata().getName())).block();
+                attachmentService.delete(attachment)
+                    .doOnNext(deletedAttachment -> {
+                        removeFinalizer(attachment.getMetadata().getName());
+                    })
+                    .blockOptional();
                 return;
             }
             // add finalizer
             addFinalizerIfNotSet(request.name(), attachment.getMetadata().getFinalizers());
-
             var annotations = attachment.getMetadata().getAnnotations();
             if (annotations != null) {
-                String permalink = null;
-                var uri = annotations.get(Constant.URI_ANNO_KEY);
-                if (uri != null) {
-                    permalink = UriComponentsBuilder.fromUri(externalUrl.get())
-                        // The URI has been encoded before, so there is no need to encode it again.
-                        .path(uri)
-                        .build()
-                        .toString();
-                } else {
-                    var externalLink = annotations.get(Constant.EXTERNAL_LINK_ANNO_KEY);
-                    if (externalLink != null) {
-                        permalink = externalLink;
-                    }
-                }
-                if (permalink != null) {
-                    log.debug("Set permalink {} for attachment {}", permalink, request.name());
-                    var status = attachment.getStatus();
-                    if (status == null) {
-                        status = new AttachmentStatus();
-                        attachment.setStatus(status);
-                    }
-                    status.setPermalink(permalink);
-                }
+                attachmentService.getPermalink(attachment)
+                    .map(URI::toString)
+                    .switchIfEmpty(Mono.fromSupplier(() -> {
+                        // Only for back-compatibility
+                        return annotations.get(Constant.EXTERNAL_LINK_ANNO_KEY);
+                    }))
+                    .doOnNext(permalink -> {
+                        log.debug("Set permalink {} for attachment {}", permalink, request.name());
+                        var status = attachment.getStatus();
+                        if (status == null) {
+                            status = new AttachmentStatus();
+                            attachment.setStatus(status);
+                        }
+                        status.setPermalink(permalink);
+                    })
+                    .blockOptional();
             }
             updateStatus(request.name(), attachment.getStatus());
         });

--- a/application/src/main/java/run/halo/app/core/extension/reconciler/attachment/AttachmentReconciler.java
+++ b/application/src/main/java/run/halo/app/core/extension/reconciler/attachment/AttachmentReconciler.java
@@ -13,7 +13,7 @@ import run.halo.app.core.extension.attachment.Attachment.AttachmentStatus;
 import run.halo.app.core.extension.attachment.Constant;
 import run.halo.app.core.extension.attachment.Policy;
 import run.halo.app.core.extension.attachment.endpoint.AttachmentHandler;
-import run.halo.app.core.extension.attachment.endpoint.AttachmentHandler.DeleteOption;
+import run.halo.app.core.extension.attachment.endpoint.DeleteOption;
 import run.halo.app.extension.ConfigMap;
 import run.halo.app.extension.ExtensionClient;
 import run.halo.app.extension.controller.Controller;

--- a/application/src/main/java/run/halo/app/core/extension/service/impl/DefaultAttachmentService.java
+++ b/application/src/main/java/run/halo/app/core/extension/service/impl/DefaultAttachmentService.java
@@ -1,0 +1,92 @@
+package run.halo.app.core.extension.service.impl;
+
+import java.util.function.Function;
+import org.springframework.core.io.buffer.DataBuffer;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.lang.NonNull;
+import org.springframework.lang.Nullable;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.ReactiveSecurityContextHolder;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+import org.springframework.web.server.ResponseStatusException;
+import org.springframework.web.server.ServerErrorException;
+import org.springframework.web.server.ServerWebInputException;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+import run.halo.app.core.extension.attachment.Attachment;
+import run.halo.app.core.extension.attachment.Policy;
+import run.halo.app.core.extension.attachment.endpoint.AttachmentHandler;
+import run.halo.app.core.extension.attachment.endpoint.UploadOption;
+import run.halo.app.core.extension.service.AttachmentService;
+import run.halo.app.extension.ConfigMap;
+import run.halo.app.extension.ReactiveExtensionClient;
+import run.halo.app.plugin.ExtensionComponentsFinder;
+
+@Component
+public class DefaultAttachmentService implements AttachmentService {
+
+    private final ReactiveExtensionClient client;
+
+    private final ExtensionComponentsFinder extensionComponentsFinder;
+
+    public DefaultAttachmentService(ReactiveExtensionClient client,
+        ExtensionComponentsFinder extensionComponentsFinder) {
+        this.client = client;
+        this.extensionComponentsFinder = extensionComponentsFinder;
+    }
+
+    @Override
+    public Mono<Attachment> upload(@NonNull String policyName,
+        @Nullable String groupName,
+        @NonNull String filename,
+        @NonNull Flux<DataBuffer> content,
+        @Nullable MediaType mediaType) {
+        return authenticationConsumer(authentication -> client.get(Policy.class, policyName)
+            .flatMap(policy -> {
+                var configMapName = policy.getSpec().getConfigMapName();
+                if (!StringUtils.hasText(configMapName)) {
+                    return Mono.error(new ServerWebInputException(
+                        "ConfigMap name not found in Policy " + policyName));
+                }
+                return client.get(ConfigMap.class, configMapName)
+                    .map(configMap -> UploadOption.from(filename,
+                        content,
+                        mediaType,
+                        policy,
+                        configMap));
+            })
+            .flatMap(uploadContext -> {
+                var handlers = extensionComponentsFinder.getExtensions(AttachmentHandler.class);
+                return Flux.fromIterable(handlers)
+                    .concatMap(handler -> handler.upload(uploadContext))
+                    .next();
+            })
+            .switchIfEmpty(Mono.error(() -> new ServerErrorException(
+                "No suitable handler found for uploading the attachment.", null)))
+            .doOnNext(attachment -> {
+                var spec = attachment.getSpec();
+                if (spec == null) {
+                    spec = new Attachment.AttachmentSpec();
+                    attachment.setSpec(spec);
+                }
+                spec.setOwnerName(authentication.getName());
+                if (StringUtils.hasText(groupName)) {
+                    spec.setGroupName(groupName);
+                }
+                spec.setPolicyName(policyName);
+            })
+            .flatMap(client::create));
+    }
+
+    private <T> Mono<T> authenticationConsumer(Function<Authentication, Mono<T>> func) {
+        return ReactiveSecurityContextHolder.getContext()
+            .switchIfEmpty(
+                Mono.error(() -> new ResponseStatusException(HttpStatus.UNAUTHORIZED,
+                    "Authentication required.")))
+            .map(SecurityContext::getAuthentication)
+            .flatMap(func);
+    }
+}

--- a/application/src/main/java/run/halo/app/plugin/SharedApplicationContextHolder.java
+++ b/application/src/main/java/run/halo/app/plugin/SharedApplicationContextHolder.java
@@ -4,6 +4,7 @@ import org.springframework.beans.factory.support.DefaultListableBeanFactory;
 import org.springframework.context.ApplicationContext;
 import org.springframework.security.web.server.context.ServerSecurityContextRepository;
 import org.springframework.stereotype.Component;
+import run.halo.app.core.extension.service.AttachmentService;
 import run.halo.app.extension.DefaultSchemeManager;
 import run.halo.app.extension.ExtensionClient;
 import run.halo.app.extension.ReactiveExtensionClient;
@@ -67,6 +68,8 @@ public class SharedApplicationContextHolder {
             rootApplicationContext.getBean(ExternalUrlSupplier.class));
         beanFactory.registerSingleton("serverSecurityContextRepository",
             rootApplicationContext.getBean(ServerSecurityContextRepository.class));
+        beanFactory.registerSingleton("attachmentService",
+            rootApplicationContext.getBean(AttachmentService.class));
         // TODO add more shared instance here
 
         return sharedApplicationContext;


### PR DESCRIPTION
#### What type of PR is this?

/kind feature
/area core
/area plugin

#### What this PR does / why we need it:

This PR refactor AttachmentEndpoint by extracting `upload`, `delete`, `getPremalink` and `getSharedURL` logic in the endpoint into AttachmentService. Meanwhile, I expose the service to plugin, so that we can use the service in plugin conveniently.

#### Special notes for your reviewer:

Please confirm that those changes won't influence existing attachment features.

#### Does this PR introduce a user-facing change?

```release-note
None
```
