### PR TITLE
Add rate limiter for signing up

### DIFF
--- a/application/src/main/resources/application.yaml
+++ b/application/src/main/resources/application.yaml
@@ -81,4 +81,7 @@ resilience4j.ratelimiter:
       limitForPeriod: 10
       limitRefreshPeriod: 1m
       timeoutDuration: 10s
-
+    signup:
+      limitForPeriod: 3
+      limitRefreshPeriod: 1h
+      timeoutDuration: 0s


### PR DESCRIPTION
#### What type of PR is this?

/kind feature
/area core
/milestone 2.7.x

#### What this PR does / why we need it:

Add rate limiter for signing up. We only allow 3 registrations within 1 hour by default, despite registration failure.

#### Special notes for your reviewer:

1. Start Halo and console.
2. Try to enable registration for public users.
3. Browse <http://localhost:8090/console/login?type=signup>
4. Input duplicate username for 4 times and see the result.
5. Or input valid username for 4 times and see the result.

#### Does this PR introduce a user-facing change?

```release-note
限制注册接口的请求速率
```
