### PR TITLE
fix: permalink of singlePage cannot contain special characters

### DIFF
--- a/application/src/main/java/run/halo/app/theme/router/SinglePageRoute.java
+++ b/application/src/main/java/run/halo/app/theme/router/SinglePageRoute.java
@@ -1,8 +1,6 @@
 package run.halo.app.theme.router;
 
-import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.springframework.web.reactive.function.server.RequestPredicates.GET;
-import static org.springframework.web.util.UriUtils.encodePath;
 
 import java.util.HashMap;
 import java.util.List;

--- a/application/src/main/java/run/halo/app/theme/router/SinglePageRoute.java
+++ b/application/src/main/java/run/halo/app/theme/router/SinglePageRoute.java
@@ -119,8 +119,7 @@ public class SinglePageRoute
     }
 
     String singlePageRoute(String slug) {
-        var permalink = encodePath(slug, UTF_8);
-        return StringUtils.prependIfMissing(permalink, "/");
+        return StringUtils.prependIfMissing(slug, "/");
     }
 
     HandlerFunction<ServerResponse> handlerFunction(String name) {


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/area core
/milestone 2.5.x

#### What this PR does / why we need it:

修复页面的链接不能包含特殊字符的问题。

#### Which issue(s) this PR fixes:

Fixes https://github.com/halo-dev/halo/issues/3808

#### Special notes for your reviewer:

测试方式：

1. 创建一个页面。
2. 尝试设置别名为中文或者其他字符。
3. 尝试包含多个 `/` 分隔符。
4. 尝试访问页面，检查是否能够正常访问。

#### Does this PR introduce a user-facing change?

```release-note
修复页面链接包含中文等字符后无法访问的问题。
```
