### PR TITLE
fix: resolve the issue of the bubble menu being obscured

### DIFF
--- a/console/packages/editor/src/components/Editor.vue
+++ b/console/packages/editor/src/components/Editor.vue
@@ -36,14 +36,12 @@ watch(
   <div v-if="editor" class="halo-rich-text-editor">
     <editor-bubble-menu :editor="editor" />
     <editor-header :editor="editor" />
-    <div class="h-full flex flex-row w-full">
-      <div class="overflow-y-auto overflow-x-hidden flex-1 relative bg-white">
-        <editor-content
-          :editor="editor"
-          :style="contentStyles"
-          class="editor-content markdown-body"
-        />
-      </div>
+    <div class="h-full flex flex-row w-full overflow-hidden">
+      <editor-content
+        :editor="editor"
+        :style="contentStyles"
+        class="editor-content markdown-body flex-1 relative bg-white overflow-y-auto"
+      />
       <div
         v-if="$slots.extra"
         class="h-full hidden sm:!block w-72 flex-shrink-0"


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/area console
/area editor

#### What this PR does / why we need it:

将默认编辑器的父级容器移除。用于解决冒泡菜单被遮挡的问题。
由于修改后默认编辑器自身可滚动，因此可以使默认编辑器容器内的绝对定位元素获取到当前滚动的位置。

#### How to test it?

输入超过一屏宽度的内容，按 `MOD + A` 全选，查看冒泡菜单是否被顶部菜单遮挡。

#### Which issue(s) this PR fixes:

Fixes #4869

#### Does this PR introduce a user-facing change?
```release-note
解决冒泡菜单会被顶部工具栏遮挡的问题
```
