### PR TITLE
fix: missing permission check in plugin installation tabs and theme list tabs extension points

### DIFF
--- a/console/src/modules/interface/themes/components/ThemeListModal.vue
+++ b/console/src/modules/interface/themes/components/ThemeListModal.vue
@@ -20,8 +20,10 @@ import LocalUpload from "./list-tabs/LocalUpload.vue";
 import RemoteDownload from "./list-tabs/RemoteDownload.vue";
 import { usePluginModuleStore } from "@/stores/plugin";
 import type { PluginModule, ThemeListTab } from "@halo-dev/console-shared";
+import { usePermission } from "@/utils/permission";
 
 const { t } = useI18n();
+const { currentUserHasPermission } = usePermission();
 
 const props = withDefaults(
   defineProps<{
@@ -115,7 +117,12 @@ onMounted(() => {
       return;
     }
 
-    const items = extensionPoints["theme:list:tabs:create"]() as ThemeListTab[];
+    let items = extensionPoints["theme:list:tabs:create"]() as ThemeListTab[];
+
+    items = items.filter((item) => {
+      return currentUserHasPermission(item.permissions);
+    });
+
     tabsFromPlugins.push(...items);
   });
 

--- a/console/src/modules/system/plugins/components/PluginInstallationModal.vue
+++ b/console/src/modules/system/plugins/components/PluginInstallationModal.vue
@@ -16,8 +16,10 @@ import type {
 } from "@halo-dev/console-shared";
 import { usePluginModuleStore } from "@/stores/plugin";
 import { onMounted } from "vue";
+import { usePermission } from "@/utils/permission";
 
 const { t } = useI18n();
+const { currentUserHasPermission } = usePermission();
 
 const props = withDefaults(
   defineProps<{
@@ -92,9 +94,13 @@ onMounted(() => {
       return;
     }
 
-    const items = extensionPoints[
+    let items = extensionPoints[
       "plugin:installation:tabs:create"
     ]() as PluginInstallationTab[];
+
+    items = items.filter((item) => {
+      return currentUserHasPermission(item.permissions);
+    });
 
     tabs.value.push(...items);
   });


### PR DESCRIPTION
#### What type of PR is this?

/area console
/kind bug
/milestone 2.10.x

#### What this PR does / why we need it:

修复主题管理选项卡和插件安装界面选项卡扩展点没有添加 UI 权限检测的问题。

#### Which issue(s) this PR fixes:

Fixes #4632 

#### Does this PR introduce a user-facing change?

```release-note
None
```
