### PR TITLE
Disable code scanning for pull requests

### DIFF
--- a/.github/workflows/halo.yaml
+++ b/.github/workflows/halo.yaml
@@ -50,6 +50,7 @@ jobs:
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v3
       - name: Analyze code
+        if: ${{ github.event_name == 'push' }} # Due to inability to access secrets during PR, only the code pushed into the branch can be analyzed.
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup
/area core

#### What this PR does / why we need it:

According to <https://docs.github.com/en/actions/security-guides/using-secrets-in-github-actions#using-secrets-in-a-workflow>, we cannot obtain secrets in pull requests. So every checks of PRs will failed due to no secrets provided after <https://github.com/halo-dev/halo/pull/4856>.

So this PR disables code scanning for pull requests except for pushing.

#### Does this PR introduce a user-facing change?

```release-note
None
```
