### PR TITLE
perf: automatically close the installation modal after installing the theme

### DIFF
--- a/console/src/locales/en.yaml
+++ b/console/src/locales/en.yaml
@@ -613,9 +613,6 @@ core:
         message: There are currently no installed themes, you can try refreshing or installing a new theme.
       not_installed_empty:
         title: There are no themes currently not installed.
-      operations:
-        install:
-          toast_success: Installation successful
     preview_model:
       title: "Preview theme: {display_name}"
       actions:
@@ -1126,6 +1123,7 @@ core:
       active_success: Activated successfully
       inactive_success: Deactivated successfully
       upgrade_success: Upgraded successfully
+      install_success: Installed successfully
       download_success: Downloaded successfully
       copy_success: Copied successfully
       operation_failed: Failed to operate

--- a/console/src/locales/zh-CN.yaml
+++ b/console/src/locales/zh-CN.yaml
@@ -613,9 +613,6 @@ core:
         message: 当前没有已安装的主题，你可以尝试刷新或者安装新主题
       not_installed_empty:
         title: 当前没有未安装的主题
-      operations:
-        install:
-          toast_success: 安装成功
     preview_model:
       title: 预览主题：{display_name}
       actions:
@@ -1126,6 +1123,7 @@ core:
       active_success: 启用成功
       inactive_success: 停用成功
       upgrade_success: 升级成功
+      install_success: 安装成功
       download_success: 下载成功
       copy_success: 复制成功
       operation_failed: 操作失败

--- a/console/src/locales/zh-TW.yaml
+++ b/console/src/locales/zh-TW.yaml
@@ -613,9 +613,6 @@ core:
         message: 當前沒有已安裝的主題，你可以嘗試刷新或者安裝新主題
       not_installed_empty:
         title: 當前沒有未安裝的主題
-      operations:
-        install:
-          toast_success: 安裝成功
     preview_model:
       title: 預覽主題：{display_name}
       actions:
@@ -1126,6 +1123,7 @@ core:
       active_success: 啟用成功
       inactive_success: 停用成功
       upgrade_success: 升級成功
+      install_success: 安裝成功
       download_success: 下載成功
       copy_success: 複製成功
       operation_failed: 操作失敗

--- a/console/src/modules/interface/themes/components/ThemeListModal.vue
+++ b/console/src/modules/interface/themes/components/ThemeListModal.vue
@@ -97,7 +97,7 @@ const handleCreateTheme = async (theme: Theme) => {
 
     activeTab.value = "installed";
 
-    Toast.success(t("core.theme.list_modal.operations.install.toast_success"));
+    Toast.success(t("core.common.toast.install_success"));
   } catch (error) {
     console.error("Failed to create theme", error);
   } finally {

--- a/console/src/modules/interface/themes/components/ThemeUploadModal.vue
+++ b/console/src/modules/interface/themes/components/ThemeUploadModal.vue
@@ -1,11 +1,15 @@
 <script lang="ts" setup>
-import { VModal } from "@halo-dev/components";
+import { Toast, VModal } from "@halo-dev/components";
 import UppyUpload from "@/components/upload/UppyUpload.vue";
 import { computed, ref, watch } from "vue";
 import type { Theme } from "@halo-dev/api-client";
 import { useI18n } from "vue-i18n";
+import { useQueryClient } from "@tanstack/vue-query";
+import { useThemeStore } from "@/stores/theme";
 
 const { t } = useI18n();
+const queryClient = useQueryClient();
+const themeStore = useThemeStore();
 
 const props = withDefaults(
   defineProps<{
@@ -60,6 +64,21 @@ watch(
     }
   }
 );
+
+const onUploaded = () => {
+  Toast.success(
+    t(
+      props.upgradeTheme
+        ? "core.common.toast.upgrade_success"
+        : "core.common.toast.install_success"
+    )
+  );
+
+  queryClient.invalidateQueries({ queryKey: ["themes"] });
+  themeStore.fetchActivatedTheme();
+
+  handleVisibleChange(false);
+};
 </script>
 <template>
   <VModal
@@ -76,6 +95,7 @@ watch(
       }"
       :endpoint="endpoint"
       auto-proceed
+      @uploaded="onUploaded"
     />
   </VModal>
 </template>


### PR DESCRIPTION
#### What type of PR is this?

/kind improvement
/area console
/milestone 2.5.x

#### What this PR does / why we need it:

优化安装主题和升级主题的流程，支持在升级或者安装之后自动关闭弹框以及刷新数据。

#### Special notes for your reviewer:

测试方式：

1. 测试升级或者安装新主题之后是否关闭弹框以及是否有提示即可。

#### Does this PR introduce a user-facing change?

```release-note
优化 Console 端安装和升级主题的流程，支持自动关闭安装弹框和显示反馈提示
```
