### PR TITLE
Add error prompt when downloading backup files that do not exist

### DIFF
--- a/application/src/main/java/run/halo/app/infra/exception/NotFoundException.java
+++ b/application/src/main/java/run/halo/app/infra/exception/NotFoundException.java
@@ -24,4 +24,8 @@ public class NotFoundException extends ResponseStatusException {
     public NotFoundException(@Nullable Throwable cause) {
         this(cause == null ? "" : cause.getMessage(), cause);
     }
+
+    public NotFoundException(String messageDetailCode, Object[] messageDetailArgs, String reason) {
+        super(HttpStatus.NOT_FOUND, reason, null, messageDetailCode, messageDetailArgs);
+    }
 }

--- a/application/src/main/resources/config/i18n/messages.properties
+++ b/application/src/main/resources/config/i18n/messages.properties
@@ -19,6 +19,7 @@ problemDetail.title.run.halo.app.infra.exception.PluginInstallationException=Plu
 problemDetail.title.run.halo.app.infra.exception.PluginAlreadyExistsException=Plugin Already Exists Error
 problemDetail.title.run.halo.app.infra.exception.DuplicateNameException=Duplicate Name Error
 problemDetail.title.run.halo.app.infra.exception.RateLimitExceededException=Request Not Permitted
+problemDetail.title.run.halo.app.infra.exception.NotFoundException=Resource Not Found
 problemDetail.title.internalServerError=Internal Server Error
 
 # Detail definitions
@@ -48,7 +49,7 @@ problemDetail.theme.install.missingManifest=Missing theme manifest file "theme.y
 problemDetail.theme.install.alreadyExists=Theme {0} already exists.
 problemDetail.theme.version.unsatisfied.requires=The theme requires a minimum system version of {0}, but the current version is {1}.
 problemDetail.directoryTraversal=Directory traversal detected. Base path is {0}, but real path is {1}.
-
 problemDetail.plugin.version.unsatisfied.requires=Plugin requires a minimum system version of {0}, but the current version is {1}.
 problemDetail.plugin.missingManifest=Missing plugin manifest file "plugin.yaml" or manifest file does not conform to the specification.
 problemDetail.internalServerError=Something went wrong, please try again later.
+problemDetail.migration.backup.notFound=The backup file does not exist or has been deleted.

--- a/application/src/main/resources/config/i18n/messages_zh.properties
+++ b/application/src/main/resources/config/i18n/messages_zh.properties
@@ -7,6 +7,7 @@ problemDetail.title.run.halo.app.infra.exception.DuplicateNameException=名称�
 problemDetail.title.run.halo.app.infra.exception.PluginAlreadyExistsException=插件已存在
 problemDetail.title.run.halo.app.infra.exception.ThemeInstallationException=主题安装失败
 problemDetail.title.run.halo.app.infra.exception.RateLimitExceededException=请求限制
+problemDetail.title.run.halo.app.infra.exception.NotFoundException=资源不存在
 problemDetail.title.internalServerError=服务器内部错误
 
 problemDetail.org.springframework.security.authentication.BadCredentialsException=用户名或密码错误。
@@ -17,10 +18,9 @@ problemDetail.run.halo.app.infra.exception.RateLimitExceededException=请求过�
 
 problemDetail.user.signUpFailed.disallowed=系统不允许注册新用户。
 problemDetail.user.duplicateName=用户名 {0} 已存在，请更换用户名后重试。
-
 problemDetail.plugin.version.unsatisfied.requires=插件要求一个最小的系统版本为 {0}, 但当前版本为 {1}。
 problemDetail.plugin.missingManifest=缺少 plugin.yaml 配置文件或配置文件不符合规范。
-
 problemDetail.theme.version.unsatisfied.requires=主题要求一个最小的系统版本为 {0}, 但当前版本为 {1}。
 problemDetail.theme.install.missingManifest=缺少 theme.yaml 配置文件或配置文件不符合规范。
 problemDetail.internalServerError=服务器内部发生错误，请稍候再试。
+problemDetail.migration.backup.notFound=备份文件不存在或已删除。

--- a/application/src/test/java/run/halo/app/migration/impl/MigrationServiceImplTest.java
+++ b/application/src/test/java/run/halo/app/migration/impl/MigrationServiceImplTest.java
@@ -31,6 +31,7 @@ import reactor.test.StepVerifier;
 import run.halo.app.extension.Metadata;
 import run.halo.app.extension.store.ExtensionStore;
 import run.halo.app.extension.store.ExtensionStoreRepository;
+import run.halo.app.infra.exception.NotFoundException;
 import run.halo.app.infra.properties.HaloProperties;
 import run.halo.app.infra.utils.FileUtils;
 import run.halo.app.migration.Backup;
@@ -165,7 +166,16 @@ class MigrationServiceImplTest {
                 }
             })
             .verifyComplete();
+    }
 
+    @Test
+    void downloadBackupWhichDoesNotExist() {
+        var backup = createSucceededBackup("fake-backup", "backup.zip");
+        when(haloProperties.getWorkDir()).thenReturn(tempDir.resolve("workdir"));
+
+        StepVerifier.create(migrationService.download(backup))
+            .expectError(NotFoundException.class)
+            .verify();
     }
 
     Backup createSucceededBackup(String name, String filename) {


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/area core
/milestone 2.8.x

#### What this PR does / why we need it:

Currently, we have not process the deletion of backup files when downloading theme. This PR will handle the situation.

Please see the example result:

```bash
curl -s -u admin:admin -H "Accept-Language: zh" http://localhost:8090/apis/api.console.migration.halo.run/v1alpha1/backups/backup-waELO/files/20230725225726-backup-waELO.zip | jq .
{
  "type": "about:blank",
  "title": "资源不存在",
  "status": 404,
  "detail": "备份文件不存在或已删除。",
  "instance": "http://localhost:8090/apis/api.console.migration.halo.run/v1alpha1/backups/backup-waELO/files/20230725225726-backup-waELO.zip",
  "requestId": "8654fdc6-1478",
  "timestamp": "2023-07-25T15:26:56.771260Z"
}
```

```bash
curl -s -u admin:admin -H "Accept-Language: en" http://localhost:8090/apis/api.console.migration.halo.run/v1alpha1/backups/backup-waELO/files/20230725225726-backup-waELO.zip | jq .
{
  "type": "about:blank",
  "title": "Resource Not Found",
  "status": 404,
  "detail": "The backup file does not exist or has been deleted.",
  "instance": "http://localhost:8090/apis/api.console.migration.halo.run/v1alpha1/backups/backup-waELO/files/20230725225726-backup-waELO.zip",
  "requestId": "4f58e158-1480",
  "timestamp": "2023-07-25T15:27:18.451308Z"
}
```

#### Which issue(s) this PR fixes:

Fixes https://github.com/halo-dev/halo/issues/4297

#### Does this PR introduce a user-facing change?

```release-note
None
```
