### PR TITLE
Fix the problem of unable to enable/disable 2FA for non-admin users

### DIFF
--- a/application/src/main/resources/extensions/role-template-authenticated.yaml
+++ b/application/src/main/resources/extensions/role-template-authenticated.yaml
@@ -127,7 +127,7 @@ metadata:
     halo.run/hidden: "true"
 rules:
   - apiGroups: [ "api.security.halo.run" ]
-    resources: [ "authentications", "authentications/totp" ]
+    resources: [ "authentications", "authentications/totp", "authentications/settings" ]
     verbs: [ "*" ]
 ---
 apiVersion: v1alpha1


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/area core
/milestone 2.12.0

#### What this PR does / why we need it:

This PR fixes the problem of unable to enable/disable 2FA for non-admin users. See https://github.com/halo-dev/halo/issues/5287 for more.

The problem is caused by <https://github.com/halo-dev/halo/pull/4737>.

#### Which issue(s) this PR fixes:

Fixes https://github.com/halo-dev/halo/issues/5287

#### Does this PR introduce a user-facing change?

```release-note
None
```
