### PR TITLE
Refactor workflow by not using composite actions from halo-sigs/actions

### DIFF
--- a/.github/actions/docker-buildx-push/action.yaml
+++ b/.github/actions/docker-buildx-push/action.yaml
@@ -1,0 +1,74 @@
+name: "Docker buildx and push"
+description: "Buildx and push the Docker image."
+
+inputs:
+  ghcr-token:
+    description: Token of current GitHub account in GitHub container registry.
+    required: false
+    default: ""
+  dockerhub-user:
+    description: "User name for the DockerHub account"
+    required: false
+    default: ""
+  dockerhub-token:
+    description: Token for the DockerHub account
+    required: false
+    default: ""
+  push:
+    description: Should push the docker image or not.
+    required: false
+    default: "false"
+  platforms:
+    description: Target platforms for building image
+    required: false
+    default: "linux/amd64,linux/arm/v7,linux/arm64/v8,linux/ppc64le,linux/s390x"
+  image-name:
+    description: The basic name of docker.
+    required: false
+    default: "halo"
+
+runs:
+  using: "composite"
+  steps:
+    - name: Docker meta for Halo
+      id: meta
+      uses: docker/metadata-action@v5
+      with:
+        images: |
+          ghcr.io/${{ github.repository_owner }}/${{ inputs.image-name }}
+          halohub/${{ inputs.image-name }}
+        tags: |
+          type=schedule,pattern=nightly-{{date 'YYYYMMDD'}},enabled=${{ github.event_name == 'schedule' }}
+          type=ref,event=branch,enabled=${{ github.event_name == 'push' }}
+          type=ref,event=pr,enabled=${{ github.event_name == 'pull_request' }}
+          type=semver,pattern={{ version }}
+          type=semver,pattern={{major}}.{{minor}}
+          type=sha,enabled=${{ github.event_name == 'push' }}
+        flavor: |
+          latest=false
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v2
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v2
+    - name: Login to GHCR
+      uses: docker/login-action@v3
+      if: inputs.ghcr-token != '' && github.event_name != 'pull_request'
+      with:
+        registry: ghcr.io
+        username: ${{ github.repository_owner }}
+        password: ${{ inputs.ghcr-token }}
+    - name: Login to DockerHub
+      if: inputs.dockerhub-token != '' && github.event_name != 'pull_request'
+      uses: docker/login-action@v2
+      with:
+        username: ${{ inputs.dockerhub-user }}
+        password: ${{ inputs.dockerhub-token }}
+    - name: Build and push
+      uses: docker/build-push-action@v5
+      with:
+        context: .
+        file: ./Dockerfile
+        platforms: ${{ inputs.platforms }}
+        labels: ${{ steps.meta.outputs.labels }}
+        tags: ${{ steps.meta.outputs.tags }}
+        push: ${{ (inputs.ghcr-token != '' || inputs.dockerhub-token != '') && inputs.push == 'true' }}

--- a/.github/actions/setup-env/action.yaml
+++ b/.github/actions/setup-env/action.yaml
@@ -1,0 +1,61 @@
+name: Setup Environment
+description: Setup environment to check and build Halo, including console and core projects.
+
+inputs:
+  node-version:
+    description: Node.js version.
+    required: false
+    default: "18"
+
+  pnpm-version:
+    description: pnpm version.
+    required: false
+    default: "8"
+
+  java-version:
+    description: Java version.
+    required: false
+    default: "17"
+
+runs:
+  using: "composite"
+  steps:
+    - name: Set up Node.js
+      uses: actions/setup-node@v3
+      with:
+        node-version: ${{ inputs.node-version }}
+
+    - uses: pnpm/action-setup@v2
+      name: Setup pnpm
+      id: pnpm-install
+      with:
+        version: ${{ inputs.pnpm-version }}
+        run_install: false
+
+    - name: Get pnpm store directory
+      id: pnpm-cache
+      shell: bash
+      run: |
+        echo "STORE_PATH=$(pnpm store path)" >> $GITHUB_OUTPUT
+
+    - uses: actions/cache@v3
+      name: Setup pnpm cache
+      with:
+        path: ${{ steps.pnpm-cache.outputs.STORE_PATH}}
+        key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
+        restore-keys: |
+          ${{ runner.os }}-pnpm-store-
+
+    - name: Setup JDK
+      uses: actions/setup-java@v4
+      with:
+        distribution: "temurin"
+        cache: "gradle"
+        java-version: ${{ inputs.java-version }}
+
+    - name: Cache SonarCloud packages
+      uses: actions/cache@v3
+      with:
+        path: ~/.sonar/cache
+        key: ${{ runner.os }}-sonar
+        restore-keys: ${{ runner.os }}-sonar

--- a/.github/workflows/halo.yaml
+++ b/.github/workflows/halo.yaml
@@ -1,4 +1,4 @@
-name: Halo CI
+name: Halo Workflow
 
 on:
   pull_request:
@@ -16,80 +16,110 @@ on:
       - "**"
       - "!**.md"
   release:
-    types: # This configuration does not affect the page_build event above
-      - created
+    types:
+      - published
 
 jobs:
-  check:
+  test:
+    if: github.event_name == 'pull_request' || github.event_name == 'push'
     runs-on: ubuntu-latest
-    # Default steps
     steps:
       - uses: actions/checkout@v3
-        with:
-          submodules: true
-      - name: Set up JDK 17
-        uses: actions/setup-java@v3
-        with:
-          distribution: 'temurin'
-          cache: 'gradle'
-          java-version: 17
-      - name: Cache SonarCloud packages
-        uses: actions/cache@v3
-        with:
-          path: ~/.sonar/cache
-          key: ${{ runner.os }}-sonar
-          restore-keys: ${{ runner.os }}-sonar
-      - uses: dorny/paths-filter@v2
-        id: changes
-        with:
-          filters: |
-            console:
-              - 'console/**'
-      - name: Check halo
+      - name: Setup Environment
+        uses: ./.github/actions/setup-env
+      - name: Check Halo console
+        run: make -C console check
+      - name: Check Halo core
         run: ./gradlew check
-      - name: Upload coverage reports to Codecov
-        uses: codecov/codecov-action@v3
       - name: Analyze code
-        if: ${{ github.event_name == 'push' }} # Due to inability to access secrets during PR, only the code pushed into the branch can be analyzed.
+        if: ${{ github.event_name == 'push' && env.SONAR_TOKEN != '' }} # Due to inability to access secrets during PR, only the code pushed into the branch can be analyzed.
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
         run: ./gradlew sonar --info
-      - name: Setup console environment
-        if: steps.changes.outputs.console == 'true'
-        uses: halo-sigs/actions/admin-env-setup@main
-      - name: Check console
-        if: steps.changes.outputs.console == 'true'
-        run: make -C console check
-  docker-build-and-push:
+  build:
     runs-on: ubuntu-latest
-    needs: check
+    if: always() && (needs.test.result == 'skipped' || needs.test.result == 'success')
+    needs: test
     steps:
       - uses: actions/checkout@v3
-      - uses: halo-sigs/actions/halo-next-docker-build@main # change the version to specific ref or release tag while the action is stable.
-        if: github.event_name != 'pull_request'
+      - name: Setup Environment
+        uses: ./.github/actions/setup-env
+      - name: Build Halo console
+        run: make -C console build
+      - name: Reset version of Halo
+        if: github.event_name == 'release'
+        shell: bash
+        run: |
+          # Set the version with tag name when releasing
+          version=${{ github.event.release.tag_name }}
+          version=${version#v}
+          sed -i "s/version=.*-SNAPSHOT$/version=$version/1" gradle.properties
+      - name: Build Halo core
+        run: ./gradlew clean && ./gradlew downloadPluginPresets && ./gradlew build -x check
+      - name: Upload Artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: halo-artifacts
+          path: application/build/libs
+          retention-days: 1
+
+  github-release:
+    runs-on: ubuntu-latest
+    if: always() && needs.build.result == 'success' && github.event_name == 'release'
+    needs: build
+    steps:
+      - uses: actions/checkout@v3
+      - name: Download Artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: halo-artifacts
+          path: application/build/libs
+      - name: Upload Artifacts
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh release upload ${{ github.event.release.tag_name }} application/build/libs/*
+
+  docker-build-and-push:
+    if: always() && needs.build.result == 'success' && (github.event_name == 'push' || github.event_name == 'release')
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - uses: actions/checkout@v3
+      - name: Download Artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: halo-artifacts
+          path: application/build/libs
+      - name: Docker Buildx and Push
+        uses: ./.github/actions/docker-buildx-push
         with:
           image-name: ${{ github.event_name == 'release' && 'halo' || 'halo-dev' }}
-          ghcr-token: ${{ secrets.GHCR_TOKEN }}
+          ghcr-token: ${{ secrets.GITHUB_TOKEN }}
           dockerhub-user: ${{ secrets.DOCKER_USERNAME }}
           dockerhub-token: ${{ secrets.DOCKER_TOKEN }}
-          push: ${{ github.event_name == 'push' || github.event_name == 'release' }} # we only push to GHCR if the push is to the next branch
-          console-ref: ${{ github.event_name == 'release' &&  github.ref || 'main' }}
+          push: true
           platforms: linux/amd64,linux/arm64/v8,linux/ppc64le,linux/s390x
-      - uses: halo-sigs/actions/halo-next-docker-build@main
-        if: github.event_name == 'pull_request'
+
+  e2e-test:
+    if: always() && needs.build.result == 'success' && (github.event_name == 'pull_request' || github.event_name == 'push')
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - uses: actions/checkout@v3
+      - name: Download Artifacts
+        uses: actions/download-artifact@v4
         with:
-          image-name: halo-dev
+          name: halo-artifacts
+          path: application/build/libs
+      - name: Docker Build
+        uses: docker/build-push-action@v5
+        with:
+          tags: ghcr.io/halo-dev/halo-dev:main
           push: false
-          console-ref: false
-          load: true
-          platforms: ""
+          context: .
       - name: E2E Testing
-        if: github.event_name == 'pull_request'
         run: |
           sudo curl -L https://github.com/docker/compose/releases/download/v2.23.0/docker-compose-linux-x86_64 -o /usr/local/bin/docker-compose
           sudo chmod u+x /usr/local/bin/docker-compose
-
-          repo=$(echo ${{ github.repository_owner }} | tr '[:upper:]' '[:lower:]')
-          docker tag ghcr.io/${repo}/halo-dev:pr-${{ github.event.number }} ghcr.io/halo-dev/halo-dev:main
           cd e2e && make all

--- a/application/build.gradle
+++ b/application/build.gradle
@@ -1,3 +1,6 @@
+import de.undercouch.gradle.tasks.download.Download
+import org.gradle.crypto.checksum.Checksum
+
 plugins {
     id 'org.springframework.boot' version '3.2.0'
     id 'io.spring.dependency-management' version '1.1.0'
@@ -7,12 +10,18 @@ plugins {
     id 'jacoco'
     id "de.undercouch.download" version "5.3.1"
     id "io.freefair.lombok" version "8.4"
+    id 'org.gradle.crypto.checksum' version '1.4.0'
 }
 
-group = "run.halo.app"
-sourceCompatibility = JavaVersion.VERSION_17
-compileJava.options.encoding = "UTF-8"
-compileTestJava.options.encoding = "UTF-8"
+group = 'run.halo.app'
+compileJava.options.encoding = 'UTF-8'
+compileTestJava.options.encoding = 'UTF-8'
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(17)
+    }
+}
 
 checkstyle {
     toolVersion = "9.3"
@@ -35,13 +44,19 @@ configurations {
 }
 
 springBoot {
-    buildInfo()
+    buildInfo {
+        properties {
+            artifact = 'halo'
+            name = 'halo'
+        }
+    }
 }
 
 bootJar {
+    archiveBaseName = 'halo'
     manifest {
-        attributes "Implementation-Title": "Halo Application",
-                "Implementation-Version": archiveVersion
+        attributes 'Implementation-Title': 'Halo Application',
+                'Implementation-Vendor': 'Halo OSS Team'
     }
 }
 
@@ -60,12 +75,23 @@ dependencies {
     testImplementation 'io.projectreactor:reactor-test'
 }
 
-tasks.named('test') {
+tasks.register('createChecksums', Checksum) {
+    dependsOn tasks.named('bootJar')
+    inputFiles.setFrom(layout.buildDirectory.files('libs'))
+    outputDirectory = layout.buildDirectory.dir("libs")
+    checksumAlgorithm = Checksum.Algorithm.SHA256
+}
+
+tasks.named('build') {
+    dependsOn tasks.named('createChecksums')
+}
+
+tasks.named('test', Test) {
     useJUnitPlatform()
     finalizedBy jacocoTestReport
 }
 
-tasks.named('jacocoTestReport') {
+tasks.named('jacocoTestReport', JacocoReport) {
     reports {
         xml.required = true
         html.required = false


### PR DESCRIPTION
#### What type of PR is this?

/kind improvement
/area core
/milestone 2.12.x

#### What this PR does / why we need it:

This PR refactors workflow by not using compiste actions from <https://github.com/halo-sigs/actions> and adds a support of publishing Halo artifact into GitHub release.

I have tested the new workflow in my repo, please see 
- Release Detail: https://github.com/JohnNiang/halo/releases/tag/v2.12.0-alpha.3
- Push Event: https://github.com/JohnNiang/halo/actions/runs/7470856348
- PullRequest Event: https://github.com/JohnNiang/halo/actions/runs/7470570889?pr=13
- Release Event: https://github.com/JohnNiang/halo/actions/runs/7470874779

After this PR, the repository <https://github.com/halo-sigs/actions> can be archived.

#### Which issue(s) this PR fixes:

Fixes https://github.com/halo-dev/halo/issues/2996

#### Does this PR introduce a user-facing change?

```release-note
支持发布构建产物 halo-x.y.z.jar
```
