### PR TITLE
fix: role templates in the plugin detail page is not loaded.

### DIFF
--- a/console/src/modules/system/plugins/PluginDetail.vue
+++ b/console/src/modules/system/plugins/PluginDetail.vue
@@ -33,6 +33,8 @@ const { data: pluginRoleTemplates } = useQuery({
 
     return data.items;
   },
+  cacheTime: 0,
+  enabled: computed(() => !!plugin?.value?.metadata.name),
 });
 
 const pluginRoleTemplateGroups = computed<RoleTemplateGroup[]>(() => {


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/area console
/milestone 2.5.x

#### What this PR does / why we need it:

修复插件页面中的角色模板在首次进入页面时，无法加载的问题。

<img width="984" alt="image" src="https://user-images.githubusercontent.com/21301288/233105675-8677b92b-e055-4b62-bfad-2947303ad901.png">


#### Which issue(s) this PR fixes:

Fixes #3793 

#### Special notes for your reviewer:

测试方式：

1. 安装一个带有角色模板的插件，比如：https://github.com/halo-sigs/plugin-links
2. 进入插件详情页面，观察角色模板是否显示正确。

#### Does this PR introduce a user-facing change?

```release-note
修复 Console 端插件详情页面中角色模板无法正常加载的问题。
```
