### PR TITLE
Fix the problem that it is always in deleting phase after deleting backups

### DIFF
--- a/application/src/main/java/run/halo/app/migration/impl/MigrationServiceImpl.java
+++ b/application/src/main/java/run/halo/app/migration/impl/MigrationServiceImpl.java
@@ -26,6 +26,7 @@ import org.springframework.core.io.Resource;
 import org.springframework.core.io.buffer.DataBuffer;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
 import org.springframework.web.server.ServerWebInputException;
 import reactor.core.Exceptions;
 import reactor.core.publisher.Flux;
@@ -145,7 +146,8 @@ public class MigrationServiceImpl implements MigrationService {
     public Mono<Void> cleanup(Backup backup) {
         return Mono.<Void>create(sink -> {
             var status = backup.getStatus();
-            if (status == null || status.getFilename() == null) {
+            if (status == null || !StringUtils.hasText(status.getFilename())) {
+                sink.success();
                 return;
             }
             var filename = status.getFilename();

--- a/application/src/test/java/run/halo/app/migration/impl/MigrationServiceImplTest.java
+++ b/application/src/test/java/run/halo/app/migration/impl/MigrationServiceImplTest.java
@@ -154,6 +154,15 @@ class MigrationServiceImplTest {
     }
 
     @Test
+    void cleanupBackupWithNoFilename() {
+        var backup = createSucceededBackup("fake-backup", null);
+        StepVerifier.create(migrationService.cleanup(backup))
+            .verifyComplete();
+        verify(haloProperties, never()).getWorkDir();
+        verify(backupRoot, never()).get();
+    }
+
+    @Test
     void downloadBackupTest() throws IOException {
         var backupFile = tempDir.resolve("workdir").resolve("backups").resolve("backup.zip");
         Files.createDirectories(backupFile.getParent());


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/area core
/milestone 2.9.x

#### What this PR does / why we need it:

Before this, if we deleted a backup without filename, the BackupReconciler would get stuck infinitely. And no further backups would be reconciled.

This PR fixes the problem that it is always in deleting phase after deleting backups.

#### Does this PR introduce a user-facing change?

```release-note
修复因备份数据状态不正常导致无法正常删除备份的问题。
```
