### PR TITLE
Fix the problem of starting reconcilers in plugin before registering scheme

### DIFF
--- a/application/src/main/java/run/halo/app/plugin/PluginControllerManager.java
+++ b/application/src/main/java/run/halo/app/plugin/PluginControllerManager.java
@@ -3,14 +3,14 @@ package run.halo.app.plugin;
 import static org.springframework.core.ResolvableType.forClassWithGenerics;
 
 import java.util.concurrent.ConcurrentHashMap;
-import org.springframework.context.event.ContextClosedEvent;
-import org.springframework.context.event.ContextRefreshedEvent;
 import org.springframework.context.event.EventListener;
 import reactor.core.Disposable;
 import run.halo.app.extension.ExtensionClient;
 import run.halo.app.extension.controller.Controller;
 import run.halo.app.extension.controller.ControllerBuilder;
 import run.halo.app.extension.controller.Reconciler;
+import run.halo.app.plugin.event.SpringPluginStartedEvent;
+import run.halo.app.plugin.event.SpringPluginStoppingEvent;
 
 public class PluginControllerManager {
 
@@ -24,8 +24,8 @@ public class PluginControllerManager {
     }
 
     @EventListener
-    public void onApplicationEvent(ContextRefreshedEvent event) {
-        event.getApplicationContext()
+    public void onApplicationEvent(SpringPluginStartedEvent event) {
+        event.getSpringPlugin().getApplicationContext()
             .<Reconciler<Reconciler.Request>>getBeanProvider(
                 forClassWithGenerics(Reconciler.class, Reconciler.Request.class))
             .orderedStream()
@@ -33,7 +33,7 @@ public class PluginControllerManager {
     }
 
     @EventListener
-    public void onApplicationEvent(ContextClosedEvent event) throws Exception {
+    public void onApplicationEvent(SpringPluginStoppingEvent event) throws Exception {
         controllers.values()
             .forEach(Disposable::dispose);
         controllers.clear();


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/area core
/area plugin
/milestone 2.12.0

#### What this PR does / why we need it:

This PR adjusts the order of starting reconcilers in plugin, or it will be stuck in starting synchronizer and no reconcilers will be executed.

The problem may be introduced by <https://github.com/halo-dev/halo/pull/5251>.

#### Does this PR introduce a user-facing change?

```release-note
None
```
