### PR TITLE
perf: close attachment upload modal after click complete button

### DIFF
--- a/console/src/components/upload/UppyUpload.vue
+++ b/console/src/components/upload/UppyUpload.vue
@@ -23,6 +23,7 @@ const props = withDefaults(
     note?: string;
     method?: "GET" | "POST" | "PUT" | "HEAD" | "get" | "post" | "put" | "head";
     disabled?: boolean;
+    doneButtonHandler?: () => void;
   }>(),
   {
     restrictions: undefined,
@@ -33,6 +34,7 @@ const props = withDefaults(
     note: undefined,
     method: "post",
     disabled: false,
+    doneButtonHandler: undefined,
   }
 );
 
@@ -94,6 +96,11 @@ onUnmounted(() => {
 <template>
   <dashboard
     :uppy="uppy"
-    :props="{ theme: 'light', disabled: disabled, note: note }"
+    :props="{
+      theme: 'light',
+      disabled: disabled,
+      note: note,
+      doneButtonHandler: doneButtonHandler,
+    }"
   />
 </template>

--- a/console/src/modules/contents/attachments/components/AttachmentUploadModal.vue
+++ b/console/src/modules/contents/attachments/components/AttachmentUploadModal.vue
@@ -226,6 +226,7 @@ watch(
             ? ''
             : $t('core.attachment.upload_modal.filters.policy.not_select')
         "
+        :done-button-handler="() => onVisibleChange(false)"
       />
     </div>
   </VModal>


### PR DESCRIPTION
#### What type of PR is this?

/kind improvement
/area console
/milestone 2.5.x

#### What this PR does / why we need it:

支持在附件上传弹框中点击完成按钮关闭弹框。

<img width="647" alt="image" src="https://user-images.githubusercontent.com/21301288/232964793-d4e94e7a-fc81-4d1b-b0fc-b93d8f5bc537.png">

#### Special notes for your reviewer:

测试方式：

1. 测试上传完附件之后，点击完成按钮，观察是否关闭上传弹框即可。

#### Does this PR introduce a user-facing change?

```release-note
优化 Console 端上传附件的弹框，支持点击完成按钮以关闭弹框。
```
