### PR TITLE
fix: compatible email are empty when comment notification triggered

### DIFF
--- a/application/src/main/java/run/halo/app/content/comment/ReplyNotificationSubscriptionHelper.java
+++ b/application/src/main/java/run/halo/app/content/comment/ReplyNotificationSubscriptionHelper.java
@@ -1,6 +1,8 @@
 package run.halo.app.content.comment;
 
+import io.micrometer.common.util.StringUtils;
 import lombok.RequiredArgsConstructor;
+import org.springframework.lang.Nullable;
 import org.springframework.stereotype.Component;
 import run.halo.app.content.NotificationReasonConst;
 import run.halo.app.core.extension.content.Comment;
@@ -56,13 +58,21 @@ public class ReplyNotificationSubscriptionHelper {
     void subscribeReply(Subscription.ReasonSubject reasonSubject,
         Identity identity) {
         var subscriber = createSubscriber(identity);
+        if (subscriber == null) {
+            return;
+        }
         var interestReason = new Subscription.InterestReason();
         interestReason.setReasonType(NotificationReasonConst.SOMEONE_REPLIED_TO_YOU);
         interestReason.setSubject(reasonSubject);
         notificationCenter.subscribe(subscriber, interestReason).block();
     }
 
+    @Nullable
     private Subscription.Subscriber createSubscriber(Identity author) {
+        if (StringUtils.isBlank(author.name())) {
+            return null;
+        }
+
         Subscription.Subscriber subscriber;
         if (author.isEmail()) {
             subscriber = subscriberEmailResolver.ofEmail(author.name());

--- a/application/src/main/resources/extensions/notification.yaml
+++ b/application/src/main/resources/extensions/notification.yaml
@@ -24,21 +24,26 @@ spec:
           value: false
           name: enable
         - $formkit: text
+          if: "$enable"
           label: "用户名"
           name: username
           validation: required
         - $formkit: password
+          if: "$enable"
           label: "密码"
           name: password
           validation: required
         - $formkit: text
+          if: "$enable"
           label: "显示名称"
           name: displayName
         - $formkit: text
+          if: "$enable"
           label: "SMTP 服务器地址"
           name: host
           validation: required
         - $formkit: text
+          if: "$enable"
           label: "端口号"
           name: port
           validation: required

--- a/application/src/main/resources/extensions/notification.yaml
+++ b/application/src/main/resources/extensions/notification.yaml
@@ -19,6 +19,10 @@ spec:
     - group: sender
       label: 发件设置
       formSchema:
+        - $formkit: checkbox
+          label: "启用邮件通知器"
+          value: false
+          name: enable
         - $formkit: text
           label: "用户名"
           name: username


### PR DESCRIPTION
#### What type of PR is this?
/kind bug
/area core
/milestone 2.10.x

#### What this PR does / why we need it:
修复当评论或回复者的邮箱为空时通知报错的问题

#### Which issue(s) this PR fixes:
Fixes #4684

#### Does this PR introduce a user-facing change?
```release-note
修复当评论或回复者的邮箱为空时通知报错的问题

```
