### PR TITLE
fix: click "next" on the last attachment will get null

### DIFF
--- a/console/src/modules/contents/attachments/composables/use-attachment.ts
+++ b/console/src/modules/contents/attachments/composables/use-attachment.ts
@@ -97,7 +97,7 @@ export function useAttachmentControl(filterOptions: {
       return;
     }
 
-    if (index === 0 && hasPrevious) {
+    if (index === 0 && hasPrevious.value) {
       page.value--;
       await refetch();
       selectedAttachment.value = data.value[data.value.length - 1];
@@ -119,7 +119,7 @@ export function useAttachmentControl(filterOptions: {
       return;
     }
 
-    if (index === data.value.length - 1 && hasNext) {
+    if (index === data.value.length - 1 && hasNext.value) {
       page.value++;
       await refetch();
       selectedAttachment.value = data.value[0];


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/area console
/milestone 2.8.x

#### What this PR does / why we need it:

修复在最后一个附件点击 "下一个" 时, 附件库内容全部消失或得到一个 "空" 附件, 且不能 "往前"

#### Which issue(s) this PR fixes:

Fixes #4326

#### Special notes for your reviewer:
1. 上传附件
2. 一直点击 "下一个" 直到最后一张
3. 在最后一张再点击下一个, 观察页面是否出现异常, 正常情况下会停在最后一个附件上且页面不会有刷新

#### Does this PR introduce a user-facing change?

```release-note
修复 Console 端在最后一个附件点击下一项按钮时得到空结果的问题。
```
