### PR TITLE
Fix the problem that OAuth2 users cannot create PATs 

### DIFF
--- a/application/src/main/java/run/halo/app/security/authentication/pat/impl/UserScopedPatHandlerImpl.java
+++ b/application/src/main/java/run/halo/app/security/authentication/pat/impl/UserScopedPatHandlerImpl.java
@@ -11,11 +11,11 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Objects;
 import java.util.function.Predicate;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.context.ReactiveSecurityContextHolder;
 import org.springframework.security.core.context.SecurityContext;
-import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.oauth2.jose.jws.SignatureAlgorithm;
 import org.springframework.security.oauth2.jwt.JwsHeader;
 import org.springframework.security.oauth2.jwt.JwtClaimsSet;
@@ -86,10 +86,9 @@ public class UserScopedPatHandlerImpl implements UserScopedPatHandler {
     }
 
     private static Mono<Authentication> mustBeRealUser(Mono<Authentication> authentication) {
-        return authentication.filter(auth -> auth.getPrincipal() instanceof UserDetails)
+        return authentication.filter(UsernamePasswordAuthenticationToken.class::isInstance)
             // Non-username-password authentication could not access the API at any time.
-            .switchIfEmpty(
-                Mono.defer(() -> Mono.error(new AccessDeniedException())));
+            .switchIfEmpty(Mono.error(AccessDeniedException::new));
     }
 
     @Override


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/area core

#### What this PR does / why we need it:

If someone logs in Halo via OAuth2, they will be prohibited from creating PATs. See https://github.com/halo-dev/halo/issues/4697 for more.

This PR also checks for UsernamePasswordAuthenticationToken while checking whether the current session was created by a real user.

#### Which issue(s) this PR fixes:

Fixes https://github.com/halo-dev/halo/issues/4697

#### Does this PR introduce a user-facing change?

```release-note
None
```
