### PR TITLE
fix: missing ui permission condition about users

### DIFF
--- a/console/src/components/permission/HasPermission.vue
+++ b/console/src/components/permission/HasPermission.vue
@@ -1,0 +1,16 @@
+<script lang="ts" setup>
+import { usePermission } from "@/utils/permission";
+
+withDefaults(
+  defineProps<{
+    permissions: string[];
+  }>(),
+  {}
+);
+
+const { currentUserHasPermission } = usePermission();
+</script>
+
+<template>
+  <slot v-if="currentUserHasPermission(permissions)" />
+</template>

--- a/console/src/modules/contents/attachments/AttachmentList.vue
+++ b/console/src/modules/contents/attachments/AttachmentList.vue
@@ -356,10 +356,12 @@ onMounted(() => {
                       }) || []),
                     ]"
                   />
-                  <UserFilterDropdown
-                    v-model="selectedUser"
-                    :label="$t('core.attachment.filters.owner.label')"
-                  />
+                  <HasPermission :permissions="['system:users:view']">
+                    <UserFilterDropdown
+                      v-model="selectedUser"
+                      :label="$t('core.attachment.filters.owner.label')"
+                    />
+                  </HasPermission>
                   <FilterDropdown
                     v-model="selectedSort"
                     :label="$t('core.common.filters.labels.sort')"

--- a/console/src/modules/contents/comments/CommentList.vue
+++ b/console/src/modules/contents/comments/CommentList.vue
@@ -283,10 +283,12 @@ const handleApproveInBatch = async () => {
                   },
                 ]"
               />
-              <UserFilterDropdown
-                v-model="selectedUser"
-                :label="$t('core.comment.filters.owner.label')"
-              />
+              <HasPermission :permissions="['system:users:view']">
+                <UserFilterDropdown
+                  v-model="selectedUser"
+                  :label="$t('core.comment.filters.owner.label')"
+                />
+              </HasPermission>
               <FilterDropdown
                 v-model="selectedSort"
                 :label="$t('core.common.filters.labels.sort')"

--- a/console/src/modules/contents/pages/SinglePageList.vue
+++ b/console/src/modules/contents/pages/SinglePageList.vue
@@ -379,10 +379,12 @@ watch(selectedPageNames, (newValue) => {
                   },
                 ]"
               />
-              <UserFilterDropdown
-                v-model="selectedContributor"
-                :label="$t('core.page.filters.author.label')"
-              />
+              <HasPermission :permissions="['system:users:view']">
+                <UserFilterDropdown
+                  v-model="selectedContributor"
+                  :label="$t('core.page.filters.author.label')"
+                />
+              </HasPermission>
               <FilterDropdown
                 v-model="selectedSort"
                 :label="$t('core.common.filters.labels.sort')"

--- a/console/src/modules/contents/posts/PostList.vue
+++ b/console/src/modules/contents/posts/PostList.vue
@@ -393,10 +393,12 @@ watch(selectedPostNames, (newValue) => {
                 v-model="selectedTag"
                 :label="$t('core.post.filters.tag.label')"
               />
-              <UserFilterDropdown
-                v-model="selectedContributor"
-                :label="$t('core.post.filters.author.label')"
-              />
+              <HasPermission :permissions="['system:users:view']">
+                <UserFilterDropdown
+                  v-model="selectedContributor"
+                  :label="$t('core.post.filters.author.label')"
+                />
+              </HasPermission>
               <FilterDropdown
                 v-model="selectedSort"
                 :label="$t('core.common.filters.labels.sort')"

--- a/console/src/setup/setupComponents.ts
+++ b/console/src/setup/setupComponents.ts
@@ -11,6 +11,7 @@ import FilterCleanButton from "@/components/filter/FilterCleanButton.vue";
 import SearchInput from "@/components/input/SearchInput.vue";
 import AnnotationsForm from "@/components/form/AnnotationsForm.vue";
 import AttachmentFileTypeIcon from "@/components/icon/AttachmentFileTypeIcon.vue";
+import HasPermission from "@/components/permission/HasPermission.vue";
 
 export function setupComponents(app: App) {
   app.use(VueGridLayout);
@@ -37,4 +38,5 @@ export function setupComponents(app: App) {
   app.component("SearchInput", SearchInput);
   app.component("AnnotationsForm", AnnotationsForm);
   app.component("AttachmentFileTypeIcon", AttachmentFileTypeIcon);
+  app.component("HasPermission", HasPermission);
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/area console
/milestone 2.10.x

#### What this PR does / why we need it:

修复关于用户数据相关的 UI 权限判断缺失的问题。

<img width="1666" alt="image" src="https://github.com/halo-dev/halo/assets/21301288/e3d239fc-bca1-498b-a220-4221c9416914">

#### Special notes for your reviewer:

需要测试：

1. 创建一个仅包含文章权限的角色并赋予给某个用户。
2. 使用这个用户登录，查看文章管理页面，观察是否有用户接口的请求，以及页面是否有报错。

#### Does this PR introduce a user-facing change?

```release-note
优化 Console 端关于用户数据相关的 UI 权限判断
```
