### PR TITLE
Change the type of site.url to URL instead of URI

### DIFF
--- a/application/src/main/java/run/halo/app/theme/SiteSettingVariablesAcquirer.java
+++ b/application/src/main/java/run/halo/app/theme/SiteSettingVariablesAcquirer.java
@@ -28,7 +28,7 @@ public class SiteSettingVariablesAcquirer implements ViewContextBasedVariablesAc
             .filter(configMap -> configMap.getData() != null)
             .map(configMap -> {
                 SiteSettingVo siteSettingVo = SiteSettingVo.from(configMap)
-                    .withUrl(externalUrlSupplier.get());
+                    .withUrl(externalUrlSupplier.getURL(exchange.getRequest()));
                 return Map.of("site", siteSettingVo);
             });
     }

--- a/application/src/main/java/run/halo/app/theme/finders/vo/SiteSettingVo.java
+++ b/application/src/main/java/run/halo/app/theme/finders/vo/SiteSettingVo.java
@@ -1,6 +1,6 @@
 package run.halo.app.theme.finders.vo;
 
-import java.net.URI;
+import java.net.URL;
 import java.util.Map;
 import lombok.Builder;
 import lombok.Value;
@@ -23,7 +23,7 @@ public class SiteSettingVo {
     String title;
 
     @With
-    URI url;
+    URL url;
 
     String subtitle;
 


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/area core
/milestone 2.6.x

#### What this PR does / why we need it:

This PR make the type of `site.url` to URL instead of URI. If we don't configure `halo.external-url`, the request URI will be used.

#### Which issue(s) this PR fixes:

Fixes https://github.com/halo-dev/halo/issues/3908

#### Special notes for your reviewer:

Add the line below into any templates:

```html
<b th:text="${site.url}"></b>
```

And check if the output is correct by accessing `http://localhost:8090` or `http://127.0.0.1:8090` or `http://192.168.xxx.xxx:8090` when `halo.external-url` is not set.

Check if the output is correct by accessing `http://localhost:8090` or `http://127.0.0.1:8090` or `http://192.168.xxx.xxx:8090` when `halo.external-url` is set to `https://halo.run/`.

#### Does this PR introduce a user-facing change?

```release-note
修复 site.url 解析有误的问题
```
