### PR TITLE
feat: add disallow tooltip for editor provider selector component

### DIFF
--- a/console/src/components/dropdown-selector/EditorProviderSelector.vue
+++ b/console/src/components/dropdown-selector/EditorProviderSelector.vue
@@ -41,6 +41,15 @@ const { editorProviders } = useEditorExtensionPoints();
       <VDropdownItem
         v-for="(editorProvider, index) in editorProviders"
         :key="index"
+        v-tooltip="{
+          disabled:
+            allowForcedSelect ||
+            provider?.rawType.toLowerCase() ===
+              editorProvider.rawType.toLowerCase(),
+          content: $t(
+            'core.components.editor_provider_selector.tooltips.disallow'
+          ),
+        }"
         :selected="provider?.name === editorProvider.name"
         :disabled="
           !allowForcedSelect &&

--- a/console/src/locales/en.yaml
+++ b/console/src/locales/en.yaml
@@ -1423,6 +1423,9 @@ core:
         flip_horizontal: Flip Horizontal
         flip_vertical: Flip Vertical
         reset: Reset
+    editor_provider_selector:
+      tooltips:
+        disallow: The content format is different and cannot be switched
   composables:
     content_cache:
       toast_recovered: Recovered unsaved content from cache

--- a/console/src/locales/zh-CN.yaml
+++ b/console/src/locales/zh-CN.yaml
@@ -1373,6 +1373,9 @@ core:
         flip_horizontal: 水平翻转
         flip_vertical: 垂直翻转
         reset: 重置
+    editor_provider_selector:
+      tooltips:
+        disallow: 内容格式不同，无法切换
   composables:
     content_cache:
       toast_recovered: 已从缓存中恢复未保存的内容

--- a/console/src/locales/zh-TW.yaml
+++ b/console/src/locales/zh-TW.yaml
@@ -1337,6 +1337,9 @@ core:
         flip_horizontal: 水平翻轉
         flip_vertical: 垂直翻轉
         reset: 重置
+    editor_provider_selector:
+      tooltips:
+        disallow: 內容格式不同，無法切換
   composables:
     content_cache:
       toast_recovered: 已從緩存中恢復未保存的內容


### PR DESCRIPTION
#### What type of PR is this?

/area console
/kind improvement
/milestone 2.12.x

#### What this PR does / why we need it:

当编辑器切换组件中有不可用编辑器时，添加提示。

<img width="304" alt="图片" src="https://github.com/halo-dev/halo/assets/21301288/a5da0549-dfd6-4392-9375-16ddf2a57517">

#### Which issue(s) this PR fixes:

Fixes #5059 

#### Special notes for your reviewer:

测试方式：

1. 安装若干不同类型的编辑器，并创建文章。
2. 修改文章时尝试选择不同类型的编辑器，观察是否有提示。

#### Does this PR introduce a user-facing change?

```release-note
当编辑器切换组件中有不可用编辑器时，添加提示。
```
