### PR TITLE
feat: add an API for reloading plugin

### DIFF
--- a/application/src/main/java/run/halo/app/core/extension/endpoint/PluginEndpoint.java
+++ b/application/src/main/java/run/halo/app/core/extension/endpoint/PluginEndpoint.java
@@ -123,6 +123,19 @@ public class PluginEndpoint implements CustomEndpoint {
                     .response(responseBuilder()
                         .implementation(ConfigMap.class))
             )
+            .PUT("plugins/{name}/reload", this::reload,
+                builder -> builder.operationId("reloadPlugin")
+                    .description("Reload a plugin by name.")
+                    .tag(tag)
+                    .parameter(parameterBuilder()
+                        .name("name")
+                        .in(ParameterIn.PATH)
+                        .required(true)
+                        .implementation(String.class)
+                    )
+                    .response(responseBuilder()
+                        .implementation(Plugin.class))
+            )
             .GET("plugins", this::list, builder -> {
                 builder.operationId("ListPlugins")
                     .tag(tag)
@@ -162,6 +175,11 @@ public class PluginEndpoint implements CustomEndpoint {
                     .tag(tag)
                     .response(responseBuilder().implementationArray(Plugin.class)))
             .build();
+    }
+
+    private Mono<ServerResponse> reload(ServerRequest serverRequest) {
+        var name = serverRequest.pathVariable("name");
+        return ServerResponse.ok().body(pluginService.reload(name), Plugin.class);
     }
 
     private Mono<ServerResponse> listPresets(ServerRequest request) {

--- a/application/src/main/java/run/halo/app/core/extension/service/PluginService.java
+++ b/application/src/main/java/run/halo/app/core/extension/service/PluginService.java
@@ -1,6 +1,7 @@
 package run.halo.app.core.extension.service;
 
 import java.nio.file.Path;
+import org.springframework.web.server.ServerWebInputException;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import run.halo.app.core.extension.Plugin;
@@ -27,4 +28,16 @@ public interface PluginService {
 
     Mono<Plugin> upgrade(String name, Path path);
 
+    /**
+     * <p>Reload a plugin by name.</p>
+     * Note that this method will set <code>spec.enabled</code> to true it means that the plugin
+     * will be started.
+     *
+     * @param name plugin name
+     * @return an updated plugin reloaded from plugin path
+     * @throws ServerWebInputException if plugin not found by the given name
+     * @see Plugin.PluginSpec#setEnabled(Boolean)
+     * @see run.halo.app.plugin.HaloPluginManager#reloadPlugin(String)
+     */
+    Mono<Plugin> reload(String name);
 }

--- a/application/src/main/java/run/halo/app/plugin/HaloPluginManager.java
+++ b/application/src/main/java/run/halo/app/plugin/HaloPluginManager.java
@@ -353,8 +353,14 @@ public class HaloPluginManager extends DefaultPluginManager
     }
 
     /**
-     * Reload plugin by id,it will be clean up memory resources of plugin and reload plugin from
-     * disk.
+     * <p>Reload plugin by id,it will be clean up memory resources of plugin and reload plugin from
+     * disk.</p>
+     * <p>
+     * Note: This method will not start plugin, you need to start plugin manually.
+     * this is to avoid starting plugins in different places, which will cause thread safety
+     * issues, so all of them are handed over to the
+     * {@link run.halo.app.core.extension.reconciler.PluginReconciler} to start the plugin
+     * </p>
      *
      * @param pluginId plugin id
      * @return plugin startup status
@@ -368,8 +374,7 @@ public class HaloPluginManager extends DefaultPluginManager
         } catch (Exception ex) {
             return null;
         }
-
-        return doStartPlugin(pluginId);
+        return getPlugin(pluginId).getPluginState();
     }
 
     /**

--- a/application/src/main/resources/extensions/role-template-plugin.yaml
+++ b/application/src/main/resources/extensions/role-template-plugin.yaml
@@ -16,7 +16,7 @@ rules:
     resources: [ "plugins" ]
     verbs: [ "create", "patch", "update", "delete", "deletecollection" ]
   - apiGroups: [ "api.console.halo.run" ]
-    resources: [ "plugins/upgrade", "plugins/resetconfig", "plugins/config" ]
+    resources: [ "plugins/upgrade", "plugins/resetconfig", "plugins/config", "plugins/reload" ]
     verbs: [ "*" ]
   - apiGroups: [ "api.console.halo.run" ]
     resources: [ "plugin-presets" ]


### PR DESCRIPTION
#### What type of PR is this?
/kind feature
/area core
/area plugin
/kind api-change
#### What this PR does / why we need it:
新增 reload 插件的 API

how to test it?
通过以下 API 测试是否可以在不重启 Halo 的情况下使新改动的插件代码生效
```shell
./gradlew clean build && curl -u your-name:your-password -X PUT http://127.0.0.1:8090/apis/api.console.halo.run/v1alpha1/plugins/{plugin-name}/reload
```
#### Which issue(s) this PR fixes:

Fixes #3748

#### Does this PR introduce a user-facing change?

```release-note
None
```
