### PR TITLE
feat: make backup list item operations extendable

### DIFF
--- a/console/docs/extension-points/entity-listitem-operation.md
+++ b/console/docs/extension-points/entity-listitem-operation.md
@@ -10,6 +10,7 @@
 
 - 文章：`"post:list-item:operation:create"?: () => | EntityDropdownItem<ListedPost>[] | Promise<EntityDropdownItem<ListedPost>[]>`
 - 插件：`"plugin:list-item:operation:create"?: () => | EntityDropdownItem<Plugin>[] | Promise<EntityDropdownItem<Plugin>[]>`
+- 备份：`"backup:list-item:operation:create"?: () => | EntityDropdownItem<Backup>[] | Promise<EntityDropdownItem<Backup>[]>`
 
 示例：
 

--- a/console/packages/shared/src/types/plugin.ts
+++ b/console/packages/shared/src/types/plugin.ts
@@ -8,7 +8,7 @@ import type { CommentSubjectRefProvider } from "@/states/comment-subject-ref";
 import type { BackupTab } from "@/states/backup";
 import type { PluginInstallationTab } from "@/states/plugin-installation-tabs";
 import type { EntityDropdownItem } from "@/states/entity";
-import type { ListedPost, Plugin } from "@halo-dev/api-client";
+import type { Backup, ListedPost, Plugin } from "@halo-dev/api-client";
 
 export interface RouteRecordAppend {
   parentName: RouteRecordName;
@@ -46,6 +46,10 @@ export interface ExtensionPoint {
   "plugin:list-item:operation:create"?: () =>
     | EntityDropdownItem<Plugin>[]
     | Promise<EntityDropdownItem<Plugin>[]>;
+
+  "backup:list-item:operation:create"?: () =>
+    | EntityDropdownItem<Backup>[]
+    | Promise<EntityDropdownItem<Backup>[]>;
 }
 
 export interface PluginModule {


### PR DESCRIPTION
#### What type of PR is this?

/area console
/kind feature
/milestone 2.9.x

#### What this PR does / why we need it:

备份列表的操作列表支持被插件扩展。

#### Does this PR introduce a user-facing change?

```release-note
Console 端的备份列表的操作按钮列表支持扩展。
```
