### PR TITLE
fix: error editing post when img component has file attribute

### DIFF
--- a/ui/src/components/editor/extensions/image/index.ts
+++ b/ui/src/components/editor/extensions/image/index.ts
@@ -22,9 +22,6 @@ const Image = ExtensionImage.extend<UiImageOptions>({
   addAttributes() {
     return {
       ...this.parent?.(),
-      file: {
-        default: null,
-      },
       width: {
         default: "100%",
         parseHTML: (element) => {
@@ -49,6 +46,15 @@ const Image = ExtensionImage.extend<UiImageOptions>({
           return {
             height: attributes.height,
           };
+        },
+      },
+      file: {
+        default: null,
+        renderHTML() {
+          return {};
+        },
+        parseHTML() {
+          return null;
         },
       },
     };

--- a/ui/src/components/editor/extensions/video/index.ts
+++ b/ui/src/components/editor/extensions/video/index.ts
@@ -24,6 +24,12 @@ const Video = ExtensionVideo.extend<UiVideoOptions>({
       ...this.parent?.(),
       file: {
         default: null,
+        renderHTML() {
+          return {};
+        },
+        parseHTML() {
+          return null;
+        },
       },
     };
   },


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/area editor
/area ui
/milestone 2.14.x

#### What this PR does / why we need it:

使用默认编辑器时，当图片、视频中具有 `file` 属性时，进入编辑界面时会报错。此 PR 将不再从渲染后的 HTML 中获取 file 属性，并且在渲染 HTML 时，抛弃掉 file 属性用于解决这个问题。

#### How to test it?

测试图片上传、视频上传功能不受影响即可。

#### Which issue(s) this PR fixes:

Fixes #5430 

#### Does this PR introduce a user-facing change?
```release-note
修复进入文章页面会偶现错误提示的问题
```
