### PR TITLE
Remap RequestNotPermittedException with RateLimitExceededException

### DIFF
--- a/application/src/main/java/run/halo/app/infra/exception/RateLimitExceededException.java
+++ b/application/src/main/java/run/halo/app/infra/exception/RateLimitExceededException.java
@@ -1,0 +1,15 @@
+package run.halo.app.infra.exception;
+
+import java.net.URI;
+import org.springframework.http.HttpStatus;
+import org.springframework.lang.Nullable;
+import org.springframework.web.server.ResponseStatusException;
+
+public class RateLimitExceededException extends ResponseStatusException {
+
+    public RateLimitExceededException(@Nullable Throwable cause) {
+        super(HttpStatus.TOO_MANY_REQUESTS, "You have exceeded your quota", cause);
+        setType(URI.create(Exceptions.REQUEST_NOT_PERMITTED_TYPE));
+    }
+
+}

--- a/application/src/main/resources/config/i18n/messages.properties
+++ b/application/src/main/resources/config/i18n/messages.properties
@@ -18,7 +18,7 @@ problemDetail.title.run.halo.app.infra.exception.ThemeUpgradeException=Theme Upg
 problemDetail.title.run.halo.app.infra.exception.PluginInstallationException=Plugin Install Error
 problemDetail.title.run.halo.app.infra.exception.PluginAlreadyExistsException=Plugin Already Exists Error
 problemDetail.title.run.halo.app.infra.exception.DuplicateNameException=Duplicate Name Error
-problemDetail.title.io.github.resilience4j.ratelimiter.RequestNotPermitted=Request Not Permitted
+problemDetail.title.run.halo.app.infra.exception.RateLimitExceededException=Request Not Permitted
 problemDetail.title.internalServerError=Internal Server Error
 
 # Detail definitions
@@ -36,7 +36,7 @@ problemDetail.run.halo.app.extension.exception.SchemaViolationException={1} of s
 problemDetail.run.halo.app.infra.exception.AttachmentAlreadyExistsException=File {0} already exists, please rename it and try again.
 problemDetail.run.halo.app.infra.exception.DuplicateNameException=Duplicate name detected, please rename it and retry.
 problemDetail.run.halo.app.infra.exception.PluginAlreadyExistsException=Plugin {0} already exists.
-problemDetail.io.github.resilience4j.ratelimiter.RequestNotPermitted=API rate limit exceeded, please try again later.
+problemDetail.run.halo.app.infra.exception.RateLimitExceededException=API rate limit exceeded, please try again later.
 
 problemDetail.user.signUpFailed.disallowed=System does not allow new users to register.
 problemDetail.user.duplicateName=The username {0} already exists, please rename it and retry.

--- a/application/src/main/resources/config/i18n/messages_zh.properties
+++ b/application/src/main/resources/config/i18n/messages_zh.properties
@@ -6,14 +6,14 @@ problemDetail.title.run.halo.app.infra.exception.AttachmentAlreadyExistsExceptio
 problemDetail.title.run.halo.app.infra.exception.DuplicateNameException=名称重复
 problemDetail.title.run.halo.app.infra.exception.PluginAlreadyExistsException=插件已存在
 problemDetail.title.run.halo.app.infra.exception.ThemeInstallationException=主题安装失败
-problemDetail.title.io.github.resilience4j.ratelimiter.RequestNotPermitted=请求限制
+problemDetail.title.run.halo.app.infra.exception.RateLimitExceededException=请求限制
 problemDetail.title.internalServerError=服务器内部错误
 
 problemDetail.org.springframework.security.authentication.BadCredentialsException=用户名或密码错误。
 problemDetail.run.halo.app.infra.exception.AttachmentAlreadyExistsException=文件 {0} 已存在，建议更名后重试。
 problemDetail.run.halo.app.infra.exception.DuplicateNameException=检测到有重复的名称，请重命名后重试。
 problemDetail.run.halo.app.infra.exception.PluginAlreadyExistsException=插件 {0} 已经存。
-problemDetail.io.github.resilience4j.ratelimiter.RequestNotPermitted=请求过于频繁，请稍候再试。
+problemDetail.run.halo.app.infra.exception.RateLimitExceededException=请求过于频繁，请稍候再试。
 
 problemDetail.user.signUpFailed.disallowed=系统不允许注册新用户。
 problemDetail.user.duplicateName=用户名 {0} 已存在，请更换用户名后重试。


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/area core

#### What this PR does / why we need it:

Remap RequestNotPremittedException with RateLimitExceededException which is an ErrorResponse instance, because we might use another RateLimit library in the future.

We will get correct response like this when comment rate limit exceeds:

```json
{
  "type": "https://halo.run/probs/request-not-permitted",
  "title": "Request Not Permitted",
  "status": 429,
  "detail": "API rate limit exceeded, please try again later.",
  "instance": "http://localhost:8090/apis/api.halo.run/v1alpha1/comments",
  "requestId": "3156eafe-62",
  "timestamp": "2023-06-26T04:23:26.205595Z"
}
```

#### Which issue(s) this PR fixes:

See https://github.com/halo-dev/halo/pull/4084#discussion_r1241219878 for more.

#### Does this PR introduce a user-facing change?

```release-note
None
```
