### PR TITLE
fix: text selected after resolving the table cannot be deleted

### DIFF
--- a/console/packages/editor/src/extensions/table/index.ts
+++ b/console/packages/editor/src/extensions/table/index.ts
@@ -394,11 +394,13 @@ const Table = TiptapTable.extend<ExtensionOptions & TableOptions>({
         return true;
       }
 
+      const { selection } = editor.state;
       // the node in the current active state is not a table
       // and the previous node is a table
       if (
         !isNodeActive(editor.state, Table.name) &&
-        hasTableBefore(editor.state)
+        hasTableBefore(editor.state) &&
+        selection.empty
       ) {
         editor.commands.selectNodeBackward();
         return true;


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

当表格后存在选中的内容时，按下退格键或删除键不再执行选中表格的操作，而是继续向下执行。

#### How to test it?

在表格后紧跟着文本，从文本开头选中文本，然后按下退格键，查看文本是否能够被删除。

#### Which issue(s) this PR fixes:

Fixes #5193 

#### Does this PR introduce a user-facing change?
```release-note
解决默认富文本编辑器中表格后的文本选中后无法删除的问题
```
