### PR TITLE
feat: support running plugins from JAR in development mode

### DIFF
--- a/api/src/main/java/run/halo/app/plugin/BasePlugin.java
+++ b/api/src/main/java/run/halo/app/plugin/BasePlugin.java
@@ -49,7 +49,7 @@ public class BasePlugin extends Plugin {
      *
      * @param context plugin context must not be null.
      */
-    void setContext(PluginContext context) {
+    final void setContext(PluginContext context) {
         Assert.notNull(context, "Plugin context must not be null");
         this.context = context;
     }

--- a/api/src/main/java/run/halo/app/plugin/BasePlugin.java
+++ b/api/src/main/java/run/halo/app/plugin/BasePlugin.java
@@ -3,6 +3,8 @@ package run.halo.app.plugin;
 import lombok.extern.slf4j.Slf4j;
 import org.pf4j.Plugin;
 import org.pf4j.PluginWrapper;
+import org.springframework.lang.NonNull;
+import org.springframework.util.Assert;
 
 /**
  * This class will be extended by all plugins and serve as the common class between a plugin and
@@ -14,12 +16,46 @@ import org.pf4j.PluginWrapper;
 @Slf4j
 public class BasePlugin extends Plugin {
 
+    protected PluginContext context;
+
     @Deprecated
     public BasePlugin(PluginWrapper wrapper) {
         super(wrapper);
         log.info("Initialized plugin {}", wrapper.getPluginId());
     }
 
+    /**
+     * Constructor a plugin with the given plugin context.
+     * TODO Mark {@link PluginContext} as final to prevent modification.
+     *
+     * @param pluginContext plugin context must not be null.
+     */
+    public BasePlugin(PluginContext pluginContext) {
+        this.context = pluginContext;
+    }
+
+    /**
+     * use {@link #BasePlugin(PluginContext)} instead of.
+     *
+     * @deprecated since 2.10.0
+     */
     public BasePlugin() {
+    }
+
+    /**
+     * Compatible with old constructors, if the plugin is not use
+     * {@link #BasePlugin(PluginContext)} constructor then base plugin factory will use this
+     * method to set plugin context.
+     *
+     * @param context plugin context must not be null.
+     */
+    void setContext(PluginContext context) {
+        Assert.notNull(context, "Plugin context must not be null");
+        this.context = context;
+    }
+
+    @NonNull
+    public PluginContext getContext() {
+        return context;
     }
 }

--- a/api/src/main/java/run/halo/app/plugin/PluginContext.java
+++ b/api/src/main/java/run/halo/app/plugin/PluginContext.java
@@ -1,0 +1,27 @@
+package run.halo.app.plugin;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.pf4j.RuntimeMode;
+
+/**
+ * <p>This class will provide a context for the plugin, which will be used to store some
+ * information about the plugin.</p>
+ * <p>An instance of this class is provided to plugins in their constructor.</p>
+ * <p>It's safe for plugins to keep a reference to the instance for later use.</p>
+ * <p>This class facilitates communication with application and plugin manager.</p>
+ * <p>Pf4j recommends that you use a custom PluginContext instead of PluginWrapper.</p>
+ * <a href="https://github.com/pf4j/pf4j/blob/e4d7c7b9ea0c9a32179c3e33da1403228838944f/pf4j/src/main/java/org/pf4j/Plugin.java#L46">Use application custom PluginContext instead of PluginWrapper</a>
+ *
+ * @author guqing
+ * @since 2.10.0
+ */
+@Getter
+@RequiredArgsConstructor
+public class PluginContext {
+    private final String name;
+
+    private final String version;
+
+    private final RuntimeMode runtimeMode;
+}

--- a/application/src/main/java/run/halo/app/core/extension/reconciler/PluginReconciler.java
+++ b/application/src/main/java/run/halo/app/core/extension/reconciler/PluginReconciler.java
@@ -60,6 +60,7 @@ import run.halo.app.infra.utils.JsonUtils;
 import run.halo.app.infra.utils.PathUtils;
 import run.halo.app.infra.utils.YamlUnstructuredLoader;
 import run.halo.app.plugin.HaloPluginManager;
+import run.halo.app.plugin.HaloPluginWrapper;
 import run.halo.app.plugin.PluginConst;
 import run.halo.app.plugin.PluginExtensionLoaderUtils;
 import run.halo.app.plugin.PluginStartingError;
@@ -184,11 +185,12 @@ public class PluginReconciler implements Reconciler<Request> {
         Assert.notNull(name, "Plugin name must not be null");
         Assert.notNull(settingName, "Setting name must not be null");
         PluginWrapper pluginWrapper = getPluginWrapper(name);
+        var runtimeMode = getRuntimeMode(name);
 
         var resourceLoader =
             new DefaultResourceLoader(pluginWrapper.getPluginClassLoader());
         return PluginExtensionLoaderUtils.lookupExtensions(pluginWrapper.getPluginPath(),
-                pluginWrapper.getRuntimeMode())
+                runtimeMode)
             .stream()
             .map(resourceLoader::getResource)
             .filter(Resource::exists)
@@ -215,6 +217,7 @@ public class PluginReconciler implements Reconciler<Request> {
             return false;
         }
 
+        var runtimeMode = getRuntimeMode(pluginName);
         Optional<Setting> settingOption = lookupPluginSetting(pluginName, settingName)
             .map(setting -> {
                 // This annotation is added to prevent it from being deleted when stopped.
@@ -804,11 +807,19 @@ public class PluginReconciler implements Reconciler<Request> {
     }
 
     private boolean isDevelopmentMode(String name) {
-        PluginWrapper pluginWrapper = haloPluginManager.getPlugin(name);
-        RuntimeMode runtimeMode = haloPluginManager.getRuntimeMode();
-        if (pluginWrapper != null) {
-            runtimeMode = pluginWrapper.getRuntimeMode();
+        return RuntimeMode.DEVELOPMENT.equals(getRuntimeMode(name));
+    }
+
+    private RuntimeMode getRuntimeMode(String name) {
+        var pluginWrapper = haloPluginManager.getPlugin(name);
+        if (pluginWrapper == null) {
+            return haloPluginManager.getRuntimeMode();
         }
-        return RuntimeMode.DEVELOPMENT.equals(runtimeMode);
+        if (pluginWrapper instanceof HaloPluginWrapper haloPluginWrapper) {
+            return haloPluginWrapper.getRuntimeMode();
+        }
+        return Files.isDirectory(pluginWrapper.getPluginPath())
+            ? RuntimeMode.DEVELOPMENT
+            : RuntimeMode.DEPLOYMENT;
     }
 }

--- a/application/src/main/java/run/halo/app/plugin/BasePluginFactory.java
+++ b/application/src/main/java/run/halo/app/plugin/BasePluginFactory.java
@@ -23,13 +23,17 @@ public class BasePluginFactory implements PluginFactory {
         return getPluginContext(pluginWrapper)
             .map(context -> {
                 try {
-                    return context.getBean(BasePlugin.class);
+                    var basePlugin = context.getBean(BasePlugin.class);
+                    var pluginContext = context.getBean(PluginContext.class);
+                    basePlugin.setContext(pluginContext);
+                    return basePlugin;
                 } catch (NoSuchBeanDefinitionException e) {
                     log.info(
                         "No bean named 'basePlugin' found in the context create default instance");
                     DefaultListableBeanFactory beanFactory =
                         context.getDefaultListableBeanFactory();
-                    BasePlugin pluginInstance = new BasePlugin();
+                    var pluginContext = beanFactory.getBean(PluginContext.class);
+                    BasePlugin pluginInstance = new BasePlugin(pluginContext);
                     beanFactory.registerSingleton(Plugin.class.getName(), pluginInstance);
                     return pluginInstance;
                 }

--- a/application/src/main/java/run/halo/app/plugin/HaloPluginManager.java
+++ b/application/src/main/java/run/halo/app/plugin/HaloPluginManager.java
@@ -109,6 +109,17 @@ public class HaloPluginManager extends DefaultPluginManager
     }
 
     @Override
+    protected PluginWrapper createPluginWrapper(PluginDescriptor pluginDescriptor, Path pluginPath,
+        ClassLoader pluginClassLoader) {
+        // create the plugin wrapper
+        log.debug("Creating wrapper for plugin '{}'", pluginPath);
+        HaloPluginWrapper pluginWrapper =
+            new HaloPluginWrapper(this, pluginDescriptor, pluginPath, pluginClassLoader);
+        pluginWrapper.setPluginFactory(getPluginFactory());
+        return pluginWrapper;
+    }
+
+    @Override
     protected void firePluginStateEvent(PluginStateEvent event) {
         rootApplicationContext.publishEvent(
             new HaloPluginStateChangedEvent(this, event.getPlugin(), event.getOldState()));

--- a/application/src/main/java/run/halo/app/plugin/HaloPluginWrapper.java
+++ b/application/src/main/java/run/halo/app/plugin/HaloPluginWrapper.java
@@ -1,0 +1,34 @@
+package run.halo.app.plugin;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.pf4j.PluginDescriptor;
+import org.pf4j.PluginManager;
+import org.pf4j.PluginWrapper;
+import org.pf4j.RuntimeMode;
+
+/**
+ * A wrapper over plugin instance for Halo.
+ *
+ * @author guqing
+ * @since 2.10.0
+ */
+public class HaloPluginWrapper extends PluginWrapper {
+
+    private final RuntimeMode runtimeMode;
+
+    /**
+     * Creates a new plugin wrapper to manage the specified plugin.
+     */
+    public HaloPluginWrapper(PluginManager pluginManager, PluginDescriptor descriptor,
+        Path pluginPath, ClassLoader pluginClassLoader) {
+        super(pluginManager, descriptor, pluginPath, pluginClassLoader);
+        this.runtimeMode = Files.isDirectory(pluginPath)
+            ? RuntimeMode.DEVELOPMENT : RuntimeMode.DEPLOYMENT;
+    }
+
+    @Override
+    public RuntimeMode getRuntimeMode() {
+        return runtimeMode;
+    }
+}

--- a/application/src/test/java/run/halo/app/core/extension/reconciler/PluginReconcilerTest.java
+++ b/application/src/test/java/run/halo/app/core/extension/reconciler/PluginReconcilerTest.java
@@ -51,6 +51,7 @@ import run.halo.app.extension.controller.Reconciler;
 import run.halo.app.infra.utils.FileUtils;
 import run.halo.app.infra.utils.JsonUtils;
 import run.halo.app.plugin.HaloPluginManager;
+import run.halo.app.plugin.HaloPluginWrapper;
 import run.halo.app.plugin.PluginConst;
 import run.halo.app.plugin.PluginStartingError;
 
@@ -70,7 +71,7 @@ class PluginReconcilerTest {
     ExtensionClient extensionClient;
 
     @Mock
-    PluginWrapper pluginWrapper;
+    HaloPluginWrapper pluginWrapper;
 
     @Mock
     ApplicationEventPublisher eventPublisher;


### PR DESCRIPTION
#### What type of PR is this?
/kind feature
/milestone 2.10.x
/area core

#### What this PR does / why we need it:
支持在开发模式下通过 JAR 运行插件

*从此版本开始 BasePlugin 的子类建议使用 BasePlugin(PluginContext context) 构造函数，而不要使用之前的 BasePlugin(PluginWrapper wrapper) 构造函数。BasePlugin(PluginWrapper wrapper) 构造函数将计划在后续版本移除* ，当移除构造函数后不再将 PluginWrapper 暴露给插件使用，它只应该在 halo core 使用。

how to test it?
1. 测试开发模式下配置的 `halo.plugin.fixed-plugin-path` 插件是否正确运行
2. 测试开发模式下通过 JAR 包安装插件是否正确运行
3. 测试生产模式下是否能通过项目目录的方式运行插件，期望是生产模式不可以运行开发模式的插件
4. 测试开发模式和生产模式的插件卸载功能是否正确

#### Which issue(s) this PR fixes:

Fixes #2908

#### Does this PR introduce a user-facing change?

```release-note
支持在开发模式下通过 JAR 运行插件
```
