### PR TITLE
feat: import zh_TW locale for uppy component

### DIFF
--- a/console/src/components/upload/UppyUpload.vue
+++ b/console/src/components/upload/UppyUpload.vue
@@ -6,6 +6,7 @@ import Uppy, { type SuccessResponse } from "@uppy/core";
 import type { Restrictions } from "@uppy/core";
 import XHRUpload from "@uppy/xhr-upload";
 import zh_CN from "@uppy/locales/lib/zh_CN";
+import zh_TW from "@uppy/locales/lib/zh_TW";
 import en_US from "@uppy/locales/lib/en_US";
 import { computed, onUnmounted } from "vue";
 import { Toast } from "@halo-dev/components";
@@ -46,6 +47,7 @@ const locales = {
   zh: zh_CN,
   "en-US": en_US,
   "zh-CN": zh_CN,
+  "zh-TW": zh_TW,
 };
 
 const uppy = computed(() => {


### PR DESCRIPTION
#### What type of PR is this?

/kind feature
/area console
/milestone 2.5.x

#### What this PR does / why we need it:

为上传组件 Uppy 导入中文繁体的语言包。

#### Which issue(s) this PR fixes:

Ref https://github.com/halo-dev/halo/pull/3672

#### Does this PR introduce a user-facing change?

```release-note
None
```
