### PR TITLE
perf: remove html lang attribute in console

### DIFF
--- a/console/index.html
+++ b/console/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html>
   <head>
     <meta charset="UTF-8" />
     <meta content="IE=edge" http-equiv="X-UA-Compatible" />


### PR DESCRIPTION
#### What type of PR is this?
/kind improvement
/area console

#### What this PR does / why we need it:

去除`index.html`的`lang`属性以避免console端出现翻译提示

#### Which issue(s) this PR fixes:

Fixes https://github.com/halo-dev/halo/issues/3692

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?


```release-note
避免 Console 端出现翻译提示
```
