### PR TITLE
chore: make editor lib external for plugin

### DIFF
--- a/console/packages/ui-plugin-bundler-kit/src/index.ts
+++ b/console/packages/ui-plugin-bundler-kit/src/index.ts
@@ -42,6 +42,7 @@ export function HaloUIPluginBundlerKit(): Plugin {
               "@vueuse/router",
               "@halo-dev/shared",
               "@halo-dev/components",
+              "@halo-dev/richtext-editor",
             ],
             output: {
               globals: {
@@ -52,6 +53,7 @@ export function HaloUIPluginBundlerKit(): Plugin {
                 "@vueuse/router": "VueUse",
                 "@halo-dev/console-shared": "HaloConsoleShared",
                 "@halo-dev/components": "HaloComponents",
+                "@halo-dev/richtext-editor": "RichTextEditor",
               },
               extend: true,
             },


### PR DESCRIPTION
#### What type of PR is this?

/area console
/kind improvement
/milestone 2.12.x

#### What this PR does / why we need it:

将默认编辑器依赖添加到插件构建库的 external 中，基于 https://github.com/halo-dev/halo/pull/4924

#### Does this PR introduce a user-facing change?

```release-note
None
```
