### PR TITLE
fix: failure in data query due to reconciler triggered by uncommitted transaction

### DIFF
--- a/application/src/main/java/run/halo/app/config/HaloConfiguration.java
+++ b/application/src/main/java/run/halo/app/config/HaloConfiguration.java
@@ -6,6 +6,8 @@ import org.springframework.boot.autoconfigure.jackson.Jackson2ObjectMapperBuilde
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.transaction.ReactiveTransactionManager;
+import org.springframework.transaction.reactive.TransactionalOperator;
 
 @Configuration(proxyBeanMethods = false)
 @EnableAsync
@@ -17,5 +19,10 @@ public class HaloConfiguration {
             builder.serializationInclusion(JsonInclude.Include.NON_NULL);
             builder.featuresToEnable(MapperFeature.ACCEPT_CASE_INSENSITIVE_ENUMS);
         };
+    }
+
+    @Bean
+    TransactionalOperator transactionTemplate(ReactiveTransactionManager transactionManager) {
+        return TransactionalOperator.create(transactionManager);
     }
 }

--- a/application/src/main/java/run/halo/app/config/HaloConfiguration.java
+++ b/application/src/main/java/run/halo/app/config/HaloConfiguration.java
@@ -6,8 +6,6 @@ import org.springframework.boot.autoconfigure.jackson.Jackson2ObjectMapperBuilde
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.scheduling.annotation.EnableAsync;
-import org.springframework.transaction.ReactiveTransactionManager;
-import org.springframework.transaction.reactive.TransactionalOperator;
 
 @Configuration(proxyBeanMethods = false)
 @EnableAsync
@@ -19,10 +17,5 @@ public class HaloConfiguration {
             builder.serializationInclusion(JsonInclude.Include.NON_NULL);
             builder.featuresToEnable(MapperFeature.ACCEPT_CASE_INSENSITIVE_ENUMS);
         };
-    }
-
-    @Bean
-    TransactionalOperator transactionTemplate(ReactiveTransactionManager transactionManager) {
-        return TransactionalOperator.create(transactionManager);
     }
 }

--- a/application/src/test/java/run/halo/app/extension/ReactiveExtensionClientTest.java
+++ b/application/src/test/java/run/halo/app/extension/ReactiveExtensionClientTest.java
@@ -36,6 +36,7 @@ import org.mockito.Mock;
 import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.transaction.ReactiveTransactionManager;
 import org.springframework.transaction.reactive.TransactionalOperator;
 import reactor.core.Exceptions;
 import reactor.core.publisher.Flux;
@@ -65,7 +66,7 @@ class ReactiveExtensionClientTest {
     IndexerFactory indexerFactory;
 
     @Mock
-    TransactionalOperator transactionalOperator;
+    ReactiveTransactionManager reactiveTransactionManager;
 
     @Spy
     ObjectMapper objectMapper = JsonMapper.builder()
@@ -80,6 +81,8 @@ class ReactiveExtensionClientTest {
         lenient().when(schemeManager.get(eq(FakeExtension.class)))
             .thenReturn(fakeScheme);
         lenient().when(schemeManager.get(eq(fakeScheme.groupVersionKind()))).thenReturn(fakeScheme);
+        var transactionalOperator = mock(TransactionalOperator.class);
+        client.setTransactionalOperator(transactionalOperator);
         lenient().when(transactionalOperator.transactional(any(Mono.class)))
             .thenAnswer(invocation -> invocation.getArgument(0));
     }

--- a/application/src/test/java/run/halo/app/extension/ReactiveExtensionClientTest.java
+++ b/application/src/test/java/run/halo/app/extension/ReactiveExtensionClientTest.java
@@ -36,6 +36,7 @@ import org.mockito.Mock;
 import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.transaction.reactive.TransactionalOperator;
 import reactor.core.Exceptions;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
@@ -63,6 +64,9 @@ class ReactiveExtensionClientTest {
     @Mock
     IndexerFactory indexerFactory;
 
+    @Mock
+    TransactionalOperator transactionalOperator;
+
     @Spy
     ObjectMapper objectMapper = JsonMapper.builder()
         .addModule(new JavaTimeModule())
@@ -76,6 +80,8 @@ class ReactiveExtensionClientTest {
         lenient().when(schemeManager.get(eq(FakeExtension.class)))
             .thenReturn(fakeScheme);
         lenient().when(schemeManager.get(eq(fakeScheme.groupVersionKind()))).thenReturn(fakeScheme);
+        lenient().when(transactionalOperator.transactional(any(Mono.class)))
+            .thenAnswer(invocation -> invocation.getArgument(0));
     }
 
     FakeExtension createFakeExtension(String name, Long version) {


### PR DESCRIPTION
#### What type of PR is this?
/kind bugfix
/milestone 2.12.x
/area core

#### What this PR does / why we need it:
修复事务未提交便触发控制器执行可能导致数据状态不正确的问题

**how to test it?**
1. 测试如 #5315 的问题是否还存在
2. 测试添加重名自定义模型对象会抛出异常且数据被回滚

#### Which issue(s) this PR fixes:
Fixes #5315

#### Does this PR introduce a user-facing change?
```release-note
修复事务未提交便触发控制器执行可能导致数据状态不正确的问题
```
