### PR TITLE
chore: bump @halo-dev/richtext-editor version to alpha.30

### DIFF
--- a/console/package.json
+++ b/console/package.json
@@ -54,7 +54,7 @@
     "@halo-dev/api-client": "workspace:*",
     "@halo-dev/components": "workspace:*",
     "@halo-dev/console-shared": "workspace:*",
-    "@halo-dev/richtext-editor": "0.0.0-alpha.29",
+    "@halo-dev/richtext-editor": "0.0.0-alpha.30",
     "@tanstack/vue-query": "^4.29.1",
     "@tiptap/extension-character-count": "^2.0.4",
     "@tiptap/vue-3": "^2.0.4",

--- a/console/pnpm-lock.yaml
+++ b/console/pnpm-lock.yaml
@@ -69,8 +69,8 @@ importers:
         specifier: workspace:*
         version: link:packages/shared
       '@halo-dev/richtext-editor':
-        specifier: 0.0.0-alpha.29
-        version: 0.0.0-alpha.29(@tiptap/pm@2.0.3)(vue@3.3.4)
+        specifier: 0.0.0-alpha.30
+        version: 0.0.0-alpha.30(@tiptap/pm@2.0.3)(vue@3.3.4)
       '@tanstack/vue-query':
         specifier: ^4.29.1
         version: 4.29.1(vue@3.3.4)
@@ -2371,8 +2371,8 @@ packages:
       - windicss
     dev: false
 
-  /@halo-dev/richtext-editor@0.0.0-alpha.29(@tiptap/pm@2.0.3)(vue@3.3.4):
-    resolution: {integrity: sha512-5lRL3rpHR6xiuYfvpAT0wvKi1dC0NIadPL2lbHwxMCQDKoZV1BQllsdzrkMfcppsSmS99ZUR+YWlFigMeKwZjw==}
+  /@halo-dev/richtext-editor@0.0.0-alpha.30(@tiptap/pm@2.0.3)(vue@3.3.4):
+    resolution: {integrity: sha512-Bv+ZN4pwd1Msi6+pUKGY+0lzS1COuuNOt1GDmX93yMzsR1i9W74UASRVZNhAt7Bt6c9b1QU97Cj8BzvzNGfIew==}
     peerDependencies:
       vue: ^3.2.37
     dependencies:

--- a/console/src/components/editor/DefaultEditor.vue
+++ b/console/src/components/editor/DefaultEditor.vue
@@ -34,6 +34,7 @@ import {
   ExtensionCodeBlock,
   ExtensionFontSize,
   ExtensionColor,
+  ExtensionIndent,
   lowlight,
   type AnyExtension,
   Editor,
@@ -206,6 +207,7 @@ onMounted(() => {
       ExtensionCharacterCount,
       ExtensionFontSize,
       ExtensionColor,
+      ExtensionIndent,
       ...extensionsFromPlugins,
       Extension.create({
         addGlobalAttributes() {
@@ -479,19 +481,12 @@ const currentLocale = i18n.global.locale.value as
     v-model:visible="attachmentSelectorModal"
     @select="onAttachmentSelect"
   />
-  <RichTextEditor
-    v-if="editor"
-    :editor="editor"
-    :locale="currentLocale"
-    :content-styles="{
-      width: 'calc(100% - 18rem)',
-    }"
-  >
+  <RichTextEditor v-if="editor" :editor="editor" :locale="currentLocale">
     <template #extra>
       <OverlayScrollbarsComponent
         element="div"
         :options="{ scrollbars: { autoHide: 'scroll' } }"
-        class="h-full w-72 border-l bg-white"
+        class="h-full border-l bg-white"
         defer
       >
         <VTabs v-model:active-id="extraActiveId" type="outline">


### PR DESCRIPTION
#### What type of PR is this?

/area console
/kind cleanup
/milestone 2.9.x

#### What this PR does / why we need it:

升级默认编辑器的版本，包含以下修改：

1. 图片支持修改 alt 属性。 https://github.com/halo-sigs/richtext-editor/pull/32
2. 拖拽修改图片大小的时候保持等比例。 https://github.com/halo-sigs/richtext-editor/pull/33
3. 优化在移动端下，编辑器右侧边栏的样式。 https://github.com/halo-sigs/richtext-editor/pull/35
4. 编辑器标题、段落及代码块增加 Tab 快捷键缩进。 https://github.com/halo-sigs/richtext-editor/pull/34

#### Does this PR introduce a user-facing change?

```release-note
升级默认编辑器的版本，包含以下更改：

1. 图片支持修改 alt 属性。 by @GodlessLiu in <https://github.com/halo-sigs/richtext-editor/pull/32>
2. 拖拽修改图片大小的时候保持等比例。 by @GodlessLiu in <https://github.com/halo-sigs/richtext-editor/pull/33>
3. 优化在移动端下，编辑器右侧边栏的样式。 by @ruibaby in <https://github.com/halo-sigs/richtext-editor/pull/35>
4. 编辑器标题、段落及代码块增加 Tab 快捷键缩进。 by @LIlGG in <https://github.com/halo-sigs/richtext-editor/pull/34>
```
