### PR TITLE
Refine search result by customizing analyzer

### DIFF
--- a/api/build.gradle
+++ b/api/build.gradle
@@ -42,7 +42,7 @@ dependencies {
     api "org.apache.lucene:lucene-queryparser"
     api "org.apache.lucene:lucene-highlighter"
     api "org.apache.lucene:lucene-backward-codecs"
-    api 'cn.shenyanchao.ik-analyzer:ik-analyzer'
+    api 'org.apache.lucene:lucene-analysis-common'
 
     api "org.apache.commons:commons-lang3"
     api "io.seruco.encoding:base62"

--- a/platform/application/build.gradle
+++ b/platform/application/build.gradle
@@ -39,7 +39,7 @@ dependencies {
         api "org.apache.lucene:lucene-queryparser:$lucene"
         api "org.apache.lucene:lucene-highlighter:$lucene"
         api "org.apache.lucene:lucene-backward-codecs:$lucene"
-        api 'cn.shenyanchao.ik-analyzer:ik-analyzer:9.0.0'
+        api "org.apache.lucene:lucene-analysis-common:$lucene"
 
         api "org.apache.commons:commons-lang3:$commonsLang3"
         api "io.seruco.encoding:base62:$base62"


### PR DESCRIPTION
#### What type of PR is this?

/kind improvement
/area core
/milestone 2.9.x

#### What this PR does / why we need it:

- Removes dependency `cn.shenyanchao.ik-analyzer:ik-analyzer:9.0.0` due to no significant effect for searching result.
- Customize our own analyzer with StandardTokenizer, HTMLStripCharFilter and LowerCaseFilterFactory.

Please be aware of that the default field to search has become to `content` instead of `title` + `excerpt` + `content`. If someone wants to search title only, use `title: halo` as query string. For more details, please refer to <https://lucene.apache.org/core/9_5_0/queryparser/org/apache/lucene/queryparser/flexible/standard/StandardQueryParser.html>.

#### Which issue(s) this PR fixes:

Fixes https://github.com/halo-dev/halo/issues/4455

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
优化本地搜索引擎
```
