### PR TITLE
Fix the problem of not initializing extensions in the plugin properly

### DIFF
--- a/application/src/main/java/run/halo/app/config/ExtensionConfiguration.java
+++ b/application/src/main/java/run/halo/app/config/ExtensionConfiguration.java
@@ -27,7 +27,7 @@ public class ExtensionConfiguration {
         matchIfMissing = true)
     static class ExtensionControllerConfiguration {
 
-        @Bean
+        @Bean("controllerManager")
         DefaultControllerManager controllerManager(ExtensionClient client) {
             return new DefaultControllerManager(client);
         }

--- a/application/src/main/java/run/halo/app/config/ExtensionConfiguration.java
+++ b/application/src/main/java/run/halo/app/config/ExtensionConfiguration.java
@@ -1,6 +1,5 @@
 package run.halo.app.config;
 
-import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.reactive.function.server.RouterFunction;
@@ -9,8 +8,10 @@ import run.halo.app.extension.ExtensionClient;
 import run.halo.app.extension.ReactiveExtensionClient;
 import run.halo.app.extension.SchemeManager;
 import run.halo.app.extension.SchemeWatcherManager;
+import run.halo.app.extension.controller.ControllerManager;
 import run.halo.app.extension.controller.DefaultControllerManager;
 import run.halo.app.extension.router.ExtensionCompositeRouterFunction;
+import run.halo.app.infra.properties.HaloProperties;
 
 @Configuration(proxyBeanMethods = false)
 public class ExtensionConfiguration {
@@ -21,15 +22,12 @@ public class ExtensionConfiguration {
         return new ExtensionCompositeRouterFunction(client, watcherManager, schemeManager);
     }
 
-    @Configuration(proxyBeanMethods = false)
-    @ConditionalOnProperty(name = "halo.extension.controller.disabled",
-        havingValue = "false",
-        matchIfMissing = true)
     static class ExtensionControllerConfiguration {
 
         @Bean("controllerManager")
-        DefaultControllerManager controllerManager(ExtensionClient client) {
-            return new DefaultControllerManager(client);
+        ControllerManager controllerManager(ExtensionClient client, HaloProperties haloProperties) {
+            return new DefaultControllerManager(client,
+                haloProperties.getExtension().getController().isDisabled());
         }
 
     }

--- a/application/src/main/java/run/halo/app/extension/gc/GcControllerInitializer.java
+++ b/application/src/main/java/run/halo/app/extension/gc/GcControllerInitializer.java
@@ -6,7 +6,7 @@ import org.springframework.stereotype.Component;
 import run.halo.app.extension.controller.Controller;
 import run.halo.app.infra.ExtensionInitializedEvent;
 
-@Component
+@Component("gcControllerInitializer")
 public class GcControllerInitializer
     implements ApplicationListener<ExtensionInitializedEvent>, DisposableBean {
 

--- a/application/src/main/java/run/halo/app/plugin/PluginAutoConfiguration.java
+++ b/application/src/main/java/run/halo/app/plugin/PluginAutoConfiguration.java
@@ -27,6 +27,7 @@ import org.springframework.boot.autoconfigure.web.WebProperties;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.DependsOn;
 import org.springframework.web.reactive.accept.RequestedContentTypeResolver;
 import org.springframework.web.reactive.function.BodyInserters;
 import org.springframework.web.reactive.function.server.RouterFunction;
@@ -75,7 +76,8 @@ public class PluginAutoConfiguration {
     }
 
     @Bean
-    public HaloPluginManager pluginManager() {
+    @DependsOn({"gcControllerInitializer", "controllerManager"})
+    public PluginManager pluginManager() {
         // Setup RuntimeMode
         System.setProperty("pf4j.mode", pluginProperties.getRuntimeMode().toString());
 

--- a/application/src/main/java/run/halo/app/plugin/PluginBeforeStopSyncListener.java
+++ b/application/src/main/java/run/halo/app/plugin/PluginBeforeStopSyncListener.java
@@ -1,10 +1,15 @@
 package run.halo.app.plugin;
 
+import java.time.Duration;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.event.EventListener;
 import org.springframework.lang.NonNull;
+import org.springframework.retry.RetryException;
 import org.springframework.stereotype.Component;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
+import reactor.util.retry.Retry;
+import run.halo.app.extension.GroupVersionKind;
 import run.halo.app.extension.ReactiveExtensionClient;
 import run.halo.app.plugin.event.HaloPluginBeforeStopEvent;
 
@@ -14,6 +19,7 @@ import run.halo.app.plugin.event.HaloPluginBeforeStopEvent;
  * @author guqing
  * @since 2.0.0
  */
+@Slf4j
 @Component
 public class PluginBeforeStopSyncListener {
 
@@ -24,22 +30,42 @@ public class PluginBeforeStopSyncListener {
     }
 
     @EventListener
-    public Mono<Void> onApplicationEvent(@NonNull HaloPluginBeforeStopEvent event) {
+    public void onApplicationEvent(@NonNull HaloPluginBeforeStopEvent event) {
         var pluginWrapper = event.getPlugin();
         ExtensionContextRegistry registry = ExtensionContextRegistry.getInstance();
         if (!registry.containsContext(pluginWrapper.getPluginId())) {
-            return Mono.empty();
+            return;
         }
         var pluginContext = registry.getByPluginId(pluginWrapper.getPluginId());
-        return cleanUpPluginExtensionResources(pluginContext);
+        cleanUpPluginExtensionResources(pluginContext).block(Duration.ofMinutes(1));
     }
 
     private Mono<Void> cleanUpPluginExtensionResources(PluginApplicationContext context) {
         var gvkExtensionNames = context.extensionNamesMapping();
         return Flux.fromIterable(gvkExtensionNames.entrySet())
             .flatMap(entry -> Flux.fromIterable(entry.getValue())
-                .flatMap(extensionName -> client.fetch(entry.getKey(), extensionName))
-                .flatMap(client::delete))
+                .flatMap(name -> client.fetch(entry.getKey(), name))
+                .flatMap(client::delete)
+                .flatMap(e -> waitForDeleted(e.groupVersionKind(), e.getMetadata().getName()))
+                .then())
             .then();
+    }
+
+    private Mono<Void> waitForDeleted(GroupVersionKind gvk, String name) {
+        return client.fetch(gvk, name)
+            .flatMap(e -> {
+                if (log.isDebugEnabled()) {
+                    log.debug("Wait for {}/{} deleted", gvk, name);
+                }
+                return Mono.error(new RetryException("Wait for extension deleted"));
+            })
+            .retryWhen(Retry.backoff(10, Duration.ofMillis(100))
+                .filter(RetryException.class::isInstance))
+            .then()
+            .doOnSuccess(v -> {
+                if (log.isDebugEnabled()) {
+                    log.debug("{}/{} was deleted successfully.", gvk, name);
+                }
+            });
     }
 }

--- a/application/src/main/java/run/halo/app/plugin/extensionpoint/DefaultExtensionGetter.java
+++ b/application/src/main/java/run/halo/app/plugin/extensionpoint/DefaultExtensionGetter.java
@@ -6,6 +6,7 @@ import java.util.Set;
 import java.util.stream.Stream;
 import lombok.RequiredArgsConstructor;
 import org.pf4j.ExtensionPoint;
+import org.pf4j.PluginManager;
 import org.springframework.context.ApplicationContext;
 import org.springframework.core.annotation.AnnotationAwareOrderComparator;
 import org.springframework.lang.NonNull;
@@ -15,7 +16,6 @@ import reactor.core.publisher.Mono;
 import run.halo.app.extension.ReactiveExtensionClient;
 import run.halo.app.infra.SystemConfigurableEnvironmentFetcher;
 import run.halo.app.infra.SystemSetting.ExtensionPointEnabled;
-import run.halo.app.plugin.HaloPluginManager;
 
 @Component
 @RequiredArgsConstructor
@@ -23,7 +23,7 @@ public class DefaultExtensionGetter implements ExtensionGetter {
 
     private final SystemConfigurableEnvironmentFetcher systemConfigFetcher;
 
-    private final HaloPluginManager pluginManager;
+    private final PluginManager pluginManager;
 
     private final ApplicationContext applicationContext;
 


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/area core
/milestone 2.12.x

#### What this PR does / why we need it:

This PR waits extensions deleted when stopping plugins and rearrange destruction order between plugin manager and reconcilers.

See https://github.com/halo-dev/halo/issues/5226 for more.

#### Which issue(s) this PR fixes:

Fixes https://github.com/halo-dev/halo/issues/5226

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
None
```
