### PR TITLE
fix: search input component cannot be rendered normally under a non-secure domain name

### DIFF
--- a/console/src/components/input/SearchInput.vue
+++ b/console/src/components/input/SearchInput.vue
@@ -1,4 +1,5 @@
 <script lang="ts" setup>
+import { randomUUID } from "@/utils/id";
 import { getNode, reset } from "@formkit/core";
 import { IconCloseCircle } from "@halo-dev/components";
 
@@ -16,7 +17,7 @@ const emit = defineEmits<{
   (event: "update:modelValue", modelValue: string): void;
 }>();
 
-const id = `search-input-${crypto.randomUUID()}`;
+const id = `search-input-${randomUUID()}`;
 
 function handleReset() {
   emit("update:modelValue", "");


### PR DESCRIPTION
#### What type of PR is this?

/area console
/kind bug
/milestone 2.8.x

#### What this PR does / why we need it:

修复在非安全域名下，SearchInput 组件无法正常渲染的问题，因为使用了 crypto 接口来随机生成表单的 id。但 crypto 在非安全域名下无法被调用，参考：https://developer.mozilla.org/en-US/docs/Web/API/Crypto

#### Which issue(s) this PR fixes:

Fixes https://github.com/halo-dev/halo/issues/4250

#### Does this PR introduce a user-facing change?

```release-note
None
```
