### PR TITLE
Support getting backup root path in plugin

### DIFF
--- a/api/src/main/java/run/halo/app/infra/BackupRootGetter.java
+++ b/api/src/main/java/run/halo/app/infra/BackupRootGetter.java
@@ -1,0 +1,14 @@
+package run.halo.app.infra;
+
+import java.nio.file.Path;
+import java.util.function.Supplier;
+
+/**
+ * Utility of getting backup root path.
+ *
+ * @author johnniang
+ * @since 2.9.0
+ */
+public interface BackupRootGetter extends Supplier<Path> {
+
+}

--- a/application/src/main/java/run/halo/app/infra/DefaultBackupRootGetter.java
+++ b/application/src/main/java/run/halo/app/infra/DefaultBackupRootGetter.java
@@ -1,0 +1,20 @@
+package run.halo.app.infra;
+
+import java.nio.file.Path;
+import org.springframework.stereotype.Component;
+import run.halo.app.infra.properties.HaloProperties;
+
+@Component
+public class DefaultBackupRootGetter implements BackupRootGetter {
+
+    private final HaloProperties haloProperties;
+
+    public DefaultBackupRootGetter(HaloProperties haloProperties) {
+        this.haloProperties = haloProperties;
+    }
+
+    @Override
+    public Path get() {
+        return haloProperties.getWorkDir().resolve("backups");
+    }
+}

--- a/application/src/main/java/run/halo/app/migration/impl/MigrationServiceImpl.java
+++ b/application/src/main/java/run/halo/app/migration/impl/MigrationServiceImpl.java
@@ -34,6 +34,7 @@ import reactor.core.scheduler.Scheduler;
 import reactor.core.scheduler.Schedulers;
 import run.halo.app.extension.store.ExtensionStore;
 import run.halo.app.extension.store.ExtensionStoreRepository;
+import run.halo.app.infra.BackupRootGetter;
 import run.halo.app.infra.exception.NotFoundException;
 import run.halo.app.infra.properties.HaloProperties;
 import run.halo.app.infra.utils.FileUtils;
@@ -47,6 +48,8 @@ public class MigrationServiceImpl implements MigrationService {
     private final ExtensionStoreRepository repository;
 
     private final HaloProperties haloProperties;
+
+    private final BackupRootGetter backupRoot;
 
     private final ObjectMapper objectMapper;
 
@@ -69,9 +72,10 @@ public class MigrationServiceImpl implements MigrationService {
     private final Scheduler scheduler = Schedulers.boundedElastic();
 
     public MigrationServiceImpl(ExtensionStoreRepository repository,
-        HaloProperties haloProperties) {
+        HaloProperties haloProperties, BackupRootGetter backupRoot) {
         this.repository = repository;
         this.haloProperties = haloProperties;
+        this.backupRoot = backupRoot;
         this.objectMapper = JsonMapper.builder()
             .defaultPrettyPrinter(new MinimalPrettyPrinter())
             .build();
@@ -90,7 +94,7 @@ public class MigrationServiceImpl implements MigrationService {
     }
 
     Path getBackupsRoot() {
-        return haloProperties.getWorkDir().resolve("backups");
+        return backupRoot.get();
     }
 
     @Override

--- a/application/src/main/java/run/halo/app/plugin/SharedApplicationContextHolder.java
+++ b/application/src/main/java/run/halo/app/plugin/SharedApplicationContextHolder.java
@@ -8,6 +8,7 @@ import run.halo.app.core.extension.service.AttachmentService;
 import run.halo.app.extension.DefaultSchemeManager;
 import run.halo.app.extension.ExtensionClient;
 import run.halo.app.extension.ReactiveExtensionClient;
+import run.halo.app.infra.BackupRootGetter;
 import run.halo.app.infra.ExternalUrlSupplier;
 
 /**
@@ -70,6 +71,8 @@ public class SharedApplicationContextHolder {
             rootApplicationContext.getBean(ServerSecurityContextRepository.class));
         beanFactory.registerSingleton("attachmentService",
             rootApplicationContext.getBean(AttachmentService.class));
+        beanFactory.registerSingleton("backupRootGetter",
+            rootApplicationContext.getBean(BackupRootGetter.class));
         // TODO add more shared instance here
 
         return sharedApplicationContext;

--- a/application/src/test/java/run/halo/app/infra/DefaultBackupRootGetterTest.java
+++ b/application/src/test/java/run/halo/app/infra/DefaultBackupRootGetterTest.java
@@ -1,0 +1,33 @@
+package run.halo.app.infra;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.nio.file.Path;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import run.halo.app.infra.properties.HaloProperties;
+
+@ExtendWith(MockitoExtension.class)
+class DefaultBackupRootGetterTest {
+
+    @Mock
+    HaloProperties haloProperties;
+
+    @InjectMocks
+    DefaultBackupRootGetter backupRootGetter;
+
+    @Test
+    void shouldGetBackupRootFromWorkDir() {
+        when(haloProperties.getWorkDir()).thenReturn(Path.of("workdir"));
+        var backupRoot = this.backupRootGetter.get();
+        assertEquals(Path.of("workdir", "backups"), backupRoot);
+        verify(haloProperties).getWorkDir();
+    }
+
+
+}


### PR DESCRIPTION
#### What type of PR is this?

/kind feature
/area core
/milestone 2.9.x

#### What this PR does / why we need it:

We already support backup and restore feature in Halo 2.8.0, but we cannot obtain backup files through regular channels in the plugin. For example, we want to upload backup files to OSS in the plugin.

This PR is aimed at solving this problem.

#### Does this PR introduce a user-facing change?

```release-note
支持在插件中获取备份文件根目录。
```
