### PR TITLE
fix: resolve the display bug after publishing content

### DIFF
--- a/console/src/composables/use-auto-save-content.ts
+++ b/console/src/composables/use-auto-save-content.ts
@@ -11,7 +11,9 @@ export function useAutoSaveContent(
 ) {
   // TODO it may be necessary to know the latest version before saving, otherwise it will overwrite the latest version
   const handleAutoSave = () => {
-    callback();
+    if (currentCache.value) {
+      callback();
+    }
   };
 
   onBeforeRouteLeave(() => {
@@ -19,7 +21,7 @@ export function useAutoSaveContent(
   });
 
   watch(useWindowFocus(), (newFocus) => {
-    if (!newFocus && currentCache.value) {
+    if (!newFocus) {
       handleAutoSave();
     }
   });


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/area console
/milestone 2.9.x

#### What this PR does / why we need it:

更改自动保存的策略，仅当内容具有缓存时才会执行自动保存。

#### How to test it?

新建/更新一篇文章之后，点击发布，查看是否还存在“文章已保存但未发布” 的提示

#### Which issue(s) this PR fixes:

Fixes #4499 

#### Does this PR introduce a user-facing change?
```release-note
修复文章发布后，文章列表显示未发布的问题。
```
