### PR TITLE
Fix the problem of being able to search private posts after making post private

### DIFF
--- a/application/src/main/java/run/halo/app/event/post/PostVisibleChangedEvent.java
+++ b/application/src/main/java/run/halo/app/event/post/PostVisibleChangedEvent.java
@@ -4,7 +4,7 @@ import lombok.Data;
 import run.halo.app.core.extension.content.Post;
 
 @Data
-public class PostVisibleChangedEvent implements PostEvent{
+public class PostVisibleChangedEvent implements PostEvent {
 
     private final String postName;
 

--- a/application/src/main/java/run/halo/app/event/post/PostVisibleChangedEvent.java
+++ b/application/src/main/java/run/halo/app/event/post/PostVisibleChangedEvent.java
@@ -1,0 +1,27 @@
+package run.halo.app.event.post;
+
+import lombok.Data;
+import run.halo.app.core.extension.content.Post;
+
+@Data
+public class PostVisibleChangedEvent implements PostEvent{
+
+    private final String postName;
+
+    private final Post.VisibleEnum oldVisible;
+
+    private final Post.VisibleEnum newVisible;
+
+    public PostVisibleChangedEvent(String postName, Post.VisibleEnum oldVisible,
+        Post.VisibleEnum newVisible) {
+        this.postName = postName;
+        this.oldVisible = oldVisible;
+        this.newVisible = newVisible;
+    }
+
+    @Override
+    public String getName() {
+        return postName;
+    }
+
+}

--- a/application/src/test/java/run/halo/app/core/extension/reconciler/PostReconcilerTest.java
+++ b/application/src/test/java/run/halo/app/core/extension/reconciler/PostReconcilerTest.java
@@ -19,7 +19,7 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.context.ApplicationContext;
+import org.springframework.context.ApplicationEventPublisher;
 import reactor.core.publisher.Mono;
 import run.halo.app.content.ContentWrapper;
 import run.halo.app.content.PostService;
@@ -50,7 +50,7 @@ class PostReconcilerTest {
     private PostService postService;
 
     @Mock
-    private ApplicationContext applicationContext;
+    private ApplicationEventPublisher eventPublisher;
 
     @InjectMocks
     private PostReconciler postReconciler;
@@ -157,7 +157,7 @@ class PostReconcilerTest {
             verify(client, times(4)).update(captor.capture());
             Post value = captor.getValue();
             assertThat(value.getStatus().getLastModifyTime()).isEqualTo(lastModifyTime);
-            verify(applicationContext).publishEvent(any(PostPublishedEvent.class));
+            verify(eventPublisher).publishEvent(any(PostPublishedEvent.class));
         }
 
         @Test


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/area core
/milestone 2.5.x

#### What this PR does / why we need it:

This PR adds PostVisibleChangedEvent to synchronizing post indices when post visible is changed, whether from public to private or from private to public.

#### Which issue(s) this PR fixes:

Fixes https://github.com/halo-dev/halo/issues/3438

#### Special notes for your reviewer:

1. Install Search plugin
2. Create a post
3. Try to search the post
4. Make post private
5. Try to search the post
6. Make post public
7. Try to search the post

#### Does this PR introduce a user-facing change?

```release-note
修复隐藏的文章已然能够被搜索到问题
```
