### PR TITLE
Reset base Docker image of builder to eclipse-temurin

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,4 @@
-FROM ibm-semeru-runtimes:open-17-jre as builder
-
-# Fix multiplatform build memory issues
-# https://github.com/docker/build-push-action/issues/621#issuecomment-1383624173
-ENV CARGO_NET_GIT_FETCH_WITH_CLI=true
+FROM eclipse-temurin:17-jre as builder
 
 WORKDIR application
 ARG JAR_FILE=application/build/libs/*.jar
@@ -22,10 +18,7 @@ COPY --from=builder application/application/ ./
 ENV JVM_OPTS="-Xmx256m -Xms256m" \
     HALO_WORK_DIR="/root/.halo2" \
     SPRING_CONFIG_LOCATION="optional:classpath:/;optional:file:/root/.halo2/" \
-    TZ=Asia/Shanghai \
-    # Fix multiplatform build memory issues
-    # https://github.com/docker/build-push-action/issues/621#issuecomment-1383624173
-    CARGO_NET_GIT_FETCH_WITH_CLI=true
+    TZ=Asia/Shanghai
 
 RUN ln -sf /usr/share/zoneinfo/$TZ /etc/localtime \
     && echo $TZ > /etc/timezone


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/area core

#### What this PR does / why we need it:

Reset base Docker image of builder to eclipse-temurin to fix the problem of OOM while building multi-platform Docker image. See https://github.com/halo-dev/halo/actions/runs/6976331252/job/18984676251 for more.

#### Does this PR introduce a user-facing change?

```release-note
None
```
