### PR TITLE
Fix the issue of always displaying `Unbind` in the login method on the user profile page

### DIFF
--- a/console/uc-src/modules/profile/tabs/Detail.vue
+++ b/console/uc-src/modules/profile/tabs/Detail.vue
@@ -185,7 +185,7 @@ const emailVerifyModal = ref(false);
                     type="secondary"
                     @click="handleBindAuth(authProvider)"
                   >
-                    {{ $t("core.uc_profile.detail.operations.unbind.button") }}
+                    {{ $t("core.uc_profile.detail.operations.bind.button") }}
                   </VButton>
                 </div>
               </div>


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Fix the issue of always displaying Unbind in the login method on the user profile page.

#### Which issue(s) this PR fixes:

Fixes #5048

#### Special notes for your reviewer:
@JohnNiang 's help.
#### Does this PR introduce a user-facing change?


```release-note
修复个人中心用户登录方式仅显示解绑问题 
```
