### PR TITLE
Add role templates for posts in user center

### DIFF
--- a/application/src/main/resources/extensions/role-template-uc-content.yaml
+++ b/application/src/main/resources/extensions/role-template-uc-content.yaml
@@ -5,11 +5,25 @@ metadata:
   labels:
     rbac.authorization.halo.run/system-reserved: "true"
   annotations:
-    rbac.authorization.halo.run/module: "Posts Management"
     # Currently, yaml definition does not support i18n, please see https://github.com/halo-dev/halo/issues/3573
     rbac.authorization.halo.run/display-name: "编辑者"
     rbac.authorization.halo.run/dependencies: |
-      ["role-template-manage-posts", "post-author"]
+      ["role-template-post-editor"]
+rules: [ ]
+
+---
+apiVersion: v1alpha1
+kind: "Role"
+metadata:
+  name: role-template-post-editor
+  labels:
+    halo.run/role-template: "true"
+  annotations:
+    rbac.authorization.halo.run/module: "Posts Management"
+    # Currently, yaml definition does not support i18n, please see https://github.com/halo-dev/halo/issues/3573
+    rbac.authorization.halo.run/display-name: "Post Editor"
+    rbac.authorization.halo.run/dependencies: |
+      ["role-template-manage-posts", "role-template-post-author"]
 rules: [ ]
 
 ---
@@ -20,13 +34,27 @@ metadata:
   labels:
     rbac.authorization.halo.run/system-reserved: "true"
   annotations:
-    rbac.authorization.halo.run/module: "Posts Management"
     # Currently, yaml definition does not support i18n, please see https://github.com/halo-dev/halo/issues/3573
     rbac.authorization.halo.run/display-name: "作者"
     rbac.authorization.halo.run/disallow-access-console: "true"
     rbac.authorization.halo.run/redirect-on-login: "/uc"
     rbac.authorization.halo.run/dependencies: |
-      [ "post-contributor", "post-publisher" ]
+      [ "role-template-post-author" ]
+rules: [ ]
+
+---
+apiVersion: v1alpha1
+kind: "Role"
+metadata:
+  name: role-template-post-author
+  labels:
+    halo.run/role-template: "true"
+  annotations:
+    rbac.authorization.halo.run/module: "Posts Management"
+    # Currently, yaml definition does not support i18n, please see https://github.com/halo-dev/halo/issues/3573
+    rbac.authorization.halo.run/display-name: "Post Author"
+    rbac.authorization.halo.run/dependencies: |
+      [ "role-template-post-contributor", "role-template-post-publisher", "role-template-post-attachment-manager" ]
 rules: [ ]
 
 ---
@@ -37,11 +65,25 @@ metadata:
   labels:
     rbac.authorization.halo.run/system-reserved: "true"
   annotations:
-    rbac.authorization.halo.run/module: "Posts Management"
     # Currently, yaml definition does not support i18n, please see https://github.com/halo-dev/halo/issues/3573
     rbac.authorization.halo.run/display-name: "投稿者"
     rbac.authorization.halo.run/disallow-access-console: "true"
     rbac.authorization.halo.run/redirect-on-login: "/uc"
+    rbac.authorization.halo.run/dependencies: |
+      [ "role-template-post-contributor" ]
+rules: [ ]
+
+---
+apiVersion: v1alpha1
+kind: "Role"
+metadata:
+  name: role-template-post-contributor
+  labels:
+    halo.run/role-template: "true"
+  annotations:
+    rbac.authorization.halo.run/module: "Posts Management"
+    # Currently, yaml definition does not support i18n, please see https://github.com/halo-dev/halo/issues/3573
+    rbac.authorization.halo.run/display-name: "Post Contributor"
     rbac.authorization.halo.run/dependencies: |
       [ "role-template-view-categories", "role-template-view-tags" ]
     rbac.authorization.halo.run/ui-permissions: |
@@ -58,7 +100,7 @@ rules:
 apiVersion: v1alpha1
 kind: Role
 metadata:
-  name: post-publisher
+  name: role-template-post-publisher
   labels:
     halo.run/role-template: "true"
   annotations:
@@ -70,18 +112,17 @@ rules:
   - apiGroups: [ "uc.api.content.halo.run" ]
     resources: [ "posts/publish", "posts/unpublish" ]
     verbs: [ "update" ]
+
 ---
 apiVersion: v1alpha1
 kind: Role
 metadata:
-  name: post-attachment-manager
+  name: role-template-post-attachment-manager
   labels:
     halo.run/role-template: "true"
   annotations:
     rbac.authorization.halo.run/module: "Posts Management"
     rbac.authorization.halo.run/display-name: "Post Attachment Manager"
-    rbac.authorization.halo.run/dependencies: |
-      [ "role-template-post-attachment-viewer" ]
     rbac.authorization.halo.run/ui-permissions: |
       [ "uc:attachments:manage" ]
 rules:

--- a/console/src/locales/en.yaml
+++ b/console/src/locales/en.yaml
@@ -1345,9 +1345,9 @@ core:
     Notification Configuration: Notification Configuration
     Configure Notifier: Configure Notifier
     Post Attachment Manager: Allow images to be uploaded in posts
-    Post Author: Author
-    Post Contributor: Contributor
-    Post Editor: Editor
+    Post Author: Contributions allowed
+    Post Contributor: Allows you to manage your own posts
+    Post Editor: Allow management of all posts
     Post Publisher: Allow to publish own posts
   components:
     submit_button:

--- a/console/src/locales/zh-CN.yaml
+++ b/console/src/locales/zh-CN.yaml
@@ -1272,9 +1272,9 @@ core:
     Cache Manage: 缓存管理
     Notification Configuration: 通知配置
     Configure Notifier: 配置通知器
-    Post Editor: 编辑者
-    Post Contributor: 投稿者
-    Post Author: 作者
+    Post Editor: 允许管理所有文章
+    Post Contributor: 允许管理自己的文章
+    Post Author: 允许投稿
     Post Attachment Manager: 允许在文章中上传图片
     Post Publisher: 允许发布自己的文章
   components:

--- a/console/src/locales/zh-TW.yaml
+++ b/console/src/locales/zh-TW.yaml
@@ -1261,9 +1261,9 @@ core:
     Configure Notifier: 配置通知器
     Notification Configuration: 通知配置
     Post Attachment Manager: 允許在文章中上傳圖片
-    Post Author: 作者
-    Post Contributor: 投稿者
-    Post Editor: 編輯者
+    Post Author: 允许管理自己的文章
+    Post Contributor: 允许投稿
+    Post Editor: 允许管理所有文章
     Post Publisher: 允許發布自己的文章
   components:
     submit_button:


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup
/area core
/milestone 2.11.0

#### What this PR does / why we need it:

This PR adds role templates for posts in user center for recreating more flexible roles. Related to <https://github.com/halo-dev/halo/pull/4866>.

#### Does this PR introduce a user-facing change?

```release-note
None
```
