### PR TITLE
Fix the problem where some Windows developers are unable to build project

### DIFF
--- a/api/build.gradle
+++ b/api/build.gradle
@@ -7,6 +7,10 @@ plugins {
 group = 'run.halo.app'
 description = 'API of halo project, connecting by other projects.'
 
+compileJava.options.encoding = "UTF-8"
+compileTestJava.options.encoding = "UTF-8"
+javadoc.options.encoding = "UTF-8"
+
 repositories {
     mavenCentral()
     maven { url 'https://repo.spring.io/milestone' }

--- a/application/build.gradle
+++ b/application/build.gradle
@@ -11,6 +11,8 @@ plugins {
 
 group = "run.halo.app"
 sourceCompatibility = JavaVersion.VERSION_17
+compileJava.options.encoding = "UTF-8"
+compileTestJava.options.encoding = "UTF-8"
 
 checkstyle {
     toolVersion = "9.3"


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/area core

#### What this PR does / why we need it:

Currently, some Windows developers using GBK as character encoding are unable to build project, please see https://github.com/halo-dev/halo/issues/4771 for more. 

Because the source code are using UTF-8 character encoding, the `javadoc`, `compileJava`, `compileTestJava` and `delombok` tasks will use the default character encoding GBK to handle the sources, which prevents the `:api:javadoc` task from running properly.

At the same time, we thank to @DaiYuANg for his first proposed solution in https://github.com/halo-dev/halo/pull/4517.

#### Which issue(s) this PR fixes:

Fixes https://github.com/halo-dev/halo/issues/4771

#### Special notes for your reviewer:

Validate the result by executing command `./gradlew clean build -x check` on Windows environment.

#### Does this PR introduce a user-facing change?

```release-note
修复在部分 Windows 开发者无法正常构建 Halo 的问题
```
