### PR TITLE
fix: twice requests in menus page

### DIFF
--- a/console/src/modules/interface/menus/Menus.vue
+++ b/console/src/modules/interface/menus/Menus.vue
@@ -195,7 +195,7 @@ const handleDelete = async (menuItem: MenuTreeItem) => {
   <div class="m-0 md:m-4">
     <div class="flex flex-col gap-4 sm:flex-row">
       <div class="w-96">
-        <MenuList v-model:selected-menu="selectedMenu" @select="refetch()" />
+        <MenuList v-model:selected-menu="selectedMenu" />
       </div>
       <div class="flex-1">
         <VCard :body-class="['!p-0']">

--- a/console/src/modules/interface/menus/components/MenuList.vue
+++ b/console/src/modules/interface/menus/components/MenuList.vue
@@ -35,7 +35,6 @@ const props = withDefaults(
 );
 
 const emit = defineEmits<{
-  (event: "select", menu: Menu): void;
   (event: "update:selectedMenu", menu: Menu): void;
 }>();
 
@@ -76,7 +75,6 @@ const {
 const menuQuery = useRouteQuery("menu");
 const handleSelect = (menu: Menu) => {
   emit("update:selectedMenu", menu);
-  emit("select", menu);
   menuQuery.value = menu.metadata.name;
 };
 


### PR DESCRIPTION
#### What type of PR is this?

/area console
/kind bug
/milestone 2.10.x

#### What this PR does / why we need it:

修复菜单管理页面，切换菜单时请求两次菜单项接口的问题。

#### Which issue(s) this PR fixes:

Fixes https://github.com/halo-dev/halo/issues/4578

#### Special notes for your reviewer:

测试切换菜单，观察浏览器控制台是否有两次请求即可。

#### Does this PR introduce a user-facing change?

```release-note
修复 Console 的菜单管理页面，切换菜单时请求两次菜单项接口的问题。
```
