### PR TITLE
fix: default sort policy of attachment groups

### DIFF
--- a/ui/console-src/modules/contents/attachments/composables/use-attachment-group.ts
+++ b/ui/console-src/modules/contents/attachments/composables/use-attachment-group.ts
@@ -17,6 +17,7 @@ export function useFetchAttachmentGroup(): useFetchAttachmentGroupReturn {
         await apiClient.extension.storage.group.liststorageHaloRunV1alpha1Group(
           {
             labelSelector: ["!halo.run/hidden"],
+            sort: ["metadata.creationTimestamp,asc"],
           }
         );
       return data.items;

--- a/ui/src/formkit/inputs/attachment-group-select.ts
+++ b/ui/src/formkit/inputs/attachment-group-select.ts
@@ -7,6 +7,7 @@ function optionsHandler(node: FormKitNode) {
     const { data } =
       await apiClient.extension.storage.group.liststorageHaloRunV1alpha1Group({
         labelSelector: ["!halo.run/hidden"],
+        sort: ["metadata.creationTimestamp,desc"],
       });
 
     node.props.options = data.items.map((group) => {


### PR DESCRIPTION
#### What type of PR is this?

/area ui
/kind bug
/milestone 2.14.0

#### What this PR does / why we need it:

为附件分组设置默认排序规则（按照创建时间升序），和 2.13.0 版本之间保持一致。

#### Which issue(s) this PR fixes:

Fixes https://github.com/halo-dev/halo/issues/5429

#### Special notes for your reviewer:

测试方式：

1. 创建若干附件分组。
2. 观察排序是否符合预期。

#### Does this PR introduce a user-facing change?

```release-note
修复附件管理中的分组排序不固定的问题。
```
