### PR TITLE
Fix the problem of deleting failed plugins for a long time

### DIFF
--- a/api/src/main/java/run/halo/app/extension/controller/RequestQueue.java
+++ b/api/src/main/java/run/halo/app/extension/controller/RequestQueue.java
@@ -56,6 +56,10 @@ public interface RequestQueue<E> extends Disposable {
             return retryAfter;
         }
 
+        public Instant getReadyAt() {
+            return readyAt;
+        }
+
         @Override
         public int compareTo(Delayed o) {
             return Long.compare(getDelay(TimeUnit.MILLISECONDS), o.getDelay(TimeUnit.MILLISECONDS));

--- a/api/src/test/java/run/halo/app/extension/controller/DefaultDelayQueueTest.java
+++ b/api/src/test/java/run/halo/app/extension/controller/DefaultDelayQueueTest.java
@@ -98,6 +98,38 @@ class DefaultDelayQueueTest {
         assertEquals(fakeEntry, queue.peek());
     }
 
+    @Test
+    void shouldNotAddIfHavingEarlierEntryInQueue() {
+        queue = new DefaultQueue<>(() -> now, Duration.ZERO);
+        var fakeEntry = new DelayedEntry<>(newRequest("fake-name"), Duration.ZERO,
+            () -> this.now);
+
+        assertTrue(queue.add(fakeEntry));
+        assertEquals(1, queue.size());
+        assertEquals(fakeEntry, queue.peek());
+
+        assertFalse(queue.add(fakeEntry));
+        var laterEntry = new DelayedEntry<>(newRequest("fake-name"), Duration.ofMillis(100),
+            () -> this.now);
+        assertFalse(queue.add(laterEntry));
+    }
+
+    @Test
+    void shouldAddIfHavingLaterEntryInQueue() {
+        queue = new DefaultQueue<>(() -> now, Duration.ZERO);
+        var fakeEntry = new DelayedEntry<>(newRequest("fake-name"), Duration.ofMillis(100),
+            () -> this.now);
+
+        assertTrue(queue.add(fakeEntry));
+        assertEquals(1, queue.size());
+        assertEquals(fakeEntry, queue.peek());
+
+        assertFalse(queue.add(fakeEntry));
+        var laterEntry = new DelayedEntry<>(newRequest("fake-name"), Duration.ofMillis(99),
+            () -> this.now);
+        assertTrue(queue.add(laterEntry));
+    }
+
     Request newRequest(String name) {
         return new Request(name);
     }

--- a/api/src/test/java/run/halo/app/extension/controller/DelayedEntryTest.java
+++ b/api/src/test/java/run/halo/app/extension/controller/DelayedEntryTest.java
@@ -18,6 +18,7 @@ class DelayedEntryTest {
         var delayedEntry = new DelayedEntry<>("fake", Duration.ofMillis(100), () -> now);
         assertEquals(100, delayedEntry.getDelay(TimeUnit.MILLISECONDS));
         assertEquals(Duration.ofMillis(100), delayedEntry.getRetryAfter());
+        assertEquals(now.plusMillis(100), delayedEntry.getReadyAt());
         assertEquals("fake", delayedEntry.getEntry());
 
         delayedEntry = new DelayedEntry<>("fake", now.plus(Duration.ofSeconds(1)), () -> now);


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/area core
/milestone 2.6.x

#### What this PR does / why we need it:

This PR fixes the problem of deleting failed plugins for a long time by replacing older delayed entry in reconciler queue.

#### Does this PR introduce a user-facing change?

```release-note
修复长时间删除失败的插件问题
```
