### PR TITLE
fix: content cache was not cleaned up after the new post was saved

### DIFF
--- a/console/src/composables/use-content-cache.ts
+++ b/console/src/composables/use-content-cache.ts
@@ -12,7 +12,7 @@ import { useI18n } from "vue-i18n";
 interface useContentCacheReturn {
   handleResetCache: () => void;
   handleSetContentCache: () => void;
-  handleClearCache: (name: string) => void;
+  handleClearCache: (name?: string) => void;
 }
 
 export function useContentCache(
@@ -71,7 +71,7 @@ export function useContentCache(
     }
   }, 500);
 
-  const handleClearCache = (name: string) => {
+  const handleClearCache = (name?: string) => {
     if (name) {
       const index = content_caches.value.findIndex(
         (c: ContentCache) => c.name === name

--- a/console/src/modules/contents/pages/SinglePageEditor.vue
+++ b/console/src/modules/contents/pages/SinglePageEditor.vue
@@ -150,6 +150,9 @@ const handleSave = async (options?: { mute?: boolean }) => {
       });
       formState.value.page = data;
       routeQueryName.value = data.metadata.name;
+
+      // Clear new page content cache
+      handleClearCache();
     }
 
     if (!options?.mute) {
@@ -195,6 +198,10 @@ const handlePublish = async () => {
       await apiClient.singlePage.draftSinglePage({
         singlePageRequest: formState.value,
       });
+
+      // Clear new page content cache
+      handleClearCache();
+
       router.push({ name: "SinglePages" });
     }
 

--- a/console/src/modules/contents/posts/PostEditor.vue
+++ b/console/src/modules/contents/posts/PostEditor.vue
@@ -153,6 +153,9 @@ const handleSave = async (options?: { mute?: boolean }) => {
       });
       formState.value.post = data;
       name.value = data.metadata.name;
+
+      // Clear new post content cache
+      handleClearCache();
     }
 
     if (!options?.mute) {
@@ -200,6 +203,9 @@ const handlePublish = async () => {
       await apiClient.post.publishPost({
         name: data.metadata.name,
       });
+
+      // Clear new post content cache
+      handleClearCache();
 
       router.push({ name: "Posts" });
     }


### PR DESCRIPTION
#### What type of PR is this?

/area console
/kind bug
/milestone 2.8.x

#### What this PR does / why we need it:

修复新建文章发布或者保存之后，浏览器中的内容缓存没有清空的问题。

#### Which issue(s) this PR fixes:

Fixes #4310 

#### Special notes for your reviewer:

需要测试：

1. 新建一篇文章，测试未保存到服务器时，刷新浏览器，观察内容是否还存在。
2. 保存之后，再次新建文章，观察编辑器是否没有内容。

#### Does this PR introduce a user-facing change?

```release-note
修复新建文章发布或者保存之后，浏览器中的内容缓存没有清空的问题。
```
