### PR TITLE
fix: loading state is not restored when Dialog's onConfirm method has exception

### DIFF
--- a/console/packages/components/src/components/dialog/Dialog.vue
+++ b/console/packages/components/src/components/dialog/Dialog.vue
@@ -78,7 +78,14 @@ const handleCancel = () => {
 const handleConfirm = async () => {
   if (props.onConfirm) {
     loading.value = true;
-    await props.onConfirm();
+
+    try {
+      await props.onConfirm();
+    } catch (error) {
+      console.error("Failed to execute onConfirm: ", error);
+    } finally {
+      loading.value = false;
+    }
   }
   handleClose();
 };


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/area console
/milestone 2.5.x

#### What this PR does / why we need it:

修复在 Dialog 组件中，如果 onConfirm 方法出现异常，按钮加载状态没有复原的问题。

#### Which issue(s) this PR fixes:

Fixes https://github.com/halo-dev/halo/issues/3844

#### Does this PR introduce a user-facing change?

```release-note
None
```
