### PR TITLE
feat: add support for fetching replies alongside comment list

### DIFF
--- a/application/src/main/java/run/halo/app/theme/finders/CommentPublicQueryService.java
+++ b/application/src/main/java/run/halo/app/theme/finders/CommentPublicQueryService.java
@@ -6,6 +6,7 @@ import run.halo.app.extension.ListResult;
 import run.halo.app.extension.PageRequest;
 import run.halo.app.extension.Ref;
 import run.halo.app.theme.finders.vo.CommentVo;
+import run.halo.app.theme.finders.vo.CommentWithReplyVo;
 import run.halo.app.theme.finders.vo.ReplyVo;
 
 /**
@@ -20,6 +21,9 @@ public interface CommentPublicQueryService {
         @Nullable Integer size);
 
     Mono<ListResult<CommentVo>> list(Ref ref, @Nullable PageRequest pageRequest);
+
+    Mono<ListResult<CommentWithReplyVo>> convertToWithReplyVo(ListResult<CommentVo> comments,
+        int replySize);
 
     Mono<ListResult<ReplyVo>> listReply(String commentName, @Nullable Integer page,
         @Nullable Integer size);

--- a/application/src/main/java/run/halo/app/theme/finders/vo/CommentVo.java
+++ b/application/src/main/java/run/halo/app/theme/finders/vo/CommentVo.java
@@ -3,9 +3,9 @@ package run.halo.app.theme.finders.vo;
 import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
 
 import io.swagger.v3.oas.annotations.media.Schema;
-import lombok.Builder;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
+import lombok.experimental.Accessors;
 import run.halo.app.content.comment.OwnerInfo;
 import run.halo.app.core.extension.content.Comment;
 import run.halo.app.extension.MetadataOperator;
@@ -17,7 +17,7 @@ import run.halo.app.extension.MetadataOperator;
  * @since 2.0.0
  */
 @Data
-@Builder
+@Accessors(chain = true)
 @EqualsAndHashCode
 public class CommentVo implements ExtensionVoOperator {
 
@@ -42,10 +42,9 @@ public class CommentVo implements ExtensionVoOperator {
      * @return a value object for {@link Comment}
      */
     public static CommentVo from(Comment comment) {
-        return CommentVo.builder()
-            .metadata(comment.getMetadata())
-            .spec(comment.getSpec())
-            .status(comment.getStatus())
-            .build();
+        return new CommentVo()
+            .setMetadata(comment.getMetadata())
+            .setSpec(comment.getSpec())
+            .setStatus(comment.getStatus());
     }
 }

--- a/application/src/main/java/run/halo/app/theme/finders/vo/CommentWithReplyVo.java
+++ b/application/src/main/java/run/halo/app/theme/finders/vo/CommentWithReplyVo.java
@@ -1,0 +1,31 @@
+package run.halo.app.theme.finders.vo;
+
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.experimental.Accessors;
+import org.springframework.beans.BeanUtils;
+import run.halo.app.extension.ListResult;
+
+/**
+ * <p>A value object for comment with reply.</p>
+ *
+ * @author guqing
+ * @since 2.14.0
+ */
+@Data
+@Accessors(chain = true)
+@EqualsAndHashCode(callSuper = true)
+public class CommentWithReplyVo extends CommentVo {
+
+    private ListResult<ReplyVo> replies;
+
+    /**
+     * Convert {@link CommentVo} to {@link CommentWithReplyVo}.
+     */
+    public static CommentWithReplyVo from(CommentVo commentVo) {
+        var commentWithReply = new CommentWithReplyVo();
+        BeanUtils.copyProperties(commentVo, commentWithReply);
+        commentWithReply.setReplies(ListResult.emptyResult());
+        return commentWithReply;
+    }
+}


### PR DESCRIPTION
#### What type of PR is this?
/kind feature
/area core
/milestone 2.14.x
/kind api-change

#### What this PR does / why we need it:
主题端评论列表支持同时获得评论数据

Resolves #5435

#### Does this PR introduce a user-facing change?
```release-note
主题端评论列表支持同时获得评论数据
```
