### PR TITLE
fix: can not create category by click in category select component

### DIFF
--- a/console/src/formkit/inputs/category-select/CategorySelect.vue
+++ b/console/src/formkit/inputs/category-select/CategorySelect.vue
@@ -293,6 +293,7 @@ const handleDelete = () => {
           v-if="text.trim() && !searchResults?.length"
           v-permission="['system:posts:manage']"
           class="group flex cursor-pointer items-center justify-between rounded bg-gray-100 p-2"
+          @click="handleCreateCategory"
         >
           <span class="text-xs text-gray-700 group-hover:text-gray-900">
             {{


### PR DESCRIPTION
#### What type of PR is this?

/area console
/kind bug
/milestone 2.10.x

#### What this PR does / why we need it:

修复在分类选择组件中，无法通过点击创建分类的问题。

<img width="729" alt="image" src="https://github.com/halo-dev/halo/assets/21301288/8b2bf92a-2efb-477c-8303-b39defc8cb30">


#### Which issue(s) this PR fixes:

Fixes #4606 

#### Special notes for your reviewer:

在任意一个分类选择组件输入一个不存在的分类，根据提示点击创建，观察是否创建成功即可。

#### Does this PR introduce a user-facing change?

```release-note
修复 Console 端的分类选择组件中，无法通过点击创建不存在的分类的问题。
```
