### PR TITLE
fix: rich text editor reuploads images or videos repeatedly during redraws

### DIFF
--- a/ui/src/components/editor/extensions/image/ImageView.vue
+++ b/ui/src/components/editor/extensions/image/ImageView.vue
@@ -97,6 +97,7 @@ const resetUpload = () => {
     props.updateAttributes({
       width: undefined,
       height: undefined,
+      file: undefined,
     });
   }
 };

--- a/ui/src/components/editor/extensions/video/VideoView.vue
+++ b/ui/src/components/editor/extensions/video/VideoView.vue
@@ -57,6 +57,7 @@ const resetUpload = () => {
     props.updateAttributes({
       width: undefined,
       height: undefined,
+      file: undefined,
     });
   }
 };


### PR DESCRIPTION
#### What type of PR is this?

/area editor
/area ui
/kind bug
/milestone 2.14.x

#### What this PR does / why we need it:

在当前富文本编辑器中，当做出使图片、视频等组件需要重绘的事件时，会导致已经上传的文件重复上传。
本 PR 在上传完成后，将图片、视频组件 `file` 设置为空，用于解决此问题。

#### How to test it?

1. 使用复制、粘贴的方式在富文本编辑器中添加图片、视频
2. 将上传的图片、视频所处位置进行变更（需要向当前位置往后移动）。
3. 查看已上传的图片、视频是否会重复上传。

#### Which issue(s) this PR fixes:

Fixes #5436 

#### Does this PR introduce a user-facing change?
```release-note
解决富文本编辑器中已上传的图片及视频会重复上传的问题
```
