### PR TITLE
fix: fix the error when saving settings for posts in the uc

### DIFF
--- a/ui/uc-src/modules/contents/posts/PostEditor.vue
+++ b/ui/uc-src/modules/contents/posts/PostEditor.vue
@@ -378,9 +378,9 @@ const { mutateAsync: handlePublish, isLoading: isPublishing } = useMutation({
 // Post setting
 const postSettingEditModal = ref(false);
 
-function handleOpenPostSettingEditModal() {
+async function handleOpenPostSettingEditModal() {
   handleSave({ mute: true });
-  getLatestPost();
+  await getLatestPost();
   postSettingEditModal.value = true;
 }
 

--- a/ui/uc-src/modules/contents/posts/PostEditor.vue
+++ b/ui/uc-src/modules/contents/posts/PostEditor.vue
@@ -121,12 +121,7 @@ const name = useRouteQuery<string | undefined>("name");
 
 onMounted(async () => {
   if (name.value) {
-    const { data: post } = await apiClient.uc.post.getMyPost({
-      name: name.value,
-    });
-
-    formState.value = post;
-
+    await getLatestPost();
     await handleFetchContent();
     handleResetCache();
     return;
@@ -188,6 +183,17 @@ useAutoSaveContent(currentCache, toRef(content.value, "raw"), async () => {
     onCreatePostSuccess(createdPost);
   }
 });
+
+async function getLatestPost() {
+  if (!name.value) {
+    return;
+  }
+  const { data: latestPost } = await apiClient.uc.post.getMyPost({
+    name: name.value,
+  });
+
+  formState.value = latestPost;
+}
 
 /**
  * Fetch content from the head snapshot.
@@ -374,6 +380,7 @@ const postSettingEditModal = ref(false);
 
 function handleOpenPostSettingEditModal() {
   handleSave({ mute: true });
+  getLatestPost();
   postSettingEditModal.value = true;
 }
 


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/area ui

#### What this PR does / why we need it:

在个人中心的文章功能中，点击设置时并不会重新获取最新的 Post 数据，进而导致点击保存时的 `version` 并非最新版本而报错。
此 PR 将在个人中心的文章页面点击设置时，额外增加一次获取最新的 Post 数据的请求，用于解决此问题。

#### How to test it?

1. 进入个人中心
2. 点击文章菜单
3. 点击右上角创建按钮
4. 在编辑器中随便输入内容
5. 点击保存
6. 修改文章的设置后点击保存。
7. 关闭设置框，再次打开设置框，然后点击保存。
8. 查看是否会出现无法保存的问题。

#### Which issue(s) this PR fixes:

Fixes #5344 

#### Does this PR introduce a user-facing change?
```release-note
解决个人中心文章设置时报错的问题
```
