### PR TITLE
chore: bump app store plugin version to 1.0.0-beta.2

### DIFF
--- a/application/build.gradle
+++ b/application/build.gradle
@@ -78,7 +78,7 @@ tasks.register('downloadPluginPresets', Download) {
             'https://github.com/halo-dev/plugin-search-widget/releases/download/v1.2.0/plugin-search-widget-1.2.0.jar',
             'https://github.com/halo-dev/plugin-sitemap/releases/download/v1.1.1/plugin-sitemap-1.1.1.jar',
             'https://github.com/halo-dev/plugin-feed/releases/download/v1.2.0/plugin-feed-1.2.0.jar',
-            'https://github.com/halo-dev/plugin-app-store/releases/download/v1.0.0-beta.1/plugin-app-store-1.0.0-beta.1.jar'
+            'https://github.com/halo-dev/plugin-app-store/releases/download/v1.0.0-beta.2/plugin-app-store-1.0.0-beta.2.jar'
     ])
     dest 'src/main/resources/presets/plugins'
 }


### PR DESCRIPTION
#### What type of PR is this?

/area core
/kind improvement
/milestone 2.10.x

#### What this PR does / why we need it:

修改应用市场插件的版本为 [1.0.0-beta.2](https://github.com/halo-dev/plugin-app-store/releases/tag/v1.0.0-beta.2)


#### Does this PR introduce a user-facing change?

```release-note
None
```
