### PR TITLE
Disable Swagger cache in development environment

### DIFF
--- a/application/src/main/resources/application-dev.yaml
+++ b/application/src/main/resources/application-dev.yaml
@@ -31,12 +31,15 @@ logging:
     run.halo.app: DEBUG
     org.springframework.boot.autoconfigure.web.reactive.error.AbstractErrorWebExceptionHandler: DEBUG
 springdoc:
+  cache:
+    disabled: true
   api-docs:
     enabled: true
     version: OPENAPI_3_1
   swagger-ui:
     enabled: true
   show-actuator: true
+
 
 management:
   endpoints:

--- a/application/src/main/resources/application-dev.yaml
+++ b/application/src/main/resources/application-dev.yaml
@@ -40,7 +40,6 @@ springdoc:
     enabled: true
   show-actuator: true
 
-
 management:
   endpoints:
     web:


### PR DESCRIPTION
#### What type of PR is this?

/kind improvement
/area  core

#### What this PR does / why we need it:

When we are developing a plugin in development environment, APIs in plugin are frequently changed. But they are not reflected in Swagger UI instantly unless we restart Halo entirely.

This PR disables Swagger cache in that case.

#### Does this PR introduce a user-facing change?

```release-note
None
```
