### PR TITLE
Set source and target compatibility to Java 17

### DIFF
--- a/api/build.gradle
+++ b/api/build.gradle
@@ -8,6 +8,11 @@ plugins {
 group = 'run.halo.app'
 description = 'API of halo project, connecting by other projects.'
 
+java {
+    sourceCompatibility = JavaVersion.VERSION_17
+    targetCompatibility = JavaVersion.VERSION_17
+}
+
 compileJava.options.encoding = "UTF-8"
 compileTestJava.options.encoding = "UTF-8"
 javadoc.options.encoding = "UTF-8"

--- a/application/build.gradle
+++ b/application/build.gradle
@@ -18,9 +18,8 @@ compileJava.options.encoding = 'UTF-8'
 compileTestJava.options.encoding = 'UTF-8'
 
 java {
-    toolchain {
-        languageVersion = JavaLanguageVersion.of(17)
-    }
+    sourceCompatibility = JavaVersion.VERSION_17
+    targetCompatibility = JavaVersion.VERSION_17
 }
 
 checkstyle {


### PR DESCRIPTION
#### What type of PR is this?

/kind chore
/area core

#### What this PR does / why we need it:

I get the following errors when I develop Halo in JDK 21:

```bash
FAILURE: Build failed with an exception.

* What went wrong:
Could not determine the dependencies of task ':application:bootRun'.
> Could not resolve all dependencies for configuration ':application:runtimeClasspath'.
   > Failed to calculate the value of task ':application:compileJava' property 'javaCompiler'.
      > No matching toolchains found for requested specification: {languageVersion=17, vendor=any, implementation=vendor-specific} for MAC_OS on aarch64.
         > No locally installed toolchains match and toolchain download repositories have not been configured.
```

This PR removes the Java toolchain configuration and adds source and target compatibility to Java 17, allowing developers to develop Halo in Java 17 or higher versions.

#### Does this PR introduce a user-facing change?

```release-note
None
```
