### PR TITLE
fix: i18n key of theme remote download tab label

### DIFF
--- a/console/src/locales/en.yaml
+++ b/console/src/locales/en.yaml
@@ -618,7 +618,7 @@ core:
         not_installed: Not installed
         local_upload: Local install / upgrade
         remote_download:
-          title: Remote
+          label: Remote
           fields:
             url: Remote URL
       empty:


### PR DESCRIPTION
#### What type of PR is this?

/area console
/kind bug
/milestone 2.10.x

#### What this PR does / why we need it:

修复了主题远程下载标签的英文语言包键，使其可以正确显示标签标题。

#### Does this PR introduce a user-facing change?

```release-note
修复 Console 端主题远程下载标签的英文语言包键名，使其可以正确显示标签标题。
```
