### PR TITLE
fix: issue of non-template roles being displayed in personal token roles

### DIFF
--- a/console/src/constants/labels.ts
+++ b/console/src/constants/labels.ts
@@ -6,6 +6,7 @@ export enum pluginLabels {
 // role
 export enum roleLabels {
   TEMPLATE = "halo.run/role-template",
+  HIDDEN = "halo.run/hidden",
   SYSTEM_RESERVED = "rbac.authorization.halo.run/system-reserved",
 }
 

--- a/console/uc-src/modules/profile/components/PersonalAccessTokenCreationModal.vue
+++ b/console/uc-src/modules/profile/components/PersonalAccessTokenCreationModal.vue
@@ -7,11 +7,11 @@ import { Dialog, Toast, VButton, VModal, VSpace } from "@halo-dev/components";
 import { useMutation, useQueryClient } from "@tanstack/vue-query";
 import { useClipboard } from "@vueuse/core";
 import type { PatSpec, PersonalAccessToken } from "@halo-dev/api-client";
-import { ref } from "vue";
+import { computed, ref } from "vue";
 import { useRoleTemplateSelection } from "@/composables/use-role";
 import { useRoleStore } from "@/stores/role";
-import { toRefs } from "vue";
 import { useI18n } from "vue-i18n";
+import { roleLabels } from "@/constants/labels";
 
 const queryClient = useQueryClient();
 const { t } = useI18n();
@@ -45,8 +45,17 @@ const formState = ref<
 
 const { permissions } = useRoleStore();
 
+const availableRoleTemplates = computed(() => {
+  return permissions.permissions.filter((role) => {
+    return (
+      role.metadata.labels?.[roleLabels.TEMPLATE] === "true" &&
+      role.metadata.labels?.[roleLabels.HIDDEN] !== "true"
+    );
+  });
+});
+
 const { roleTemplateGroups, handleRoleTemplateSelect, selectedRoleTemplates } =
-  useRoleTemplateSelection(toRefs(permissions).permissions);
+  useRoleTemplateSelection(availableRoleTemplates);
 
 const { copy } = useClipboard({
   legacy: true,


### PR DESCRIPTION
#### What type of PR is this?

/area console
/kind bug
/milestone 2.12.0

#### What this PR does / why we need it:

修复个人令牌创建表单中，角色设置显示了非模板角色的问题。

#### Which issue(s) this PR fixes:

Fixes #5288 

#### Does this PR introduce a user-facing change?

```release-note
修复个人令牌创建表单中，角色设置显示了非模板角色的问题。
```
