### PR TITLE
Set open mode of indices to CREATE_OR_APPEND

### DIFF
--- a/application/src/main/java/run/halo/app/search/post/LucenePostSearchService.java
+++ b/application/src/main/java/run/halo/app/search/post/LucenePostSearchService.java
@@ -3,7 +3,6 @@ package run.halo.app.search.post;
 import static org.apache.commons.lang3.StringUtils.stripToEmpty;
 import static org.apache.lucene.document.Field.Store.NO;
 import static org.apache.lucene.document.Field.Store.YES;
-import static org.apache.lucene.index.IndexWriterConfig.OpenMode.APPEND;
 import static org.apache.lucene.index.IndexWriterConfig.OpenMode.CREATE_OR_APPEND;
 
 import java.io.IOException;
@@ -116,7 +115,7 @@ public class LucenePostSearchService implements PostSearchService, DisposableBea
     @Override
     public void removeDocuments(Set<String> postNames) throws IOException {
         var writeConfig = new IndexWriterConfig(analyzer);
-        writeConfig.setOpenMode(APPEND);
+        writeConfig.setOpenMode(CREATE_OR_APPEND);
         try (var writer = new IndexWriter(postIndexDir, writeConfig)) {
             var terms = postNames.stream()
                 .map(postName -> new Term(PostDoc.ID_FIELD, postName))
@@ -129,7 +128,7 @@ public class LucenePostSearchService implements PostSearchService, DisposableBea
     @Override
     public void removeAllDocuments() throws Exception {
         var writeConfig = new IndexWriterConfig(analyzer);
-        writeConfig.setOpenMode(APPEND);
+        writeConfig.setOpenMode(CREATE_OR_APPEND);
         try (var writer = new IndexWriter(postIndexDir, writeConfig)) {
             writer.deleteAll();
         }


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/area core
/milestone 2.6.x

#### What this PR does / why we need it:

On first start, we will receive an exception about post indices, please see the logs below:

```java
2023-06-01T10:49:57.191+08:00  INFO 7 --- [         task-1] run.halo.app.search.IndicesInitializer   : Initialize post indices...
2023-06-01T10:49:57.352+08:00 ERROR 7 --- [-controller-t-1] reactor.core.publisher.Operators         : Operator called default onErrorDropped

reactor.core.Exceptions$ErrorCallbackNotImplemented: org.apache.lucene.index.IndexNotFoundException: no segments* file found in LockValidatingDirectoryWrapper(MMapDirectory@/root/.halo2/indices/posts lockFactory=org.apache.lucene.store.NativeFSLockFactory@3de15f4f): files: [write.lock]
Caused by: org.apache.lucene.index.IndexNotFoundException: no segments* file found in LockValidatingDirectoryWrapper(MMapDirectory@/root/.halo2/indices/posts lockFactory=org.apache.lucene.store.NativeFSLockFactory@3de15f4f): files: [write.lock]
	at org.apache.lucene.index.IndexWriter.<init>(IndexWriter.java:1075) ~[lucene-core-9.5.0.jar:9.5.0 13803aa6ea7fee91f798cfeded4296182ac43a21 - 2023-01-25 16:44:59]
	at run.halo.app.search.post.LucenePostSearchService.removeAllDocuments(LucenePostSearchService.java:133) ~[classes/:2.6.0-SNAPSHOT]
	at run.halo.app.search.IndicesServiceImpl.lambda$rebuildPostIndices$0(IndicesServiceImpl.java:31) ~[classes/:2.6.0-SNAPSHOT]
	at reactor.core.publisher.MonoRunnable.call(MonoRunnable.java:73) ~[reactor-core-3.5.6.jar:3.5.6]
	at reactor.core.publisher.MonoRunnable.call(MonoRunnable.java:32) ~[reactor-core-3.5.6.jar:3.5.6]
```

The problem is caused by <https://github.com/halo-dev/halo/pull/3877>.

This PR sets open mode of indices to `CREATE_OR_APPEND`, which should resolve the problem.

#### Special notes for your reviewer:

1. Try to delete indices folder, such as `~/halo2-dev/indices`
2. Start Halo and check the log

#### Does this PR introduce a user-facing change?

```release-note
None
```
