### PR TITLE
feat: supports redirecting to a specified page after successful login

### DIFF
--- a/application/src/main/java/run/halo/app/security/authentication/login/UsernamePasswordAuthenticator.java
+++ b/application/src/main/java/run/halo/app/security/authentication/login/UsernamePasswordAuthenticator.java
@@ -118,6 +118,7 @@ public class UsernamePasswordAuthenticator implements AdditionalWebFilter {
             return ignoringMediaTypeAll(MediaType.APPLICATION_JSON)
                 .matches(webFilterExchange.getExchange())
                 .filter(ServerWebExchangeMatcher.MatchResult::isMatch)
+                .switchIfEmpty(redirectToOriginalUrl(webFilterExchange).then(Mono.empty()))
                 .flatMap(matchResult -> {
                     var principal = authentication.getPrincipal();
                     if (principal instanceof CredentialsContainer credentialsContainer) {
@@ -129,8 +130,7 @@ public class UsernamePasswordAuthenticator implements AdditionalWebFilter {
                         .bodyValue(principal)
                         .flatMap(serverResponse ->
                             serverResponse.writeTo(webFilterExchange.getExchange(), context));
-                })
-                .switchIfEmpty(redirectToOriginalUrl(webFilterExchange));
+                });
         }
 
         Mono<Void> redirectToOriginalUrl(WebFilterExchange webFilterExchange) {

--- a/application/src/test/java/run/halo/app/security/authentication/login/UsernamePasswordAuthenticatorTest.java
+++ b/application/src/test/java/run/halo/app/security/authentication/login/UsernamePasswordAuthenticatorTest.java
@@ -1,0 +1,102 @@
+package run.halo.app.security.authentication.login;
+
+import java.net.URI;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.mock.http.server.reactive.MockServerHttpRequest;
+import org.springframework.mock.web.server.MockServerWebExchange;
+import org.springframework.security.core.userdetails.ReactiveUserDetailsPasswordService;
+import org.springframework.security.core.userdetails.ReactiveUserDetailsService;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.server.context.ServerSecurityContextRepository;
+import reactor.test.StepVerifier;
+
+/**
+ * Tests for {@link UsernamePasswordAuthenticator}.
+ *
+ * @author guqing
+ * @since 2.6.0
+ */
+@ExtendWith(MockitoExtension.class)
+class UsernamePasswordAuthenticatorTest {
+
+    @Mock
+    private ReactiveUserDetailsPasswordService userDetailsPasswordService;
+
+    @Mock
+    private ReactiveUserDetailsService userDetailsService;
+
+    @Mock
+    private PasswordEncoder passwordEncoder;
+
+    @Mock
+    private ServerSecurityContextRepository serverSecurityContextRepository;
+
+    @InjectMocks
+    private UsernamePasswordAuthenticator authenticator;
+
+    @Nested
+    class RedirectUriFromRequest {
+        private UsernamePasswordAuthenticator.LoginSuccessHandler loginSuccessHandler;
+
+        @BeforeEach
+        void setUp() {
+            loginSuccessHandler =
+                authenticator.new LoginSuccessHandler();
+        }
+
+        @Test
+        void validRedirectUri() {
+            // Mock a request with a valid redirect_uri
+            MockServerHttpRequest request1 = MockServerHttpRequest
+                .get("/some/path?redirect_uri=http://localhost:8080/redirect")
+                .build();
+            MockServerWebExchange exchange1 = MockServerWebExchange.from(request1);
+            // Verify that the method returns the correct redirect_uri
+            StepVerifier.create(loginSuccessHandler.getRedirectUri(exchange1))
+                .expectComplete()
+                .verify();
+
+            request1 = MockServerHttpRequest
+                .get("/some/path?redirect_uri=/console/")
+                .build();
+            exchange1 = MockServerWebExchange.from(request1);
+            // Verify that the method returns the correct redirect_uri
+            StepVerifier.create(loginSuccessHandler.getRedirectUri(exchange1))
+                .expectNext(URI.create("/console/"))
+                .expectComplete()
+                .verify();
+        }
+
+        @Test
+        void noRedirectUri() {
+            // Mock a request with no redirect_uri
+            MockServerHttpRequest request2 = MockServerHttpRequest
+                .get("/some/path")
+                .build();
+            MockServerWebExchange exchange2 = MockServerWebExchange.from(request2);
+            // Verify that the method returns empty
+            StepVerifier.create(loginSuccessHandler.getRedirectUri(exchange2))
+                .expectComplete()
+                .verify();
+        }
+
+        @Test
+        void differentHostRedirectUri() {
+            // Mock a request with a redirect_uri pointing to a different host
+            MockServerHttpRequest request3 = MockServerHttpRequest
+                .get("/some/path?redirect_uri=http://example.com/redirect")
+                .build();
+            MockServerWebExchange exchange3 = MockServerWebExchange.from(request3);
+            // Verify that the method returns empty
+            StepVerifier.create(loginSuccessHandler.getRedirectUri(exchange3))
+                .expectComplete()
+                .verify();
+        }
+    }
+}


### PR DESCRIPTION
#### What type of PR is this?
/kind improvement
/area core
/area console
/milestone 2.6.x

#### What this PR does / why we need it:
登录成功后支持跳转到指定页面

登录 API `POST /login` 支持携带查询参数 `redirect_uri` 跳转到同源 URI
 
#### Which issue(s) this PR fixes:

Fixes #3982

#### Does this PR introduce a user-facing change?

```release-note
登录成功后支持跳转到指定页面
```
