### PR TITLE
chore: use ibm-semeru-runtimes to replace eclipse-temurin as the base image

### DIFF
--- a/.github/workflows/halo.yaml
+++ b/.github/workflows/halo.yaml
@@ -74,3 +74,4 @@ jobs:
           dockerhub-token: ${{ secrets.DOCKER_TOKEN }}
           push: ${{ github.event_name == 'push' || github.event_name == 'release' }} # we only push to GHCR if the push is to the next branch
           console-ref: ${{ github.event_name == 'release' &&  github.ref || 'main' }}
+          platforms: linux/amd64,linux/arm64/v8,linux/ppc64le,linux/s390x

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,9 @@
 FROM ibm-semeru-runtimes:open-17-jre as builder
+
+# Fix multiplatform build memory issues
+# https://github.com/docker/build-push-action/issues/621#issuecomment-1383624173
+ENV CARGO_NET_GIT_FETCH_WITH_CLI=true
+
 WORKDIR application
 ARG JAR_FILE=application/build/libs/*.jar
 COPY ${JAR_FILE} application.jar
@@ -17,7 +22,10 @@ COPY --from=builder application/application/ ./
 ENV JVM_OPTS="-Xmx256m -Xms256m" \
     HALO_WORK_DIR="/root/.halo2" \
     SPRING_CONFIG_LOCATION="optional:classpath:/;optional:file:/root/.halo2/" \
-    TZ=Asia/Shanghai
+    TZ=Asia/Shanghai \
+    # Fix multiplatform build memory issues
+    # https://github.com/docker/build-push-action/issues/621#issuecomment-1383624173
+    CARGO_NET_GIT_FETCH_WITH_CLI=true
 
 RUN ln -sf /usr/share/zoneinfo/$TZ /etc/localtime \
     && echo $TZ > /etc/timezone

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM eclipse-temurin:17-jre as builder
+FROM ibm-semeru-runtimes:open-17-jre as builder
 WORKDIR application
 ARG JAR_FILE=application/build/libs/*.jar
 COPY ${JAR_FILE} application.jar
@@ -6,7 +6,7 @@ RUN java -Djarmode=layertools -jar application.jar extract
 
 ################################
 
-FROM eclipse-temurin:17-jre
+FROM ibm-semeru-runtimes:open-17-jre
 MAINTAINER johnniang <johnniang@fastmail.com>
 WORKDIR application
 COPY --from=builder application/dependencies/ ./


### PR DESCRIPTION
#### What type of PR is this?

/area core
/milestone 2.11.x
/kind improvement

#### What this PR does / why we need it:

使用 ibm-semeru-runtimes:open-17-jre 作为基础镜像构建 Halo 镜像，以获得更优的内存消耗。

#### Which issue(s) this PR fixes:

Fixes #2584 

#### Special notes for your reviewer:

```
./gradlew build

docker build -t halohub/halo:openj9 .
```

#### Does this PR introduce a user-facing change?

```release-note
使用 ibm-semeru-runtimes:open-17-jre 作为基础镜像构建 Halo 镜像，以获得更优的内存消耗。
```
