### PR TITLE
chore: bump editor version and let it load globally

### DIFF
--- a/console/package.json
+++ b/console/package.json
@@ -59,7 +59,7 @@
     "@halo-dev/api-client": "workspace:*",
     "@halo-dev/components": "workspace:*",
     "@halo-dev/console-shared": "workspace:*",
-    "@halo-dev/richtext-editor": "0.0.0-alpha.32",
+    "@halo-dev/richtext-editor": "0.0.0-alpha.33",
     "@tanstack/vue-query": "^4.29.1",
     "@tiptap/extension-character-count": "^2.0.4",
     "@uppy/core": "^3.4.0",

--- a/console/pnpm-lock.yaml
+++ b/console/pnpm-lock.yaml
@@ -69,8 +69,8 @@ importers:
         specifier: workspace:*
         version: link:packages/shared
       '@halo-dev/richtext-editor':
-        specifier: 0.0.0-alpha.32
-        version: 0.0.0-alpha.32(vue@3.3.4)
+        specifier: 0.0.0-alpha.33
+        version: 0.0.0-alpha.33(vue@3.3.4)
       '@tanstack/vue-query':
         specifier: ^4.29.1
         version: 4.29.1(vue@3.3.4)
@@ -2401,8 +2401,8 @@ packages:
       - windicss
     dev: false
 
-  /@halo-dev/richtext-editor@0.0.0-alpha.32(vue@3.3.4):
-    resolution: {integrity: sha512-CHYjOrMXHSP2ts03YTIp/y3Bmn6E1n3KAECWo9ksZal1k1Ja2P/q7fAERE9v3GwnGKCqVWvF/XJWlsvcbDjn1Q==}
+  /@halo-dev/richtext-editor@0.0.0-alpha.33(vue@3.3.4):
+    resolution: {integrity: sha512-qHz3tNoDMkED8A3vEd2rV1EXRLjey7YcquAnEEY6Z8Av53kWlvPVKpytm9G0mbuv8bue7Mi0JFUDQgQoYeBZjw==}
     peerDependencies:
       vue: ^3.2.37
     dependencies:

--- a/console/src/vite/library-external.ts
+++ b/console/src/vite/library-external.ts
@@ -74,6 +74,11 @@ export const setupLibraryExternal = (
       dest: "assets/console-shared",
       rename: `halo-console-shared.iife.${staticSuffix}.js`,
     },
+    {
+      src: "./node_modules/@halo-dev/richtext-editor/dist/rich-text-editor.iife.js",
+      dest: "assets/richtext-editor",
+      rename: `halo-rich-text-editor.iife.${staticSuffix}.js`,
+    },
   ];
 
   const injectTags = staticTargets
@@ -99,6 +104,7 @@ export const setupLibraryExternal = (
       "@vueuse/components": "VueUse",
       "@vueuse/router": "VueUse",
       "vue-demi": "VueDemi",
+      "@halo-dev/richtext-editor": "RichTextEditor",
     }),
     ViteStaticCopy({
       targets: staticTargets,


### PR DESCRIPTION
#### What type of PR is this?

/area console
/area editor
/milestone 2.11.0
/kind improvement

#### What this PR does / why we need it:

升级编辑器依赖，并将其全局注册，此 PR 合并之后，插件如果需要扩展编辑器，则不必引入其中依赖，可以完全排除。

#### Which issue(s) this PR fixes:

- https://github.com/halo-sigs/richtext-editor/pull/71 Fixes https://github.com/halo-dev/halo/issues/4868

#### Does this PR introduce a user-facing change?

```release-note
升级默认编辑器版本。
```
