### PR TITLE
Upgrade to SpringDoc 2.2.0 for OpenAPI 3.1 support

### DIFF
--- a/application/src/main/resources/application-dev.yaml
+++ b/application/src/main/resources/application-dev.yaml
@@ -33,6 +33,7 @@ logging:
 springdoc:
   api-docs:
     enabled: true
+    version: OPENAPI_3_1
   swagger-ui:
     enabled: true
   show-actuator: true

--- a/platform/application/build.gradle
+++ b/platform/application/build.gradle
@@ -18,7 +18,7 @@ ext {
     guava = "32.0.1-jre"
     jsoup = '1.15.3'
     jsonPatch = "1.13"
-    springDocOpenAPI = "2.1.0"
+    springDocOpenAPI = "2.2.0"
     lucene = "9.5.0"
     resilience4jVersion = "2.0.2"
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

This PR upgrades SpringDoc to 2.2.0 for OpenAPI 3.1 support. Please see https://github.com/springdoc/springdoc-openapi/releases/tag/v2.2.0 for more.

#### Special notes for your reviewer:

- Start Halo by using following command:
    ```bash
    ./gradlew bootRun --args="--spring.profiles.active=dev --halo.plugin.runtime-mode=deployment"
    ```
- Try to request <http://localhost:8090/swagger-ui.html> and check if the OpenAPI version is 3.1

#### Does this PR introduce a user-facing change?

```release-note
升级 SpringDoc 至 2.2.0
```
