### PR TITLE
fix: duplicate scroller issue in post edit page

### DIFF
--- a/ui/packages/editor/src/components/Editor.vue
+++ b/ui/packages/editor/src/components/Editor.vue
@@ -37,7 +37,7 @@ watch(
     <editor-bubble-menu :editor="editor" />
     <editor-header :editor="editor" />
     <div class="h-full flex flex-row w-full overflow-hidden">
-      <div class="overflow-y-auto flex-1 bg-white">
+      <div class="overflow-y-auto flex-1 bg-white relative">
         <div v-if="$slots.content" class="editor-header-extra">
           <slot name="content" />
         </div>


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/area editor
/milestone 2.14.x

#### What this PR does / why we need it:

在默认富文本编辑器下，当滚动时有概率会使页面小于正常大小。在文章最底部使用 AI 插件更加容易复现。

#### How to test it?

测试文章滚动时是否会小于正常大小，推荐在文章最底部使用 AI 插件来复现和测试。

#### Which issue(s) this PR fixes:

Fixes #3853 

#### Does this PR introduce a user-facing change?
```release-note
修复文章编辑页面出现多个滚动条导致的页面高度样式问题。
```
