### PR TITLE
fix: resolve the issue of receiving duplicate key error after deleting metadata

### DIFF
--- a/console/src/components/form/AnnotationsForm.vue
+++ b/console/src/components/form/AnnotationsForm.vue
@@ -17,10 +17,12 @@ import { randomUUID } from "@/utils/id";
 const themeStore = useThemeStore();
 
 function keyValidationRule(node: FormKitNode) {
-  return (
-    !annotations.value?.[node.value as string] &&
-    !customAnnotationsDuplicateKey.value
-  );
+  const validAnnotations = [
+    ...Object.keys(annotations.value),
+    ...customAnnotationsState.value.map((item) => item.key),
+  ];
+  const count = validAnnotations.filter((item) => item === node.value);
+  return count.length < 2;
 }
 
 const props = withDefaults(
@@ -72,12 +74,6 @@ const annotations = ref<{
   [key: string]: string;
 }>({});
 const customAnnotationsState = ref<{ key: string; value: string }[]>([]);
-
-const customAnnotationsDuplicateKey = computed(() => {
-  const keys = customAnnotationsState.value.map((item) => item.key);
-  const uniqueKeys = new Set(keys);
-  return keys.length !== uniqueKeys.size;
-});
 
 const customAnnotations = computed(() => {
   return customAnnotationsState.value.reduce((acc, cur) => {


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/area console
/milestone 2.11.x

#### What this PR does / why we need it:

重构去重元数据的逻辑，解决删除元数据后仍旧提示 key 不能重复的问题。

#### How to test it?

1. 在文章列表点击设置按钮
2. 添加两个个空的元数据，不保存直接关闭设置框。
3. 再次打开设置框，点击删除空的元数据，查看是否会提示 key 重复。

#### Does this PR introduce a user-facing change?
```release-note
解决删除元数据后仍旧提示 key 不能重复的问题
```
