### PR TITLE
Revert "ci: push image to GHCR for pull_request event"

### DIFF
--- a/.github/workflows/halo.yaml
+++ b/.github/workflows/halo.yaml
@@ -72,5 +72,5 @@ jobs:
           ghcr-token: ${{ secrets.GHCR_TOKEN }}
           dockerhub-user: ${{ secrets.DOCKER_USERNAME }}
           dockerhub-token: ${{ secrets.DOCKER_TOKEN }}
-          push: ${{ github.event_name == 'pull_request' || github.event_name == 'push' || github.event_name == 'release' }}
+          push: ${{ github.event_name == 'push' || github.event_name == 'release' }} # we only push to GHCR if the push is to the next branch
           console-ref: ${{ github.event_name == 'release' &&  github.ref || 'main' }}


### PR DESCRIPTION
Reverts halo-dev/halo#4588

According to https://docs.github.com/en/actions/security-guides/using-secrets-in-github-actions#using-secrets-in-a-workflow, we cannot obtain secrets in pull requests, so that we are not able to push docker image for every pull request.

```release-note
None
```