### PR TITLE
fix: resolve the issue of occasional blank annotation and error occurrences

### DIFF
--- a/console/src/components/form/AnnotationsForm.vue
+++ b/console/src/components/form/AnnotationsForm.vue
@@ -109,8 +109,15 @@ const handleProcessCustomAnnotations = () => {
           value,
         };
       }
+      return {
+        key: "",
+        value: "",
+      };
     })
-    .filter((item) => item) as { key: string; value: string }[];
+    .filter((item) => item.key)
+    .filter(
+      (item, index, self) => self.findIndex((t) => t.key === item.key) === index
+    );
 
   annotations.value = formSchemas
     .map((item) => {


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

在获取自定义元数据时，将空白 key 与重复的 key 过滤，用于解决可能出现的额外空白元数据及报错问题。

#### How to test it?

尝试点击编辑文章 -> 设置，查看是否有额外空白元数据的出现。

由于是概率性问题，因此若本地环境未复现，则需要使用生产环境进行验证。

#### Which issue(s) this PR fixes:

Fixes #4764 

#### Does this PR introduce a user-facing change?
```release-note
解决文章设置中可能出现空白元数据的问题
```
