### PR TITLE
chore: change editor version to 2.12.0

### DIFF
--- a/console/packages/editor/package.json
+++ b/console/packages/editor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@halo-dev/richtext-editor",
-  "version": "0.0.0-alpha.33",
+  "version": "2.12.0",
   "description": "Default editor for Halo",
   "homepage": "https://github.com/halo-dev/halo/tree/main/console/packages/editor#readme",
   "bugs": {


### PR DESCRIPTION
#### What type of PR is this?

/area console
/kind improvement
/milestone 2.12.x

#### What this PR does / why we need it:

修改 `@halo-dev/richtext-editor` 的版本号，为发布 Halo 2.12 做准备。

#### Does this PR introduce a user-facing change?

```release-note
None
```
