### PR TITLE
fix: page does not refresh or get wrong page when turn page

### DIFF
--- a/console/src/modules/contents/attachments/composables/use-attachment.ts
+++ b/console/src/modules/contents/attachments/composables/use-attachment.ts
@@ -1,5 +1,5 @@
 import type { Attachment, Group, Policy } from "@halo-dev/api-client";
-import { computed, type Ref } from "vue";
+import { computed, nextTick, type Ref } from "vue";
 import { ref, watch } from "vue";
 import type { AttachmentLike } from "@halo-dev/console-shared";
 import { apiClient } from "@/utils/api-client";
@@ -99,6 +99,7 @@ export function useAttachmentControl(filterOptions: {
 
     if (index === 0 && hasPrevious.value) {
       page.value--;
+      await nextTick();
       await refetch();
       selectedAttachment.value = data.value[data.value.length - 1];
     }
@@ -121,6 +122,7 @@ export function useAttachmentControl(filterOptions: {
 
     if (index === data.value.length - 1 && hasNext.value) {
       page.value++;
+      await nextTick();
       await refetch();
       selectedAttachment.value = data.value[0];
     }

--- a/console/src/modules/contents/attachments/composables/use-attachment.ts
+++ b/console/src/modules/contents/attachments/composables/use-attachment.ts
@@ -97,7 +97,7 @@ export function useAttachmentControl(filterOptions: {
       return;
     }
 
-    if (index === 0 && hasPrevious) {
+    if (index === 0 && hasPrevious.value) {
       page.value--;
       await refetch();
       selectedAttachment.value = data.value[data.value.length - 1];
@@ -119,7 +119,7 @@ export function useAttachmentControl(filterOptions: {
       return;
     }
 
-    if (index === data.value.length - 1 && hasNext) {
+    if (index === data.value.length - 1 && hasNext.value) {
       page.value++;
       await refetch();
       selectedAttachment.value = data.value[0];


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/area console

#### What this PR does / why we need it:

在预览附件时点击 "下一个" 或者 "上一个", 如果这时翻页, 预览页面可能不会刷新, 也可能刷新到其他非预料中的页面

#### Which issue(s) this PR fixes:

Fixes #4330

#### Special notes for your reviewer:
1. 准备附件测试翻页
2. 在第一页的最后一个附件预览中点击 "next", 观察是否正常
3. 在第二页的第一个附件预览中点击 "pre", 观察是否正常

#### Does this PR introduce a user-facing change?

```release-note
预览附件点击 "下一个" 或者 "上一个" 翻页后, 预览页面不正常刷新
```
