### PR TITLE
feat: add mouse hover style to the default type of button

### DIFF
--- a/console/packages/components/src/components/button/Button.vue
+++ b/console/packages/components/src/components/button/Button.vue
@@ -123,6 +123,10 @@ function handleClick() {
 .btn-default {
   border: 1px solid #d9d9d9;
 
+  &:hover {
+    @apply bg-gray-100;
+  }
+
   .btn-icon {
     @apply text-secondary;
   }


### PR DESCRIPTION
#### What type of PR is this?

/area console
/kind improvement
/milestone 2.7.x

#### What this PR does / why we need it:

为默认类型的按钮添加鼠标悬浮的样式。

<img width="333" alt="image" src="https://github.com/halo-dev/halo/assets/21301288/922dd681-a2f1-4875-adef-9d1c5a075467">

#### Which issue(s) this PR fixes:

Fixes #4067 

#### Does this PR introduce a user-facing change?

```release-note
Console 端默认类型的按钮添加鼠标悬浮的样式。
```
