### PR TITLE
chore: bump up version to 2.5.0-rc.2

### DIFF
--- a/console/package.json
+++ b/console/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@halo-dev/console",
-  "version": "2.5.0-rc.1",
+  "version": "2.5.0-rc.2",
   "scripts": {
     "prepare": "cd .. && husky install console/.husky",
     "dev": "vite --host",

--- a/console/packages/api-client/package.json
+++ b/console/packages/api-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@halo-dev/api-client",
-  "version": "2.5.0-rc.1",
+  "version": "2.5.0-rc.2",
   "description": "",
   "scripts": {
     "build": "unbuild",

--- a/console/packages/shared/package.json
+++ b/console/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@halo-dev/console-shared",
-  "version": "2.5.0-rc.1",
+  "version": "2.5.0-rc.2",
   "description": "",
   "files": [
     "dist"


### PR DESCRIPTION
#### What this PR does / why we need it:

修改版本号，准备发布 2.5.0-rc.2。

#### Does this PR introduce a user-facing change?

```release-note
None
```
