### PR TITLE
fix: theme page displays error without management permissions.

### DIFF
--- a/console/src/modules/interface/themes/layouts/ThemeLayout.vue
+++ b/console/src/modules/interface/themes/layouts/ThemeLayout.vue
@@ -172,7 +172,7 @@ watch([() => route.name, () => route.params], async () => {
       <template #actions>
         <VSpace>
           <VButton
-            v-if="!isActivated"
+            v-show="!isActivated"
             v-permission="['system:themes:manage']"
             size="sm"
             type="primary"


### PR DESCRIPTION
#### What type of PR is this?
/kind bug
/area console
/milestone 2.6.x

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:

Fixes #3933 

#### Special notes for your reviewer:

1. 创建一个拥有主题查看而没有主题管理权限的角色，并为某个用户分配这个角色。
2. 使用该用户登录 console，点击主题选项卡查看控制台是否报错。

#### Does this PR introduce a user-facing change?
```release-note
修复没有主题管理权限时，进入主题功能页面报错的问题。
```
