### PR TITLE
feat: record the attachment query conditions in the route query parameters

### DIFF
--- a/console/src/modules/contents/attachments/AttachmentList.vue
+++ b/console/src/modules/contents/attachments/AttachmentList.vue
@@ -57,12 +57,16 @@ const { groups, handleFetchGroups } = useFetchAttachmentGroup();
 const selectedGroup = ref<Group>();
 
 // Filter
-const keyword = ref<string>("");
-const page = ref<number>(1);
-const size = ref<number>(60);
-const selectedPolicy = ref();
-const selectedUser = ref();
-const selectedSort = ref();
+const keyword = useRouteQuery<string>("keyword", "");
+const page = useRouteQuery<number>("page", 1, {
+  transform: Number,
+});
+const size = useRouteQuery<number>("size", 60, {
+  transform: Number,
+});
+const selectedPolicy = useRouteQuery<string | undefined>("policy");
+const selectedUser = useRouteQuery<string | undefined>("user");
+const selectedSort = useRouteQuery<string | undefined>("sort");
 
 watch(
   () => [


### PR DESCRIPTION
#### What type of PR is this?

/area console
/kind feature
/milestone 2.8.x

#### What this PR does / why we need it:

在附件数据管理列表页面路由中记录查询条件，包括分页信息、筛选信息等。可以保证在刷新浏览器窗口或者从编辑页面返回时保留之前的查询状态。

<img width="1714" alt="image" src="https://github.com/halo-dev/halo/assets/21301288/cd3ab1da-ac5c-48c7-a8f2-83f2f86a47bc">

#### Special notes for your reviewer:

需要测试：

1. 附件管理列表的所有筛选项是否可以正常工作。
2. 尝试设置部分筛选，然后刷新页面，观察筛选条件是否正常保留。

#### Does this PR introduce a user-facing change?

```release-note
Console 端的附件管理列表支持在地址栏记录筛选条件。
```
