### PR TITLE
chore: bump console version to prepare release 2.8

### DIFF
--- a/console/package.json
+++ b/console/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@halo-dev/console",
-  "version": "2.8.0-rc.2",
+  "version": "2.8.0",
   "scripts": {
     "prepare": "cd .. && husky install console/.husky",
     "dev": "vite --host",

--- a/console/packages/api-client/package.json
+++ b/console/packages/api-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@halo-dev/api-client",
-  "version": "2.8.0-rc.2",
+  "version": "2.8.0",
   "description": "",
   "scripts": {
     "build": "unbuild",

--- a/console/packages/components/package.json
+++ b/console/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@halo-dev/components",
-  "version": "1.7.0-rc.2",
+  "version": "1.7.0",
   "description": "",
   "files": [
     "dist"

--- a/console/packages/shared/package.json
+++ b/console/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@halo-dev/console-shared",
-  "version": "2.8.0-rc.2",
+  "version": "2.8.0",
   "description": "",
   "files": [
     "dist"


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

修改 Console 以及其下 packages 的版本号，发布 Halo 2.8

#### Does this PR introduce a user-facing change?

```release-note
None
```
