### PR TITLE
fix: unable to request session keep-alive API when browser tabs are inactive

### DIFF
--- a/console/src/composables/use-session-keep-alive.ts
+++ b/console/src/composables/use-session-keep-alive.ts
@@ -9,6 +9,7 @@ export function useSessionKeepAlive() {
     queryKey: ["health", "keep-session-alive"],
     queryFn: () => fetch("/actuator/health"),
     refetchInterval: 1000 * 60 * 5, // 5 minutes
+    refetchIntervalInBackground: true,
     refetchOnWindowFocus: true,
     enabled: computed(() => !isAnonymous),
   });


### PR DESCRIPTION
#### What type of PR is this?

/area console
/kind bug
/milestone 2.12.x

#### What this PR does / why we need it:

修复当浏览器标签页不活跃时，文章编辑页面的 health 接口没有定时请求的问题。

#### Which issue(s) this PR fixes:

Fixes #5265 

#### Special notes for your reviewer:

测试方式：

1. 可以在本地先将 refetchInterval 改为 1000 以方便测试。
2. 进入文章编辑页面。
3. 切换至其他标签页。
4. 返回之后查看浏览器开发者工具的 Network ，观察 health 接口是否有请求。

#### Does this PR introduce a user-facing change?

```release-note
修复当浏览器标签页不活跃时，文章编辑页面的 health 接口没有定时请求的问题。
```
