### PR TITLE
Refactor the transformation between data buffers and input stream

### DIFF
--- a/application/src/main/java/run/halo/app/core/extension/theme/ThemeEndpoint.java
+++ b/application/src/main/java/run/halo/app/core/extension/theme/ThemeEndpoint.java
@@ -7,11 +7,9 @@ import static org.springdoc.core.fn.builders.parameter.Builder.parameterBuilder;
 import static org.springdoc.core.fn.builders.requestbody.Builder.requestBodyBuilder;
 import static org.springdoc.core.fn.builders.schema.Builder.schemaBuilder;
 import static org.springframework.web.reactive.function.server.RequestPredicates.contentType;
-import static run.halo.app.infra.utils.DataBufferUtils.toInputStream;
 
 import io.swagger.v3.oas.annotations.enums.ParameterIn;
 import io.swagger.v3.oas.annotations.media.Schema;
-import java.io.IOException;
 import java.net.URI;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -29,14 +27,11 @@ import org.springframework.lang.NonNull;
 import org.springframework.stereotype.Component;
 import org.springframework.util.Assert;
 import org.springframework.util.MultiValueMap;
-import org.springframework.web.reactive.function.BodyExtractors;
 import org.springframework.web.reactive.function.server.RouterFunction;
 import org.springframework.web.reactive.function.server.ServerRequest;
 import org.springframework.web.reactive.function.server.ServerResponse;
 import org.springframework.web.server.ServerWebInputException;
-import reactor.core.Exceptions;
 import reactor.core.publisher.Mono;
-import reactor.core.scheduler.Schedulers;
 import reactor.util.retry.Retry;
 import run.halo.app.core.extension.Setting;
 import run.halo.app.core.extension.Theme;
@@ -51,9 +46,6 @@ import run.halo.app.infra.SystemConfigurableEnvironmentFetcher;
 import run.halo.app.infra.SystemSetting;
 import run.halo.app.infra.ThemeRootGetter;
 import run.halo.app.infra.exception.NotFoundException;
-import run.halo.app.infra.exception.ThemeInstallationException;
-import run.halo.app.infra.exception.ThemeUpgradeException;
-import run.halo.app.infra.utils.DataBufferUtils;
 import run.halo.app.infra.utils.JsonUtils;
 import run.halo.app.theme.TemplateEngineManager;
 
@@ -78,7 +70,7 @@ public class ThemeEndpoint implements CustomEndpoint {
 
     private final SystemConfigurableEnvironmentFetcher systemEnvironmentFetcher;
 
-    private final ReactiveUrlDataBufferFetcher reactiveUrlDataBufferFetcher;
+    private final ReactiveUrlDataBufferFetcher urlDataBufferFetcher;
 
     @Override
     public RouterFunction<ServerResponse> endpoint() {
@@ -244,43 +236,25 @@ public class ThemeEndpoint implements CustomEndpoint {
 
     private Mono<ServerResponse> upgradeFromUri(ServerRequest request) {
         final var name = request.pathVariable("name");
-        return request.bodyToMono(UpgradeFromUriRequest.class)
-            .flatMap(upgradeRequest -> Mono.fromCallable(() -> DataBufferUtils.toInputStream(
-                reactiveUrlDataBufferFetcher.fetch(upgradeRequest.uri())))
+        var content = request.bodyToMono(UpgradeFromUriRequest.class)
+            .map(UpgradeFromUriRequest::uri)
+            .flatMapMany(urlDataBufferFetcher::fetch);
+
+        return themeService.upgrade(name, content)
+            .flatMap((updatedTheme) ->
+                templateEngineManager.clearCache(updatedTheme.getMetadata().getName())
+                    .thenReturn(updatedTheme)
             )
-            .subscribeOn(Schedulers.boundedElastic())
-            .doOnError(throwable -> {
-                log.error("Failed to fetch zip file from uri.", throwable);
-                throw new ThemeUpgradeException("Failed to fetch zip file from uri.", null,
-                    null);
-            })
-            .flatMap(inputStream -> themeService.upgrade(name, inputStream))
-            .flatMap((updatedTheme) -> templateEngineManager.clearCache(
-                    updatedTheme.getMetadata().getName())
-                .thenReturn(updatedTheme)
-            )
-            .flatMap(theme -> ServerResponse.ok()
-                .contentType(MediaType.APPLICATION_JSON)
-                .bodyValue(theme)
-            );
+            .flatMap(theme -> ServerResponse.ok().bodyValue(theme));
     }
 
     private Mono<ServerResponse> installFromUri(ServerRequest request) {
-        return request.bodyToMono(InstallFromUriRequest.class)
-            .flatMap(installRequest -> Mono.fromCallable(() -> DataBufferUtils.toInputStream(
-                reactiveUrlDataBufferFetcher.fetch(installRequest.uri())))
-            )
-            .subscribeOn(Schedulers.boundedElastic())
-            .doOnError(throwable -> {
-                log.error("Failed to fetch zip file from uri.", throwable);
-                throw new ThemeInstallationException("Failed to fetch zip file from uri.", null,
-                    null);
-            })
-            .flatMap(themeService::install)
-            .flatMap(theme -> ServerResponse.ok()
-                .contentType(MediaType.APPLICATION_JSON)
-                .bodyValue(theme)
-            );
+        var content = request.bodyToMono(InstallFromUriRequest.class)
+            .map(InstallFromUriRequest::uri)
+            .flatMapMany(urlDataBufferFetcher::fetch);
+
+        return themeService.install(content)
+            .flatMap(theme -> ServerResponse.ok().bodyValue(theme));
     }
 
     private Mono<ServerResponse> activateTheme(ServerRequest request) {
@@ -328,7 +302,7 @@ public class ThemeEndpoint implements CustomEndpoint {
                         if (!configMapName.equals(configMapNameToUpdate)) {
                             throw new ServerWebInputException(
                                 "The name from the request body does not match the theme "
-                                    + "configMapName name.");
+                                + "configMapName name.");
                         }
                     })
                     .flatMap(configMapToUpdate -> client.fetch(ConfigMap.class, configMapName)
@@ -442,22 +416,15 @@ public class ThemeEndpoint implements CustomEndpoint {
 
     private Mono<ServerResponse> upgrade(ServerRequest request) {
         // validate the theme first
-        var themeNameInPath = request.pathVariable("name");
+        var name = request.pathVariable("name");
         return request.multipartData()
             .map(UpgradeRequest::new)
             .map(UpgradeRequest::getFile)
-            .flatMap(file -> {
-                try {
-                    return themeService.upgrade(themeNameInPath, toInputStream(file.content()));
-                } catch (IOException e) {
-                    return Mono.error(e);
-                }
-            })
-            .flatMap((updatedTheme) -> templateEngineManager.clearCache(
-                    updatedTheme.getMetadata().getName())
-                .thenReturn(updatedTheme))
-            .flatMap(updatedTheme -> ServerResponse.ok()
-                .bodyValue(updatedTheme));
+            .flatMap(filePart -> themeService.upgrade(name, filePart.content()))
+            .flatMap((updatedTheme) ->
+                templateEngineManager.clearCache(updatedTheme.getMetadata().getName())
+                    .thenReturn(updatedTheme))
+            .flatMap(updatedTheme -> ServerResponse.ok().bodyValue(updatedTheme));
     }
 
     Mono<ListResult<Theme>> listUninstalled(ThemeQuery query) {
@@ -500,39 +467,39 @@ public class ThemeEndpoint implements CustomEndpoint {
     }
 
     @Schema(name = "ThemeInstallRequest")
-    public record InstallRequest(
-        @Schema(requiredMode = REQUIRED, description = "Theme zip file.") FilePart file) {
+    public static class InstallRequest {
+
+        @Schema(hidden = true)
+        private final MultiValueMap<String, Part> multipartData;
+
+        public InstallRequest(MultiValueMap<String, Part> multipartData) {
+            this.multipartData = multipartData;
+        }
+
+        @Schema(requiredMode = REQUIRED, description = "Theme zip file.")
+        FilePart getFile() {
+            Part part = multipartData.getFirst("file");
+            if (!(part instanceof FilePart file)) {
+                throw new ServerWebInputException(
+                    "Invalid parameter of file, binary data is required");
+            }
+            if (!Paths.get(file.filename()).toString().endsWith(".zip")) {
+                throw new ServerWebInputException(
+                    "Invalid file type, only zip format is supported");
+            }
+            return file;
+        }
     }
 
     public record InstallFromUriRequest(@Schema(requiredMode = REQUIRED) URI uri) {
     }
 
     Mono<ServerResponse> install(ServerRequest request) {
-        return request.body(BodyExtractors.toMultipartData())
-            .flatMap(this::getZipFilePart)
-            .flatMap(file -> {
-                try {
-                    return themeService.install(toInputStream(file.content()));
-                } catch (IOException e) {
-                    return Mono.error(Exceptions.propagate(e));
-                }
-            })
-            .flatMap(theme -> ServerResponse.ok()
-                .contentType(MediaType.APPLICATION_JSON)
-                .bodyValue(theme));
-    }
-
-    Mono<FilePart> getZipFilePart(MultiValueMap<String, Part> formData) {
-        Part part = formData.getFirst("file");
-        if (!(part instanceof FilePart file)) {
-            return Mono.error(new ServerWebInputException(
-                "Invalid parameter of file, binary data is required"));
-        }
-        if (!Paths.get(file.filename()).toString().endsWith(".zip")) {
-            return Mono.error(new ServerWebInputException(
-                "Invalid file type, only zip format is supported"));
-        }
-        return Mono.just(file);
+        return request.multipartData()
+            .map(InstallRequest::new)
+            .map(InstallRequest::getFile)
+            .flatMap(filePart -> themeService.install(filePart.content()))
+            .flatMap(theme -> ServerResponse.ok().bodyValue(theme));
     }
 
 }

--- a/application/src/main/java/run/halo/app/core/extension/theme/ThemeService.java
+++ b/application/src/main/java/run/halo/app/core/extension/theme/ThemeService.java
@@ -1,15 +1,16 @@
 package run.halo.app.core.extension.theme;
 
-import java.io.InputStream;
+import org.reactivestreams.Publisher;
+import org.springframework.core.io.buffer.DataBuffer;
 import reactor.core.publisher.Mono;
 import run.halo.app.core.extension.Theme;
 import run.halo.app.extension.ConfigMap;
 
 public interface ThemeService {
 
-    Mono<Theme> install(InputStream is);
+    Mono<Theme> install(Publisher<DataBuffer> content);
 
-    Mono<Theme> upgrade(String themeName, InputStream is);
+    Mono<Theme> upgrade(String themeName, Publisher<DataBuffer> content);
 
     Mono<Theme> reloadTheme(String name);
 

--- a/application/src/main/java/run/halo/app/infra/DefaultThemeInitializer.java
+++ b/application/src/main/java/run/halo/app/infra/DefaultThemeInitializer.java
@@ -1,12 +1,14 @@
 package run.halo.app.infra;
 
 import java.io.IOException;
-import java.util.concurrent.CountDownLatch;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.ApplicationListener;
-import org.springframework.core.io.support.PathMatchingResourcePatternResolver;
+import org.springframework.core.io.UrlResource;
+import org.springframework.core.io.buffer.DataBufferUtils;
+import org.springframework.core.io.buffer.DefaultDataBufferFactory;
 import org.springframework.stereotype.Component;
 import org.springframework.util.ResourceUtils;
+import org.springframework.util.StreamUtils;
 import run.halo.app.core.extension.theme.ThemeService;
 import run.halo.app.infra.properties.HaloProperties;
 import run.halo.app.infra.properties.ThemeProperties;
@@ -41,20 +43,18 @@ public class DefaultThemeInitializer implements ApplicationListener<SchemeInitia
             // TODO Checking if any themes are installed here in the future might be better?
             if (!FileUtils.isEmpty(themeRoot)) {
                 log.debug("Skipped initializing default theme because there are themes "
-                    + "inside theme root");
+                          + "inside theme root");
                 return;
             }
             log.info("Initializing default theme from {}", location);
-            PathMatchingResourcePatternResolver resolver =
-                new PathMatchingResourcePatternResolver();
-            var latch = new CountDownLatch(1);
-            themeService.install(ResourceUtils.getURL(location).openStream())
-                .doFinally(signalType -> latch.countDown())
-                .subscribe(theme -> log.info("Initialized default theme: {}",
-                    theme.getMetadata().getName()));
-            latch.await();
+            var themeUrl = ResourceUtils.getURL(location);
+            var content = DataBufferUtils.read(new UrlResource(themeUrl),
+                DefaultDataBufferFactory.sharedInstance,
+                StreamUtils.BUFFER_SIZE);
+            var theme = themeService.install(content).block();
+            log.info("Initialized default theme: {}", theme);
             // Because default active theme is default, we don't need to enabled it manually.
-        } catch (IOException | InterruptedException e) {
+        } catch (IOException e) {
             // we should skip the initialization error at here
             log.warn("Failed to initialize theme from " + location, e);
         }

--- a/application/src/main/java/run/halo/app/infra/utils/DataBufferUtils.java
+++ b/application/src/main/java/run/halo/app/infra/utils/DataBufferUtils.java
@@ -8,35 +8,36 @@ import java.io.InputStream;
 import java.io.PipedInputStream;
 import java.io.PipedOutputStream;
 import lombok.extern.slf4j.Slf4j;
+import org.reactivestreams.Publisher;
 import org.springframework.core.io.buffer.DataBuffer;
-import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+import reactor.core.scheduler.Scheduler;
 import reactor.core.scheduler.Schedulers;
+import reactor.util.context.Context;
 
 @Slf4j
-public final class DataBufferUtils {
+public enum DataBufferUtils {
+    ;
 
-    private DataBufferUtils() {
+    public static Mono<InputStream> toInputStream(Publisher<DataBuffer> content) {
+        return toInputStream(content, Schedulers.boundedElastic());
     }
 
-    public static InputStream toInputStream(Flux<DataBuffer> content) throws IOException {
-        var pos = new PipedOutputStream();
-        var pis = new PipedInputStream(pos);
-        write(content, pos)
-            .doOnComplete(() -> {
-                try {
-                    pos.close();
-                } catch (IOException ignored) {
-                    // Ignore the error
-                }
-            })
-            .subscribeOn(Schedulers.boundedElastic())
-            .subscribe(releaseConsumer(), error -> {
-                if (error instanceof IOException) {
-                    // Ignore the error
-                    return;
-                }
-                log.error("Failed to write DataBuffer into OutputStream", error);
-            });
-        return pis;
+    public static Mono<InputStream> toInputStream(Publisher<DataBuffer> content,
+        Scheduler scheduler) {
+        return Mono.create(sink -> {
+            try {
+                var pos = new PipedOutputStream();
+                var pis = new PipedInputStream(pos);
+                var disposable = write(content, pos)
+                    .subscribeOn(scheduler)
+                    .subscribe(releaseConsumer(), sink::error, () -> FileUtils.closeQuietly(pos),
+                        Context.of(sink.contextView()));
+                sink.onDispose(disposable);
+                sink.success(pis);
+            } catch (IOException e) {
+                sink.error(e);
+            }
+        });
     }
 }

--- a/application/src/main/java/run/halo/app/infra/utils/FileUtils.java
+++ b/application/src/main/java/run/halo/app/infra/utils/FileUtils.java
@@ -2,6 +2,7 @@ package run.halo.app.infra.utils;
 
 import static java.nio.file.StandardCopyOption.REPLACE_EXISTING;
 import static org.springframework.util.FileSystemUtils.deleteRecursively;
+import static run.halo.app.infra.utils.DataBufferUtils.toInputStream;
 
 import java.io.Closeable;
 import java.io.IOException;
@@ -23,10 +24,13 @@ import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
 import java.util.zip.ZipOutputStream;
 import lombok.extern.slf4j.Slf4j;
+import org.reactivestreams.Publisher;
+import org.springframework.core.io.buffer.DataBuffer;
 import org.springframework.lang.NonNull;
 import org.springframework.util.AntPathMatcher;
 import org.springframework.util.Assert;
 import reactor.core.publisher.Mono;
+import reactor.core.scheduler.Scheduler;
 import reactor.core.scheduler.Schedulers;
 import run.halo.app.infra.exception.AccessDeniedException;
 
@@ -38,6 +42,26 @@ import run.halo.app.infra.exception.AccessDeniedException;
 public abstract class FileUtils {
 
     private FileUtils() {
+    }
+
+    public static Mono<Void> unzip(Publisher<DataBuffer> content, @NonNull Path targetPath) {
+        return unzip(content, targetPath, Schedulers.boundedElastic());
+    }
+
+    public static Mono<Void> unzip(Publisher<DataBuffer> content, @NonNull Path targetPath,
+        Scheduler scheduler) {
+        return Mono.usingWhen(
+            toInputStream(content, scheduler),
+            is -> {
+                try (var zis = new ZipInputStream(is)) {
+                    unzip(zis, targetPath);
+                    return Mono.empty();
+                } catch (IOException e) {
+                    return Mono.error(e);
+                }
+            },
+            is -> Mono.fromRunnable(() -> closeQuietly(is))
+        );
     }
 
     public static void unzip(@NonNull ZipInputStream zis, @NonNull Path targetPath)
@@ -170,7 +194,7 @@ public abstract class FileUtils {
      * the given {@code consumer}.
      *
      * @param closeable The resource to close, may be null.
-     * @param consumer Consumes the IOException thrown by {@link Closeable#close()}.
+     * @param consumer  Consumes the IOException thrown by {@link Closeable#close()}.
      */
     public static void closeQuietly(final Closeable closeable,
         final Consumer<IOException> consumer) {
@@ -188,7 +212,7 @@ public abstract class FileUtils {
     /**
      * Checks directory traversal vulnerability.
      *
-     * @param parentPath parent path must not be null.
+     * @param parentPath  parent path must not be null.
      * @param pathToCheck path to check must not be null
      */
     public static void checkDirectoryTraversal(@NonNull Path parentPath,
@@ -207,7 +231,7 @@ public abstract class FileUtils {
     /**
      * Checks directory traversal vulnerability.
      *
-     * @param parentPath parent path must not be null.
+     * @param parentPath  parent path must not be null.
      * @param pathToCheck path to check must not be null
      */
     public static void checkDirectoryTraversal(@NonNull String parentPath,
@@ -218,7 +242,7 @@ public abstract class FileUtils {
     /**
      * Checks directory traversal vulnerability.
      *
-     * @param parentPath parent path must not be null.
+     * @param parentPath  parent path must not be null.
      * @param pathToCheck path to check must not be null
      */
     public static void checkDirectoryTraversal(@NonNull Path parentPath,
@@ -237,15 +261,27 @@ public abstract class FileUtils {
             if (log.isDebugEnabled()) {
                 log.debug("Delete {} result: {}", root, deleted);
             }
-        } catch (IOException e) {
+        } catch (IOException ignored) {
             // Ignore this error
-            if (log.isTraceEnabled()) {
-                log.trace("Failed to delete {} recursively", root);
-            }
         }
     }
 
+    public static Mono<Boolean> deleteRecursivelyAndSilently(Path root, Scheduler scheduler) {
+        return Mono.fromSupplier(() -> {
+            try {
+                return deleteRecursively(root);
+            } catch (IOException ignored) {
+                return false;
+            }
+        }).subscribeOn(scheduler);
+    }
+
+
     public static Mono<Boolean> deleteFileSilently(Path file) {
+        return deleteFileSilently(file, Schedulers.boundedElastic());
+    }
+
+    public static Mono<Boolean> deleteFileSilently(Path file, Scheduler scheduler) {
         return Mono.fromSupplier(
                 () -> {
                     if (file == null || !Files.isRegularFile(file)) {
@@ -257,7 +293,7 @@ public abstract class FileUtils {
                         return false;
                     }
                 })
-            .subscribeOn(Schedulers.boundedElastic());
+            .subscribeOn(scheduler);
     }
 
     public static void copy(Path source, Path dest, CopyOption... options) {
@@ -295,4 +331,7 @@ public abstract class FileUtils {
         });
     }
 
+    public static Mono<Path> createTempDir(String prefix, Scheduler scheduler) {
+        return Mono.fromCallable(() -> Files.createTempDirectory(prefix)).subscribeOn(scheduler);
+    }
 }

--- a/application/src/main/java/run/halo/app/migration/impl/MigrationServiceImpl.java
+++ b/application/src/main/java/run/halo/app/migration/impl/MigrationServiceImpl.java
@@ -1,38 +1,37 @@
 package run.halo.app.migration.impl;
 
-import static org.springframework.core.io.buffer.DataBufferUtils.releaseConsumer;
-import static run.halo.app.infra.utils.FileUtils.closeQuietly;
+import static java.nio.file.Files.deleteIfExists;
+import static org.springframework.util.FileSystemUtils.copyRecursively;
+import static run.halo.app.infra.utils.FileUtils.checkDirectoryTraversal;
+import static run.halo.app.infra.utils.FileUtils.copyRecursively;
+import static run.halo.app.infra.utils.FileUtils.createTempDir;
 import static run.halo.app.infra.utils.FileUtils.deleteRecursivelyAndSilently;
+import static run.halo.app.infra.utils.FileUtils.unzip;
 
 import com.fasterxml.jackson.core.util.MinimalPrettyPrinter;
 import com.fasterxml.jackson.databind.MappingIterator;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.json.JsonMapper;
 import java.io.IOException;
-import java.io.PipedInputStream;
-import java.io.PipedOutputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 import java.util.Locale;
 import java.util.Set;
-import java.util.zip.ZipInputStream;
 import lombok.extern.slf4j.Slf4j;
 import org.reactivestreams.Publisher;
 import org.springframework.core.io.FileSystemResource;
 import org.springframework.core.io.Resource;
 import org.springframework.core.io.buffer.DataBuffer;
-import org.springframework.core.io.buffer.DataBufferUtils;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import org.springframework.util.FileSystemUtils;
 import org.springframework.web.server.ServerWebInputException;
 import reactor.core.Exceptions;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
+import reactor.core.scheduler.Scheduler;
 import reactor.core.scheduler.Schedulers;
-import reactor.util.context.Context;
 import run.halo.app.extension.store.ExtensionStore;
 import run.halo.app.extension.store.ExtensionStoreRepository;
 import run.halo.app.infra.exception.NotFoundException;
@@ -67,6 +66,8 @@ public class MigrationServiceImpl implements MigrationService {
 
     private final DateTimeFormatter dateTimeFormatter;
 
+    private final Scheduler scheduler = Schedulers.boundedElastic();
+
     public MigrationServiceImpl(ExtensionStoreRepository repository,
         HaloProperties haloProperties) {
         this.repository = repository;
@@ -94,55 +95,51 @@ public class MigrationServiceImpl implements MigrationService {
 
     @Override
     public Mono<Void> backup(Backup backup) {
-        try {
-            // create temporary folder to store all backup files into single files.
-            var tempDir = Files.createTempDirectory("halo-full-backup-");
-            return backupExtensions(tempDir)
-                .and(backupWorkDir(tempDir))
-                .and(packageBackup(tempDir, backup))
-                .doFinally(signalType -> deleteRecursivelyAndSilently(tempDir))
-                .subscribeOn(Schedulers.boundedElastic());
-        } catch (IOException e) {
-            return Mono.error(e);
-        }
+        return Mono.usingWhen(
+            createTempDir("halo-full-backup-", scheduler),
+            tempDir -> backupExtensions(tempDir)
+                .then(Mono.defer(() -> backupWorkDir(tempDir)))
+                .then(Mono.defer(() -> packageBackup(tempDir, backup))),
+            tempDir -> deleteRecursivelyAndSilently(tempDir, scheduler)
+        );
     }
 
     @Override
     public Mono<Resource> download(Backup backup) {
-        var status = backup.getStatus();
-        if (!Backup.Phase.SUCCEEDED.equals(status.getPhase()) || status.getFilename() == null) {
-            return Mono.error(new ServerWebInputException("Current backup is not downloadable."));
-        }
-
-        var backupFile = getBackupsRoot().resolve(status.getFilename());
-        var resource = new FileSystemResource(backupFile);
-        if (!resource.exists()) {
-            return Mono.error(new NotFoundException("problemDetail.migration.backup.notFound",
-                new Object[] {}, "Backup file doesn't exist or deleted."));
-        }
-        return Mono.just(resource);
+        return Mono.create(sink -> {
+            var status = backup.getStatus();
+            if (!Backup.Phase.SUCCEEDED.equals(status.getPhase()) || status.getFilename() == null) {
+                sink.error(new ServerWebInputException("Current backup is not downloadable."));
+                return;
+            }
+            var backupFile = getBackupsRoot().resolve(status.getFilename());
+            var resource = new FileSystemResource(backupFile);
+            if (!resource.exists()) {
+                sink.error(
+                    new NotFoundException("problemDetail.migration.backup.notFound",
+                        new Object[] {},
+                        "Backup file doesn't exist or deleted."));
+                return;
+            }
+            sink.success(resource);
+        });
     }
 
     @Override
     @Transactional
     public Mono<Void> restore(Publisher<DataBuffer> content) {
-        return Mono.defer(() -> {
-            try {
-                var tempDir = Files.createTempDirectory("halo-restore-");
-                return unpackBackup(content, tempDir)
-                    .and(restoreExtensions(tempDir))
-                    .and(restoreWorkdir(tempDir))
-                    .doFinally(signalType -> deleteRecursivelyAndSilently(tempDir))
-                    .subscribeOn(Schedulers.boundedElastic());
-            } catch (IOException e) {
-                return Mono.error(e);
-            }
-        });
+        return Mono.usingWhen(
+            createTempDir("halo-restore-", scheduler),
+            tempDir -> unpackBackup(content, tempDir)
+                .then(Mono.defer(() -> restoreExtensions(tempDir)))
+                .then(Mono.defer(() -> restoreWorkdir(tempDir))),
+            tempDir -> deleteRecursivelyAndSilently(tempDir, scheduler)
+        );
     }
 
     @Override
     public Mono<Void> cleanup(Backup backup) {
-        return Mono.<Void>fromRunnable(() -> {
+        return Mono.<Void>create(sink -> {
             var status = backup.getStatus();
             if (status == null || status.getFilename() == null) {
                 return;
@@ -151,110 +148,104 @@ public class MigrationServiceImpl implements MigrationService {
             var backupsRoot = getBackupsRoot();
             var backupFile = backupsRoot.resolve(filename);
             try {
-                FileUtils.checkDirectoryTraversal(backupsRoot, backupFile);
-                Files.deleteIfExists(backupFile);
-            } catch (IOException e) {
-                throw Exceptions.propagate(e);
-            }
-        }).subscribeOn(Schedulers.boundedElastic());
-    }
-
-    private Mono<Void> restoreWorkdir(Path backupRoot) {
-        return Mono.fromRunnable(() -> {
-            try {
-                var workdir = backupRoot.resolve("workdir");
-                if (Files.exists(workdir)) {
-                    FileSystemUtils.copyRecursively(workdir, haloProperties.getWorkDir());
-                }
-            } catch (IOException e) {
-                throw Exceptions.propagate(e);
-            }
-        });
-    }
-
-    private Mono<Void> restoreExtensions(Path backupRoot) {
-        var extensionsPath = backupRoot.resolve("extensions.data");
-        var reader = objectMapper.readerFor(ExtensionStore.class);
-        return Mono.<Void, MappingIterator<ExtensionStore>>using(
-            () -> reader.readValues(extensionsPath.toFile()),
-            itr -> Flux.<ExtensionStore>create(
-                    sink -> {
-                        while (itr.hasNext()) {
-                            sink.next(itr.next());
-                        }
-                        sink.complete();
-                    })
-                // reset version
-                .doOnNext(extensionStore -> extensionStore.setVersion(null))
-                .buffer(100)
-                // We might encounter OptimisticLockingFailureException when saving extension store,
-                // So we have to delete all extension stores before saving.
-                .flatMap(extensionStores -> repository.deleteAll(extensionStores)
-                    .thenMany(repository.saveAll(extensionStores)))
-                .doOnNext(extensionStore ->
-                    log.info("Restored extension store: {}", extensionStore.getName()))
-                .then(),
-            itr -> {
-                try {
-                    itr.close();
-                } catch (IOException e) {
-                    throw Exceptions.propagate(e);
-                }
-            });
-    }
-
-    private Mono<Void> unpackBackup(Publisher<DataBuffer> content, Path target) {
-        return Mono.create(sink -> {
-            try (var pipedIs = new PipedInputStream();
-                 var pipedOs = new PipedOutputStream(pipedIs);
-                 var zipIs = new ZipInputStream(pipedIs)) {
-                DataBufferUtils.write(content, pipedOs)
-                    .subscribe(
-                        releaseConsumer(),
-                        sink::error,
-                        () -> closeQuietly(pipedOs),
-                        Context.of(sink.contextView()));
-                FileUtils.unzip(zipIs, target);
+                checkDirectoryTraversal(backupsRoot, backupFile);
+                deleteIfExists(backupFile);
                 sink.success();
             } catch (IOException e) {
                 sink.error(e);
             }
-        });
+        }).subscribeOn(scheduler);
+    }
+
+    private Mono<Void> restoreWorkdir(Path backupRoot) {
+        return Mono.<Void>create(sink -> {
+            try {
+                var workdir = backupRoot.resolve("workdir");
+                if (Files.exists(workdir)) {
+                    copyRecursively(workdir, haloProperties.getWorkDir());
+                }
+                sink.success();
+            } catch (IOException e) {
+                sink.error(e);
+            }
+        }).subscribeOn(scheduler);
+    }
+
+    private Mono<Void> restoreExtensions(Path backupRoot) {
+        var extensionsPath = backupRoot.resolve("extensions.data");
+        if (Files.notExists(extensionsPath)) {
+            return Mono.empty();
+        }
+        var reader = objectMapper.readerFor(ExtensionStore.class);
+        return Mono.<Void, MappingIterator<ExtensionStore>>using(
+                () -> reader.readValues(extensionsPath.toFile()),
+                itr -> Flux.<ExtensionStore>create(
+                        sink -> {
+                            while (itr.hasNext()) {
+                                sink.next(itr.next());
+                            }
+                            sink.complete();
+                        })
+                    // reset version
+                    .doOnNext(extensionStore -> extensionStore.setVersion(null)).buffer(100)
+                    // We might encounter OptimisticLockingFailureException when saving extension
+                    // store,
+                    // So we have to delete all extension stores before saving.
+                    .flatMap(extensionStores -> repository.deleteAll(extensionStores)
+                        .thenMany(repository.saveAll(extensionStores))
+                    )
+                    .doOnNext(extensionStore -> log.info("Restored extension store: {}",
+                        extensionStore.getName()))
+                    .then(),
+                FileUtils::closeQuietly)
+            .subscribeOn(scheduler);
+    }
+
+    private Mono<Void> unpackBackup(Publisher<DataBuffer> content, Path target) {
+        return unzip(content, target, scheduler);
     }
 
     private Mono<Void> packageBackup(Path baseDir, Backup backup) {
-        return Mono.fromRunnable(() -> {
-            try {
-                var backupsFolder = getBackupsRoot();
-                Files.createDirectories(backupsFolder);
+        return Mono.fromCallable(
+                () -> {
+                    var backupsFolder = getBackupsRoot();
+                    Files.createDirectories(backupsFolder);
+                    return backupsFolder;
+                })
+            .<Void>handle((backupsFolder, sink) -> {
                 var backupName = backup.getMetadata().getName();
                 var startTimestamp = backup.getStatus().getStartTimestamp();
                 var timePart = this.dateTimeFormatter.format(startTimestamp);
                 var backupFile = backupsFolder.resolve(timePart + '-' + backupName + ".zip");
-                FileUtils.zip(baseDir, backupFile);
-                backup.getStatus().setFilename(backupFile.getFileName().toString());
-                backup.getStatus().setSize(Files.size(backupFile));
-            } catch (IOException e) {
-                throw Exceptions.propagate(e);
-            }
-        });
+                try {
+                    FileUtils.zip(baseDir, backupFile);
+                    backup.getStatus().setFilename(backupFile.getFileName().toString());
+                    backup.getStatus().setSize(Files.size(backupFile));
+                    sink.complete();
+                } catch (IOException e) {
+                    sink.error(e);
+                }
+            })
+            .subscribeOn(scheduler);
     }
 
     private Mono<Void> backupWorkDir(Path baseDir) {
-        return Mono.fromRunnable(() -> {
-            try {
-                var workdirPath = Files.createDirectory(baseDir.resolve("workdir"));
-                FileUtils.copyRecursively(haloProperties.getWorkDir(), workdirPath, excludes);
-            } catch (IOException e) {
-                throw Exceptions.propagate(e);
-            }
-        });
+        return Mono.fromCallable(() -> Files.createDirectory(baseDir.resolve("workdir")))
+            .<Void>handle((workdirPath, sink) -> {
+                try {
+                    copyRecursively(haloProperties.getWorkDir(), workdirPath, excludes);
+                    sink.complete();
+                } catch (IOException e) {
+                    sink.error(e);
+                }
+            })
+            .subscribeOn(scheduler);
     }
 
     private Mono<Void> backupExtensions(Path baseDir) {
-        try {
-            var extensionsPath = Files.createFile(baseDir.resolve("extensions.data"));
-            return Mono.using(() -> objectMapper.writerFor(ExtensionStore.class)
+        return Mono.fromCallable(() -> Files.createFile(baseDir.resolve("extensions.data")))
+            .flatMap(extensionsPath -> Mono.using(
+                () -> objectMapper.writerFor(ExtensionStore.class)
                     .writeValuesAsArray(extensionsPath.toFile()),
                 seqWriter -> repository.findAll()
                     .doOnNext(extensionStore -> {
@@ -263,17 +254,8 @@ public class MigrationServiceImpl implements MigrationService {
                         } catch (IOException e) {
                             throw Exceptions.propagate(e);
                         }
-                    })
-                    .then(),
-                seqWriter -> {
-                    try {
-                        seqWriter.close();
-                    } catch (IOException e) {
-                        throw Exceptions.propagate(e);
-                    }
-                });
-        } catch (IOException e) {
-            return Mono.error(e);
-        }
+                    }).then(),
+                FileUtils::closeQuietly))
+            .subscribeOn(scheduler);
     }
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup
/area core
/milestone 2.9.x

#### What this PR does / why we need it:

Before this, If we use a file with length less than 256KB for recovery, the process remains stagnant until we cancel the request.

This PR refactors the transformation between data buffers and input stream and resolve the issue above. We should avoid returning InputStream directly in reactive stream.

- DataBufferUtils before

    ```java
        public static InputStream toInputStream(Flux<DataBuffer> content) throws IOException {
            var pos = new PipedOutputStream();
            var pis = new PipedInputStream(pos);
            write(content, pos)
                .doOnComplete(() -> {
                    try {
                        pos.close();
                    } catch (IOException ignored) {
                        // Ignore the error
                    }
                })
                .subscribeOn(Schedulers.boundedElastic())
                .subscribe(releaseConsumer(), error -> {
                    if (error instanceof IOException) {
                        // Ignore the error
                        return;
                    }
                    log.error("Failed to write DataBuffer into OutputStream", error);
                });
            return pis;
    ```

- DataBufferUtils after

    ```java
        public static Mono<InputStream> toInputStream(Publisher<DataBuffer> content,
            Scheduler scheduler) {
            return Mono.create(sink -> {
                try {
                    var pos = new PipedOutputStream();
                    var pis = new PipedInputStream(pos);
                    var disposable = write(content, pos)
                        .subscribeOn(scheduler)
                        .subscribe(releaseConsumer(), sink::error, () -> FileUtils.closeQuietly(pos),
                            Context.of(sink.contextView()));
                    sink.onDispose(disposable);
                    sink.success(pis);
                } catch (IOException e) {
                    sink.error(e);
                }
            });
    ```

#### Special notes for your reviewer:

Please test for plugins, themes and migrations.

#### Does this PR introduce a user-facing change?

```release-note
解决备份恢复时因文件小于 256KB 而导致接口卡住的问题。
```
