### PR TITLE
fix: style issue of tabbar component of default type

### DIFF
--- a/console/packages/components/src/components/tabs/Tabbar.vue
+++ b/console/packages/components/src/components/tabs/Tabbar.vue
@@ -136,7 +136,7 @@ onUnmounted(() => {
     @apply border-b-gray-100;
 
     .tabbar-items {
-      margin-bottom: -2px;
+      margin-bottom: -4px;
       justify-content: flex-start;
     }
 


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/area console
/milestone 2.9.x

#### What this PR does / why we need it:

修复 Console 端 Tabbar 组件默认类型的样式问题。

before:

<img width="295" alt="image" src="https://github.com/halo-dev/halo/assets/21301288/ae0f9114-4708-48ec-817c-2808f8fbf582">

after:

<img width="285" alt="image" src="https://github.com/halo-dev/halo/assets/21301288/f955be60-223d-443c-ad04-98fe86c55a55">

#### Does this PR introduce a user-facing change?

```release-note
修复 Console 端 Tabbar 组件默认类型的样式问题。
```
