### PR TITLE
chore: update the waiting time for publishing post

### DIFF
--- a/application/src/main/java/run/halo/app/core/extension/endpoint/PostEndpoint.java
+++ b/application/src/main/java/run/halo/app/core/extension/endpoint/PostEndpoint.java
@@ -243,7 +243,7 @@ public class PostEndpoint implements CustomEndpoint {
                 })
                 .switchIfEmpty(Mono.error(
                     () -> new RetryException("Retry to check post publish status"))))
-            .retryWhen(Retry.fixedDelay(10, Duration.ofMillis(200))
+            .retryWhen(Retry.backoff(getMaxAttemptsWaitForPublish(), Duration.ofMillis(100))
                 .filter(t -> t instanceof RetryException));
     }
 
@@ -277,5 +277,12 @@ public class PostEndpoint implements CustomEndpoint {
         PostQuery postQuery = new PostQuery(request);
         return postService.listPost(postQuery)
             .flatMap(listedPosts -> ServerResponse.ok().bodyValue(listedPosts));
+    }
+
+    /**
+     * Convenient for testing, to avoid waiting too long for post published when testing.
+     */
+    int getMaxAttemptsWaitForPublish() {
+        return 10;
     }
 }


### PR DESCRIPTION
#### What type of PR is this?
/kind improvement
/area core
/milestone 2.11.x

#### What this PR does / why we need it:
修改发布文章的等待时间以防止因数据库执行延迟较高导致的错误提示

最大等待时间为：`100ms * 2 ^ (retryNum - 1)` = `25600ms`
总共需等待时间为：`100ms * (2 ^ retryNum - 1)` = `31900ms` = `31.9 s`

#### Does this PR introduce a user-facing change?

```release-note
None
```