### PR TITLE
fix: approved filter in comment management is ineffective

### DIFF
--- a/console/src/modules/contents/comments/CommentList.vue
+++ b/console/src/modules/contents/comments/CommentList.vue
@@ -88,10 +88,9 @@ const {
     const { data } = await apiClient.comment.listComments({
       page: page.value,
       size: size.value,
-      approved:
-        selectedApprovedStatus.value !== undefined
-          ? Boolean(selectedApprovedStatus.value)
-          : undefined,
+      approved: selectedApprovedStatus.value
+        ? selectedApprovedStatus.value === "true"
+        : undefined,
       sort: [selectedSort.value].filter(Boolean) as string[],
       keyword: keyword.value,
       ownerName: selectedUser.value,

--- a/console/src/modules/contents/comments/CommentList.vue
+++ b/console/src/modules/contents/comments/CommentList.vue
@@ -28,10 +28,14 @@ const selectedComment = ref<ListedComment>();
 const selectedCommentNames = ref<string[]>([]);
 
 const keyword = useRouteQuery<string>("keyword", "");
-const selectedApprovedStatus = useRouteQuery<string | undefined>(
-  "approved",
-  undefined
-);
+const selectedApprovedStatus = useRouteQuery<
+  string | undefined,
+  boolean | undefined
+>("approved", undefined, {
+  transform: (value) => {
+    return value ? value === "true" : undefined;
+  },
+});
 const selectedSort = useRouteQuery<string | undefined>("sort");
 const selectedUser = useRouteQuery<string | undefined>("user");
 
@@ -88,9 +92,7 @@ const {
     const { data } = await apiClient.comment.listComments({
       page: page.value,
       size: size.value,
-      approved: selectedApprovedStatus.value
-        ? selectedApprovedStatus.value === "true"
-        : undefined,
+      approved: selectedApprovedStatus.value,
       sort: [selectedSort.value].filter(Boolean) as string[],
       keyword: keyword.value,
       ownerName: selectedUser.value,


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/area console
/milestone 2.9.x

#### What this PR does / why we need it:

解决评论管理中，根据是否已审核状态的筛选无效的问题

#### How to test it?

在评论列表上切换审核状态，查看是否有效。

#### Which issue(s) this PR fixes:

Fixes #4494 

#### Does this PR introduce a user-facing change?
```release-note
修复评论管理中审核状态筛选无效的问题
```
