### PR TITLE
refactor: update chinese display name of post editor role

### DIFF
--- a/application/src/main/resources/extensions/role-template-uc-content.yaml
+++ b/application/src/main/resources/extensions/role-template-uc-content.yaml
@@ -6,7 +6,7 @@ metadata:
     rbac.authorization.halo.run/system-reserved: "true"
   annotations:
     # Currently, yaml definition does not support i18n, please see https://github.com/halo-dev/halo/issues/3573
-    rbac.authorization.halo.run/display-name: "编辑者"
+    rbac.authorization.halo.run/display-name: "文章管理员"
     rbac.authorization.halo.run/dependencies: |
       ["role-template-post-editor"]
 rules: [ ]


### PR DESCRIPTION
#### What type of PR is this?

/area core
/milestone 2.12.x

#### What this PR does / why we need it:

修改文章编辑角色的显示名称为**文章管理员**，这样会更加直观。

#### Which issue(s) this PR fixes:

Fixes #5221 

#### Does this PR introduce a user-facing change?

```release-note
修改文章编辑角色的显示名称为**文章管理员**。
```
