### PR TITLE
feat: add supports for ui permissions of notification reason type

### DIFF
--- a/application/src/main/resources/extensions/notification.yaml
+++ b/application/src/main/resources/extensions/notification.yaml
@@ -64,6 +64,9 @@ apiVersion: notification.halo.run/v1alpha1
 kind: ReasonType
 metadata:
   name: new-comment-on-post
+  annotations:
+    rbac.authorization.halo.run/ui-permissions: |
+      [ "uc:posts:publish" ]
 spec:
   displayName: "我的文章收到新评论"
   description: "如果有读者在你的文章下方留下了新的评论，你将会收到一条通知，告诉你有新的评论。
@@ -90,6 +93,9 @@ apiVersion: notification.halo.run/v1alpha1
 kind: ReasonType
 metadata:
   name: new-comment-on-single-page
+  annotations:
+    rbac.authorization.halo.run/ui-permissions: |
+      [ "system:singlepages:manage" ]
 spec:
   displayName: "我的自定义页面收到新评论"
   description: "当你创建的自定义页面收到新评论时，你将会收到一条通知，告诉你有新的评论。"

--- a/console/packages/api-client/src/models/post-status.ts
+++ b/console/packages/api-client/src/models/post-status.ts
@@ -60,6 +60,12 @@ export interface PostStatus {
   lastModifyTime?: string;
   /**
    *
+   * @type {number}
+   * @memberof PostStatus
+   */
+  observedVersion?: number;
+  /**
+   *
    * @type {string}
    * @memberof PostStatus
    */

--- a/console/packages/api-client/src/models/reason-type-info.ts
+++ b/console/packages/api-client/src/models/reason-type-info.ts
@@ -36,4 +36,10 @@ export interface ReasonTypeInfo {
    * @memberof ReasonTypeInfo
    */
   name?: string;
+  /**
+   *
+   * @type {Array<string>}
+   * @memberof ReasonTypeInfo
+   */
+  uiPermissions?: Array<string>;
 }

--- a/console/packages/api-client/src/models/single-page-status.ts
+++ b/console/packages/api-client/src/models/single-page-status.ts
@@ -60,6 +60,12 @@ export interface SinglePageStatus {
   lastModifyTime?: string;
   /**
    *
+   * @type {number}
+   * @memberof SinglePageStatus
+   */
+  observedVersion?: number;
+  /**
+   *
    * @type {string}
    * @memberof SinglePageStatus
    */

--- a/console/uc-src/modules/profile/tabs/NotificationPreferences.vue
+++ b/console/uc-src/modules/profile/tabs/NotificationPreferences.vue
@@ -8,6 +8,7 @@ import { computed } from "vue";
 import { inject } from "vue";
 import { cloneDeep } from "lodash-es";
 import type { ReasonTypeNotifierRequest } from "@halo-dev/api-client";
+import HasPermission from "@/components/permission/HasPermission.vue";
 
 const queryClient = useQueryClient();
 
@@ -114,37 +115,41 @@ const {
           </tr>
         </thead>
         <tbody class="divide-y divide-gray-100 bg-white">
-          <tr
+          <template
             v-for="(reasonType, index) in data?.reasonTypes"
             :key="reasonType.name"
           >
-            <td
-              class="whitespace-nowrap px-4 py-3 text-sm font-medium text-gray-900"
-            >
-              {{ reasonType.displayName }}
-            </td>
-            <td
-              v-for="(notifier, notifierIndex) in data?.notifiers"
-              :key="notifier.name"
-              class="whitespace-nowrap px-4 py-3 text-sm text-gray-500"
-            >
-              <VSwitch
-                :model-value="data?.stateMatrix?.[index][notifierIndex]"
-                :loading="
-                  mutating &&
-                  variables?.reasonTypeIndex === index &&
-                  variables?.notifierIndex === notifierIndex
-                "
-                @change="
-                  mutate({
-                    state: !data?.stateMatrix?.[index][notifierIndex],
-                    reasonTypeIndex: index,
-                    notifierIndex: notifierIndex,
-                  })
-                "
-              />
-            </td>
-          </tr>
+            <HasPermission :permissions="reasonType.uiPermissions || []">
+              <tr>
+                <td
+                  class="whitespace-nowrap px-4 py-3 text-sm font-medium text-gray-900"
+                >
+                  {{ reasonType.displayName }}
+                </td>
+                <td
+                  v-for="(notifier, notifierIndex) in data?.notifiers"
+                  :key="notifier.name"
+                  class="whitespace-nowrap px-4 py-3 text-sm text-gray-500"
+                >
+                  <VSwitch
+                    :model-value="data?.stateMatrix?.[index][notifierIndex]"
+                    :loading="
+                      mutating &&
+                      variables?.reasonTypeIndex === index &&
+                      variables?.notifierIndex === notifierIndex
+                    "
+                    @change="
+                      mutate({
+                        state: !data?.stateMatrix?.[index][notifierIndex],
+                        reasonTypeIndex: index,
+                        notifierIndex: notifierIndex,
+                      })
+                    "
+                  />
+                </td>
+              </tr>
+            </HasPermission>
+          </template>
         </tbody>
       </table>
     </div>


### PR DESCRIPTION
#### What type of PR is this?

/kind feature
/area core
/area console
/milestone 2.12.x

#### What this PR does / why we need it:

为通知类型设置添加 UI 权限判断。

#### Which issue(s) this PR fixes:

Fixes https://github.com/halo-dev/halo/issues/4728

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
为通知类型设置添加 UI 权限判断。
```
