### PR TITLE
[Release-2.10] fix: resolve errors caused by blank annotations

### DIFF
--- a/console/src/components/form/AnnotationsForm.vue
+++ b/console/src/components/form/AnnotationsForm.vue
@@ -13,6 +13,7 @@ import cloneDeep from "lodash.clonedeep";
 import { getValidationMessages } from "@formkit/validation";
 import { useThemeStore } from "@/stores/theme";
 import { randomUUID } from "@/utils/id";
+import { onUnmounted } from "vue";
 
 const themeStore = useThemeStore();
 
@@ -150,9 +151,20 @@ onMounted(async () => {
   handleProcessCustomAnnotations();
 });
 
+onUnmounted(() => {
+  cleanAnnotations();
+  annotationSettings.value = [];
+});
+
+const cleanAnnotations = () => {
+  annotations.value = {};
+  customAnnotationsState.value = [];
+};
+
 watch(
   () => props.value,
   (value) => {
+    cleanAnnotations();
     reset(specFormId);
     reset(customFormId);
     annotations.value = cloneDeep(props.value) || {};


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/area console
/milestone 2.10.x

#### What this PR does / why we need it:

重构去重元数据的逻辑，解决删除元数据后仍旧提示 key 不能重复的问题。

#### How to test it?

1. 在文章列表点击设置按钮
2. 添加两个个空的元数据，不保存直接关闭设置框。
3. 再次打开设置框，点击删除空的元数据，查看是否会提示 key 重复。

#### Which issue(s) this PR fixes:

Fixes #4764 

#### Does this PR introduce a user-facing change?
```release-note
解决删除元数据后仍旧提示 key 不能重复的问题
```
