### PR TITLE
feat: add showCancel prop for dialog component

### DIFF
--- a/console/packages/components/src/components/dialog/Dialog.vue
+++ b/console/packages/components/src/components/dialog/Dialog.vue
@@ -19,6 +19,7 @@ const props = withDefaults(
     description?: string;
     confirmText?: string;
     confirmType?: ButtonType;
+    showCancel?: boolean;
     cancelText?: string;
     visible?: boolean;
     onConfirm?: () => void;
@@ -30,6 +31,7 @@ const props = withDefaults(
     description: "",
     confirmText: "确定",
     confirmType: "primary",
+    showCancel: true,
     cancelText: "取消",
     visible: false,
     onConfirm: () => {
@@ -126,7 +128,9 @@ const handleClose = () => {
         <VButton :loading="loading" :type="confirmType" @click="handleConfirm">
           {{ confirmText }}
         </VButton>
-        <VButton @click="handleCancel">{{ cancelText }}</VButton>
+        <VButton v-if="showCancel" @click="handleCancel">
+          {{ cancelText }}
+        </VButton>
       </div>
     </template>
   </VModal>

--- a/console/packages/components/src/components/dialog/interface.ts
+++ b/console/packages/components/src/components/dialog/interface.ts
@@ -2,28 +2,22 @@ export type Type = "success" | "info" | "warning" | "error";
 export const DialogProviderProvideKey = "DIALOG_PROVIDER_PROVIDE_KEY";
 import type { Type as ButtonType } from "../button/interface";
 
-export interface useDialogOptions {
-  type?: Type;
-  visible: boolean;
-  title: string;
-  description?: string;
-  confirmType?: ButtonType;
-  confirmText?: string;
-  cancelText?: string;
-  onConfirm?: () => void;
-  onCancel?: () => void;
-}
-
 export interface DialogProps {
   type?: Type;
   visible?: boolean;
   title?: string;
   description?: string;
   confirmType?: ButtonType;
+  showCancel?: boolean;
   confirmText?: string;
   cancelText?: string;
   onConfirm?: () => void;
   onCancel?: () => void;
 }
+
+type useDialogOptions = Omit<DialogProps, "visible" | "title"> & {
+  visible: boolean;
+  title: string;
+};
 
 export type useDialogUserOptions = Omit<useDialogOptions, "type" | "visible">;

--- a/console/src/modules/contents/pages/SinglePageEditor.vue
+++ b/console/src/modules/contents/pages/SinglePageEditor.vue
@@ -257,11 +257,8 @@ const handleFetchContent = async () => {
           raw_type: data.rawType,
         }),
         confirmText: t("core.common.buttons.confirm"),
-        cancelText: t("core.common.buttons.cancel"),
+        showCancel: false,
         onConfirm: () => {
-          router.back();
-        },
-        onCancel: () => {
           router.back();
         },
       });

--- a/console/src/modules/contents/posts/PostEditor.vue
+++ b/console/src/modules/contents/posts/PostEditor.vue
@@ -269,11 +269,8 @@ const handleFetchContent = async () => {
           raw_type: data.rawType,
         }),
         confirmText: t("core.common.buttons.confirm"),
-        cancelText: t("core.common.buttons.cancel"),
+        showCancel: false,
         onConfirm: () => {
-          router.back();
-        },
-        onCancel: () => {
           router.back();
         },
       });

--- a/console/src/modules/system/backup/tabs/Restore.vue
+++ b/console/src/modules/system/backup/tabs/Restore.vue
@@ -16,11 +16,8 @@ const onUploaded = () => {
     title: t("core.backup.operations.restore.title"),
     description: t("core.backup.operations.restore.description"),
     confirmText: t("core.common.buttons.confirm"),
-    cancelText: t("core.common.buttons.cancel"),
+    showCancel: false,
     async onConfirm() {
-      await handleShutdown();
-    },
-    async onCancel() {
       await handleShutdown();
     },
   });


### PR DESCRIPTION
#### What type of PR is this?

/area console
/kind improvement
/milestone 2.8.x

#### What this PR does / why we need it:

为 Dialog 组件添加 showCancel 属性用于控制是否显示取消按钮，某些场景下 Dialog 只是用于提示切必须点击确定。

此外，还对以下位置做了对应修改：

1. 进入文章编辑时检查编辑器是否存在的弹框，只允许点击确定并返回。
2. 备份恢复完成之后点击确定关闭 Halo。

#### Does this PR introduce a user-facing change?

```release-note
Console 端的 Dialog 组件添加 showCancel 属性用于控制是否显示取消按钮。
```
