### PR TITLE
refactor: error prompt for inability to obtain avatar permalink when starting

### DIFF
--- a/application/src/main/java/run/halo/app/core/extension/reconciler/UserReconciler.java
+++ b/application/src/main/java/run/halo/app/core/extension/reconciler/UserReconciler.java
@@ -27,6 +27,7 @@ import run.halo.app.extension.controller.Controller;
 import run.halo.app.extension.controller.ControllerBuilder;
 import run.halo.app.extension.controller.Reconciler;
 import run.halo.app.extension.controller.Reconciler.Request;
+import run.halo.app.extension.controller.RequeueException;
 import run.halo.app.infra.AnonymousUserConst;
 import run.halo.app.infra.ExternalUrlSupplier;
 import run.halo.app.infra.utils.JsonUtils;
@@ -83,7 +84,10 @@ public class UserReconciler implements Reconciler<Request> {
                     .ifPresent(attachment -> {
                         URI avatarUri = attachmentService.getPermalink(attachment).block();
                         if (avatarUri == null) {
-                            throw new IllegalStateException("User avatar attachment not found.");
+                            log.warn("Failed to get avatar permalink for user [{}] with attachment "
+                                + "[{}], re-enqueuing...", name, avatarAttachmentName);
+                            throw new RequeueException(new Result(true, null),
+                                "Failed to get avatar permalink.");
                         }
                         user.getSpec().setAvatar(avatarUri.toString());
                     });


### PR DESCRIPTION
#### What type of PR is this?
/kind improvement
/area core
/milestone 2.12.x

#### What this PR does / why we need it:
优化启动时用户头像获取不到的错误提示

原因是在启动时用户被执行 reconcile 时使用的 plugin-s3 插件还没有启动所以无法获取到 permalink 需要重试

how to test it?
使用 plugin-s3 插件作为用户头像的存储策略然后上传头像测试此 PR 在启动时的异常提示是否输出为：
```
2024-01-29T11:53:13.674+08:00  WARN 31937 --- [rReconciler-t-1] r.h.a.c.e.reconciler.UserReconciler      : Failed to get avatar permalink for user [guqing] with attachment [460be0c4-b09f-4b25-ad93-e45f30331ec7], re-enqueuing...
```
#### Which issue(s) this PR fixes:
Fixes #5268

#### Does this PR introduce a user-facing change?
```release-note
优化启动时用户头像获取不到的错误提示
```
