### PR TITLE
fix: only users with an authenticated role are allowed to modify their profile

### DIFF
--- a/application/src/main/resources/extensions/role-template-anonymous.yaml
+++ b/application/src/main/resources/extensions/role-template-anonymous.yaml
@@ -7,7 +7,7 @@ metadata:
     halo.run/hidden: "true"
   annotations:
     rbac.authorization.halo.run/dependencies: |
-      [ "role-template-own-user-info", "role-template-own-permissions"]
+      [ "role-template-own-permissions"]
 rules:
   - apiGroups: [ "api.halo.run" ]
     resources: [ "comments", "comments/reply" ]
@@ -15,6 +15,10 @@ rules:
   - apiGroups: [ "api.halo.run" ]
     resources: [ "*" ]
     verbs: [ "*" ]
+  - apiGroups: [ "api.console.halo.run" ]
+    resources: [ "users" ]
+    resourceNames: [ "-" ]
+    verbs: [ "get" ]
   - nonResourceURLs: [ "/apis/api.halo.run/v1alpha1/trackers/*" ]
     verbs: [ "create" ]
   - nonResourceURLs: [ "/actuator/globalinfo", "/actuator/health", "/actuator/health/*", "/login/public-key"]


### PR DESCRIPTION
#### What type of PR is this?
/kind improvement
/area core
/milestone 2.5.x

#### What this PR does / why we need it:
仅允许拥有 authenticated 角色的用户修改个人资料

how to test it?
用户在未登录时访问 `PUT /apis/api.console.halo.run/v1alpha1/users/-` 出现 401 状态码则符合预期，登录后则可以正常调用

#### Which issue(s) this PR fixes:
Fixes #3737
#### Does this PR introduce a user-facing change?
```release-note
None
```
