### PR TITLE
pref: remove nofollow from the default editor link

### DIFF
--- a/ui/packages/editor/src/extensions/link/index.ts
+++ b/ui/packages/editor/src/extensions/link/index.ts
@@ -2,6 +2,17 @@ import TiptapLink from "@tiptap/extension-link";
 import type { LinkOptions } from "@tiptap/extension-link";
 import type { ExtensionOptions } from "@/types";
 
-const Link = TiptapLink.extend<ExtensionOptions & LinkOptions>();
+const Link = TiptapLink.extend<ExtensionOptions & LinkOptions>({
+  addOptions() {
+    return {
+      ...this.parent?.(),
+      ...{
+        HTMLAttributes: {
+          rel: null,
+        },
+      },
+    };
+  },
+});
 
 export default Link;


### PR DESCRIPTION
#### What type of PR is this?

/kind improvement
/area editor
/area ui
/milestone 2.14.x

#### What this PR does / why we need it:

将默认富文本编辑器中的链接中的 rel 属性由默认的 `noopener noreferrer nofollow` 属性改为 null，优化 SEO 。
 
#### How to test it?

查看使用默认富文本编辑器创建的链接，其 rel 属性是否不再是 `noopener noreferrer nofollow`

#### Which issue(s) this PR fixes:

Fixes #5328 

#### Does this PR introduce a user-facing change?
```release-note
移除默认富文本编辑器中链接的 nofollow 等属性，优化 SEO。
```
