### PR TITLE
fix: unable to display if the logo changes after the plugin upgrade

### DIFF
--- a/application/src/main/java/run/halo/app/core/extension/reconciler/PluginReconciler.java
+++ b/application/src/main/java/run/halo/app/core/extension/reconciler/PluginReconciler.java
@@ -142,7 +142,7 @@ public class PluginReconciler implements Reconciler<Request> {
                 if (waitForSettingCreation(plugin)) {
                     return true;
                 }
-                createInitialReverseProxyIfNotPresent(plugin);
+                recreateDefaultReverseProxy(plugin);
 
                 updateStatus(name, status -> {
                     String logoUrl = generateAccessibleLogoUrl(plugin);
@@ -764,7 +764,7 @@ public class PluginReconciler implements Reconciler<Request> {
         return Paths.get(pluginLocation);
     }
 
-    void createInitialReverseProxyIfNotPresent(Plugin plugin) {
+    void recreateDefaultReverseProxy(Plugin plugin) {
         String pluginName = plugin.getMetadata().getName();
         String reverseProxyName = initialReverseProxyName(pluginName);
         ReverseProxy reverseProxy = new ReverseProxy();
@@ -785,11 +785,9 @@ public class PluginReconciler implements Reconciler<Request> {
 
         client.fetch(ReverseProxy.class, reverseProxyName)
             .ifPresentOrElse(persisted -> {
-                if (isDevelopmentMode(pluginName)) {
-                    reverseProxy.getMetadata()
-                        .setVersion(persisted.getMetadata().getVersion());
-                    client.update(reverseProxy);
-                }
+                reverseProxy.getMetadata()
+                    .setVersion(persisted.getMetadata().getVersion());
+                client.update(reverseProxy);
             }, () -> client.create(reverseProxy));
     }
 

--- a/application/src/test/java/run/halo/app/core/extension/reconciler/PluginReconcilerTest.java
+++ b/application/src/test/java/run/halo/app/core/extension/reconciler/PluginReconcilerTest.java
@@ -40,7 +40,6 @@ import org.mockito.stubbing.Answer;
 import org.pf4j.PluginDescriptor;
 import org.pf4j.PluginState;
 import org.pf4j.PluginWrapper;
-import org.pf4j.RuntimeMode;
 import org.skyscreamer.jsonassert.JSONAssert;
 import org.springframework.context.ApplicationEventPublisher;
 import run.halo.app.core.extension.Plugin;
@@ -233,14 +232,14 @@ class PluginReconcilerTest {
     }
 
     @Test
-    void createInitialReverseProxyWhenNotExistAndLogoIsPath() throws JSONException {
+    void recreateDefaultReverseProxyWhenNotExistAndLogoIsPath() throws JSONException {
         Plugin plugin = need2ReconcileForStopState();
         String reverseProxyName = initialReverseProxyName(plugin.getMetadata().getName());
         when(extensionClient.fetch(eq(ReverseProxy.class), eq(reverseProxyName)))
             .thenReturn(Optional.empty());
 
         plugin.getSpec().setLogo("/logo.png");
-        pluginReconciler.createInitialReverseProxyIfNotPresent(plugin);
+        pluginReconciler.recreateDefaultReverseProxy(plugin);
         ArgumentCaptor<ReverseProxy> captor = ArgumentCaptor.forClass(ReverseProxy.class);
         verify(extensionClient, times(1)).create(captor.capture());
         ReverseProxy value = captor.getValue();
@@ -269,14 +268,14 @@ class PluginReconcilerTest {
     }
 
     @Test
-    void createInitialReverseProxyWhenNotExistAndLogoIsAbsolute() {
+    void recreateDefaultReverseProxyWhenNotExistAndLogoIsAbsolute() {
         Plugin plugin = need2ReconcileForStopState();
         String reverseProxyName = initialReverseProxyName(plugin.getMetadata().getName());
         when(extensionClient.fetch(eq(ReverseProxy.class), eq(reverseProxyName)))
             .thenReturn(Optional.empty());
 
         plugin.getSpec().setLogo("http://example.com/logo");
-        pluginReconciler.createInitialReverseProxyIfNotPresent(plugin);
+        pluginReconciler.recreateDefaultReverseProxy(plugin);
         ArgumentCaptor<ReverseProxy> captor = ArgumentCaptor.forClass(ReverseProxy.class);
         verify(extensionClient, times(1)).create(captor.capture());
         ReverseProxy value = captor.getValue();
@@ -284,7 +283,7 @@ class PluginReconcilerTest {
     }
 
     @Test
-    void createInitialReverseProxyWhenExist() {
+    void recreateDefaultReverseProxyWhenExist() {
         Plugin plugin = need2ReconcileForStopState();
         plugin.getSpec().setLogo("/logo.png");
 
@@ -296,14 +295,9 @@ class PluginReconcilerTest {
 
         when(extensionClient.fetch(eq(ReverseProxy.class), eq(reverseProxyName)))
             .thenReturn(Optional.of(reverseProxy));
-        when(pluginWrapper.getRuntimeMode()).thenReturn(RuntimeMode.DEPLOYMENT);
 
-        pluginReconciler.createInitialReverseProxyIfNotPresent(plugin);
-        verify(extensionClient, times(0)).update(any());
-
-        when(pluginWrapper.getRuntimeMode()).thenReturn(RuntimeMode.DEVELOPMENT);
-        pluginReconciler.createInitialReverseProxyIfNotPresent(plugin);
-        verify(extensionClient, times(1)).update(any());
+        pluginReconciler.recreateDefaultReverseProxy(plugin);
+        verify(extensionClient).update(any());
     }
 
     @Nested


### PR DESCRIPTION
#### What type of PR is this?
/kind bug
/area core
/area plugin
/milestone 2.10.x

#### What this PR does / why we need it:
修复当插件升级后 Logo 改变会无法显示的问题

how to test it?
1. 使用生产模式运行插件
2. 使用 sitemap 插件 1.0.1版本,https://www.halo.run/store/apps/app-QDFMI?tab=releases
3. 升级 sitemap 插件到 1.1.0, https://www.halo.run/store/apps/app-QDFMI?tab=releases
4. 期望 logo 由原先的 halo 图标变为新图标

#### Which issue(s) this PR fixes:
Fixes #4646

#### Does this PR introduce a user-facing change?
```release-note
修复当插件升级后 Logo 改变会无法显示的问题
```
