### PR TITLE
pref: allow annotations value to be empty

### DIFF
--- a/console/src/components/form/AnnotationsForm.vue
+++ b/console/src/components/form/AnnotationsForm.vue
@@ -234,7 +234,7 @@ defineExpose({
           type="text"
           label="Key"
           name="key"
-          validation="required|keyValidationRule"
+          validation="required:trim|keyValidationRule"
           :validation-rules="{ keyValidationRule }"
           :validation-messages="{
             keyValidationRule: $t(
@@ -242,12 +242,7 @@ defineExpose({
             ),
           }"
         ></FormKit>
-        <FormKit
-          type="text"
-          label="Value"
-          name="value"
-          validation="required"
-        ></FormKit>
+        <FormKit type="text" label="Value" name="value" value=""></FormKit>
       </FormKit>
     </FormKit>
   </div>


### PR DESCRIPTION
#### What type of PR is this?

/kind improvement

#### What this PR does / why we need it:

由于后端 annotation 的值可以为空，而前端则规定 annotation 值为必填项，因此去除前端必填属性。

#### Which issue(s) this PR fixes:

Fixes #4279 

#### Does this PR introduce a user-facing change?
```release-note
将元数据值更改为非必填
```
