### PR TITLE
refactor: remove username input validation rule in user editing form

### DIFF
--- a/console/src/modules/system/users/components/UserEditingModal.vue
+++ b/console/src/modules/system/users/components/UserEditingModal.vue
@@ -159,19 +159,6 @@ const handleUpdateUser = async () => {
               :label="$t('core.user.editing_modal.fields.username.label')"
               type="text"
               name="name"
-              :validation="[
-                ['required'],
-                ['length:0,63'],
-                [
-                  'matches',
-                  /^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$/,
-                ],
-              ]"
-              :validation-messages="{
-                matches: $t(
-                  'core.user.editing_modal.fields.username.validation'
-                ),
-              }"
             ></FormKit>
             <FormKit
               id="displayNameInput"


### PR DESCRIPTION
#### What type of PR is this?

/area console
/kind improvement
/milestone 2.8.x

#### What this PR does / why we need it:

移除用户编辑表单中用户名的校验规则，在这个表单中，用户名本身就是不能修改的，所以不需要验证。移除之后还能够解决旧版本 Halo 升级之后无法修改资料的问题。（旧版本没有用户名校验）

#### Which issue(s) this PR fixes:

Fixes #4269 

#### Does this PR introduce a user-facing change?

```release-note
移除 Console 端用户编辑表单中用户名的校验规则，防止旧版本 Halo 升级之后无法修改资料。
```
