### PR TITLE
Fix the problem of being unable to login when 2FA was enabled but TOTP was not configured

### DIFF
--- a/application/src/main/java/run/halo/app/security/authentication/twofactor/TwoFactorAuthSettings.java
+++ b/application/src/main/java/run/halo/app/security/authentication/twofactor/TwoFactorAuthSettings.java
@@ -17,6 +17,6 @@ public class TwoFactorAuthSettings {
      * @return true if 2FA is enabled and configured, false otherwise.
      */
     public boolean isAvailable() {
-        return enabled && (emailVerified || totpConfigured);
+        return enabled && totpConfigured;
     }
 }

--- a/application/src/test/java/run/halo/app/security/authentication/twofactor/TwoFactorAuthSettingsTest.java
+++ b/application/src/test/java/run/halo/app/security/authentication/twofactor/TwoFactorAuthSettingsTest.java
@@ -1,0 +1,41 @@
+package run.halo.app.security.authentication.twofactor;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
+
+import java.util.stream.Stream;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+class TwoFactorAuthSettingsTest {
+
+    @ParameterizedTest
+    @MethodSource("isAvailableCases")
+    void isAvailableTest(TwoFactorAuthSettings settings, boolean expectAvailable) {
+        assertEquals(expectAvailable, settings.isAvailable());
+    }
+
+    static Stream<Arguments> isAvailableCases() {
+        return Stream.of(
+            arguments(settings(false, true, true), false),
+            arguments(settings(false, false, false), false),
+            arguments(settings(false, false, true), false),
+            arguments(settings(false, true, false), false),
+            arguments(settings(true, true, true), true),
+            arguments(settings(true, false, false), false),
+            arguments(settings(true, false, true), true),
+            arguments(settings(true, true, false), false)
+        );
+    }
+
+    static TwoFactorAuthSettings settings(boolean enabled, boolean emailVerified,
+        boolean totpConfigured) {
+        var settings = new TwoFactorAuthSettings();
+        settings.setEnabled(enabled);
+        settings.setEmailVerified(emailVerified);
+        settings.setTotpConfigured(totpConfigured);
+        return settings;
+    }
+
+}


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/area core
/milestone 2.13.x

#### What this PR does / why we need it:

This PR ignored `email verified` status while 2FA was enabled.

#### Which issue(s) this PR fixes:

Fixes https://github.com/halo-dev/halo/issues/5398

#### Does this PR introduce a user-facing change?

```release-note
修复开启两步验证但未配置 TOTP 可能无法登录的问题
```
