### PR TITLE
fix: user avatar link does not support relative paths

### DIFF
--- a/console/src/modules/system/users/components/UserCreationModal.vue
+++ b/console/src/modules/system/users/components/UserCreationModal.vue
@@ -154,7 +154,7 @@ const handleCreateUser = async () => {
         :label="$t('core.user.editing_modal.fields.avatar.label')"
         type="attachment"
         name="avatar"
-        validation="url|length:0,1024"
+        validation="length:0,1024"
       ></FormKit>
       <FormKit
         v-model="formState.password"

--- a/console/src/modules/system/users/components/UserEditingModal.vue
+++ b/console/src/modules/system/users/components/UserEditingModal.vue
@@ -201,7 +201,7 @@ const handleUpdateUser = async () => {
               type="attachment"
               name="avatar"
               :accepts="['image/*']"
-              validation="url|length:0,1024"
+              validation="length:0,1024"
             ></FormKit>
             <FormKit
               v-model="formState.spec.bio"


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/area console
/milestone 2.6.x

#### What this PR does / why we need it:

修复用户头像不支持相对链接的问题。

#### Which issue(s) this PR fixes:

Fixes #3879 

#### Special notes for your reviewer:

测试方式：

1. 创建或者编辑用户资料。
2. 从附件库选择头像，检查是否可以通过表单验证。

#### Does this PR introduce a user-facing change?

```release-note
修复创建用户或者修改用户资料时，头像链接不支持相对链接的问题。
```
