### PR TITLE
perf: improve the text length style of the comment subject ref title

### DIFF
--- a/console/src/modules/contents/comments/components/CommentListItem.vue
+++ b/console/src/modules/contents/comments/components/CommentListItem.vue
@@ -304,7 +304,7 @@ const subjectRefResult = computed(() => {
               <VTag>{{ subjectRefResult.label }}</VTag>
               <RouterLink
                 :to="subjectRefResult.route || $route"
-                class="truncate text-sm font-medium text-gray-900 hover:text-gray-600"
+                class="line-clamp-2 inline-block text-sm font-medium text-gray-900 hover:text-gray-600"
               >
                 {{ subjectRefResult.title }}
               </RouterLink>


### PR DESCRIPTION
#### What type of PR is this?

/area console
/kind improvement
/milestone 2.7.x

#### What this PR does / why we need it:

Fix style issue of the comment subject ref title.

before:

<img width="1386" alt="image" src="https://github.com/halo-dev/halo/assets/21301288/d6c845d4-039b-42bb-855a-01c9ddf113ee">

after:

<img width="1390" alt="image" src="https://github.com/halo-dev/halo/assets/21301288/0f53f3fb-ab59-4b12-9352-49623b121347">


#### Which issue(s) this PR fixes:

Fixes #4068 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
None
```
