### PR TITLE
feat: support for configuring the redirection location after login for roles

### DIFF
--- a/console/console-src/modules/system/roles/components/RoleEditingModal.vue
+++ b/console/console-src/modules/system/roles/components/RoleEditingModal.vue
@@ -154,6 +154,15 @@ const handleResetForm = () => {
               type="text"
               validation="required|length:0,50"
             ></FormKit>
+            <FormKit
+              v-model="
+                formState.metadata.annotations[
+                  rbacAnnotations.REDIRECT_ON_LOGIN
+                ]
+              "
+              type="text"
+              label="登录之后默认跳转位置"
+            ></FormKit>
           </FormKit>
         </div>
       </div>

--- a/console/console-src/router/guards/auth-check.ts
+++ b/console/console-src/router/guards/auth-check.ts
@@ -1,3 +1,4 @@
+import { rbacAnnotations } from "@/constants/annotations";
 import { useUserStore } from "@/stores/user";
 import type { Router } from "vue-router";
 
@@ -29,12 +30,26 @@ export function setupAuthCheckGuard(router: Router) {
               redirect_uri: to.query.redirect_uri,
             },
           });
-        } else {
-          next({
-            name: "Dashboard",
-          });
           return;
         }
+
+        const roleHasRedirectOnLogin = userStore.currentRoles?.find(
+          (role) =>
+            role.metadata.annotations?.[rbacAnnotations.REDIRECT_ON_LOGIN]
+        );
+
+        if (roleHasRedirectOnLogin) {
+          window.location.href =
+            roleHasRedirectOnLogin.metadata.annotations?.[
+              rbacAnnotations.REDIRECT_ON_LOGIN
+            ] || "/";
+          return;
+        }
+
+        next({
+          name: "Dashboard",
+        });
+        return;
       }
     }
 

--- a/console/src/constants/annotations.ts
+++ b/console/src/constants/annotations.ts
@@ -11,6 +11,7 @@ export enum rbacAnnotations {
   DEPENDENCIES = "rbac.authorization.halo.run/dependencies",
   AVATAR_ATTACHMENT_NAME = "halo.run/avatar-attachment-name",
   LAST_AVATAR_ATTACHMENT_NAME = "halo.run/last-avatar-attachment-name",
+  REDIRECT_ON_LOGIN = "rbac.authorization.halo.run/redirect-on-login",
 }
 
 // content


### PR DESCRIPTION
#### What type of PR is this?

/area console
/kind feature
/milestone 2.11.x

#### What this PR does / why we need it:

支持为自定义的角色配置登录之后默认跳转位置。

#### Special notes for your reviewer:

1. 创建一个新的角色，设置跳转位置。
2. 为一个用户赋予这个角色。
3. 测试登录之后是否正常跳转到设置的位置。

#### Does this PR introduce a user-facing change?

```release-note
支持为自定义的角色配置登录之后默认跳转位置。
```
