### PR TITLE
[release-2.11] Bump versions for next development

### DIFF
--- a/.github/workflows/halo.yaml
+++ b/.github/workflows/halo.yaml
@@ -3,15 +3,13 @@ name: Halo CI
 on:
   pull_request:
     branches:
-      - main
-      - release-*
+      - release-2.11
     paths:
       - "**"
       - "!**.md"
   push:
     branches:
-      - main
-      - release-*
+      - release-2.11
     paths:
       - "**"
       - "!**.md"
@@ -57,7 +55,7 @@ jobs:
         run: ./gradlew sonar --info
       - name: Setup console environment
         if: steps.changes.outputs.console == 'true'
-        uses: halo-sigs/actions/admin-env-setup@main
+        uses: halo-sigs/actions/admin-env-setup@release-2.11
       - name: Check console
         if: steps.changes.outputs.console == 'true'
         run: make -C console check
@@ -66,7 +64,7 @@ jobs:
     needs: check
     steps:
       - uses: actions/checkout@v3
-      - uses: halo-sigs/actions/halo-next-docker-build@main # change the version to specific ref or release tag while the action is stable.
+      - uses: halo-sigs/actions/halo-next-docker-build@release-2.11 # change the version to specific ref or release tag while the action is stable.
         if: github.event_name != 'pull_request'
         with:
           image-name: ${{ github.event_name == 'release' && 'halo' || 'halo-dev' }}
@@ -76,7 +74,7 @@ jobs:
           push: ${{ github.event_name == 'push' || github.event_name == 'release' }} # we only push to GHCR if the push is to the next branch
           console-ref: ${{ github.event_name == 'release' &&  github.ref || 'main' }}
           platforms: linux/amd64,linux/arm64/v8,linux/ppc64le,linux/s390x
-      - uses: halo-sigs/actions/halo-next-docker-build@main
+      - uses: halo-sigs/actions/halo-next-docker-build@release-2.11
         if: github.event_name == 'pull_request'
         with:
           image-name: halo-dev

--- a/console/package.json
+++ b/console/package.json
@@ -1,6 +1,4 @@
 {
-  "name": "@halo-dev/console",
-  "version": "2.11.0",
   "scripts": {
     "prepare": "cd .. && husky install console/.husky",
     "dev": "run-p dev:console dev:uc",

--- a/console/packages/api-client/package.json
+++ b/console/packages/api-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@halo-dev/api-client",
-  "version": "2.11.0",
+  "version": "2.11.1",
   "description": "",
   "scripts": {
     "build": "unbuild",

--- a/console/packages/components/package.json
+++ b/console/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@halo-dev/components",
-  "version": "1.10.0",
+  "version": "2.11.1",
   "description": "",
   "files": [
     "dist"

--- a/console/packages/editor/package.json
+++ b/console/packages/editor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@halo-dev/richtext-editor",
-  "version": "0.0.0-alpha.33",
+  "version": "2.11.1",
   "description": "Default editor for Halo",
   "homepage": "https://github.com/halo-dev/halo/tree/main/console/packages/editor#readme",
   "bugs": {

--- a/console/packages/shared/package.json
+++ b/console/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@halo-dev/console-shared",
-  "version": "2.11.0",
+  "version": "2.11.1",
   "description": "",
   "files": [
     "dist"

--- a/console/packages/ui-plugin-bundler-kit/package.json
+++ b/console/packages/ui-plugin-bundler-kit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@halo-dev/ui-plugin-bundler-kit",
-  "version": "1.0.0",
+  "version": "2.11.1",
   "homepage": "https://github.com/halo-dev/halo/tree/main/console/packages/ui-plugin-bundler-kit#readme",
   "bugs": {
     "url": "https://github.com/halo-dev/halo/issues"

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
-version=2.11.0-SNAPSHOT
+version=2.11.1-SNAPSHOT
 snakeyaml.version=2.2


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup
/area core

#### What this PR does / why we need it:

Bump versions for next development.

Meanwhile, I also created a branch `release-2.11` for actions at [here](https://github.com/halo-sigs/actions/tree/release-2.11).

#### Does this PR introduce a user-facing change?

```release-note
None
```
