### PR TITLE
pref: do not auto save when the setting modal is open

### DIFF
--- a/console/src/modules/contents/pages/SinglePageEditor.vue
+++ b/console/src/modules/contents/pages/SinglePageEditor.vue
@@ -353,6 +353,10 @@ const {
 );
 
 useAutoSaveContent(currentCache, toRef(formState.value.content, "raw"), () => {
+  // Do not save when the setting modal is open
+  if (settingModal.value) {
+    return;
+  }
   handleSave({ mute: true });
 });
 

--- a/console/src/modules/contents/posts/PostEditor.vue
+++ b/console/src/modules/contents/posts/PostEditor.vue
@@ -369,6 +369,10 @@ const {
 );
 
 useAutoSaveContent(currentCache, toRef(formState.value.content, "raw"), () => {
+  // Do not save when the setting modal is open
+  if (settingModal.value) {
+    return;
+  }
   handleSave({ mute: true });
 });
 


### PR DESCRIPTION
#### What type of PR is this?

/kind improvement
/area console

#### What this PR does / why we need it:

当设置模态框打开时，禁用自动保存功能。

#### How to test it?

1. 新建一篇文章，随意输入内容。
2. 打开保存或发布表单，填写文章标题等内容
3. 切换至其他 tab 页
4. 再切换回来，查看文章标题是否没有被覆盖。

#### Which issue(s) this PR fixes:

Fixes #4566 

#### Does this PR introduce a user-facing change?
```release-note
当文章或页面设置窗口打开时，禁用自动保存功能。
```
