### PR TITLE
refactor: support for custom api group in plugin controllers

### DIFF
--- a/application/src/test/java/run/halo/app/plugin/PluginRequestMappingHandlerMappingTest.java
+++ b/application/src/test/java/run/halo/app/plugin/PluginRequestMappingHandlerMappingTest.java
@@ -174,6 +174,15 @@ class PluginRequestMappingHandlerMappingTest {
                 Set.of(HttpMethod.GET, HttpMethod.HEAD)));
     }
 
+    @Test
+    void buildPrefix() {
+        String s = handlerMapping.buildPrefix("fakePlugin", "v1");
+        assertThat(s).isEqualTo("/apis/api.plugin.halo.run/v1/plugins/fakePlugin");
+
+        s = handlerMapping.buildPrefix("fakePlugin", "fake.halo.run/v1alpha1");
+        assertThat(s).isEqualTo("/apis/fake.halo.run/v1alpha1");
+    }
+
     @SuppressWarnings("unchecked")
     private <T> void assertError(Mono<Object> mono, final Class<T> exceptionClass,
         final Consumer<T> consumer) {


### PR DESCRIPTION
#### What type of PR is this?
/kind improvement
/area core
/milestone 2.7.x

#### What this PR does / why we need it:
插件的 Controllers 支持自定义 API Group
如：
```java
@RestController
@ApiVersion("fake.halo.run/v1")
@RequestMapping("/fake")
public class DemoController {
}
```
则生成路由为 `/apis/fake.halo.run/v1/fake`
如果没有 group 默认兼容以前的为 `/apis/api.plugin.halo.run/{version}/plugins/{pluginName}/**`
```java
@RestController
@ApiVersion("v1alpha1")
@RequestMapping("/fake")
public class DemoController {
}
```

#### Which issue(s) this PR fixes:
Fixes #4053

#### Does this PR introduce a user-facing change?
```release-note
插件的 Controllers 支持自定义 API Group
```
