### PR TITLE
Fix the problem of resolving logo starting with slash

### DIFF
--- a/application/src/main/java/run/halo/app/core/extension/reconciler/PluginReconciler.java
+++ b/application/src/main/java/run/halo/app/core/extension/reconciler/PluginReconciler.java
@@ -240,7 +240,7 @@ public class PluginReconciler implements Reconciler<Request> {
             log.info("Resolving logo resource for plugin {}", pluginName);
             // the logo might be:
             // 1. URL
-            // 2. file name
+            // 2. relative path to "resources" folder
             // 3. base64 format data image
             var logo = specLogo;
             if (!specLogo.startsWith("data:image")) {
@@ -249,7 +249,8 @@ public class PluginReconciler implements Reconciler<Request> {
                 } catch (MalformedURLException ignored) {
                     // indicate the logo is a path
                     logo = UriComponentsBuilder.newInstance()
-                        .pathSegment("plugins", pluginName, "assets", specLogo)
+                        .pathSegment("plugins", pluginName, "assets")
+                        .path(specLogo)
                         .queryParam("version", pluginVersion)
                         .build(true)
                         .toString();


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/area core
/milestone 2.12.x

#### What this PR does / why we need it:

This PR treats logo as a path when building logo HTTP URL instead of a path segment. The concrete rules of logo is described [here](https://github.com/halo-dev/halo/issues/5253#issuecomment-1911729063).

See https://github.com/halo-dev/halo/issues/5253 for more.

#### Which issue(s) this PR fixes:

Fixes https://github.com/halo-dev/halo/issues/5253

#### Does this PR introduce a user-facing change?

```release-note
None
```
