### PR TITLE
fix: vue warning issue in BackupListItem component

### DIFF
--- a/console/console-src/modules/system/backup/components/BackupListItem.vue
+++ b/console/console-src/modules/system/backup/components/BackupListItem.vue
@@ -26,7 +26,7 @@ const { t } = useI18n();
 const props = withDefaults(
   defineProps<{
     backup: Backup;
-    showOperations: boolean;
+    showOperations?: boolean;
   }>(),
   {
     showOperations: true,


### PR DESCRIPTION
#### What type of PR is this?

/area console
/kind improvement
/milestone 2.11.x

#### What this PR does / why we need it:

修复代码错误导致的控制台警告。异常现象：备份列表页面，有多少备份文件就会有多少个警告日志。
![image](https://github.com/halo-dev/halo/assets/44720422/2dc64621-9731-4647-b23e-c3a5aa115c37)

#### Which issue(s) this PR fixes:

Fixes #4871

#### Special notes for your reviewer:

None

#### Does this PR introduce a user-facing change?

```release-note
修复备份页面中的浏览器控制台警告日志
```
