### PR TITLE
feat: support obtaining the raw external URL configuration

### DIFF
--- a/api/src/main/java/run/halo/app/infra/ExternalUrlSupplier.java
+++ b/api/src/main/java/run/halo/app/infra/ExternalUrlSupplier.java
@@ -3,6 +3,7 @@ package run.halo.app.infra;
 import java.net.URI;
 import java.net.URL;
 import java.util.function.Supplier;
+import javax.annotation.Nullable;
 import org.springframework.http.HttpRequest;
 
 /**
@@ -30,4 +31,11 @@ public interface ExternalUrlSupplier extends Supplier<URI> {
      */
     URL getURL(HttpRequest request);
 
+    /**
+     * Gets user-configured external URL from <code>HaloProperties#getExternalUrl()</code>.
+     *
+     * @return user-configured external URL or null if it is not provided.
+     */
+    @Nullable
+    URL getRaw();
 }

--- a/application/src/main/java/run/halo/app/infra/HaloPropertiesExternalUrlSupplier.java
+++ b/application/src/main/java/run/halo/app/infra/HaloPropertiesExternalUrlSupplier.java
@@ -6,6 +6,7 @@ import java.net.URISyntaxException;
 import java.net.URL;
 import org.springframework.boot.autoconfigure.web.reactive.WebFluxProperties;
 import org.springframework.http.HttpRequest;
+import org.springframework.lang.Nullable;
 import org.springframework.stereotype.Component;
 import org.springframework.util.StringUtils;
 import run.halo.app.infra.properties.HaloProperties;
@@ -52,6 +53,12 @@ public class HaloPropertiesExternalUrlSupplier implements ExternalUrlSupplier {
             }
         }
         return externalUrl;
+    }
+
+    @Nullable
+    @Override
+    public URL getRaw() {
+        return haloProperties.getExternalUrl();
     }
 
     private String getBasePath() {

--- a/application/src/test/java/run/halo/app/infra/HaloPropertiesExternalUrlSupplierTest.java
+++ b/application/src/test/java/run/halo/app/infra/HaloPropertiesExternalUrlSupplierTest.java
@@ -1,6 +1,7 @@
 package run.halo.app.infra;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -103,6 +104,16 @@ class HaloPropertiesExternalUrlSupplierTest {
         when(mockRequest.getURI()).thenReturn(fakeUri);
         var url = externalUrl.getURL(mockRequest);
         assertEquals(new URL("https://localhost/blog"), url);
+    }
+
+    @Test
+    void getRaw() throws MalformedURLException {
+        var fakeUri = URI.create("http://localhost/fake");
+        when(haloProperties.getExternalUrl()).thenReturn(fakeUri.toURL());
+        assertEquals(fakeUri.toURL(), externalUrl.getRaw());
+
+        when(haloProperties.getExternalUrl()).thenReturn(null);
+        assertNull(externalUrl.getRaw());
     }
 
 }


### PR DESCRIPTION
#### What type of PR is this?
/kind feature
/area core
/milestone 2.7.x

#### What this PR does / why we need it:
支持通过 ExternalUrlSupplier 获取 externalUrl 配置

#### Which issue(s) this PR fixes:

Fixes #4149

#### Does this PR introduce a user-facing change?
```release-note
支持通过 ExternalUrlSupplier 获取 externalUrl 配置
```

