### PR TITLE
refactor: refresh the plugin wrapper when starting the plugin

### DIFF
--- a/api/src/main/java/run/halo/app/plugin/BasePlugin.java
+++ b/api/src/main/java/run/halo/app/plugin/BasePlugin.java
@@ -2,7 +2,6 @@ package run.halo.app.plugin;
 
 import lombok.extern.slf4j.Slf4j;
 import org.pf4j.Plugin;
-import org.pf4j.PluginManager;
 import org.pf4j.PluginWrapper;
 
 /**
@@ -15,12 +14,12 @@ import org.pf4j.PluginWrapper;
 @Slf4j
 public class BasePlugin extends Plugin {
 
+    @Deprecated
     public BasePlugin(PluginWrapper wrapper) {
         super(wrapper);
         log.info("Initialized plugin {}", wrapper.getPluginId());
     }
 
-    private PluginManager getPluginManager() {
-        return getWrapper().getPluginManager();
+    public BasePlugin() {
     }
 }

--- a/application/src/main/java/run/halo/app/core/extension/reconciler/PluginReconciler.java
+++ b/application/src/main/java/run/halo/app/core/extension/reconciler/PluginReconciler.java
@@ -289,8 +289,7 @@ public class PluginReconciler implements Reconciler<Request> {
 
     void stateTransition(String name, Function<PluginState, Boolean> stateAction,
         PluginState desiredState) {
-        PluginWrapper pluginWrapper = getPluginWrapper(name);
-        PluginState currentState = pluginWrapper.getPluginState();
+        PluginState currentState = getPluginWrapper(name).getPluginState();
         int maxRetries = PluginState.values().length;
         for (int i = 0; i < maxRetries && currentState != desiredState; i++) {
             try {
@@ -303,7 +302,7 @@ public class PluginReconciler implements Reconciler<Request> {
                     break;
                 }
                 // update current state
-                currentState = pluginWrapper.getPluginState();
+                currentState = getPluginWrapper(name).getPluginState();
             } catch (Throwable e) {
                 persistenceFailureStatus(name, e);
                 throw e;

--- a/application/src/main/java/run/halo/app/plugin/BasePluginFactory.java
+++ b/application/src/main/java/run/halo/app/plugin/BasePluginFactory.java
@@ -29,7 +29,7 @@ public class BasePluginFactory implements PluginFactory {
                         "No bean named 'basePlugin' found in the context create default instance");
                     DefaultListableBeanFactory beanFactory =
                         context.getDefaultListableBeanFactory();
-                    BasePlugin pluginInstance = new BasePlugin(pluginWrapper);
+                    BasePlugin pluginInstance = new BasePlugin();
                     beanFactory.registerSingleton(Plugin.class.getName(), pluginInstance);
                     return pluginInstance;
                 }


### PR DESCRIPTION
#### What type of PR is this?
/kind improvement
/kind bug
/area core
/area plugin
/milestone 2.6.x

#### What this PR does / why we need it:
修复插件重启后 MainClass 对象缓存未清除的问题

how to test it?
下载此插件：
[plugin-starter-1.0.0-SNAPSHOT.jar.zip](https://github.com/halo-dev/halo/files/11620847/plugin-starter-1.0.0-SNAPSHOT.jar.zip)

安装并启动插件，会看到类似如下日志：
```
测试从 [/var/folders/1z/3hlt62691tx63dxx6y0mryw00000gn/T/halo-plugin3709893537121269748.txt] 文件读取内容
插件启动成功！
```
修改日志中给出的文件的内容后 reload 插件会看到`插件启动成功！` 后会跟随最新的文件内容则表示 MainClass 是最新的状态没有缓存。

#### Which issue(s) this PR fixes:

Fixes #4016

#### Does this PR introduce a user-facing change?

```release-note
修复插件重启后 MainClass 对象缓存未清除的问题
```
