### PR TITLE
fix: outline not displayed when first entering the editor.

### DIFF
--- a/console/src/components/editor/DefaultEditor.vue
+++ b/console/src/components/editor/DefaultEditor.vue
@@ -531,6 +531,9 @@ watch(
         handleGenerateTableOfContent();
       });
     }
+  },
+  {
+    immediate: true,
   }
 );
 </script>


### PR DESCRIPTION
#### What type of PR is this?
/kind bug
/area console

#### What this PR does / why we need it:
为默认编辑器侦听器增加 `immediate` 属性，使其在创建之后立即执行，生成目录。

#### Which issue(s) this PR fixes:
Fixes #3769 

#### Special notes for your reviewer:
打开已经存在并且具有标题的文章/页面，查看大纲是否正常生成。

#### Does this PR introduce a user-facing change?
```release-note
修复文章/页面已有内容重新编辑时，无法立即显示大纲的问题。
```
