### PR TITLE
chore: bump @halo-dev/richtext-editor to fix image size was abnormally modified

### DIFF
--- a/console/package.json
+++ b/console/package.json
@@ -54,7 +54,7 @@
     "@halo-dev/api-client": "workspace:*",
     "@halo-dev/components": "workspace:*",
     "@halo-dev/console-shared": "workspace:*",
-    "@halo-dev/richtext-editor": "0.0.0-alpha.24",
+    "@halo-dev/richtext-editor": "0.0.0-alpha.25",
     "@tanstack/vue-query": "^4.29.1",
     "@tiptap/extension-character-count": "^2.0.0-beta.220",
     "@tiptap/vue-3": "^2.0.3",

--- a/console/pnpm-lock.yaml
+++ b/console/pnpm-lock.yaml
@@ -69,8 +69,8 @@ importers:
         specifier: workspace:*
         version: link:packages/shared
       '@halo-dev/richtext-editor':
-        specifier: 0.0.0-alpha.24
-        version: 0.0.0-alpha.24(@tiptap/pm@2.0.3)(vue@3.2.45)
+        specifier: 0.0.0-alpha.25
+        version: 0.0.0-alpha.25(@tiptap/pm@2.0.3)(vue@3.2.45)
       '@tanstack/vue-query':
         specifier: ^4.29.1
         version: 4.29.1(vue@3.2.45)
@@ -2354,8 +2354,8 @@ packages:
       - windicss
     dev: false
 
-  /@halo-dev/richtext-editor@0.0.0-alpha.24(@tiptap/pm@2.0.3)(vue@3.2.45):
-    resolution: {integrity: sha512-x/R6Y1v6LslvlAwRm99mx04GPchw0ubIKSQazfx3i4s+WSWzrcDR91bxZEYrK8Nei38BKalkTj2SPolbescDIg==}
+  /@halo-dev/richtext-editor@0.0.0-alpha.25(@tiptap/pm@2.0.3)(vue@3.2.45):
+    resolution: {integrity: sha512-J56ZzcBiIopP/hr92dFjExB1TBnj/j8wS2y3ql2t5V9C82hHdrIgtkXq5xaOSiDzZmY8mBjs6QYGqwjnG/tYkA==}
     peerDependencies:
       vue: ^3.2.37
     dependencies:


### PR DESCRIPTION
#### What type of PR is this?

/area console
/kind bug
/milestone 2.8.x

#### What this PR does / why we need it:

升级编辑器以修复图片被自动修改尺寸的问题，see https://github.com/halo-sigs/richtext-editor/pull/22

#### Which issue(s) this PR fixes:

Fixes https://github.com/halo-dev/halo/issues/4215

#### Special notes for your reviewer:

测试方法可以参考：https://github.com/halo-sigs/richtext-editor/pull/22

#### Does this PR introduce a user-facing change?

```release-note
修复编辑文章时，原来的图片尺寸被自动修改的问题。
```
