### PR TITLE
feat: request health api for session keep-alive

### DIFF
--- a/console/src/components/base-app/BaseApp.vue
+++ b/console/src/components/base-app/BaseApp.vue
@@ -12,10 +12,13 @@ import type { FormKitConfig } from "@formkit/core";
 import { i18n } from "@/locales";
 import { AppName } from "@/constants/app";
 import { useGlobalInfoStore } from "@/stores/global-info";
+import { useQuery } from "@tanstack/vue-query";
+import { useUserStore } from "@/stores/user";
 
 const { t } = useI18n();
 
 const globalInfoStore = useGlobalInfoStore();
+const { isAnonymous } = useUserStore();
 
 const route = useRoute();
 const title = useTitle();
@@ -86,6 +89,15 @@ window.addEventListener(
   "resize",
   setViewportProperty(document.documentElement)
 );
+
+// keep session alive
+useQuery({
+  queryKey: ["health", "keep-session-alive"],
+  queryFn: () => fetch("/actuator/health"),
+  refetchInterval: 1000 * 60 * 5, // 5 minutes
+  refetchOnWindowFocus: true,
+  enabled: computed(() => !isAnonymous),
+});
 </script>
 
 <template>


### PR DESCRIPTION
#### What type of PR is this?

/area console
/kind improvement
/milestone 2.11.0

#### What this PR does / why we need it:

在 Console 和 UC 轮询 /actuator/health 接口保持登录会话，目前是 5min 请求一次。

#### Which issue(s) this PR fixes:

Fixes #4947 

#### Does this PR introduce a user-facing change?

```release-note
优化 Console 的登录会话保活机制。
```
