### PR TITLE
refactor: make tanstack query's network mode option to always

### DIFF
--- a/console/src/setup/setupVueQuery.ts
+++ b/console/src/setup/setupVueQuery.ts
@@ -9,6 +9,10 @@ const options: VueQueryPluginOptions = {
     defaultOptions: {
       queries: {
         refetchOnWindowFocus: false,
+        networkMode: "always",
+      },
+      mutations: {
+        networkMode: "always",
       },
     },
   },

--- a/console/src/setup/setupVueQuery.ts
+++ b/console/src/setup/setupVueQuery.ts
@@ -4,15 +4,17 @@ import {
   type VueQueryPluginOptions,
 } from "@tanstack/vue-query";
 
+const networkMode = import.meta.env.PROD ? "online" : "always";
+
 const options: VueQueryPluginOptions = {
   queryClientConfig: {
     defaultOptions: {
       queries: {
         refetchOnWindowFocus: false,
-        networkMode: "always",
+        networkMode,
       },
       mutations: {
-        networkMode: "always",
+        networkMode,
       },
     },
   },


### PR DESCRIPTION
#### What type of PR is this?

/kind improvement
/area core
/milstone 2.6.x

#### What this PR does / why we need it:

将 TanStack Query 的 Network Mode 设置为 always，防止在无网络的情况下，开发环境也无法请求数据。

#### Special notes for your reviewer:

测试方式：断网之后使用开发模式访问 Console，观察请求是否正常发送即可。

#### Does this PR introduce a user-facing change?

```release-note
None
```
