### PR TITLE
chore: add app store plugin as preset-plugin

### DIFF
--- a/application/build.gradle
+++ b/application/build.gradle
@@ -77,7 +77,8 @@ tasks.register('downloadPluginPresets', Download) {
             'https://github.com/halo-dev/plugin-comment-widget/releases/download/v1.8.0/plugin-comment-widget-1.8.0.jar',
             'https://github.com/halo-dev/plugin-search-widget/releases/download/v1.2.0/plugin-search-widget-1.2.0.jar',
             'https://github.com/halo-dev/plugin-sitemap/releases/download/v1.1.1/plugin-sitemap-1.1.1.jar',
-            'https://github.com/halo-dev/plugin-feed/releases/download/v1.2.0/plugin-feed-1.2.0.jar'
+            'https://github.com/halo-dev/plugin-feed/releases/download/v1.2.0/plugin-feed-1.2.0.jar',
+            'https://github.com/halo-dev/plugin-app-store/releases/download/v1.0.0-beta.1/plugin-app-store-1.0.0-beta.1.jar'
     ])
     dest 'src/main/resources/presets/plugins'
 }


### PR DESCRIPTION
#### What type of PR is this?

/area core
/kind improvement
/milestone 2.10.x

#### What this PR does / why we need it:

添加 https://github.com/halo-dev/plugin-app-store 作为预设插件。

#### Does this PR introduce a user-facing change?

```release-note
添加应用市场预设插件
```
