### PR TITLE
fix: current selected role templates will be clear after select a other role

### DIFF
--- a/console/src/composables/use-role.ts
+++ b/console/src/composables/use-role.ts
@@ -277,10 +277,10 @@ export function useRoleTemplateSelection(
       return;
     }
 
-    selectedRoleTemplates.value = new Set([
-      role.metadata.name,
-      ...resolveDeepDependencies(role, roleTemplates.value || []),
-    ]);
+    selectedRoleTemplates.value.add(role.metadata.name);
+    resolveDeepDependencies(role, roleTemplates.value || []).forEach((name) => {
+      selectedRoleTemplates.value.add(name);
+    });
   };
 
   return {


### PR DESCRIPTION
#### What type of PR is this?

/area console
/kind bug
/milestone 2.12.x

#### What this PR does / why we need it:

修复创建角色时，勾选某个角色模板导致已选角色模板被清空的问题。

#### Which issue(s) this PR fixes:

Fixes #5275 

#### Does this PR introduce a user-facing change?

```release-note
None
```
