### PR TITLE
refactor: compatibility issues with plugins lacking loadLocation after upgrading

### DIFF
--- a/application/src/main/java/run/halo/app/core/extension/service/impl/PluginServiceImpl.java
+++ b/application/src/main/java/run/halo/app/core/extension/service/impl/PluginServiceImpl.java
@@ -11,7 +11,6 @@ import java.util.Map;
 import java.util.Objects;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.Validate;
 import org.pf4j.PluginWrapper;
 import org.springframework.core.io.Resource;
@@ -35,6 +34,7 @@ import run.halo.app.infra.utils.VersionUtils;
 import run.halo.app.plugin.HaloPluginManager;
 import run.halo.app.plugin.PluginConst;
 import run.halo.app.plugin.PluginProperties;
+import run.halo.app.plugin.PluginUtils;
 import run.halo.app.plugin.YamlPluginFinder;
 
 @Slf4j
@@ -144,7 +144,7 @@ public class PluginServiceImpl implements PluginService {
     private Mono<Path> copyToPluginHome(Plugin plugin) {
         return Mono.fromCallable(
                 () -> {
-                    var fileName = generateFileName(plugin);
+                    var fileName = PluginUtils.generateFileName(plugin);
                     var pluginRoot = Paths.get(pluginProperties.getPluginsRoot());
                     try {
                         Files.createDirectories(pluginRoot);
@@ -160,17 +160,6 @@ public class PluginServiceImpl implements PluginService {
                     return pluginFilePath;
                 })
             .subscribeOn(Schedulers.boundedElastic());
-    }
-
-    static String generateFileName(Plugin plugin) {
-        Assert.notNull(plugin, "The plugin must not be null.");
-        Assert.notNull(plugin.getMetadata(), "The plugin metadata must not be null.");
-        Assert.notNull(plugin.getSpec(), "The plugin spec must not be null.");
-        String version = plugin.getSpec().getVersion();
-        if (StringUtils.isBlank(version)) {
-            throw new ServerWebInputException("The plugin version must not be blank.");
-        }
-        return String.format("%s-%s.jar", plugin.getMetadata().getName(), version);
     }
 
     private void satisfiesRequiresVersion(Plugin newPlugin) {

--- a/application/src/main/java/run/halo/app/plugin/PluginUtils.java
+++ b/application/src/main/java/run/halo/app/plugin/PluginUtils.java
@@ -1,0 +1,22 @@
+package run.halo.app.plugin;
+
+import lombok.experimental.UtilityClass;
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.util.Assert;
+import org.springframework.web.server.ServerWebInputException;
+import run.halo.app.core.extension.Plugin;
+
+@UtilityClass
+public class PluginUtils {
+
+    public static String generateFileName(Plugin plugin) {
+        Assert.notNull(plugin, "The plugin must not be null.");
+        Assert.notNull(plugin.getMetadata(), "The plugin metadata must not be null.");
+        Assert.notNull(plugin.getSpec(), "The plugin spec must not be null.");
+        String version = plugin.getSpec().getVersion();
+        if (StringUtils.isBlank(version)) {
+            throw new ServerWebInputException("The plugin version must not be blank.");
+        }
+        return String.format("%s-%s.jar", plugin.getMetadata().getName(), version);
+    }
+}


### PR DESCRIPTION
#### What type of PR is this?
/kind improvement
/area core
/milestone 2.5.x

#### What this PR does / why we need it:
修复插件缺失路径信息升级后无法使用的兼容性问题

how to test it?
1. 生产模式安装插件
2. 更新插件将插件中的 status.loadLocation 和 metadata.annotations["plugin.halo.run/plugin-path"] 删除
3. 查看插件功能是否正常
#### Does this PR introduce a user-facing change?

```release-note
修复插件缺失路径信息升级后无法使用的兼容性问题
```
