### PR TITLE
Revert: refresh the plugin wrapper when starting the plugin

### DIFF
--- a/application/src/main/java/run/halo/app/plugin/HaloPluginManager.java
+++ b/application/src/main/java/run/halo/app/plugin/HaloPluginManager.java
@@ -223,10 +223,7 @@ public class HaloPluginManager extends DefaultPluginManager
     private PluginState doStartPlugin(String pluginId) {
         checkPluginId(pluginId);
 
-        // refresh plugin to ensure cache object of PluginWrapper.plugin is up-to-date
-        // see gh-4016 to know why we need this
-        // TODO if has a better way to do this?
-        PluginWrapper pluginWrapper = refreshPluginWrapper(pluginId);
+        PluginWrapper pluginWrapper = getPlugin(pluginId);
 
         checkExtensionFinderReady(pluginWrapper);
 
@@ -350,37 +347,6 @@ public class HaloPluginManager extends DefaultPluginManager
         if (extensionFinder instanceof SpringComponentsFinder springComponentsFinder) {
             springComponentsFinder.removeComponentsStorage(pluginId);
         }
-    }
-
-    /**
-     * <p>Refresh plugin wrapper by plugin name.</p>
-     *
-     * <p>It will be create a new plugin wrapper and replace old plugin wrapper to clean
-     * {@link PluginWrapper#getPlugin()} cache object.</p>
-     *
-     * @param pluginName plugin name
-     * @return refreshed plugin wrapper instance, plugin cache object will be null
-     * @throws IllegalArgumentException if plugin not found
-     */
-    protected synchronized PluginWrapper refreshPluginWrapper(String pluginName) {
-        checkPluginId(pluginName);
-        // get old plugin wrapper
-        PluginWrapper pluginWrapper = getPlugin(pluginName);
-        // create new plugin wrapper to replace old plugin wrapper
-        PluginWrapper refreshed = copyPluginWrapper(pluginWrapper);
-        this.plugins.put(pluginName, refreshed);
-        return refreshed;
-    }
-
-    @NonNull
-    PluginWrapper copyPluginWrapper(@NonNull PluginWrapper pluginWrapper) {
-        PluginWrapper refreshed =
-            createPluginWrapper(pluginWrapper.getDescriptor(), pluginWrapper.getPluginPath(),
-                pluginWrapper.getPluginClassLoader());
-        refreshed.setPluginFactory(getPluginFactory());
-        refreshed.setPluginState(pluginWrapper.getPluginState());
-        refreshed.setFailedException(pluginWrapper.getFailedException());
-        return refreshed;
     }
 
     @Override


### PR DESCRIPTION
#### What type of PR is this?

/kind improvement
/area core
/milestone 2.12.x

#### What this PR does / why we need it:

This PR reverts changes in PR <https://github.com/halo-dev/halo/pull/4023>, mainly thanks to PR <https://github.com/halo-dev/halo/pull/5148>.

We don't need to refresh the plugin wrapper on every startup, because we entirely disable the plugin in plugin manager when disabling plugin at console.

#### Which issue(s) this PR fixes:

Fixes https://github.com/halo-dev/halo/issues/4016

#### Does this PR introduce a user-facing change?

```release-note
None
```
