### PR TITLE
refactor: remove the duplicate button to create a backup

### DIFF
--- a/console/src/locales/en.yaml
+++ b/console/src/locales/en.yaml
@@ -992,8 +992,6 @@ core:
     empty:
       title: No backups have been created yet
       message: You can click the button below to create a backup
-      actions:
-        create: Create backup
     operations:
       create:
         button: Create backup

--- a/console/src/locales/zh-CN.yaml
+++ b/console/src/locales/zh-CN.yaml
@@ -992,8 +992,6 @@ core:
     empty:
       title: 没有备份
       message: 当前没有已创建的备份，你可以点击刷新或者创建新的备份
-      actions:
-        create: 创建备份
     operations:
       create:
         button: 创建备份

--- a/console/src/locales/zh-TW.yaml
+++ b/console/src/locales/zh-TW.yaml
@@ -992,8 +992,6 @@ core:
     empty:
       title: 沒有備份
       message: 目前沒有已建立的備份，您可以點擊重新整理或建立新的備份。
-      actions:
-        create: 建立備份
     operations:
       create:
         button: 建立備份

--- a/console/src/modules/system/backup/tabs/List.vue
+++ b/console/src/modules/system/backup/tabs/List.vue
@@ -2,15 +2,8 @@
 import { apiClient } from "@/utils/api-client";
 import { useQuery } from "@tanstack/vue-query";
 import { BackupStatusPhaseEnum } from "@halo-dev/api-client";
-import {
-  IconAddCircle,
-  VButton,
-  VEmpty,
-  VLoading,
-  VSpace,
-} from "@halo-dev/components";
+import { VButton, VEmpty, VLoading } from "@halo-dev/components";
 import BackupListItem from "../components/BackupListItem.vue";
-import { useBackup } from "../composables/use-backup";
 
 const {
   data: backups,
@@ -49,8 +42,6 @@ const {
     return false;
   },
 });
-
-const { handleCreate } = useBackup();
 </script>
 
 <template>
@@ -61,17 +52,9 @@ const { handleCreate } = useBackup();
       :title="$t('core.backup.empty.title')"
     >
       <template #actions>
-        <VSpace>
-          <VButton :loading="isFetching" @click="refetch()">
-            {{ $t("core.common.buttons.refresh") }}
-          </VButton>
-          <VButton type="secondary" @click="handleCreate">
-            <template #icon>
-              <IconAddCircle class="h-full w-full" />
-            </template>
-            {{ $t("core.backup.empty.actions.create") }}
-          </VButton>
-        </VSpace>
+        <VButton :loading="isFetching" @click="refetch()">
+          {{ $t("core.common.buttons.refresh") }}
+        </VButton>
       </template>
     </VEmpty>
   </Transition>


### PR DESCRIPTION
#### What type of PR is this?

/area console
/kind improvement
/milestone 2.8.x

#### What this PR does / why we need it:

移除备份列表空状态的创建备份按钮，防止出现多个创建的按钮。

<img width="1669" alt="image" src="https://github.com/halo-dev/halo/assets/21301288/2f79c05e-090d-4318-bd91-07680bb881be">

#### Does this PR introduce a user-facing change?

```release-note
None 
```
