### PR TITLE
fix: query mismatch with non-intersecting OR and nested AND condition

### DIFF
--- a/api/src/main/java/run/halo/app/extension/index/query/And.java
+++ b/api/src/main/java/run/halo/app/extension/index/query/And.java
@@ -25,8 +25,6 @@ public class And extends LogicalQuery {
         NavigableSet<String> resultSet = null;
         for (Query query : childQueries) {
             NavigableSet<String> currentResult = query.matches(indexView);
-            // Trim unneeded rows to shrink the dataset for the next query
-            indexView.removeByIdNotIn(currentResult);
             if (resultSet == null) {
                 resultSet = Sets.newTreeSet(currentResult);
             } else {

--- a/api/src/test/java/run/halo/app/extension/index/query/AndTest.java
+++ b/api/src/test/java/run/halo/app/extension/index/query/AndTest.java
@@ -94,4 +94,23 @@ public class AndTest {
         var resultSet = query.matches(indexView);
         assertThat(resultSet).containsExactly("100");
     }
+
+    @Test
+    void orAndMatch() {
+        var indexView = IndexViewDataSet.createEmployeeIndexView();
+        // test the case when the data matched by the query does not intersect with the data
+        // matched by the and query
+        // or(query, and(otherQuery1, otherQuery2))
+        var query = or(
+            // matched with id 101
+            and(equal("lastName", "Day"), equal("managerId", "102")),
+            // matched with id 100, 103
+            and(
+                equal("hireDate", "17"),
+                greaterThan("salary", "1800")
+            )
+        );
+        var resultSet = query.matches(indexView);
+        assertThat(resultSet).containsExactly("100", "101", "103");
+    }
 }


### PR DESCRIPTION
#### What type of PR is this?
/kind bug
/area core
/milestone 2.14.x

#### What this PR does / why we need it:
修复了索引查询使用含有 OR 条件嵌套 AND 条件时若匹配数据集间无交集导致的查询结果不正确的问题

如伪查询：`or(query, and(otherQuery1, otherQuery2))`
问题描述：当 `query` 匹配的结果与 `and(otherQuery1, otherQuery2)` 匹配的结果无交集时 and 会将自身不匹配的数据剔除导致 `query` 无法匹配到而出现缺少数据的问题


#### Does this PR introduce a user-facing change?

```release-note
None
```
