### PR TITLE
fix: setup state is not set due to an exception when initializing the data

### DIFF
--- a/console/src/views/system/SetupInitialData.vue
+++ b/console/src/views/system/SetupInitialData.vue
@@ -113,7 +113,9 @@ async function setupInitialData() {
     for (let i = 0; i < presetPlugins.length; i++) {
       pluginInstallMutate(presetPlugins[i]);
     }
-
+  } catch (error) {
+    console.error(error);
+  } finally {
     await apiClient.extension.configMap.createv1alpha1ConfigMap({
       configMap: {
         metadata: {
@@ -126,9 +128,6 @@ async function setupInitialData() {
         },
       },
     });
-  } catch (error) {
-    console.error(error);
-  } finally {
     processing.value = false;
   }
 


### PR DESCRIPTION
#### What type of PR is this?

/area console
/kind bug
/milestone 2.9.x

#### What this PR does / why we need it:

修复因为初始化数据异常导致没有记录初始化状态的问题，这个问题可能会导致失败之后无法再让系统正常访问。

#### Does this PR introduce a user-facing change?

```release-note
None
```
