### PR TITLE
perf: reload page after active theme

### DIFF
--- a/console/src/modules/interface/themes/components/components/ThemeListItem.vue
+++ b/console/src/modules/interface/themes/components/components/ThemeListItem.vue
@@ -193,7 +193,7 @@ const handleUninstall = async (theme: Theme, deleteExtensions?: boolean) => {
       v-if="currentUserHasPermission(['system:themes:manage'])"
       #dropdownItems
     >
-      <VDropdownItem v-if="!isActivated" @click="handleActiveTheme">
+      <VDropdownItem v-if="!isActivated" @click="handleActiveTheme(true)">
         {{ $t("core.common.buttons.active") }}
       </VDropdownItem>
       <VDropdownItem @click="emit('upgrade')">

--- a/console/src/modules/interface/themes/components/preview/ThemePreviewListItem.vue
+++ b/console/src/modules/interface/themes/components/preview/ThemePreviewListItem.vue
@@ -80,7 +80,7 @@ const { isActivated, handleActiveTheme } = useThemeLifeCycle(theme);
     </template>
 
     <template #dropdownItems>
-      <VDropdownItem v-if="!isActivated" @click="handleActiveTheme">
+      <VDropdownItem v-if="!isActivated" @click="handleActiveTheme()">
         {{ $t("core.common.buttons.active") }}
       </VDropdownItem>
       <VDropdownItem @click="emit('open-settings')">

--- a/console/src/modules/interface/themes/composables/use-theme.ts
+++ b/console/src/modules/interface/themes/composables/use-theme.ts
@@ -11,7 +11,7 @@ interface useThemeLifeCycleReturn {
   loading: Ref<boolean>;
   isActivated: ComputedRef<boolean>;
   getFailedMessage: () => string | undefined;
-  handleActiveTheme: () => void;
+  handleActiveTheme: (reload?: boolean) => void;
   handleResetSettingConfig: () => void;
 }
 
@@ -42,7 +42,7 @@ export function useThemeLifeCycle(
     }
   };
 
-  const handleActiveTheme = async () => {
+  const handleActiveTheme = async (reload?: boolean) => {
     Dialog.info({
       title: t("core.theme.operations.active.title"),
       description: theme.value?.spec.displayName,
@@ -57,6 +57,10 @@ export function useThemeLifeCycle(
           });
 
           Toast.success(t("core.theme.operations.active.toast_success"));
+
+          if (reload) {
+            window.location.reload();
+          }
         } catch (e) {
           console.error("Failed to active theme", e);
         } finally {

--- a/console/src/modules/interface/themes/layouts/ThemeLayout.vue
+++ b/console/src/modules/interface/themes/layouts/ThemeLayout.vue
@@ -177,7 +177,7 @@ watch([() => route.name, () => route.params], async () => {
             v-permission="['system:themes:manage']"
             size="sm"
             type="primary"
-            @click="handleActiveTheme"
+            @click="handleActiveTheme()"
           >
             {{ $t("core.common.buttons.active") }}
           </VButton>


### PR DESCRIPTION
#### What type of PR is this?

/kind improvement
/area console
/milestone 2.5.x

#### What this PR does / why we need it:

在主题列表激活主题之后，自动刷新页面。

#### Which issue(s) this PR fixes:

Fixes #3778 

#### Special notes for your reviewer:

测试方式：

1. 打开主题列表，选择任意主题激活，观察是否刷新页面。

#### Does this PR introduce a user-facing change?

```release-note
优化 Console 端激活主题的流程，支持激活后自动刷新页面
```
