### PR TITLE
fix: post status filter item cannot be displayed when the page is refreshed

### DIFF
--- a/console/src/modules/contents/posts/PostList.vue
+++ b/console/src/modules/contents/posts/PostList.vue
@@ -435,11 +435,11 @@ const getExternalUrl = (post: Post) => {
                     },
                     {
                       label: t('core.post.filters.status.items.published'),
-                      value: true,
+                      value: 'true',
                     },
                     {
                       label: t('core.post.filters.status.items.draft'),
-                      value: false,
+                      value: 'false',
                     },
                   ]"
                 />


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/area console
/milestone 2.8.x

#### What this PR does / why we need it:

修复文章状态筛选在刷新页面之后无法回显的问题。

#### Which issue(s) this PR fixes:

see https://github.com/halo-dev/halo/pull/4219#issuecomment-1641310000

#### Special notes for your reviewer:

需要测试：

1. 在文章管理页面选择某个状态筛序项，观察数据是否正常。
2. 刷新页面，观察筛选项是否回显。

#### Does this PR introduce a user-facing change?

```release-note
None
```
