### PR TITLE
Fix the problem of upgrading plugins with same version

### DIFF
--- a/application/src/main/java/run/halo/app/plugin/YamlPluginFinder.java
+++ b/application/src/main/java/run/halo/app/plugin/YamlPluginFinder.java
@@ -73,16 +73,20 @@ public class YamlPluginFinder {
 
     protected Plugin readPluginDescriptor(Path pluginPath) {
         Path propertiesPath = getManifestPath(pluginPath, propertiesFileName);
-        if (propertiesPath == null) {
-            throw new PluginRuntimeException("Cannot find the plugin manifest path");
-        }
+        try {
+            if (propertiesPath == null) {
+                throw new PluginRuntimeException("Cannot find the plugin manifest path");
+            }
 
-        log.debug("Lookup plugin descriptor in '{}'", propertiesPath);
-        if (Files.notExists(propertiesPath)) {
-            throw new PluginRuntimeException("Cannot find '{}' path", propertiesPath);
+            log.debug("Lookup plugin descriptor in '{}'", propertiesPath);
+            if (Files.notExists(propertiesPath)) {
+                throw new PluginRuntimeException("Cannot find '{}' path", propertiesPath);
+            }
+            Resource propertyResource = new FileSystemResource(propertiesPath);
+            return unstructuredToPlugin(propertyResource);
+        } finally {
+            FileUtils.closePath(propertiesPath);
         }
-        Resource propertyResource = new FileSystemResource(propertiesPath);
-        return unstructuredToPlugin(propertyResource);
     }
 
     protected Plugin unstructuredToPlugin(Resource propertyResource) {


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/area plugin
/area core

#### What this PR does / why we need it:

Close file system after reading plugin descriptor.

#### Which issue(s) this PR fixes:

Fixes https://github.com/halo-dev/halo/issues/3720

#### How to test?

1. Build a plugin and install it
2. Update plugin.yaml of the plugin, rebuild and upgrade it
3. Check the change you modified

#### Does this PR introduce a user-facing change?

```release-note
修复无法正常升级插件的问题
```
