### PR TITLE
fix: issue of clicking on the post tag in uc to report an error

### DIFF
--- a/console/uc-src/modules/contents/posts/components/PostListItem.vue
+++ b/console/uc-src/modules/contents/posts/components/PostListItem.vue
@@ -158,7 +158,7 @@ function handleUnpublish() {
                 v-for="(tag, tagIndex) in post.tags"
                 :key="tagIndex"
                 :tag="tag"
-                route
+                :route="false"
               ></PostTag>
             </VSpace>
           </div>


### PR DESCRIPTION
#### What type of PR is this?

/area console
/kind bug
/milestone 2.11.0

#### What this PR does / why we need it:

修复在个人中心的文章列表中点击标签控制台报错的问题。

#### Does this PR introduce a user-facing change?

```release-note
None
```
