### PR TITLE
Support publishing to Maven central repository

### DIFF
--- a/.github/workflows/halo.yaml
+++ b/.github/workflows/halo.yaml
@@ -39,47 +39,19 @@ jobs:
           filters: |
             console:
               - 'console/**'
-      - name: Check code style
-        run: ./gradlew check -x test
-      - name: Setup console environment
-        if: steps.changes.outputs.console == 'true'
-        uses: halo-sigs/actions/admin-env-setup@main
-      - name: Check console
-        if: steps.changes.outputs.console == 'true'
-        run: make -C console lint
-
-  test:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-        with:
-          submodules: true
-      - name: Set up JDK 17
-        uses: actions/setup-java@v3
-        with:
-          distribution: 'temurin'
-          cache: 'gradle'
-          java-version: 17
-      - uses: dorny/paths-filter@v2
-        id: changes
-        with:
-          filters: |
-            console:
-              - 'console/**'
-      - name: Run tests
-        run: ./gradlew test
+      - name: Check halo
+        run: ./gradlew check
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v3
       - name: Setup console environment
         if: steps.changes.outputs.console == 'true'
         uses: halo-sigs/actions/admin-env-setup@main
-      - name: Test console
+      - name: Check console
         if: steps.changes.outputs.console == 'true'
-        run: make -C console test
-
+        run: make -C console check
   docker-build-and-push:
     runs-on: ubuntu-latest
-    needs: test
+    needs: check
     steps:
       - uses: actions/checkout@v3
       - uses: halo-sigs/actions/halo-next-docker-build@main # change the version to specific ref or release tag while the action is stable.

--- a/api/build.gradle
+++ b/api/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'java-library'
-    id 'maven-publish'
+    id 'halo.publish'
     id "io.freefair.lombok" version "8.0.0-rc2"
 }
 
@@ -67,15 +67,4 @@ java {
 
 tasks.named('test') {
     useJUnitPlatform()
-}
-
-publishing {
-    publications {
-        library(MavenPublication) {
-            from components.java
-        }
-    }
-    repositories {
-        mavenLocal()
-    }
 }

--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -1,0 +1,3 @@
+plugins {
+    id 'groovy-gradle-plugin'
+}

--- a/buildSrc/src/main/groovy/halo.publish.gradle
+++ b/buildSrc/src/main/groovy/halo.publish.gradle
@@ -1,0 +1,56 @@
+plugins {
+    id 'maven-publish'
+}
+
+publishing {
+    publications {
+        def pubName = "${archivesBaseName}"
+        pluginManager.withPlugin('java-platform') {
+            pubName = pubName + 'Pom'
+        }
+        pluginManager.withPlugin('java') {
+            pubName = pubName + 'Library'
+        }
+        "${pubName}"(MavenPublication) {
+            pluginManager.withPlugin('java-platform') {
+                from components.javaPlatform
+            }
+            pluginManager.withPlugin('java') {
+                from components.java
+            }
+            pom {
+                licenses {
+                    license {
+                        name = 'The GNU General Public License v3.0'
+                        url = 'https://www.gnu.org/licenses/gpl-3.0.en.html'
+                    }
+                }
+                developers {
+                    developer {
+                        id = 'johnniang'
+                        name = 'JohnNiang'
+                        email = 'johnniang@foxmil.com'
+                    }
+                }
+                scm {
+                    connection = 'scm:git:https://github.com/halo-dev/halo.git'
+                    developerConnection = 'scm:git:ssh://git@github.com:halo-dev/halo.git'
+                    url = 'https://github.com/halo-dev/halo'
+                }
+            }
+        }
+    }
+
+    repositories {
+        mavenLocal()
+        if (project.hasProperty("release")) {
+            maven {
+                name = 'ossrh'
+                def releasesRepoUrl = 'https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/'
+                def snapshotsRepoUrl = 'https://s01.oss.sonatype.org/content/repositories/snapshots/'
+                url = version.endsWith('-SNAPSHOT') ? snapshotsRepoUrl : releasesRepoUrl
+                credentials(PasswordCredentials)
+            }
+        }
+    }
+}

--- a/console/Makefile
+++ b/console/Makefile
@@ -16,6 +16,8 @@ lint: build-packages ## Lint console
 test: build-packages ## Test console
 	pnpm test:unit
 
+check: lint test ## Check console
+
 dev: build-packages ## Run console with development environment
 	pnpm dev
 

--- a/platform/application/build.gradle
+++ b/platform/application/build.gradle
@@ -3,7 +3,8 @@ import org.springframework.boot.gradle.plugin.SpringBootPlugin
 plugins {
     id 'org.springframework.boot' version '3.0.5' apply false
     id 'java-platform'
-    id 'maven-publish'
+    id 'halo.publish'
+    id 'signing'
 }
 
 group = 'run.halo.tools.platform'
@@ -56,16 +57,4 @@ dependencies {
         runtime 'com.github.jasync-sql:jasync-r2dbc-mysql:2.1.23'
     }
 
-}
-
-publishing {
-    publications {
-        applicationPlatform(MavenPublication) {
-            from components.javaPlatform
-        }
-    }
-
-    repositories {
-        mavenLocal()
-    }
 }

--- a/platform/plugin/build.gradle
+++ b/platform/plugin/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'java-platform'
-    id 'maven-publish'
+    id 'halo.publish'
 }
 
 group = 'run.halo.tools.platform'
@@ -17,16 +17,5 @@ dependencies {
         api project(':api')
         // TODO other plugin API dependencies
         // e.g.: api 'halo.run.plugin:links-api:1.1.0'
-    }
-}
-
-publishing {
-    publications {
-        pluginPlatform(MavenPublication) {
-            from components.javaPlatform
-        }
-    }
-    repositories {
-        mavenLocal()
     }
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind feature
/area core

#### What this PR does / why we need it:

Use Gradle plugin `maven-publish` to publish Halo modules(`platform.application`, `platform.plugin` and `api`) to Maven central repository.

```bash
# Try to publish to Maven local repository.
./gradlew publish
# Really publish to Maven central repository.
./gradlew -Prelease publish -PossrhUsername=username -PossrhPassword=password
```

Note that currently we only support manually publishing.

#### Which issue(s) this PR fixes:

Fixes https://github.com/halo-dev/halo/issues/2730

#### Does this PR introduce a user-facing change?

```release-note
None
```
