### PR TITLE
refactor: set cache-control for bundle resources of plugin

### DIFF
--- a/application/src/main/java/run/halo/app/core/extension/endpoint/PluginEndpoint.java
+++ b/application/src/main/java/run/halo/app/core/extension/endpoint/PluginEndpoint.java
@@ -249,7 +249,7 @@ public class PluginEndpoint implements CustomEndpoint {
         return pluginService.uglifyJsBundle()
             .defaultIfEmpty("")
             .flatMap(bundle -> ServerResponse.ok()
-                .cacheControl(CacheControl.maxAge(1, TimeUnit.DAYS))
+                .cacheControl(CacheControl.maxAge(7, TimeUnit.DAYS))
                 .contentType(MediaType.valueOf("text/javascript"))
                 .bodyValue(bundle)
             );
@@ -266,7 +266,7 @@ public class PluginEndpoint implements CustomEndpoint {
         }
         return pluginService.uglifyCssBundle()
             .flatMap(bundle -> ServerResponse.ok()
-                .cacheControl(CacheControl.maxAge(1, TimeUnit.DAYS))
+                .cacheControl(CacheControl.maxAge(7, TimeUnit.DAYS))
                 .contentType(MediaType.valueOf("text/css"))
                 .bodyValue(bundle)
             );

--- a/application/src/main/java/run/halo/app/core/extension/endpoint/PluginEndpoint.java
+++ b/application/src/main/java/run/halo/app/core/extension/endpoint/PluginEndpoint.java
@@ -30,6 +30,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 import java.util.function.Predicate;
 import lombok.AllArgsConstructor;
@@ -39,6 +40,7 @@ import org.springdoc.webflux.core.fn.SpringdocRouteBuilder;
 import org.springframework.core.io.buffer.DataBuffer;
 import org.springframework.dao.OptimisticLockingFailureException;
 import org.springframework.data.domain.Sort;
+import org.springframework.http.CacheControl;
 import org.springframework.http.MediaType;
 import org.springframework.http.codec.multipart.FilePart;
 import org.springframework.http.codec.multipart.FormFieldPart;
@@ -247,6 +249,7 @@ public class PluginEndpoint implements CustomEndpoint {
         return pluginService.uglifyJsBundle()
             .defaultIfEmpty("")
             .flatMap(bundle -> ServerResponse.ok()
+                .cacheControl(CacheControl.maxAge(1, TimeUnit.DAYS))
                 .contentType(MediaType.valueOf("text/javascript"))
                 .bodyValue(bundle)
             );
@@ -263,6 +266,7 @@ public class PluginEndpoint implements CustomEndpoint {
         }
         return pluginService.uglifyCssBundle()
             .flatMap(bundle -> ServerResponse.ok()
+                .cacheControl(CacheControl.maxAge(1, TimeUnit.DAYS))
                 .contentType(MediaType.valueOf("text/css"))
                 .bodyValue(bundle)
             );

--- a/application/src/main/java/run/halo/app/core/extension/endpoint/PluginEndpoint.java
+++ b/application/src/main/java/run/halo/app/core/extension/endpoint/PluginEndpoint.java
@@ -72,6 +72,7 @@ import run.halo.app.plugin.PluginNotFoundException;
 @Component
 @AllArgsConstructor
 public class PluginEndpoint implements CustomEndpoint {
+    private static final CacheControl MAX_CACHE_CONTROL = CacheControl.maxAge(365, TimeUnit.DAYS);
 
     private final ReactiveExtensionClient client;
 
@@ -249,7 +250,7 @@ public class PluginEndpoint implements CustomEndpoint {
         return pluginService.uglifyJsBundle()
             .defaultIfEmpty("")
             .flatMap(bundle -> ServerResponse.ok()
-                .cacheControl(CacheControl.maxAge(7, TimeUnit.DAYS))
+                .cacheControl(MAX_CACHE_CONTROL)
                 .contentType(MediaType.valueOf("text/javascript"))
                 .bodyValue(bundle)
             );
@@ -266,7 +267,7 @@ public class PluginEndpoint implements CustomEndpoint {
         }
         return pluginService.uglifyCssBundle()
             .flatMap(bundle -> ServerResponse.ok()
-                .cacheControl(CacheControl.maxAge(7, TimeUnit.DAYS))
+                .cacheControl(MAX_CACHE_CONTROL)
                 .contentType(MediaType.valueOf("text/css"))
                 .bodyValue(bundle)
             );


### PR DESCRIPTION
#### What type of PR is this?
/kind improvement
/milestone 2.10.x
/area core

#### What this PR does / why we need it:
为插件捆绑资源设置 cache-control 以优化静态资源加载

如获取插件 bundle.js 会自动携带参数缓存时间为 7 天，当有插件停止或新增时 v 参数会变化浏览器则使用新的 key 缓存静态资源，旧的 key 将在一天内失效
```
/apis/api.console.halo.run/v1alpha1/plugins/-/bundle.js?v=6c5956f37e7207ab1c0f2f2340f51a101f46b748233992d73729415cd58f3587
```
#### Which issue(s) this PR fixes:
Fixes #4543

#### Does this PR introduce a user-facing change?
```release-note
为插件捆绑资源设置 cache-control 以优化静态资源加载
```
