### PR TITLE
fix: not reload page after upgrading a plugin

### DIFF
--- a/console/src/modules/system/plugins/components/PluginUploadModal.vue
+++ b/console/src/modules/system/plugins/components/PluginUploadModal.vue
@@ -52,7 +52,8 @@ const endpoint = computed(() => {
 
 const onUploaded = async (response: SuccessResponse) => {
   if (props.upgradePlugin) {
-    handleVisibleChange(false);
+    Toast.success(t("core.common.toast.upgrade_success"));
+    window.location.reload();
     return;
   }
 


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/area console
/milestone 2.5.x

#### What this PR does / why we need it:

修复升级插件之后没有自动刷新页面的问题，一般情况来说，升级插件之后需要重载插件 Console 部分的资源。

#### Special notes for your reviewer:

测试方式：

1. 以 deployment 模式启动 Halo
2. 测试升级插件之后是否有正常刷新页面

#### Does this PR introduce a user-facing change?

```release-note
修复 Console 端升级插件之后没有自动刷新页面的问题。
```
