### PR TITLE
revert: changes to the return value type of And query

### DIFF
--- a/api/src/main/java/run/halo/app/extension/index/query/QueryFactory.java
+++ b/api/src/main/java/run/halo/app/extension/index/query/QueryFactory.java
@@ -120,7 +120,7 @@ public class QueryFactory {
         return new And(queries);
     }
 
-    public static Query and(Query query1, Query query2) {
+    public static And and(Query query1, Query query2) {
         Collection<Query> queries = Arrays.asList(query1, query2);
         return new And(queries);
     }


### PR DESCRIPTION
#### What type of PR is this?
/area core
/milestone 2.14.x

#### What this PR does / why we need it:
撤销 https://github.com/halo-dev/halo/pull/5453/files#diff-0577b8395b1acb8e87aff2150dfe0bd15b6768c433d73d9cf43ced91d8debc4cR123 中对 And query 返回值类型的更改 这会导致插件中用到这个方法的地方出现类型不兼容问题

see also https://github.com/halo-sigs/plugin-moments/issues/89

#### Does this PR introduce a user-facing change?
```release-note
None
```
