### PR TITLE
fix: error occurs when the link is purely numerical

### DIFF
--- a/ui/packages/editor/src/extensions/link/index.ts
+++ b/ui/packages/editor/src/extensions/link/index.ts
@@ -1,7 +1,30 @@
 import TiptapLink from "@tiptap/extension-link";
 import type { LinkOptions } from "@tiptap/extension-link";
 import type { ExtensionOptions } from "@/types";
+import { mergeAttributes } from "@/tiptap/vue-3";
 
-const Link = TiptapLink.extend<ExtensionOptions & LinkOptions>();
+const Link = TiptapLink.extend<ExtensionOptions & LinkOptions>({
+  renderHTML({ HTMLAttributes }) {
+    const href = HTMLAttributes.href;
+    // False positive; we're explicitly checking for javascript: links to ignore them
+    // eslint-disable-next-line no-script-url
+    if (href?.toString().startsWith("javascript:")) {
+      // strip out the href
+      return [
+        "a",
+        mergeAttributes(this.options.HTMLAttributes, {
+          ...HTMLAttributes,
+          href: "",
+        }),
+        0,
+      ];
+    }
+    return [
+      "a",
+      mergeAttributes(this.options.HTMLAttributes, HTMLAttributes),
+      0,
+    ];
+  },
+});
 
 export default Link;


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/area editor
/area ui
/milestone 2.14.x

#### What this PR does / why we need it:

在默认的富文本编辑器中，使用了 [tiptap link](https://github.com/ueberdosis/tiptap/blob/b3ef574f3dd92852bc4dac24a82eb360db96c9c3/packages/extension-link/src/link.ts#L127C3-L135C5) ，而其中的 renderHTML 会对 href 进行处理，但当链接为纯数字的时候，`HTMLAttributes.href` 将不会有 `startsWith` 方法。

此 PR 将在解析 renderHTML 时，将 `HTMLAttributes.href` 转为 string，进而解决这个问题。

#### How to test it?

测试使用默认富文本编辑器时，编写一个链接，并将其设置为纯数字。
刷新页面，查看是否具有报错。

#### Which issue(s) this PR fixes:

Fixes #5478 

#### Does this PR introduce a user-facing change?
```release-note
解决在默认富文本编辑器中当链接为纯数字时报错的问题
```
