### PR TITLE
fix: category select dropdown cannot be fully displayed in repeater component

### DIFF
--- a/console/src/formkit/theme.ts
+++ b/console/src/formkit/theme.ts
@@ -86,8 +86,8 @@ const theme: Record<string, Record<string, string>> = {
     wrapper: boxClassification.wrapper,
     help: boxClassification.wrapper,
     inner: "flex flex-col gap-4",
-    items: "flex flex-col w-full gap-2",
-    item: "border rounded-base grid grid-cols-12 focus-within:border-primary transition-all overflow-hidden focus-within:shadow-sm",
+    items: "flex flex-col w-full gap-2 rounded-base",
+    item: "border rounded-base grid grid-cols-12 focus-within:border-primary transition-all overflow-visible focus-within:shadow-sm",
     content: "flex-1 p-2 col-span-11",
     controls: "bg-gray-200 col-span-1 flex items-center justify-center",
   },
@@ -102,7 +102,7 @@ const theme: Record<string, Record<string, string>> = {
       "h-4 w-4 cursor-pointer text-gray-600 hover:text-gray-900",
     "post-tags-button": "inline-flex h-full cursor-pointer items-center px-1",
     "dropdown-wrapper":
-      "absolute ring-1 ring-white top-full bottom-auto right-0 z-10 mt-1 max-h-96 w-full overflow-auto rounded bg-white shadow-lg",
+      "absolute ring-1 ring-gray-100 top-full bottom-auto right-0 z-10 mt-1 max-h-96 w-full overflow-auto rounded bg-white shadow-lg",
   },
   categorySelect: {
     ...textClassification,
@@ -113,7 +113,7 @@ const theme: Record<string, Record<string, string>> = {
     "post-categories-button":
       "inline-flex h-full cursor-pointer items-center px-1",
     "dropdown-wrapper":
-      "absolute ring-1 ring-white top-full bottom-auto right-0 z-10 mt-1 max-h-96 w-full overflow-auto rounded bg-white shadow-lg",
+      "absolute ring-1 ring-gray-100 top-full bottom-auto right-0 z-10 mt-1 max-h-96 w-full overflow-auto rounded bg-white shadow-lg",
   },
 };
 


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/area console
/milestone 2.5.x

#### What this PR does / why we need it:

修复文章分类和标签选择组件在 Repeater 组件中，下拉框无法完整显示的问题。

<img width="598" alt="image" src="https://user-images.githubusercontent.com/21301288/233818471-0334b449-e2eb-44aa-a5ce-ed9a4ad54e8b.png">

#### Which issue(s) this PR fixes:

Fixes #3479 

#### Does this PR introduce a user-facing change?

```release-note
修复 Console 端的文章分类和标签选择组件在 Repeater 组件中，下拉框无法完整显示的问题。
```
