### PR TITLE
chore: add storybook-static folder to .gitignore

### DIFF
--- a/console/.gitignore
+++ b/console/.gitignore
@@ -29,3 +29,4 @@ coverage
 *.sw?
 
 !src/build
+storybook-static


### PR DESCRIPTION
#### What type of PR is this?

/area console

#### What this PR does / why we need it:

storybook-static 文件夹为 Storybook 的构建目录，此 PR 将此文件夹添加到 .gitignore

#### Does this PR introduce a user-facing change?

```release-note
None
```
