### PR TITLE
fix: add disabled validation to the addButton click event for the repeater

### DIFF
--- a/console/src/formkit/inputs/repeater/AddButton.vue
+++ b/console/src/formkit/inputs/repeater/AddButton.vue
@@ -3,7 +3,7 @@ import { VButton, IconAddCircle } from "@halo-dev/components";
 import type { FormKitFrameworkContext } from "@formkit/core";
 import type { PropType } from "vue";
 
-defineProps({
+const props = defineProps({
   context: {
     type: Object as PropType<FormKitFrameworkContext>,
     required: true,
@@ -12,11 +12,21 @@ defineProps({
     type: Boolean,
     required: false,
   },
+  onClick: {
+    type: Function as PropType<() => void>,
+    required: true,
+  },
 });
+
+const handleAppendClick = () => {
+  if (!props.disabled && props.onClick) {
+    props.onClick();
+  }
+};
 </script>
 
 <template>
-  <div :class="context.classes.add">
+  <div :class="context.classes.add" @click="handleAppendClick">
     <VButton :disabled="disabled" type="secondary">
       <template #icon>
         <IconAddCircle class="h-full w-full" />


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/area console
/milestone 2.11.0

#### What this PR does / why we need it:

为 repeater 中的 addButton 点击事件增加校验 disabled 属性。

#### How to test it?

在 safari 浏览器下测试具有 max repeater 的组件，当其 addButton 按钮变灰之后继续点击。查看是否不再添加新的项。 

#### Which issue(s) this PR fixes:

Fixes #4948 

#### Does this PR introduce a user-facing change?
```release-note
修复 safari 浏览器下，repeater 的 max 属性无效的问题
```
