### PR TITLE
fix: fix anchor positioning for identical table of contents names

### DIFF
--- a/console/packages/editor/src/utils/anchor.ts
+++ b/console/packages/editor/src/utils/anchor.ts
@@ -3,3 +3,18 @@ export function generateAnchor(text: string) {
     String(text).trim().toLowerCase().replace(/\s+/g, "-")
   );
 }
+
+export const generateAnchorId = (text: string, ids: string[]) => {
+  const originId = generateAnchor(text);
+  let id = originId;
+  while (ids.includes(id)) {
+    const temporarySuffix = id.replace(originId, "");
+    const match = temporarySuffix.match(/-(\d+)$/);
+    if (match) {
+      id = `${originId}-${Number(match[1]) + 1}`;
+    } else {
+      id = `${originId}-1`;
+    }
+  }
+  return id;
+};

--- a/console/src/components/editor/DefaultEditor.vue
+++ b/console/src/components/editor/DefaultEditor.vue
@@ -308,7 +308,6 @@ onMounted(() => {
                     }
                   });
                   headingNodes.value = headings;
-                  console.log("headingNodes", headingNodes);
                   if (!selectedHeadingNode.value) {
                     selectedHeadingNode.value = headings[0];
                   }

--- a/console/src/components/editor/DefaultEditor.vue
+++ b/console/src/components/editor/DefaultEditor.vue
@@ -308,6 +308,7 @@ onMounted(() => {
                     }
                   });
                   headingNodes.value = headings;
+                  console.log("headingNodes", headingNodes);
                   if (!selectedHeadingNode.value) {
                     selectedHeadingNode.value = headings[0];
                   }


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/area editor
/milestone 2.12.x

#### What this PR does / why we need it:

重写了对默认编辑器标题的 id 生成逻辑。目前将会在对标题进行任意的修改之后，对所有的标题进行 id 计算，用以解决当标题名称具有重复时，生成了相同的 id.

需要注意的是，由于需要对任意标题进行修改之后才会进行生效，因此已经存在重名标题 id 的问题时，需要修改任意的标题使其生效。

#### How to test it?

在文章内新增多个相同内容的标题，查看是否可以正常跳转。

#### Which issue(s) this PR fixes:

Fixes #5068 

#### Does this PR introduce a user-facing change?
```release-note
解决默认编辑器中具有重名标题时，锚点只会跳转至首个的问题。
```
