### PR TITLE
fix: the search for comments by username yields empty results

### DIFF
--- a/console/src/modules/contents/comments/CommentList.vue
+++ b/console/src/modules/contents/comments/CommentList.vue
@@ -34,6 +34,7 @@ const selectedApprovedStatus = useRouteQuery<string | undefined>(
 );
 const selectedSort = useRouteQuery<string | undefined>("sort");
 const selectedUser = useRouteQuery<string | undefined>("user");
+const selectedUserKind = useRouteQuery<string | undefined>("kind");
 
 watch(
   () => [
@@ -42,7 +43,9 @@ watch(
     selectedUser.value,
     keyword.value,
   ],
-  () => {
+  ([user]) => {
+    // TODO: email users are not supported at the moment.
+    selectedUserKind.value = user ? "User" : undefined;
     page.value = 1;
   }
 );
@@ -51,7 +54,8 @@ const hasFilters = computed(() => {
   return (
     selectedApprovedStatus.value !== undefined ||
     selectedSort.value ||
-    selectedUser.value
+    selectedUser.value ||
+    selectedUserKind.value
   );
 });
 
@@ -59,6 +63,7 @@ function handleClearFilters() {
   selectedApprovedStatus.value = undefined;
   selectedSort.value = undefined;
   selectedUser.value = undefined;
+  selectedUserKind.value = undefined;
 }
 
 const page = useRouteQuery<number>("page", 1, {
@@ -82,6 +87,7 @@ const {
     selectedApprovedStatus,
     selectedSort,
     selectedUser,
+    selectedUserKind,
     keyword,
   ],
   queryFn: async () => {
@@ -95,6 +101,7 @@ const {
       sort: [selectedSort.value].filter(Boolean) as string[],
       keyword: keyword.value,
       ownerName: selectedUser.value,
+      ownerKind: selectedUserKind.value,
     });
 
     total.value = data.total;

--- a/console/src/modules/contents/comments/CommentList.vue
+++ b/console/src/modules/contents/comments/CommentList.vue
@@ -43,7 +43,8 @@ watch(
     selectedUser.value,
     keyword.value,
   ],
-  ([user]) => {
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  ([approvedStatus, sort, user]) => {
     // TODO: email users are not supported at the moment.
     selectedUserKind.value = user ? "User" : undefined;
     page.value = 1;

--- a/console/src/modules/contents/comments/CommentList.vue
+++ b/console/src/modules/contents/comments/CommentList.vue
@@ -34,7 +34,6 @@ const selectedApprovedStatus = useRouteQuery<string | undefined>(
 );
 const selectedSort = useRouteQuery<string | undefined>("sort");
 const selectedUser = useRouteQuery<string | undefined>("user");
-const selectedUserKind = useRouteQuery<string | undefined>("kind");
 
 watch(
   () => [
@@ -43,10 +42,7 @@ watch(
     selectedUser.value,
     keyword.value,
   ],
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  ([approvedStatus, sort, user]) => {
-    // TODO: email users are not supported at the moment.
-    selectedUserKind.value = user ? "User" : undefined;
+  () => {
     page.value = 1;
   }
 );
@@ -55,8 +51,7 @@ const hasFilters = computed(() => {
   return (
     selectedApprovedStatus.value !== undefined ||
     selectedSort.value ||
-    selectedUser.value ||
-    selectedUserKind.value
+    selectedUser.value
   );
 });
 
@@ -64,7 +59,6 @@ function handleClearFilters() {
   selectedApprovedStatus.value = undefined;
   selectedSort.value = undefined;
   selectedUser.value = undefined;
-  selectedUserKind.value = undefined;
 }
 
 const page = useRouteQuery<number>("page", 1, {
@@ -88,7 +82,6 @@ const {
     selectedApprovedStatus,
     selectedSort,
     selectedUser,
-    selectedUserKind,
     keyword,
   ],
   queryFn: async () => {
@@ -102,7 +95,8 @@ const {
       sort: [selectedSort.value].filter(Boolean) as string[],
       keyword: keyword.value,
       ownerName: selectedUser.value,
-      ownerKind: selectedUserKind.value,
+      // TODO: email users are not supported at the moment.
+      ownerKind: selectedUser.value ? "User" : undefined,
     });
 
     total.value = data.total;


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/area console
/milestone 2.9.x

#### What this PR does / why we need it:

Console 评论列表中，使用用户名查询时携带 kind

#### How to test it?

在 Console 端评论列表，选中右上角评论者，进行选择。

#### Which issue(s) this PR fixes:

Fixes #4465 

#### Does this PR introduce a user-facing change?
```release-note
解决评论列表根据评论者条件筛选时为空的问题
```
