### PR TITLE
Move username-password authentication into security filter chain

### DIFF
--- a/application/src/main/resources/extensions/extension-definitions.yaml
+++ b/application/src/main/resources/extensions/extension-definitions.yaml
@@ -1,9 +1,11 @@
+# TODO Remove the username-password-authenticator in the future.
 apiVersion: plugin.halo.run/v1alpha1
 kind: ExtensionDefinition
 metadata:
   name: username-password-authenticator
   labels:
     auth.halo.run/extension-point-name: "additional-webfilter"
+  deletionTimestamp: 2024-02-18T08:27:41.257531Z
 spec:
   className: run.halo.app.security.authentication.login.UsernamePasswordAuthenticator
   extensionPointName: additional-webfilter


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup
/area core
/milestone 2.13.x

#### What this PR does / why we need it:

UsernamePasswordAuthenticator is a normal webfilter instead of authentication webfilter in security filter chain. There does not guarentee expected results due to different in execution order. So this PR changes UsernamePasswordAuthenticator to AuthenticationWebFilter for managing the filter by security filter chain.

By the way, these changes will not affect any plugins.

#### Does this PR introduce a user-facing change?

```release-note
None
```
