### PR TITLE
fix: can not change ref type in menu item modal

### DIFF
--- a/console/src/formkit/inputs/category-select/index.ts
+++ b/console/src/formkit/inputs/category-select/index.ts
@@ -44,4 +44,5 @@ export const categorySelect: FormKitTypeDefinition = {
   library: {
     CategorySelect: CategorySelect,
   },
+  schemaMemoKey: "custom-category-select",
 };

--- a/console/src/formkit/inputs/tag-select/index.ts
+++ b/console/src/formkit/inputs/tag-select/index.ts
@@ -44,4 +44,5 @@ export const tagSelect: FormKitTypeDefinition = {
   library: {
     TagSelect: TagSelect,
   },
+  schemaMemoKey: "custom-tag-select",
 };


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/area console
/milestone 2.10.x

#### What this PR does / why we need it:

修复菜单项编辑表单中，切换分类和标签类型可能导致分类或者标签选择框异常的问题。

<img width="726" alt="image" src="https://github.com/halo-dev/halo/assets/21301288/300b88c0-dfbc-48fa-90c2-1862925a1eea">


#### Which issue(s) this PR fixes:

Fixes #4643 

#### Special notes for your reviewer:

测试方式：

1. 新建菜单项，先选择分类或者标签，然后选择另外一个类型，观察选择框是否正常。

#### Does this PR introduce a user-facing change?

```release-note
修复 Console 端菜单项编辑表单中可能无法正常切换类型的问题。
```
