### PR TITLE
feat: add shortcut for table deletion

### DIFF
--- a/console/packages/editor/src/extensions/list-keymap/index.ts
+++ b/console/packages/editor/src/extensions/list-keymap/index.ts
@@ -15,8 +15,7 @@ const ExtensionListKeymap = ListKeymap.extend<ListKeymapOptions>({
       let handled = false;
 
       if (!editor.state.selection.empty) {
-        editor.commands.deleteSelection();
-        return true;
+        return false;
       }
 
       this.options.listTypes.forEach(

--- a/console/packages/editor/src/extensions/table/index.ts
+++ b/console/packages/editor/src/extensions/table/index.ts
@@ -31,7 +31,6 @@ import { i18n } from "@/locales";
 import type { ExtensionOptions, NodeBubbleMenu } from "@/types";
 import { BlockActionSeparator, ToolboxItem } from "@/components";
 import { hasTableBefore, isTableSelected } from "./util";
-import { Editor } from "@tiptap/core";
 
 function updateColumns(
   node: ProseMirrorNode,

--- a/console/packages/editor/src/extensions/table/util.ts
+++ b/console/packages/editor/src/extensions/table/util.ts
@@ -1,6 +1,6 @@
 import { findParentNode } from "@/tiptap/vue-3";
 import { Node, CellSelection, TableMap } from "@/tiptap/pm";
-import type { Selection, Transaction } from "@/tiptap/pm";
+import type { EditorState, Selection, Transaction } from "@/tiptap/pm";
 
 export const selectTable = (tr: Transaction) => {
   const table = findTable(tr.selection);
@@ -235,4 +235,18 @@ export const isTableSelected = (selection: any) => {
   }
 
   return false;
+};
+
+export const hasTableBefore = (editorState: EditorState) => {
+  const { $anchor } = editorState.selection;
+
+  const previousNodePos = Math.max(0, $anchor.pos - 2);
+
+  const previousNode = editorState.doc.resolve(previousNodePos).node();
+
+  if (!previousNode || !(previousNode.type.name === "table")) {
+    return false;
+  }
+
+  return true;
 };


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

为表格增加删除快捷键，删除逻辑为

1. 光标处于表格下一行，按下退格键（Backspace），将会选中表格
2. 选中表格后再次按下退格键（Backspace），将会删除表格

#### How to test it?

由于修改了无序列表等快捷键的部分逻辑，因此需要同步测试无序列表、有序列表、任务列表这三个功能是否正确。

1. 测试表格按照上述逻辑是否可删除
2. 测试 无序列表、有序列表、任务列表删除功能是否正确。

#### Which issue(s) this PR fixes:

Fixes #5141 

#### Does this PR introduce a user-facing change?
```release-note
为默认富文本编辑器表格组件增加退格键删除方式
```
