### PR TITLE
feat: refine validation for password field

### DIFF
--- a/console/src/components/signup/SignupForm.vue
+++ b/console/src/components/signup/SignupForm.vue
@@ -125,7 +125,10 @@ const inputClasses = {
       :validation-label="$t('core.signup.fields.password.placeholder')"
       :classes="inputClasses"
       type="password"
-      validation="required|length:0,100"
+      validation="required:trim|length:5,100|matches:/^\S.*\S$/"
+      :validation-messages="{
+        matches: $t('core.formkit.validation.trim'),
+      }"
     >
     </FormKit>
     <FormKit
@@ -134,7 +137,10 @@ const inputClasses = {
       :validation-label="$t('core.signup.fields.password_confirm.placeholder')"
       :classes="inputClasses"
       type="password"
-      validation="required|confirm|length:0,100"
+      validation="confirm|required:trim|length:5,100|matches:/^\S.*\S$/"
+      :validation-messages="{
+        matches: $t('core.formkit.validation.trim'),
+      }"
     >
     </FormKit>
   </FormKit>

--- a/console/src/locales/en.yaml
+++ b/console/src/locales/en.yaml
@@ -1105,6 +1105,8 @@ core:
       creation_label: "Create {text} category"
     tag_select:
       creation_label: "Create {text} tag"
+    validation:
+      trim: Please remove the leading and trailing spaces
   common:
     buttons:
       save: Save

--- a/console/src/locales/zh-CN.yaml
+++ b/console/src/locales/zh-CN.yaml
@@ -1105,6 +1105,8 @@ core:
       creation_label: 创建 {text} 分类
     tag_select:
       creation_label: 创建 {text} 标签
+    validation:
+      trim: 不能以空格开头或结尾
   common:
     buttons:
       save: 保存

--- a/console/src/locales/zh-TW.yaml
+++ b/console/src/locales/zh-TW.yaml
@@ -1105,6 +1105,8 @@ core:
       creation_label: 創建 {text} 分類
     tag_select:
       creation_label: 創建 {text} 標籤
+    validation:
+      trim: 不能以空格開頭或結尾
   common:
     buttons:
       save: 保存

--- a/console/src/modules/system/users/components/UserCreationModal.vue
+++ b/console/src/modules/system/users/components/UserCreationModal.vue
@@ -161,7 +161,10 @@ const handleCreateUser = async () => {
         :label="$t('core.user.change_password_modal.fields.new_password.label')"
         type="password"
         name="password"
-        validation="required|length:0,100"
+        validation="required:trim|length:5,100|matches:/^\S.*\S$/"
+        :validation-messages="{
+          matches: $t('core.formkit.validation.trim'),
+        }"
       ></FormKit>
       <FormKit
         v-model="selectedRole"

--- a/console/src/modules/system/users/components/UserPasswordChangeModal.vue
+++ b/console/src/modules/system/users/components/UserPasswordChangeModal.vue
@@ -112,7 +112,10 @@ const handleChangePassword = async () => {
         :label="$t('core.user.change_password_modal.fields.new_password.label')"
         name="password"
         type="password"
-        validation="required|length:0,100"
+        validation="required:trim|length:5,100|matches:/^\S.*\S$/"
+        :validation-messages="{
+          matches: $t('core.formkit.validation.trim'),
+        }"
       ></FormKit>
       <FormKit
         :label="
@@ -120,7 +123,10 @@ const handleChangePassword = async () => {
         "
         name="password_confirm"
         type="password"
-        validation="required|confirm|length:0,100"
+        validation="confirm|required:trim|length:5,100|matches:/^\S.*\S$/"
+        :validation-messages="{
+          matches: $t('core.formkit.validation.trim'),
+        }"
       ></FormKit>
     </FormKit>
     <template #footer>


### PR DESCRIPTION
#### What type of PR is this?

/area console
/kind feature
/milestone 2.8.x

#### What this PR does / why we need it:

在 Console 端关于用户密码输入的部分添加基本的验证，目前的规则是：

1. 必填，且不能全为空格符
2. 长度为 5-100
3. 字符串前后不能有空格

#### Which issue(s) this PR fixes:

Fixes https://github.com/halo-dev/halo/issues/4203

#### Special notes for your reviewer:

按照以上规则测试即可。

#### Does this PR introduce a user-facing change?

```release-note
Console 端关于用户密码输入的部分添加基本的验证
```
