### PR TITLE
refactor: use createWebHistory instead of createWebHashHistory

### DIFF
--- a/console/src/router/guards/auth-check.ts
+++ b/console/src/router/guards/auth-check.ts
@@ -16,7 +16,7 @@ export function setupAuthCheckGuard(router: Router) {
       next({
         name: "Login",
         query: {
-          redirect_uri: from.path !== "/" ? window.location.href : undefined,
+          redirect_uri: window.location.href,
         },
       });
       return;

--- a/console/src/router/index.ts
+++ b/console/src/router/index.ts
@@ -1,6 +1,6 @@
 import {
   createRouter,
-  createWebHashHistory,
+  createWebHistory,
   type RouteLocationNormalized,
   type RouteLocationNormalizedLoaded,
 } from "vue-router";
@@ -10,7 +10,7 @@ import { setupCheckStatesGuard } from "./guards/check-states";
 import { setupAuthCheckGuard } from "./guards/auth-check";
 
 const router = createRouter({
-  history: createWebHashHistory(import.meta.env.BASE_URL),
+  history: createWebHistory(import.meta.env.BASE_URL),
   routes: routesConfig,
   scrollBehavior: (
     to: RouteLocationNormalized,


### PR DESCRIPTION
#### What type of PR is this?

/kind improvement
/area console
/milestone 2.6.x

#### What this PR does / why we need it:

将 Console 的 Router 模式从 Hash History 改为 Web History。可以让路由看起来更加简洁，也方便在后端或者页面上构建路由。

文档：https://router.vuejs.org/zh/guide/essentials/history-mode.html

#### Special notes for your reviewer:

测试 Console 的各个页面是否正常访问即可。

#### Does this PR introduce a user-facing change?

```release-note
修改 Console 的路由模式为 HTML5 模式。
```
