### PR TITLE
fix: the label of some radio is displayed incorrectly

### DIFF
--- a/console/src/formkit/plugins/required-asterisk.ts
+++ b/console/src/formkit/plugins/required-asterisk.ts
@@ -1,8 +1,7 @@
 import type { FormKitNode } from "@formkit/core";
 
-const isCheckboxAndRadioMultiple = (node) =>
-  (node.props.type === "checkbox" || node.props.type === "radio") &&
-  node.props.options;
+const hasLegendNode = (node) =>
+  ["checkbox", "radio", "repeater", "group"].includes(node.props.type);
 
 export default function requiredAsterisk(node: FormKitNode) {
   node.on("created", () => {
@@ -18,7 +17,7 @@ export default function requiredAsterisk(node: FormKitNode) {
       );
 
       if (isRequired) {
-        if (isCheckboxAndRadioMultiple(node)) {
+        if (hasLegendNode(node)) {
           sectionsSchema.legend = {
             children: ["$label", " *"],
           };


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/area console
/milestone 2.6.x

#### What this PR does / why we need it:

修复部分 FormKit 的 radio 表单项的 label 设置不正确的问题。目前影响范围：

1. 使用了 type 为 `menuCheckbox`  `menuRadio` 并将 validation 设置为了 `required`。

![image](https://user-images.githubusercontent.com/21301288/235104292-5324be1d-af48-4c7f-8f31-30a9b3dc9c02.png)

#### Which issue(s) this PR fixes:

Fixes #3876 

#### Does this PR introduce a user-facing change?

```release-note
修复部分 FormKit 的 radio 表单项的 label 设置不正确的问题。
```
