### PR TITLE
feat: add encryption setting for email notifier

### DIFF
--- a/application/src/main/java/run/halo/app/notification/EmailNotifier.java
+++ b/application/src/main/java/run/halo/app/notification/EmailNotifier.java
@@ -97,7 +97,19 @@ public class EmailNotifier implements ReactiveNotifier {
         Properties props = javaMailSender.getJavaMailProperties();
         props.put("mail.transport.protocol", "smtp");
         props.put("mail.smtp.auth", "true");
-        props.put("mail.smtp.starttls.enable", "true");
+        if ("SSL".equals(emailSenderConfig.getEncryption())) {
+            props.put("mail.smtp.ssl.enable", "true");
+        }
+
+        if ("TLS".equals(emailSenderConfig.getEncryption())) {
+            props.put("mail.smtp.starttls.enable", "true");
+        }
+
+        if ("NONE".equals(emailSenderConfig.getEncryption())) {
+            props.put("mail.smtp.ssl.enable", "false");
+            props.put("mail.smtp.starttls.enable", "false");
+        }
+
         if (log.isDebugEnabled()) {
             props.put("mail.debug", "true");
         }
@@ -143,6 +155,7 @@ public class EmailNotifier implements ReactiveNotifier {
         private String password;
         private String host;
         private Integer port;
+        private String encryption;
 
         /**
          * Gets email display name.

--- a/application/src/main/resources/extensions/notification.yaml
+++ b/application/src/main/resources/extensions/notification.yaml
@@ -48,6 +48,7 @@ spec:
           name: port
           validation: required
         - $formkit: select
+          if: "$enable"
           label: "加密方式"
           name: encryption
           value: "SSL"

--- a/application/src/main/resources/extensions/notification.yaml
+++ b/application/src/main/resources/extensions/notification.yaml
@@ -38,6 +38,17 @@ spec:
           label: "端口号"
           name: port
           validation: required
+        - $formkit: select
+          label: "加密方式"
+          name: encryption
+          value: "SSL"
+          options:
+            - label: "SSL"
+              value: "SSL"
+            - label: "TLS"
+              value: "TLS"
+            - label: "不加密"
+              value: "NONE"
 ---
 apiVersion: notification.halo.run/v1alpha1
 kind: ReasonType


### PR DESCRIPTION
#### What type of PR is this?
/kind improvement
/area core
/milestone 2.10.x

#### What this PR does / why we need it:
为邮件通知发件设置增加加密方式配置

#### Which issue(s) this PR fixes:
Fixes #4674

#### Does this PR introduce a user-facing change?
```release-note
为邮件通知发件设置增加加密方式配置
```
