### PR TITLE
feat: add min and max props for repeater input

### DIFF
--- a/console/docs/custom-formkit-input/README.md
+++ b/console/docs/custom-formkit-input/README.md
@@ -16,6 +16,9 @@
   - 参数
     1. accepts：允许上传的文件类型，如：`image/*`
 - `repeater`: 定义一个对象集合，可以让使用者可视化的操作集合。
+  - 参数
+    1. min: 最小数量，默认为 `0`
+    2. max: 最大数量，默认为 `Infinity`，即无限制。
 - `menuCheckbox`：选择一组菜单
 - `menuRadio`：选择一个菜单
 - `menuItemSelect`：选择菜单项

--- a/console/src/formkit/inputs/repeater/index.ts
+++ b/console/src/formkit/inputs/repeater/index.ts
@@ -23,6 +23,7 @@ export const repeater: FormKitTypeDefinition = {
     messages(message("$message.value"))
   ),
   type: "list",
+  props: ["min", "max"],
   library: {
     Repeater: Repeater,
   },


### PR DESCRIPTION
#### What type of PR is this?

/area console
/kind feature
/milestone 2.6.x

#### What this PR does / why we need it:

Console 端的 FormKit Repeater 输入框支持 min 和 max 参数用于限制项目数量。

<img width="630" alt="image" src="https://github.com/halo-dev/halo/assets/21301288/541da770-0439-4731-a796-a58277c33e05">

#### Which issue(s) this PR fixes:

Fixes #3449 

#### Special notes for your reviewer:

定义方式：

```yaml
- $formkit: repeater
  name: test_repeater
  label: 测试 Repeater
  min: 2
  max: 3
  children:
    - $formkit: text
      name: test_text
      label: 测试 Text
    - $formkit: select
      name: test_select
      label: 测试 Select
      options:
        - value: prose-gray
          label: prose-gray
        - value: prose-slate
          label: prose-slate
        - value: prose-zinc
          label: prose-zinc
        - value: prose-neutral
          label: prose-neutral
        - value: prose-stone
          label: prose-stone
```

#### Does this PR introduce a user-facing change?

```release-note
Console 端的 FormKit Repeater 输入框支持 min 和 max 参数用于限制项目数量。
```
