### PR TITLE
perf: improve the logic of input selection for category and tag

### DIFF
--- a/console/src/formkit/inputs/category-select/CategorySelect.vue
+++ b/console/src/formkit/inputs/category-select/CategorySelect.vue
@@ -129,6 +129,7 @@ const handleSelect = (category: CategoryTree | Category) => {
       );
     } else {
       props.context.node.input([...currentValue, category.metadata.name]);
+      text.value = "";
     }
     return;
   }

--- a/console/src/formkit/inputs/tag-select/TagSelect.vue
+++ b/console/src/formkit/inputs/tag-select/TagSelect.vue
@@ -119,6 +119,7 @@ const handleSelect = (tag: Tag) => {
       );
     } else {
       props.context.node.input([...currentValue, tag.metadata.name]);
+      text.value = "";
     }
     return;
   }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. 如果这是你的第一次，请阅读我们的贡献指南：<https://github.com/halo-dev/halo/blob/master/CONTRIBUTING.md>。
1. If this is your first time, please read our contributor guidelines: <https://github.com/halo-dev/halo/blob/master/CONTRIBUTING.md>.
2. 请根据你解决问题的类型为 Pull Request 添加合适的标签。
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request.
3. 请确保你已经添加并运行了适当的测试。
3. Ensure you have added or ran the appropriate tests for your PR.
-->

#### What type of PR is this?
/kind improvement
<!--
添加其中一个类别：
Add one of the following kinds:
/kind improvement
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind improvement

适当添加其中一个或多个类别（可选）：
Optionally add one or more of the following kinds if applicable:

/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

改善分类和标签选择性输入框的输入逻辑

![Kapture 2023-05-22 at 01 20 41](https://github.com/halo-dev/halo/assets/106857035/cf2d60f5-9ec5-4e5c-99e2-e3cd7a97d692)


#### Which issue(s) this PR fixes:

<!--
PR 合并时自动关闭 issue。
Automatically closes linked issue when PR is merged.

用法：`Fixes #<issue 号>`，或者 `Fixes (粘贴 issue 完整链接)`
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #3959

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
如果当前 Pull Request 的修改不会造成用户侧的任何变更，在 `release-note` 代码块儿中填写 `NONE`。
否则请填写用户侧能够理解的 Release Note。如果当前 Pull Request 包含破坏性更新（Break Change），
Release Note 需要以 `action required` 开头。
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->

```release-note
NONE
```
