### PR TITLE
fix: missing notifier descriptors permissions in notification role template

### DIFF
--- a/application/src/main/resources/extensions/role-template-notification.yaml
+++ b/application/src/main/resources/extensions/role-template-notification.yaml
@@ -4,12 +4,14 @@ metadata:
   name: role-template-notifier-config
   labels:
     halo.run/role-template: "true"
+    halo.run/hidden: "true"
   annotations:
     rbac.authorization.halo.run/module: "Notification Configuration"
     rbac.authorization.halo.run/display-name: "Configure Notifier"
-    rbac.authorization.halo.run/ui-permissions: |
-      ["system:notifier:configuration"]
 rules:
+  - apiGroups: [ "notification.halo.run" ]
+    resources: [ "notifierDescriptors" ]
+    verbs: [ "*" ]
   - apiGroups: [ "api.console.halo.run" ]
     resources: [ "notifiers/sender-config" ]
     verbs: [ "get", "update" ]

--- a/application/src/main/resources/extensions/role-template-setting.yaml
+++ b/application/src/main/resources/extensions/role-template-setting.yaml
@@ -5,11 +5,11 @@ metadata:
   labels:
     halo.run/role-template: "true"
   annotations:
-    rbac.authorization.halo.run/dependencies: "[ \"role-template-view-settings\" ]"
+    rbac.authorization.halo.run/dependencies: "[ \"role-template-view-settings\", \"role-template-notifier-config\" ]"
     rbac.authorization.halo.run/module: "Settings Management"
     rbac.authorization.halo.run/display-name: "Setting Manage"
     rbac.authorization.halo.run/ui-permissions: |
-      ["system:settings:manage"]
+      ["system:settings:manage", "system:notifier:configuration"]
 rules:
   - apiGroups: [ "" ]
     resources: [ "settings" ]

--- a/ui/src/locales/en.yaml
+++ b/ui/src/locales/en.yaml
@@ -1367,7 +1367,7 @@ core:
     Cache Management: Cache
     Cache Manage: Cache Manage
     Notification Configuration: Notification Configuration
-    Configure Notifier: Configure Notifier
+    role-template-notifier-config: Configure Notifier
     Post Attachment Manager: Allow images to be uploaded in posts
     Post Author: Allows you to manage your own posts
     Post Contributor: Contributions allowed

--- a/ui/src/locales/zh-CN.yaml
+++ b/ui/src/locales/zh-CN.yaml
@@ -1315,7 +1315,7 @@ core:
     Cache Management: 缓存
     Cache Manage: 缓存管理
     Notification Configuration: 通知配置
-    Configure Notifier: 配置通知器
+    role-template-notifier-config: 配置通知器
     Post Contributor: 允许投稿
     Post Author: 允许管理自己的文章
     Post Attachment Manager: 允许在文章中上传图片

--- a/ui/src/locales/zh-TW.yaml
+++ b/ui/src/locales/zh-TW.yaml
@@ -1280,7 +1280,7 @@ core:
     Actuator Manage: 訪問系統指標
     Cache Management: 緩存
     Cache Manage: 緩存管理
-    Configure Notifier: 配置通知器
+    role-template-notifier-config: 配置通知器
     Notification Configuration: 通知配置
     Post Attachment Manager: 允許在文章中上傳圖片
     Post Author: 允許管理自己的文章


### PR DESCRIPTION
#### What type of PR is this?
/kind bug
/area core
/milestone 2.14.x

#### What this PR does / why we need it:
修复分配通知器权限时一片空白的问题

- 隐藏了原先权限中展示的通知器配置权限选项
- 系统设置的权限中依赖了通知器配置权限,但需要有系统设置管理权限才会展示通知配置的 Tab

Fixes #5492

#### Does this PR introduce a user-facing change?
```release-note
修复仅拥有通知器配置权限时无法修改配置的问题
```
