### PR TITLE
Bump plugin preset

### DIFF
--- a/application/build.gradle
+++ b/application/build.gradle
@@ -76,7 +76,7 @@ tasks.register('downloadPluginPresets', Download) {
         delete 'src/main/resources/presets/plugins'
     }
     src([
-            'https://github.com/halo-sigs/plugin-comment-widget/releases/download/v1.6.1/plugin-comment-widget-1.6.1.jar',
+            'https://github.com/halo-sigs/plugin-comment-widget/releases/download/v1.7.0/plugin-comment-widget-1.7.0.jar',
             'https://github.com/halo-sigs/plugin-search-widget/releases/download/v1.1.0/plugin-search-widget-1.1.0.jar',
             'https://github.com/halo-sigs/plugin-sitemap/releases/download/v1.0.2/plugin-sitemap-1.0.2.jar',
             'https://github.com/halo-sigs/plugin-feed/releases/download/v1.1.1/plugin-feed-1.1.1.jar'


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup
/area core
/milestone 2.8.x

#### What this PR does / why we need it:

Bump plugin preset. See https://github.com/halo-sigs/plugin-comment-widget/releases/tag/v1.7.0 for more.

#### Does this PR introduce a user-facing change?

```release-note
None
```
