### PR TITLE
Bump actions' versions for muting warning from GitHub workflow

### DIFF
--- a/.github/actions/docker-buildx-push/action.yaml
+++ b/.github/actions/docker-buildx-push/action.yaml
@@ -48,9 +48,9 @@ runs:
         flavor: |
           latest=false
     - name: Set up QEMU
-      uses: docker/setup-qemu-action@v2
+      uses: docker/setup-qemu-action@v3
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v2
+      uses: docker/setup-buildx-action@v3
     - name: Login to GHCR
       uses: docker/login-action@v3
       if: inputs.ghcr-token != '' && github.event_name != 'pull_request'
@@ -60,7 +60,7 @@ runs:
         password: ${{ inputs.ghcr-token }}
     - name: Login to DockerHub
       if: inputs.dockerhub-token != '' && github.event_name != 'pull_request'
-      uses: docker/login-action@v2
+      uses: docker/login-action@v3
       with:
         username: ${{ inputs.dockerhub-user }}
         password: ${{ inputs.dockerhub-token }}

--- a/.github/actions/setup-env/action.yaml
+++ b/.github/actions/setup-env/action.yaml
@@ -20,31 +20,17 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - name: Set up Node.js
-      uses: actions/setup-node@v3
-      with:
-        node-version: ${{ inputs.node-version }}
-
     - uses: pnpm/action-setup@v2
       name: Setup pnpm
-      id: pnpm-install
       with:
         version: ${{ inputs.pnpm-version }}
-        run_install: false
 
-    - name: Get pnpm store directory
-      id: pnpm-cache
-      shell: bash
-      run: |
-        echo "STORE_PATH=$(pnpm store path)" >> $GITHUB_OUTPUT
-
-    - uses: actions/cache@v3
-      name: Setup pnpm cache
+    - name: Set up Node.js
+      uses: actions/setup-node@v4
       with:
-        path: ${{ steps.pnpm-cache.outputs.STORE_PATH}}
-        key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
-        restore-keys: |
-          ${{ runner.os }}-pnpm-store-
+        node-version: ${{ inputs.node-version }}
+        cache: 'pnpm'
+        cache-dependency-path: 'ui/pnpm-lock.yaml'
 
     - name: Setup JDK
       uses: actions/setup-java@v4
@@ -52,10 +38,3 @@ runs:
         distribution: "temurin"
         cache: "gradle"
         java-version: ${{ inputs.java-version }}
-
-    - name: Cache SonarCloud packages
-      uses: actions/cache@v3
-      with:
-        path: ~/.sonar/cache
-        key: ${{ runner.os }}-sonar
-        restore-keys: ${{ runner.os }}-sonar

--- a/.github/workflows/halo.yaml
+++ b/.github/workflows/halo.yaml
@@ -24,20 +24,20 @@ jobs:
     if: github.event_name == 'pull_request' || github.event_name == 'push'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Setup Environment
         uses: ./.github/actions/setup-env
       - name: Check Halo
         run: ./gradlew check
       - name: Upload coverage reports to Codecov
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v4
 
   build:
     runs-on: ubuntu-latest
     if: always() && (needs.test.result == 'skipped' || needs.test.result == 'success')
     needs: test
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Setup Environment
         uses: ./.github/actions/setup-env
       - name: Reset version of Halo
@@ -62,7 +62,7 @@ jobs:
     if: always() && needs.build.result == 'success' && github.event_name == 'release'
     needs: build
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Download Artifacts
         uses: actions/download-artifact@v4
         with:
@@ -78,7 +78,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: build
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Download Artifacts
         uses: actions/download-artifact@v4
         with:
@@ -99,7 +99,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: build
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Download Artifacts
         uses: actions/download-artifact@v4
         with:


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup
/area core
/milestone 2.13.x

#### What this PR does / why we need it:

Recently, I noticed that there are a few warnings from GitHub actions, please see the annotations below:

```log
Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: actions/checkout@v3, actions/setup-node@v3, pnpm/action-setup@v2, actions/cache@v3, codecov/codecov-action@v3. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.
```

According to [the instruction](https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/), I bump actions' verisons which have adapted to node 20.

However, only `pnpm/action-setup` hasn't adapted to node 20 yet, see https://github.com/pnpm/action-setup/issues/99 for more.

#### Does this PR introduce a user-facing change?

```release-note
None
```
