### PR TITLE
Adapt workflow for release-2.5 branch

### DIFF
--- a/.github/workflows/halo.yaml
+++ b/.github/workflows/halo.yaml
@@ -3,15 +3,13 @@ name: Halo CI
 on:
   pull_request:
     branches:
-      - main
-      - release-*
+      - release-2.5
     paths:
       - "**"
       - "!**.md"
   push:
     branches:
-      - main
-      - release-*
+      - release-2.5
     paths:
       - "**"
       - "!**.md"
@@ -45,7 +43,7 @@ jobs:
         uses: codecov/codecov-action@v3
       - name: Setup console environment
         if: steps.changes.outputs.console == 'true'
-        uses: halo-sigs/actions/admin-env-setup@main
+        uses: halo-sigs/actions/admin-env-setup@release-2.5
       - name: Check console
         if: steps.changes.outputs.console == 'true'
         run: make -C console check
@@ -54,11 +52,11 @@ jobs:
     needs: check
     steps:
       - uses: actions/checkout@v3
-      - uses: halo-sigs/actions/halo-next-docker-build@main # change the version to specific ref or release tag while the action is stable.
+      - uses: halo-sigs/actions/halo-next-docker-build@release-2.5 # change the version to specific ref or release tag while the action is stable.
         with:
           image-name: ${{ github.event_name == 'release' && 'halo' || 'halo-dev' }}
           ghcr-token: ${{ secrets.GHCR_TOKEN }}
           dockerhub-user: ${{ secrets.DOCKER_USERNAME }}
           dockerhub-token: ${{ secrets.DOCKER_TOKEN }}
           push: ${{ github.event_name == 'push' || github.event_name == 'release' }} # we only push to GHCR if the push is to the next branch
-          console-ref: ${{ github.event_name == 'release' &&  github.ref || 'main' }}
+          console-ref: ${{ github.event_name == 'release' &&  github.ref || 'release-2.5' }}

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ docker run \
   --name halo \
   -p 8090:8090 \
   -v ~/.halo2:/root/.halo2 \
-  halohub/halo:2.4 \
+  halohub/halo:2.5 \
   --halo.external-url=http://localhost:8090/ \
   --halo.security.initializer.superadminusername=admin \
   --halo.security.initializer.superadminpassword=P@88w0rd

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-version=2.5.0-SNAPSHOT
+version=2.5.3-SNAPSHOT


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup
/area core

#### What this PR does / why we need it:

This PR adapts GitHub workflow for branch `release-2.5` and bumps Halo version to 2.5.3-SNAPSHOT. Or the workflow on branch `release-2.5` will fail.

#### Does this PR introduce a user-facing change?

```release-note
None
```
