### PR TITLE
fix: FormKit code input type error

### DIFF
--- a/ui/env.d.ts
+++ b/ui/env.d.ts
@@ -119,5 +119,10 @@ declare module "@formkit/inputs" {
       type: "menuCheckbox";
       value?: string[];
     };
+
+    code: {
+      type: "code";
+      value?: string;
+    };
   }
 }


### PR DESCRIPTION
#### What type of PR is this?

/area ui
/kind bug
/milestone 2.14.0

#### What this PR does / why we need it:

修复 FormKit 中 code 输入框的类型异常，在此之前如果这样使用：

```vue
<FormKit type="code" v-model="text" />
```

那么 v-model 的类型会不正确。

#### Does this PR introduce a user-facing change?

```release-note
None
```
