### PR TITLE
Support extending username password authentication

### DIFF
--- a/api/src/main/java/run/halo/app/security/authentication/login/UsernamePasswordAuthenticationManager.java
+++ b/api/src/main/java/run/halo/app/security/authentication/login/UsernamePasswordAuthenticationManager.java
@@ -1,0 +1,18 @@
+package run.halo.app.security.authentication.login;
+
+import org.pf4j.ExtensionPoint;
+import org.springframework.security.authentication.ReactiveAuthenticationManager;
+
+/**
+ * An extension point for username password authentication.
+ * Any non-authentication exception occurs, the default authentication will be used.
+ * If you want to skip authentication, please return Mono.empty() directly, the default
+ * authentication will be used.
+ *
+ * @author johnniang
+ * @since 2.8
+ */
+public interface UsernamePasswordAuthenticationManager
+    extends ReactiveAuthenticationManager, ExtensionPoint {
+
+}

--- a/application/src/main/java/run/halo/app/security/authentication/login/UsernamePasswordDelegatingAuthenticationManager.java
+++ b/application/src/main/java/run/halo/app/security/authentication/login/UsernamePasswordDelegatingAuthenticationManager.java
@@ -1,0 +1,41 @@
+package run.halo.app.security.authentication.login;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.authentication.ReactiveAuthenticationManager;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.AuthenticationException;
+import reactor.core.publisher.Mono;
+import run.halo.app.plugin.extensionpoint.ExtensionGetter;
+
+@Slf4j
+public class UsernamePasswordDelegatingAuthenticationManager
+    implements ReactiveAuthenticationManager {
+
+    private final ExtensionGetter extensionGetter;
+
+    private final ReactiveAuthenticationManager defaultAuthenticationManager;
+
+    public UsernamePasswordDelegatingAuthenticationManager(ExtensionGetter extensionGetter,
+        ReactiveAuthenticationManager defaultAuthenticationManager) {
+        this.extensionGetter = extensionGetter;
+        this.defaultAuthenticationManager = defaultAuthenticationManager;
+    }
+
+    @Override
+    public Mono<Authentication> authenticate(Authentication authentication) {
+        return extensionGetter.getEnabledExtension(UsernamePasswordAuthenticationManager.class)
+            .flatMap(authenticationManager -> authenticationManager.authenticate(authentication)
+                .doOnError(t -> log.error(
+                    "failed to authenticate with {}, fallback to default username password "
+                        + "authentication.", authenticationManager.getClass(), t)
+                )
+                .onErrorResume(
+                    t -> !(t instanceof AuthenticationException),
+                    t -> Mono.empty()
+                )
+            )
+            .switchIfEmpty(
+                Mono.defer(() -> defaultAuthenticationManager.authenticate(authentication))
+            );
+    }
+}

--- a/application/src/main/java/run/halo/app/security/authentication/login/UsernamePasswordDelegatingAuthenticationManager.java
+++ b/application/src/main/java/run/halo/app/security/authentication/login/UsernamePasswordDelegatingAuthenticationManager.java
@@ -23,7 +23,8 @@ public class UsernamePasswordDelegatingAuthenticationManager
 
     @Override
     public Mono<Authentication> authenticate(Authentication authentication) {
-        return extensionGetter.getEnabledExtension(UsernamePasswordAuthenticationManager.class)
+        return extensionGetter.getEnabledExtensionByDefinition(UsernamePasswordAuthenticationManager.class)
+            .next()
             .flatMap(authenticationManager -> authenticationManager.authenticate(authentication)
                 .doOnError(t -> log.error(
                     "failed to authenticate with {}, fallback to default username password "

--- a/application/src/main/java/run/halo/app/security/authentication/login/UsernamePasswordDelegatingAuthenticationManager.java
+++ b/application/src/main/java/run/halo/app/security/authentication/login/UsernamePasswordDelegatingAuthenticationManager.java
@@ -23,7 +23,8 @@ public class UsernamePasswordDelegatingAuthenticationManager
 
     @Override
     public Mono<Authentication> authenticate(Authentication authentication) {
-        return extensionGetter.getEnabledExtensionByDefinition(UsernamePasswordAuthenticationManager.class)
+        return extensionGetter
+            .getEnabledExtensionByDefinition(UsernamePasswordAuthenticationManager.class)
             .next()
             .flatMap(authenticationManager -> authenticationManager.authenticate(authentication)
                 .doOnError(t -> log.error(

--- a/application/src/main/resources/extensions/extensionpoint-definitions.yaml
+++ b/application/src/main/resources/extensions/extensionpoint-definitions.yaml
@@ -50,5 +50,5 @@ metadata:
 spec:
   className: run.halo.app.security.authentication.login.UsernamePasswordAuthenticationManager
   displayName: Username password authentication manager
-  type: SINGLE_INSTANCE
+  type: SINGLETON
   description: "Provides a way to extend the username password authentication."

--- a/application/src/main/resources/extensions/extensionpoint-definitions.yaml
+++ b/application/src/main/resources/extensions/extensionpoint-definitions.yaml
@@ -30,3 +30,14 @@ spec:
   displayName: ReactiveSinglePageContentHandler
   type: MULTI_INSTANCE
   description: "Provides a way to extend the single page content to be displayed in the theme-side."
+
+---
+apiVersion: plugin.halo.run/v1alpha1
+kind: ExtensionPointDefinition
+metadata:
+  name: username-password-authentication-manager
+spec:
+  className: run.halo.app.security.authentication.login.UsernamePasswordAuthenticationManager
+  displayName: Username password authentication manager
+  type: SINGLE_INSTANCE
+  description: "Provides a way to extend the username password authentication."


### PR DESCRIPTION
#### What type of PR is this?

/kind feature
/area core
/area plugin

#### What this PR does / why we need it:

Plugin developers are able to define own UsernamePasswordAuthenticationManager to take charge of username password authentication. 

1. If the manager fails to handle, the default authentication manager will be used.
2. If the manager returns `Mono.empty()`, the default authentication manager will be used.

For example:

```java
@Component
public class LdapAuthenticationManager
    extends UserDetailsRepositoryReactiveAuthenticationManager
    implements UsernamePasswordAuthenticationManager {

    public LdapAuthenticationManager(ReactiveUserDetailsService userDetailsService) {
        super(userDetailsService);
    }

    @Override
    protected Mono<UserDetails> retrieveUser(String username) {
        return super.retrieveUser(username);
    }
}
```

#### Which issue(s) this PR fixes:

See https://github.com/halo-dev/halo/issues/4207#issuecomment-1643042348 for more.

#### Does this PR introduce a user-facing change?

```release-note
提供用户名密码认证扩展
```
