### PR TITLE
fix: resolve the issue of reduced row count after merging cells

### DIFF
--- a/console/packages/editor/src/extensions/table/table-row.ts
+++ b/console/packages/editor/src/extensions/table/table-row.ts
@@ -2,6 +2,16 @@ import { TableRow as BuiltInTableRow } from "@tiptap/extension-table-row";
 
 const TableRow = BuiltInTableRow.extend({
   allowGapCursor: false,
+
+  addAttributes() {
+    return {
+      ...this.parent?.(),
+      style: {
+        default: "height: 60px;",
+        parseHTML: (element) => element.getAttribute("style"),
+      },
+    };
+  },
 });
 
 export default TableRow;


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

为表格 tr 增加 style 字段，解决由于合并单元格后 tr 高度为 0 的问题

#### How to test it?

将三列三行的表格，每列进行不一样的组合合并单元格后，查看其是否会出现变成两行的问题。

#### Which issue(s) this PR fixes:

Fixes #5143 

#### Does this PR introduce a user-facing change?
```release-note
解决默认编辑器表格合并单元格后行丢失的问题
```
