### PR TITLE
Fix the problem of incorrect old data passed to watcher during updates

### DIFF
--- a/api/src/main/java/run/halo/app/extension/JsonExtension.java
+++ b/api/src/main/java/run/halo/app/extension/JsonExtension.java
@@ -17,6 +17,7 @@ import com.fasterxml.jackson.databind.node.TextNode;
 import java.io.IOException;
 import java.time.Instant;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 
 /**
@@ -115,6 +116,23 @@ class JsonExtension implements Extension {
         var metadataNode = objectMapper.createObjectNode();
         objectNode.set("metadata", metadataNode);
         return new ObjectNodeMetadata(metadataNode);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        JsonExtension that = (JsonExtension) o;
+        return Objects.equals(objectNode, that.objectNode);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(objectNode);
     }
 
     class ObjectNodeMetadata implements MetadataOperator {

--- a/application/src/test/java/run/halo/app/extension/FakeExtension.java
+++ b/application/src/test/java/run/halo/app/extension/FakeExtension.java
@@ -1,11 +1,20 @@
 package run.halo.app.extension;
 
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+
 @GVK(group = "fake.halo.run",
     version = "v1alpha1",
     kind = "Fake",
     plural = "fakes",
     singular = "fake")
+@Data
+@ToString(callSuper = true)
+@EqualsAndHashCode(callSuper = true)
 public class FakeExtension extends AbstractExtension {
+
+    private FakeStatus status = new FakeStatus();
 
     public static FakeExtension createFake(String name) {
         var metadata = new Metadata();
@@ -15,4 +24,8 @@ public class FakeExtension extends AbstractExtension {
         return fake;
     }
 
+    @Data
+    public static class FakeStatus {
+        private String state;
+    }
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/area core
/milestone 2.11.0

#### What this PR does / why we need it:

This PR resolves the problem of incorrect old data passed to watcher during updates. As shown in the following line, the old value should be `old` instead of `extension` from outside.

https://github.com/halo-dev/halo/blob/7a84f553005b2d8047ccdb0acf473693384a7b51/application/src/main/java/run/halo/app/extension/ReactiveExtensionClientImpl.java#L172

#### Does this PR introduce a user-facing change?

```release-note
None
```
