### PR TITLE
fix: plugin delete lifecycle method will not be triggered when the plugin is uninstalled

### DIFF
--- a/application/src/main/java/run/halo/app/core/extension/reconciler/PluginReconciler.java
+++ b/application/src/main/java/run/halo/app/core/extension/reconciler/PluginReconciler.java
@@ -714,22 +714,8 @@ public class PluginReconciler implements Reconciler<Request> {
         if (pluginWrapper != null) {
             // pluginWrapper must not be null in below code
             // stop and unload plugin, see also PluginBeforeStopSyncListener
-            if (!haloPluginManager.unloadPlugin(name)) {
-                throw new IllegalStateException("Failed to unload plugin: " + name);
-            }
-        }
-
-        // delete plugin resources
-        Path pluginPath = Optional.ofNullable(plugin.statusNonNull().getLoadLocation())
-            .map(URI::getPath)
-            .map(Paths::get)
-            .orElse(null);
-        if (pluginPath != null && isJarFile(pluginPath)) {
-            // delete plugin file
-            try {
-                Files.deleteIfExists(pluginPath);
-            } catch (IOException e) {
-                throw new RuntimeException(e);
+            if (!haloPluginManager.deletePlugin(name)) {
+                throw new IllegalStateException("Failed to delete plugin: " + name);
             }
         }
     }

--- a/application/src/main/java/run/halo/app/plugin/DefaultDevelopmentPluginRepository.java
+++ b/application/src/main/java/run/halo/app/plugin/DefaultDevelopmentPluginRepository.java
@@ -7,6 +7,11 @@ import org.pf4j.DevelopmentPluginRepository;
 import org.springframework.util.CollectionUtils;
 
 /**
+ * <p>A {@link org.pf4j.PluginRepository} implementation that can add fixed plugin paths for
+ * development {@link org.pf4j.RuntimeMode#DEVELOPMENT}.</p>
+ * <p>change {@link #deletePluginPath(Path)} to a no-op method.</p>
+ * Note: This class is not thread-safe.
+ *
  * @author guqing
  * @since 2.0.0
  */
@@ -38,5 +43,11 @@ public class DefaultDevelopmentPluginRepository extends DevelopmentPluginReposit
         List<Path> paths = new ArrayList<>(fixedPaths);
         paths.addAll(super.getPluginPaths());
         return paths;
+    }
+
+    @Override
+    public boolean deletePluginPath(Path pluginPath) {
+        // do nothing
+        return true;
     }
 }

--- a/application/src/test/java/run/halo/app/plugin/DefaultDevelopmentPluginRepositoryTest.java
+++ b/application/src/test/java/run/halo/app/plugin/DefaultDevelopmentPluginRepositoryTest.java
@@ -1,0 +1,46 @@
+package run.halo.app.plugin;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.pf4j.PluginRepository;
+
+/**
+ * Tests for {@link DefaultDevelopmentPluginRepository}.
+ *
+ * @author guqing
+ * @since 2.7.0
+ */
+class DefaultDevelopmentPluginRepositoryTest {
+
+    private PluginRepository developmentPluginRepository;
+    private Path tempDir;
+
+    @BeforeEach
+    void setUp() throws IOException {
+        this.tempDir = Files.createTempDirectory("halo-plugin-repo");
+        this.developmentPluginRepository =
+            new DefaultDevelopmentPluginRepository();
+    }
+
+    @AfterEach
+    void tearDown() throws IOException {
+        Files.delete(tempDir);
+    }
+
+    @Test
+    void deletePluginPath() {
+        boolean deleted = developmentPluginRepository.deletePluginPath(null);
+        assertThat(deleted).isTrue();
+
+        // deletePluginPath is a no-op
+        deleted = developmentPluginRepository.deletePluginPath(tempDir);
+        assertThat(deleted).isTrue();
+        assertThat(Files.exists(tempDir)).isTrue();
+    }
+}

--- a/application/src/test/java/run/halo/app/plugin/DefaultDevelopmentPluginRepositoryTest.java
+++ b/application/src/test/java/run/halo/app/plugin/DefaultDevelopmentPluginRepositoryTest.java
@@ -2,12 +2,11 @@ package run.halo.app.plugin;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 import org.pf4j.PluginRepository;
 
 /**
@@ -19,18 +18,14 @@ import org.pf4j.PluginRepository;
 class DefaultDevelopmentPluginRepositoryTest {
 
     private PluginRepository developmentPluginRepository;
+
+    @TempDir
     private Path tempDir;
 
     @BeforeEach
-    void setUp() throws IOException {
-        this.tempDir = Files.createTempDirectory("halo-plugin-repo");
+    void setUp() {
         this.developmentPluginRepository =
             new DefaultDevelopmentPluginRepository();
-    }
-
-    @AfterEach
-    void tearDown() throws IOException {
-        Files.delete(tempDir);
     }
 
     @Test


### PR DESCRIPTION
#### What type of PR is this?
/kind bug
/kind improvement
/area core
/milestone 2.8.x

#### What this PR does / why we need it:
修复插件被卸载时 delete 生命周期方法不会被触发的问题

how to test it?
1. 测试开发模式下卸载插件，delete 生命周期方法被触发且不会误删项目目录
2. 测试生产模式下插件卸载，文件正确被删除且触发 delete 生命生命周期方法

#### Which issue(s) this PR fixes:
Fixes #4238

#### Does this PR introduce a user-facing change?
```release-note
修复插件被卸载时 delete 生命周期方法不会被触发的问题
```