### PR TITLE
Upgrade plugin presets

### DIFF
--- a/application/build.gradle
+++ b/application/build.gradle
@@ -91,8 +91,8 @@ tasks.register('downloadPluginPresets', Download) {
     src([
             'https://github.com/halo-sigs/plugin-comment-widget/releases/download/v1.5.0/plugin-comment-widget-1.5.0.jar',
             'https://github.com/halo-sigs/plugin-search-widget/releases/download/v1.0.0/plugin-search-widget-1.0.0.jar',
-            'https://github.com/halo-sigs/plugin-sitemap/releases/download/v1.0.1/plugin-sitemap-1.0.1.jar',
-            'https://github.com/halo-sigs/plugin-feed/releases/download/v1.1.0-beta.1/plugin-feed-1.1.0-beta.1.jar'
+            'https://github.com/halo-sigs/plugin-sitemap/releases/download/v1.0.2/plugin-sitemap-1.0.2.jar',
+            'https://github.com/halo-sigs/plugin-feed/releases/download/v1.1.1/plugin-feed-1.1.1.jar'
     ])
     dest 'src/main/resources/presets/plugins'
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup
/area core

#### What this PR does / why we need it:

Upgrade to plugin-sitemap 1.0.2 and plugin-feed 1.1.1.

```bash
❯ ./gradlew :application:downloadPluginPresets  
Starting a Gradle Daemon, 1 incompatible Daemon could not be reused, use --status for details

> Task :application:downloadPluginPresets
Download https://github.com/halo-sigs/plugin-search-widget/releases/download/v1.0.0/plugin-search-widget-1.0.0.jar
Download https://github.com/halo-sigs/plugin-comment-widget/releases/download/v1.5.0/plugin-comment-widget-1.5.0.jar
Download https://github.com/halo-sigs/plugin-sitemap/releases/download/v1.0.2/plugin-sitemap-1.0.2.jar
Download https://github.com/halo-sigs/plugin-feed/releases/download/v1.1.1/plugin-feed-1.1.1.jar

BUILD SUCCESSFUL in 4s
8 actionable tasks: 1 executed, 7 up-to-date
```

#### Which issue(s) this PR fixes:

Fixes https://github.com/halo-dev/halo/issues/3850

#### Does this PR introduce a user-facing change?

```release-note
升级预设插件
```
