### PR TITLE
Support building Docker image with major version tag

### DIFF
--- a/.github/actions/docker-buildx-push/action.yaml
+++ b/.github/actions/docker-buildx-push/action.yaml
@@ -41,8 +41,9 @@ runs:
           type=schedule,pattern=nightly-{{date 'YYYYMMDD'}},enabled=${{ github.event_name == 'schedule' }}
           type=ref,event=branch,enabled=${{ github.event_name == 'push' }}
           type=ref,event=pr,enabled=${{ github.event_name == 'pull_request' }}
-          type=semver,pattern={{ version }}
+          type=semver,pattern={{major}}
           type=semver,pattern={{major}}.{{minor}}
+          type=semver,pattern={{ version }}
           type=sha,enabled=${{ github.event_name == 'push' }}
         flavor: |
           latest=false


### PR DESCRIPTION
#### What type of PR is this?

/kind improvement
/area core
/milestone 2.13.x

#### What this PR does / why we need it:

This PR supports building Docker image with major version tag, e.g.: `halohub/halo:2`.

#### Which issue(s) this PR fixes:

Fixes https://github.com/halo-dev/halo/issues/4976

#### Does this PR introduce a user-facing change?

```release-note
None
```
