### PR TITLE
feat: enhance additional web filter with scope and portal interception

### DIFF
--- a/api/src/main/java/run/halo/app/security/AdditionalWebFilter.java
+++ b/api/src/main/java/run/halo/app/security/AdditionalWebFilter.java
@@ -22,4 +22,14 @@ public interface AdditionalWebFilter extends WebFilter, ExtensionPoint, Ordered 
     default int getOrder() {
         return Ordered.LOWEST_PRECEDENCE;
     }
+
+    default Scope getScope() {
+        return Scope.PROTECTED_API;
+    }
+
+    enum Scope {
+        PROTECTED_API,
+        PORTAL,
+        ALL
+    }
 }


### PR DESCRIPTION
#### What type of PR is this?
/kind improvement
/area core
/milestone 2.13.x

#### What this PR does / why we need it:
增强 AdditionalWebFilter 扩展点支持 Scope 属性并支持拦截门户请求

#### Which issue(s) this PR fixes:
Fixes #5300

#### Does this PR introduce a user-facing change?
```release-note
增强 AdditionalWebFilter 扩展点支持 Scope 属性并支持拦截门户请求
```
