### PR TITLE
chore: bump google guava version to 32.0.1-jre

### DIFF
--- a/application/build.gradle
+++ b/application/build.gradle
@@ -51,7 +51,6 @@ ext {
     base62 = "0.1.3"
     pf4j = '3.9.0'
     javaDiffUtils = "4.12"
-    guava = "31.1-jre"
     jsoup = '1.15.3'
     jsonPatch = "1.13"
     springDocOpenAPI = "2.0.2"

--- a/platform/application/build.gradle
+++ b/platform/application/build.gradle
@@ -15,7 +15,7 @@ ext {
     base62 = "0.1.3"
     pf4j = '3.9.0'
     javaDiffUtils = "4.12"
-    guava = "31.1-jre"
+    guava = "32.0.1-jre"
     jsoup = '1.15.3'
     jsonPatch = "1.13"
     springDocOpenAPI = "2.1.0"


### PR DESCRIPTION
#### What type of PR is this?
/milestone 2.7.x
/area core

#### What this PR does / why we need it:
升级 Google Guava 版本至 32.0.1-jre

Guava [31.1](https://github.com/google/guava/releases/tag/v31.1) 至 [32.0.1](https://github.com/google/guava/releases/tag/v32.0.1) 的变化：
1. 移除了部分 API 的 `@Beta` 注解进入稳定版
2. 关于 `Files.createTempDir` 方法的安全性修复 https://github.com/advisories/GHSA-7g45-4rm6-3mm3 (https://github.com/google/guava/issues/2575)

详情参考：https://github.com/google/guava/releases/tag/v32.0.0

#### Does this PR introduce a user-facing change?

```release-note
升级 Google Guava 版本至 32.0.1-jre
```
