### PR TITLE
fix: preserve white spaces when parsing the default editor

### DIFF
--- a/console/packages/editor/src/dev/App.vue
+++ b/console/packages/editor/src/dev/App.vue
@@ -112,6 +112,9 @@ const editor = useEditor({
     ExtensionListKeymap,
     ExtensionSearchAndReplace,
   ],
+  parseOptions: {
+    preserveWhitespace: true,
+  },
   onUpdate: () => {
     content.value = editor.value?.getHTML() + "";
   },

--- a/console/src/components/editor/DefaultEditor.vue
+++ b/console/src/components/editor/DefaultEditor.vue
@@ -392,6 +392,9 @@ onMounted(() => {
       ExtensionSearchAndReplace,
     ],
     autofocus: "start",
+    parseOptions: {
+      preserveWhitespace: true,
+    },
     onUpdate: () => {
       debounceOnUpdate();
     },


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/area editor
/area console
/milestone 2.12.x

#### What this PR does / why we need it:

在默认富文本编辑器解析文本时，使其保留空白符。

see https://prosemirror.net/docs/ref/#model.ParseOptions.preserveWhitespace

#### How to test it?

1. 输入一串文字，在其开始、结束、内容中分别键入空白字符。
2. 保存内容
3. 刷新页面，查看空白字符是否保留。

#### Which issue(s) this PR fixes:

Fixes #5260 

#### Does this PR introduce a user-facing change?
```release-note
解决默认富文本编辑器内容刷新后空白字符丢失的问题
```
