### PR TITLE
chore: set eslint max-warnings option and remove unused imports

### DIFF
--- a/console/package.json
+++ b/console/package.json
@@ -15,7 +15,7 @@
     "test:e2e": "start-server-and-test preview http://127.0.0.1:5050/ 'cypress open'",
     "test:e2e:ci": "start-server-and-test preview http://127.0.0.1:5050/ 'cypress run'",
     "typecheck": "vue-tsc --noEmit -p tsconfig.app.json --composite false && pnpm run typecheck:packages",
-    "lint": "eslint ./src --ext .vue,.js,.jsx,.cjs,.mjs,.ts,.tsx,.cts,.mts --ignore-path .gitignore && pnpm run lint:packages",
+    "lint": "eslint ./src --ext .vue,.js,.jsx,.cjs,.mjs,.ts,.tsx,.cts,.mts --ignore-path .gitignore --max-warnings=0 && pnpm run lint:packages",
     "prettier": "prettier --write './src/**/*.{vue,js,jsx,ts,tsx,css,scss,json,yml,yaml,html}' && pnpm run prettier:packages",
     "typecheck:packages": "pnpm --parallel --filter \"./packages/**\" run typecheck",
     "lint:packages": "pnpm --parallel --filter \"./packages/**\" lint",
@@ -27,7 +27,7 @@
       "prettier --write"
     ],
     "*.{js,ts,vue,tsx,jsx}": [
-      "eslint --fix"
+      "eslint --fix --max-warnings=0"
     ]
   },
   "workspaces": [

--- a/console/src/modules/interface/themes/ThemeDetail.vue
+++ b/console/src/modules/interface/themes/ThemeDetail.vue
@@ -1,13 +1,10 @@
 <script lang="ts" setup>
 // core libs
 import { inject, ref } from "vue";
-import { RouterLink } from "vue-router";
 import { useThemeLifeCycle } from "./composables/use-theme";
 
 // components
 import {
-  VAlert,
-  VSpace,
   VTag,
   IconMore,
   Dialog,

--- a/console/src/modules/system/roles/RoleDetail.vue
+++ b/console/src/modules/system/roles/RoleDetail.vue
@@ -1,13 +1,11 @@
 <script lang="ts" setup>
 import {
-  IconArrowRight,
   IconShieldUser,
   VButton,
   VCard,
   VPageHeader,
   VTabbar,
   VTag,
-  VAvatar,
   VAlert,
   VDescription,
   VDescriptionItem,


### PR DESCRIPTION
#### What type of PR is this?

/kind improvement
/area console

#### What this PR does / why we need it:

调整 ESLint 的执行参数，添加 max-warnings 为 0，意味着在提交或者运行 CI 的时候不再允许包含 warning 级别的检测。

#### Does this PR introduce a user-facing change?

```release-note
None
```
