### PR TITLE
Mark the security policy for version 1.x as unsupported

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -11,7 +11,7 @@ Halo currently supports the versions listed below, where as:
 | Version | Supported          |
 | ------- | ------------------ |
 | 0.x     | :x:                |
-| 1.x     | :white_check_mark: |
+| 1.x     | :x:                |
 | 2.x     | :white_check_mark: |
 
 ## Reporting a Vulnerability


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Not long ago, we announced the cessation of maintenance for 1.x at <https://www.halo.run/archives/halo-1.x-eol>. So we also need to to synchronize changes to security policies.

#### Does this PR introduce a user-facing change?

```release-note
None
```
