### PR TITLE
Respond HTTP status CREATED for system initialization API

### DIFF
--- a/application/src/main/java/run/halo/app/core/extension/endpoint/SystemInitializationEndpoint.java
+++ b/application/src/main/java/run/halo/app/core/extension/endpoint/SystemInitializationEndpoint.java
@@ -2,9 +2,11 @@ package run.halo.app.core.extension.endpoint;
 
 import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
 import static org.springdoc.core.fn.builders.apiresponse.Builder.responseBuilder;
+import static org.springdoc.core.fn.builders.header.Builder.headerBuilder;
 import static org.springdoc.core.fn.builders.requestbody.Builder.requestBodyBuilder;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import java.net.URI;
 import java.time.Duration;
 import java.util.LinkedHashMap;
 import java.util.Map;
@@ -13,6 +15,7 @@ import lombok.RequiredArgsConstructor;
 import org.apache.commons.lang3.StringUtils;
 import org.springdoc.webflux.core.fn.SpringdocRouteBuilder;
 import org.springframework.dao.OptimisticLockingFailureException;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Component;
 import org.springframework.web.reactive.function.server.RouterFunction;
@@ -56,7 +59,14 @@ public class SystemInitializationEndpoint implements CustomEndpoint {
                     .tag(tag)
                     .requestBody(requestBodyBuilder()
                         .implementation(SystemInitializationRequest.class))
-                    .response(responseBuilder().implementation(Boolean.class))
+                    .response(responseBuilder()
+                        .responseCode(HttpStatus.CREATED.value() + "")
+                        .description("System initialization successfully.")
+                        .header(headerBuilder()
+                            .name(HttpHeaders.LOCATION)
+                            .description("Redirect URL.")
+                        )
+                    )
             )
             .build();
     }
@@ -87,7 +97,7 @@ public class SystemInitializationEndpoint implements CustomEndpoint {
                     return initializeSystem(requestBody);
                 })
             )
-            .then(ServerResponse.ok().bodyValue(true));
+            .then(ServerResponse.created(URI.create("/console")).build());
     }
 
     private Mono<Void> initializeSystem(SystemInitializationRequest requestBody) {

--- a/application/src/test/java/run/halo/app/core/extension/endpoint/SystemInitializationEndpointTest.java
+++ b/application/src/test/java/run/halo/app/core/extension/endpoint/SystemInitializationEndpointTest.java
@@ -1,13 +1,25 @@
 package run.halo.app.core.extension.endpoint;
 
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 import static org.springframework.test.web.reactive.server.WebTestClient.bindToRouterFunction;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
+import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.web.reactive.server.WebTestClient;
+import reactor.core.publisher.Mono;
+import run.halo.app.core.extension.endpoint.SystemInitializationEndpoint.SystemInitializationRequest;
+import run.halo.app.extension.ConfigMap;
+import run.halo.app.extension.ReactiveExtensionClient;
+import run.halo.app.infra.InitializationStateGetter;
+import run.halo.app.infra.SystemSetting;
+import run.halo.app.security.SuperAdminInitializer;
+import run.halo.app.security.SuperAdminInitializer.InitializationParam;
 
 /**
  * Tests for {@link SystemInitializationEndpoint}.
@@ -17,6 +29,15 @@ import org.springframework.test.web.reactive.server.WebTestClient;
  */
 @ExtendWith(MockitoExtension.class)
 class SystemInitializationEndpointTest {
+
+    @Mock
+    InitializationStateGetter initializationStateGetter;
+
+    @Mock
+    SuperAdminInitializer superAdminInitializer;
+
+    @Mock
+    ReactiveExtensionClient client;
 
     @InjectMocks
     SystemInitializationEndpoint initializationEndpoint;
@@ -29,11 +50,40 @@ class SystemInitializationEndpointTest {
     }
 
     @Test
-    void initialize() {
+    void initializeWithoutRequestBody() {
         webTestClient.post()
             .uri("/system/initialize")
             .exchange()
             .expectStatus()
             .isBadRequest();
+    }
+
+    @Test
+    void initializeWithRequestBody() {
+        var initialization = new SystemInitializationRequest();
+        initialization.setUsername("faker");
+        initialization.setPassword("openfaker");
+        initialization.setEmail("faker@halo.run");
+        initialization.setSiteTitle("Fake Site");
+
+        when(initializationStateGetter.userInitialized()).thenReturn(Mono.just(false));
+        when(superAdminInitializer.initialize(any(InitializationParam.class)))
+            .thenReturn(Mono.empty());
+
+        var configMap = new ConfigMap();
+        when(client.get(ConfigMap.class, SystemSetting.SYSTEM_CONFIG))
+            .thenReturn(Mono.just(configMap));
+        when(client.update(configMap)).thenReturn(Mono.just(configMap));
+
+        webTestClient.post().uri("/system/initialize")
+            .bodyValue(initialization)
+            .exchange()
+            .expectStatus().isCreated()
+            .expectHeader().location("/console");
+
+        verify(initializationStateGetter).userInitialized();
+        verify(superAdminInitializer).initialize(any());
+        verify(client).get(ConfigMap.class, SystemSetting.SYSTEM_CONFIG);
+        verify(client).update(configMap);
     }
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind improvement
/area core
/milestone 2.11.x

#### What this PR does / why we need it:

Respond HTTP status CREATED for system initialization API instead of string `true`.

#### Which issue(s) this PR fixes:

Fixes #4885 

#### Does this PR introduce a user-facing change?

```release-note
None
```
