### PR TITLE
fix: text content overflowing the container in the dialog component

### DIFF
--- a/console/packages/components/src/components/dialog/Dialog.vue
+++ b/console/packages/components/src/components/dialog/Dialog.vue
@@ -118,7 +118,7 @@ const handleClose = () => {
     </div>
     <div class="flex items-center gap-4">
       <div class="flex-1 flex items-stretch">
-        <div class="text-sm text-gray-700">{{ description }}</div>
+        <div class="text-sm text-gray-700 break-all">{{ description }}</div>
       </div>
     </div>
     <template #footer>


### PR DESCRIPTION
#### What type of PR is this?

/kind improvement
/area console
/milestone 2.6.x

#### What this PR does / why we need it:

修复 Console 端 Dialog 对话框组件中的文字内容可能会溢出容器的问题。

before:

<img width="623" alt="image" src="https://github.com/halo-dev/halo/assets/21301288/ca9817c6-66e4-41f0-8112-4308913efcf2">

after:

<img width="666" alt="image" src="https://github.com/halo-dev/halo/assets/21301288/9d64ee23-124c-434a-b8da-669cfd727dd0">


#### Which issue(s) this PR fixes:

Fixes #4006 

#### Does this PR introduce a user-facing change?

```release-note
修复 Console 端 Dialog 对话框组件中的文字内容可能会溢出容器的问题。
```
