### PR TITLE
Remove analyzing code step in test job

### DIFF
--- a/.github/workflows/halo.yaml
+++ b/.github/workflows/halo.yaml
@@ -33,12 +33,7 @@ jobs:
         run: ./gradlew check
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v3
-      - name: Analyze code
-        if: ${{ github.event_name == 'push' && env.SONAR_TOKEN != '' }} # Due to inability to access secrets during PR, only the code pushed into the branch can be analyzed.
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
-          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-        run: ./gradlew sonar --info
+
   build:
     runs-on: ubuntu-latest
     if: always() && (needs.test.result == 'skipped' || needs.test.result == 'success')


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup
/area core

#### What this PR does / why we need it:

This PR removes analyzing code step in test job because we have enabled Automatic Analysis in SonarCloud. There is no need to run CI analysis manually.

This PR also resolves [failing CI](https://github.com/halo-dev/halo/actions/runs/7708283716/job/21007037279):

```bash
User cache: /home/runner/.sonar/cache
Loading required plugins
Load plugins index
Load plugins index (done) | time=655ms
Load/download plugins
Load/download plugins (done) | time=815ms
Found an active CI vendor: 'Github Actions'
Load project settings for component key: 'halo-dev_halo'
Load project settings for component key: 'halo-dev_halo' (done) | time=650ms

FAILURE: Build failed with an exception.


* What went wrong:
Execution failed for task ':sonar'.
> Task :sonar FAILED
> You are running CI analysis while Automatic Analysis is enabled. Please consider disabling one or the other.

* Try:
> Run with --stacktrace option to get the stack trace.
> Run with --debug option to get more log output.
> Run with --scan to get full insights.
> Get more help at https://help.gradle.org./

BUILD FAILED in 10s

Deprecated Gradle features were used in this build, making it incompatible with Gradle 9.0.

You can use '--warning-mode all' to show the individual deprecation warnings and determine if they come from your own scripts or plugins.

For more on this, please refer to https://docs.gradle.org/8.4/userguide/command_line_interface.html#sec:command_line_warnings in the Gradle documentation.
19 actionable tasks: 2 executed, 17 up-to-date
Error: Process completed with exit code 1.
```

#### Does this PR introduce a user-facing change?

```release-note
None
```
