### PR TITLE
fix: resolve the issue of ineffective duplicate key validation in AnnotationsForm

### DIFF
--- a/console/src/components/form/AnnotationsForm.vue
+++ b/console/src/components/form/AnnotationsForm.vue
@@ -16,7 +16,10 @@ import { useThemeStore } from "@/stores/theme";
 const themeStore = useThemeStore();
 
 function keyValidationRule(node: FormKitNode) {
-  return !annotations?.[node.value as string];
+  return (
+    !annotations.value?.[node.value as string] &&
+    !customAnnotationsDuplicateKey.value
+  );
 }
 
 const props = withDefaults(
@@ -66,6 +69,13 @@ const annotations = ref<{
   [key: string]: string;
 }>({});
 const customAnnotationsState = ref<{ key: string; value: string }[]>([]);
+
+const customAnnotationsDuplicateKey = computed(() => {
+  const keys = customAnnotationsState.value.map((item) => item.key);
+  const uniqueKeys = new Set(keys);
+  console.log(keys.length !== uniqueKeys.size);
+  return keys.length !== uniqueKeys.size;
+});
 
 const customAnnotations = computed(() => {
   return customAnnotationsState.value.reduce((acc, cur) => {

--- a/console/src/components/form/AnnotationsForm.vue
+++ b/console/src/components/form/AnnotationsForm.vue
@@ -73,7 +73,6 @@ const customAnnotationsState = ref<{ key: string; value: string }[]>([]);
 const customAnnotationsDuplicateKey = computed(() => {
   const keys = customAnnotationsState.value.map((item) => item.key);
   const uniqueKeys = new Set(keys);
-  console.log(keys.length !== uniqueKeys.size);
   return keys.length !== uniqueKeys.size;
 });
 


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/area console

#### What this PR does / why we need it:

在 AnnotationsForm 新增 customAnnotationsDuplicateKey 校验规则，校验自定义元数据中是否具有重复的 key。

#### Which issue(s) this PR fixes:

Fixes #4367 

#### Special notes for your reviewer:

在任意一个使用 AnnotationsForm 的位置，例如`文章设置 - 元数据` 中，新增一个已经存在的 key，查看是否有重复 key 的校验。

#### Does this PR introduce a user-facing change?
```release-note
修复 AnnotationsForm 重复的 key 校验无效的问题。
```
