### PR TITLE
chore: update download url of presets plugin

### DIFF
--- a/application/build.gradle
+++ b/application/build.gradle
@@ -74,10 +74,10 @@ tasks.register('downloadPluginPresets', Download) {
         delete 'src/main/resources/presets/plugins'
     }
     src([
-            'https://github.com/halo-sigs/plugin-comment-widget/releases/download/v1.7.0/plugin-comment-widget-1.7.0.jar',
-            'https://github.com/halo-sigs/plugin-search-widget/releases/download/v1.1.0/plugin-search-widget-1.1.0.jar',
-            'https://github.com/halo-sigs/plugin-sitemap/releases/download/v1.0.2/plugin-sitemap-1.0.2.jar',
-            'https://github.com/halo-sigs/plugin-feed/releases/download/v1.1.1/plugin-feed-1.1.1.jar'
+            'https://github.com/halo-dev/plugin-comment-widget/releases/download/v1.7.0/plugin-comment-widget-1.7.0.jar',
+            'https://github.com/halo-dev/plugin-search-widget/releases/download/v1.1.0/plugin-search-widget-1.1.0.jar',
+            'https://github.com/halo-dev/plugin-sitemap/releases/download/v1.0.2/plugin-sitemap-1.0.2.jar',
+            'https://github.com/halo-dev/plugin-feed/releases/download/v1.1.1/plugin-feed-1.1.1.jar'
     ])
     dest 'src/main/resources/presets/plugins'
 }


### PR DESCRIPTION
#### What type of PR is this?

/area core
/kind cleanup

#### What this PR does / why we need it:

修改预设插件的下载地址，目前四个预设插件的仓库都已经转移到 halo-dev 组织。

#### Special notes for your reviewer:

需要测试 `./gradlew downloadPluginPresets` 是否能够正常下载预设插件。 

#### Does this PR introduce a user-facing change?

```release-note
None
```
