### PR TITLE
fix: encode the redirect uri

### DIFF
--- a/console/src/router/guards/auth-check.ts
+++ b/console/src/router/guards/auth-check.ts
@@ -16,7 +16,7 @@ export function setupAuthCheckGuard(router: Router) {
       next({
         name: "Login",
         query: {
-          redirect_uri: window.location.href,
+          redirect_uri: encodeURIComponent(window.location.href),
         },
       });
       return;

--- a/console/src/views/system/Redirect.vue
+++ b/console/src/views/system/Redirect.vue
@@ -5,7 +5,7 @@ const route = useRoute();
 const router = useRouter();
 
 if (allowRedirect()) {
-  window.location.href = route.query.redirect_uri as string;
+  window.location.href = decodeURIComponent(route.query.redirect_uri as string);
 } else {
   router.push({
     name: "Dashboard",
@@ -13,7 +13,7 @@ if (allowRedirect()) {
 }
 
 function allowRedirect() {
-  const redirect_uri = route.query.redirect_uri as string;
+  const redirect_uri = decodeURIComponent(route.query.redirect_uri as string);
 
   if (!redirect_uri || redirect_uri === window.location.href) {
     return false;


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

对 console 跳转链接进行编码，用于解决跳转链接中如果携带非标准字符而导致的报错

#### How to test it?

本地开发环境：重定向地址无误且进行了 uri 编码即可。

生产环境：
在 console 后端未登录时，前往应用市场输入网站地址进行安装，之后进行登录，查看是否能够正确跳转。

#### Which issue(s) this PR fixes:

Fixes #4351

#### Does this PR introduce a user-facing change?
```release-note
对 console 重定向链接进行编码
```
