### PR TITLE
fix: missing code validation label in signup form

### DIFF
--- a/ui/src/components/signup/SignupForm.vue
+++ b/ui/src/components/signup/SignupForm.vue
@@ -208,6 +208,7 @@ const sendVerifyCodeButtonText = computed(() => {
       type="number"
       name="code"
       :placeholder="$t('core.signup.fields.verify_code.placeholder')"
+      :validation-label="$t('core.signup.fields.verify_code.placeholder')"
       validation="required"
     >
       <template #suffix>


### PR DESCRIPTION
#### What type of PR is this?

/area ui
/kind bug
/milestone 2.13.0

#### What this PR does / why we need it:

修复注册表单中，验证码的验证提示文字无法显示表单项标题的问题。

before:

<img width="333" alt="image" src="https://github.com/halo-dev/halo/assets/21301288/14f640ce-8e81-4dd4-84e5-d74ca4830a96">

after:

<img width="307" alt="image" src="https://github.com/halo-dev/halo/assets/21301288/f4eb2c30-40b4-4275-bd20-a49771c4bc0f">

#### Does this PR introduce a user-facing change?

```release-note
None
```
