### PR TITLE
fix: correct the tooltip of view type in the Attachments page

### DIFF
--- a/console/src/modules/contents/attachments/AttachmentList.vue
+++ b/console/src/modules/contents/attachments/AttachmentList.vue
@@ -178,12 +178,12 @@ const onUploadModalClose = () => {
 const viewTypes = [
   {
     name: "list",
-    tooltip: t("core.attachment.filters.view_type.items.grid"),
+    tooltip: t("core.attachment.filters.view_type.items.list"),
     icon: IconList,
   },
   {
     name: "grid",
-    tooltip: t("core.attachment.filters.view_type.items.list"),
+    tooltip: t("core.attachment.filters.view_type.items.grid"),
     icon: IconGrid,
   },
 ];


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

console附件页面List Mode和Grid Mode的tooltip写反了：
<img width="1172" alt="image" src="https://github.com/halo-dev/halo/assets/4889894/6645b29f-7e92-4c42-9938-892e53f92115">


#### Which issue(s) this PR fixes:

Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
修复附件管理布局切换按钮的提示文字。
```
