### PR TITLE
chore: bump @halo-dev/components version to 1.9.0

### DIFF
--- a/console/packages/components/package.json
+++ b/console/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@halo-dev/components",
-  "version": "1.8.0",
+  "version": "1.9.0",
   "description": "",
   "files": [
     "dist"


### PR DESCRIPTION
#### What type of PR is this?

/area console
/milestone 2.10.x
/kind improvement

#### What this PR does / why we need it:

修改 @halo-dev/components 的版本号为 1.9.0，将在 2.10.0 发布之后推送到 npmjs.com

#### Does this PR introduce a user-facing change?

```release-note
None
```
