### PR TITLE
refactor: remove the confirmation box of the enable/disable plugin

### DIFF
--- a/console/src/locales/en.yaml
+++ b/console/src/locales/en.yaml
@@ -736,9 +736,6 @@ core:
       uninstall_when_enabled:
         confirm_text: Stop running and uninstall
         description: The current plugin is still in the enabled state and will be uninstalled after it stops running. This operation cannot be undone.
-      change_status:
-        active_title: Are you sure you want to active this plugin?
-        inactive_title: Are you sure you want to inactive this plugin?
       remote_download:
         title: Remote download address detected, do you want to download?
         description: "Please carefully verify whether this address can be trusted: {url}"

--- a/console/src/locales/zh-CN.yaml
+++ b/console/src/locales/zh-CN.yaml
@@ -736,9 +736,6 @@ core:
       uninstall_when_enabled:
         confirm_text: 停止运行并卸载
         description: 当前插件还在启用状态，将在停止运行后卸载，该操作不可恢复。
-      change_status:
-        active_title: 确定要启用该插件吗？
-        inactive_title: 确定要停用该插件吗？
       remote_download:
         title: 检测到了远程下载地址，是否需要下载？
         description: 请仔细鉴别此地址是否可信：{url}

--- a/console/src/locales/zh-TW.yaml
+++ b/console/src/locales/zh-TW.yaml
@@ -736,9 +736,6 @@ core:
       uninstall_when_enabled:
         confirm_text: 停止運行並卸載
         description: 當前插件還在啟用狀態，將在停止運行後卸載，該操作不可恢復。
-      change_status:
-        active_title: 確定要啟用該插件嗎？
-        inactive_title: 確定要停用該插件嗎？
       remote_download:
         title: 偵測到遠端下載地址，是否需要下載？
         description: 請仔細鑑別此地址是否可信：{url}

--- a/console/src/modules/system/plugins/components/PluginListItem.vue
+++ b/console/src/modules/system/plugins/components/PluginListItem.vue
@@ -37,7 +37,7 @@ const emit = defineEmits<{
 
 const { plugin } = toRefs(props);
 
-const { getFailedMessage, changeStatus, uninstall } =
+const { getFailedMessage, changeStatus, changingStatus, uninstall } =
   usePluginLifeCycle(plugin);
 
 const handleResetSettingConfig = async () => {
@@ -125,6 +125,7 @@ const handleResetSettingConfig = async () => {
           <div class="flex items-center">
             <VSwitch
               :model-value="plugin?.spec.enabled"
+              :disabled="changingStatus"
               @click="changeStatus"
             />
           </div>


### PR DESCRIPTION
#### What type of PR is this?

/area console
/kind improvement
/milestone 2.9.x

#### What this PR does / why we need it:

移除启动/停止插件的确认弹框。

#### Which issue(s) this PR fixes:

Fixes #4471 

#### Special notes for your reviewer:

测试启动和停止插件是否正常工作即可。

#### Does this PR introduce a user-facing change?

```release-note
移除 Console 端启动/停止插件的确认弹框。
```
