### PR TITLE
fix: cannot change the user's own avatar

### DIFF
--- a/console/src/modules/system/users/components/UserAvatar.vue
+++ b/console/src/modules/system/users/components/UserAvatar.vue
@@ -67,7 +67,7 @@ const handleUploadAvatar = () => {
 
     apiClient.user
       .uploadUserAvatar({
-        name: isCurrentUser ? "-" : user.value.user.metadata.name,
+        name: isCurrentUser?.value ? "-" : user.value.user.metadata.name,
         file: file,
       })
       .then(() => {
@@ -97,7 +97,7 @@ const handleRemoveCurrentAvatar = () => {
 
       apiClient.user
         .deleteUserAvatar({
-          name: isCurrentUser ? "-" : user.value.user.metadata.name,
+          name: isCurrentUser?.value ? "-" : user.value.user.metadata.name,
         })
         .then(() => {
           queryClient.invalidateQueries({ queryKey: ["user-detail"] });

--- a/console/src/modules/system/users/components/UserAvatar.vue
+++ b/console/src/modules/system/users/components/UserAvatar.vue
@@ -67,7 +67,7 @@ const handleUploadAvatar = () => {
 
     apiClient.user
       .uploadUserAvatar({
-        name: user.value.user.metadata.name,
+        name: isCurrentUser ? "-" : user.value.user.metadata.name,
         file: file,
       })
       .then(() => {
@@ -97,7 +97,7 @@ const handleRemoveCurrentAvatar = () => {
 
       apiClient.user
         .deleteUserAvatar({
-          name: user.value.user.metadata.name,
+          name: isCurrentUser ? "-" : user.value.user.metadata.name,
         })
         .then(() => {
           queryClient.invalidateQueries({ queryKey: ["user-detail"] });


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

当前用户上传头像时的接口中名字应该是 `-` 而不是具体的 metadata name。

#### How to test it?

使用无用户管理权限的用户登录，查看是否能上传头像。

#### Which issue(s) this PR fixes:

Fixes #4776 

#### Does this PR introduce a user-facing change?
```release-note
解决无用户管理权限的用户无法上传头像的问题
```
