### PR TITLE
refactor: exception prompts during plugin installation

### DIFF
--- a/application/src/main/java/run/halo/app/plugin/YamlPluginFinder.java
+++ b/application/src/main/java/run/halo/app/plugin/YamlPluginFinder.java
@@ -75,8 +75,9 @@ public class YamlPluginFinder {
     }
 
     protected Plugin readPluginDescriptor(Path pluginPath) {
-        Path propertiesPath = getManifestPath(pluginPath, propertiesFileName);
+        Path propertiesPath = null;
         try {
+            propertiesPath = getManifestPath(pluginPath, propertiesFileName);
             if (propertiesPath == null) {
                 throw new PluginRuntimeException("Cannot find the plugin manifest path");
             }

--- a/application/src/main/resources/config/i18n/messages.properties
+++ b/application/src/main/resources/config/i18n/messages.properties
@@ -45,3 +45,4 @@ problemDetail.theme.version.unsatisfied.requires=The theme requires a minimum sy
 problemDetail.directoryTraversal=Directory traversal detected. Base path is {0}, but real path is {1}.
 
 problemDetail.plugin.version.unsatisfied.requires=Plugin requires a minimum system version of {0}, but the current version is {1}.
+problemDetail.plugin.missingManifest=Missing plugin manifest file "plugin.yaml" or manifest file does not conform to the specification.

--- a/application/src/main/resources/config/i18n/messages_zh.properties
+++ b/application/src/main/resources/config/i18n/messages_zh.properties
@@ -14,6 +14,7 @@ problemDetail.user.signUpFailed.disallowed=系统不允许注册新用户。
 problemDetail.user.duplicateName=用户名 {0} 已存在，请更换用户名后重试。
 
 problemDetail.plugin.version.unsatisfied.requires=插件要求一个最小的系统版本为 {0}, 但当前版本为 {1}。
+problemDetail.plugin.missingManifest=缺少 plugin.yaml 配置文件或配置文件不符合规范。
 
 problemDetail.theme.version.unsatisfied.requires=主题要求一个最小的系统版本为 {0}, 但当前版本为 {1}。
 problemDetail.theme.install.missingManifest=缺少 theme.yaml 配置文件或配置文件不符合规范。


### PR DESCRIPTION
#### What type of PR is this?
/kind improvement
/area core
/milestone 2.6.x

#### What this PR does / why we need it:
优化插件安装失败的提示信息

插件安装和升级时由于包格式不正确改为如下提示（Localization）
<img width="449" alt="image" src="https://github.com/halo-dev/halo/assets/38999863/37da0d42-88fa-40c5-a2b9-b8e2698a5930">

how to test it?
使用下面的插件安装和升级会提示 plugin.yaml 缺失
[failed-plugins.zip](https://github.com/halo-dev/halo/files/11560921/failed-plugins.zip)

see #3843 for more details

#### Which issue(s) this PR fixes:

Fixes #3843

#### Does this PR introduce a user-facing change?

```release-note
优化插件安装失败的提示信息
```
