### PR TITLE
fix: creating a draft cannot be displayed in the post list

### DIFF
--- a/application/src/main/java/run/halo/app/content/AbstractContentService.java
+++ b/application/src/main/java/run/halo/app/content/AbstractContentService.java
@@ -26,14 +26,17 @@ public abstract class AbstractContentService {
     private final ReactiveExtensionClient client;
 
     public Mono<ContentWrapper> getContent(String snapshotName, String baseSnapshotName) {
-        return client.get(Snapshot.class, baseSnapshotName)
+        if (StringUtils.isBlank(snapshotName) || StringUtils.isBlank(baseSnapshotName)) {
+            return Mono.empty();
+        }
+        return client.fetch(Snapshot.class, baseSnapshotName)
             .doOnNext(this::checkBaseSnapshot)
             .flatMap(baseSnapshot -> {
                 if (StringUtils.equals(snapshotName, baseSnapshotName)) {
                     var contentWrapper = ContentWrapper.patchSnapshot(baseSnapshot, baseSnapshot);
                     return Mono.just(contentWrapper);
                 }
-                return client.get(Snapshot.class, snapshotName)
+                return client.fetch(Snapshot.class, snapshotName)
                     .map(snapshot -> ContentWrapper.patchSnapshot(snapshot, baseSnapshot));
             });
     }

--- a/application/src/main/java/run/halo/app/content/AbstractContentService.java
+++ b/application/src/main/java/run/halo/app/content/AbstractContentService.java
@@ -4,6 +4,7 @@ import java.security.Principal;
 import java.time.Instant;
 import java.util.UUID;
 import lombok.AllArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.lang.Nullable;
 import org.springframework.security.core.context.ReactiveSecurityContextHolder;
@@ -20,6 +21,7 @@ import run.halo.app.extension.ReactiveExtensionClient;
  * @author guqing
  * @since 2.0.0
  */
+@Slf4j
 @AllArgsConstructor
 public abstract class AbstractContentService {
 
@@ -29,6 +31,7 @@ public abstract class AbstractContentService {
         if (StringUtils.isBlank(snapshotName) || StringUtils.isBlank(baseSnapshotName)) {
             return Mono.empty();
         }
+        // TODO: refactor this method to use client.get instead of fetch but please be careful
         return client.fetch(Snapshot.class, baseSnapshotName)
             .doOnNext(this::checkBaseSnapshot)
             .flatMap(baseSnapshot -> {
@@ -38,7 +41,12 @@ public abstract class AbstractContentService {
                 }
                 return client.fetch(Snapshot.class, snapshotName)
                     .map(snapshot -> ContentWrapper.patchSnapshot(snapshot, baseSnapshot));
-            });
+            })
+            .switchIfEmpty(Mono.defer(() -> {
+                log.error("The content snapshot [{}] or base snapshot [{}] not found.",
+                    snapshotName, baseSnapshotName);
+                return Mono.empty();
+            }));
     }
 
     protected void checkBaseSnapshot(Snapshot snapshot) {

--- a/application/src/main/java/run/halo/app/theme/router/PreviewRouterFunction.java
+++ b/application/src/main/java/run/halo/app/theme/router/PreviewRouterFunction.java
@@ -70,7 +70,7 @@ public class PreviewRouterFunction {
             .flatMap(post -> canPreview(post.getContributors())
                 .doOnNext(canPreview -> {
                     if (!canPreview) {
-                        throw new NotFoundException("Page not found.");
+                        throw new NotFoundException("Post not found.");
                     }
                 })
                 .thenReturn(post)
@@ -138,7 +138,7 @@ public class PreviewRouterFunction {
             .flatMap(singlePageVo -> canPreview(singlePageVo.getContributors())
                 .doOnNext(canPreview -> {
                     if (!canPreview) {
-                        throw new NotFoundException("Page not found.");
+                        throw new NotFoundException("Single page not found.");
                     }
                 })
                 .thenReturn(singlePageVo)


### PR DESCRIPTION
#### What this PR does / why we need it:
此改动为还原 AbstractContentService 的 getContent 逻辑

当将 AbstractContentService 的 getContent 的查询改为 client.get 时会影响到文章 reconciler 的调用导致出错后一直requeue 所以无法完成文章逻辑处理。
<img width="633" alt="image" src="https://github.com/halo-dev/halo/assets/38999863/93743cac-f3db-4ff7-837c-bd42dfcf1280">
reconciler 这里获取 releaseSnapshot 时可能文章还是草稿，所以会导致调用 getContent 时多一次查询，所以最好是后续判断一下，当然这里已经在 getContent 判断了

#### Which issue(s) this PR fixes:
Fixes #4154

#### Does this PR introduce a user-facing change?

```release-note
None
```
