### PR TITLE
Upgrade Halo runtime environment to JRE 21

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM eclipse-temurin:17-jre as builder
+FROM eclipse-temurin:21-jre as builder
 
 WORKDIR application
 ARG JAR_FILE=application/build/libs/*.jar
@@ -7,7 +7,7 @@ RUN java -Djarmode=layertools -jar application.jar extract
 
 ################################
 
-FROM ibm-semeru-runtimes:open-17-jre
+FROM ibm-semeru-runtimes:open-21-jre
 MAINTAINER johnniang <johnniang@fastmail.com>
 WORKDIR application
 COPY --from=builder application/dependencies/ ./


### PR DESCRIPTION
#### What type of PR is this?

/kind improvement
/area core
/milestone 2.13.x

#### What this PR does / why we need it:

Last month, Eclipse has released [OpenJ9 0.42](https://projects.eclipse.org/projects/technology.openj9/releases/0.42.0) supported Java 21. It's time for Halo to run JRE 21.

Closes https://github.com/halo-dev/halo/issues/4929

#### Does this PR introduce a user-facing change?

```release-note
升级 Halo 运行环境至 JRE 21
```
