### PR TITLE
feat: add image editor feature for attachment upload component

### DIFF
--- a/ui/console-src/modules/contents/attachments/components/AttachmentUploadModal.vue
+++ b/ui/console-src/modules/contents/attachments/components/AttachmentUploadModal.vue
@@ -1,10 +1,10 @@
 <script lang="ts" setup>
 import {
-  VModal,
   IconAddCircle,
   VAlert,
   VDropdown,
   VDropdownItem,
+  VModal,
 } from "@halo-dev/components";
 import { ref, watch } from "vue";
 import type { Policy, PolicyTemplate } from "@halo-dev/api-client";
@@ -119,6 +119,7 @@ watch(
     :body-class="['!p-0']"
     :visible="visible"
     :width="650"
+    :centered="false"
     :title="$t('core.attachment.upload_modal.title')"
     @update:visible="onVisibleChange"
   >

--- a/ui/package.json
+++ b/ui/package.json
@@ -64,6 +64,7 @@
     "@uppy/dashboard": "^3.7.1",
     "@uppy/drag-drop": "^3.0.3",
     "@uppy/file-input": "^3.0.4",
+    "@uppy/image-editor": "^2.4.4",
     "@uppy/locales": "^3.5.0",
     "@uppy/progress-bar": "^3.0.4",
     "@uppy/status-bar": "^3.2.5",

--- a/ui/pnpm-lock.yaml
+++ b/ui/pnpm-lock.yaml
@@ -89,6 +89,9 @@ importers:
       '@uppy/file-input':
         specifier: ^3.0.4
         version: 3.0.4(@uppy/core@3.8.0)
+      '@uppy/image-editor':
+        specifier: ^2.4.4
+        version: 2.4.4(@uppy/core@3.8.0)
       '@uppy/locales':
         specifier: ^3.5.0
         version: 3.5.0
@@ -5618,7 +5621,7 @@ packages:
       ts-dedent: 2.2.0
       type-fest: 2.19.0
       vue: 3.4.19(typescript@5.3.3)
-      vue-component-type-helpers: 2.0.6
+      vue-component-type-helpers: 2.0.7
     transitivePeerDependencies:
       - encoding
       - supports-color
@@ -6698,6 +6701,17 @@ packages:
       preact: 10.11.2
     dev: false
 
+  /@uppy/image-editor@2.4.4(@uppy/core@3.8.0):
+    resolution: {integrity: sha512-ASjv2Mh4mhlhkh1isDvIj3tlbERG77jo/ETwtajRSERGV6Ga9w1QGG7vL19bmNW9McHPFMZvOKNojAgv4SAtPg==}
+    peerDependencies:
+      '@uppy/core': ^3.9.3
+    dependencies:
+      '@uppy/core': 3.8.0
+      '@uppy/utils': 5.7.4
+      cropperjs: 1.5.7
+      preact: 10.11.2
+    dev: false
+
   /@uppy/informer@3.0.4(@uppy/core@3.8.0):
     resolution: {integrity: sha512-gzocdxn8qAFsW2EryehwjghladaBgv6Isjte53FTBV7o/vjaHPP6huKGbYpljyuQi8i9V+KrmvNGslofssgJ4g==}
     peerDependencies:
@@ -6772,6 +6786,13 @@ packages:
 
   /@uppy/utils@5.7.0:
     resolution: {integrity: sha512-AJj7gAx5YfMgyevwOxVdIP2h4Nw/O6h57wKA6gj+Lce6tMORcqzGt4yQiKBsrBI0bPyFWCbzA3vX5t0//1JCBA==}
+    dependencies:
+      lodash: 4.17.21
+      preact: 10.11.2
+    dev: false
+
+  /@uppy/utils@5.7.4:
+    resolution: {integrity: sha512-0Xsr7Xqdrb9mgfY3hi0YdhIaAxUw6qJasAflNMwNsyLGt3kH4pLfQHucolBKfWglVGtk1vfb49hZYvJGpcpzYA==}
     dependencies:
       lodash: 4.17.21
       preact: 10.11.2
@@ -8761,6 +8782,10 @@ packages:
 
   /cropperjs@1.5.13:
     resolution: {integrity: sha512-by7jKAo73y5/Do0K6sxdTKHgndY0NMjG2bEdgeJxycbcmHuCiMXqw8sxy5C5Y5WTOTcDGmbT7Sr5CgKOXR06OA==}
+    dev: false
+
+  /cropperjs@1.5.7:
+    resolution: {integrity: sha512-sGj+G/ofKh+f6A4BtXLJwtcKJgMUsXYVUubfTo9grERiDGXncttefmue/fyQFvn8wfdyoD1KhDRYLfjkJFl0yw==}
     dev: false
 
   /cross-spawn@5.1.0:
@@ -17566,8 +17591,8 @@ packages:
     resolution: {integrity: sha512-0vOfAtI67UjeO1G6UiX5Kd76CqaQ67wrRZiOe7UAb9Jm6GzlUr/fC7CV90XfwapJRjpCMaZFhv1V0ajWRmE9Dg==}
     dev: true
 
-  /vue-component-type-helpers@2.0.6:
-    resolution: {integrity: sha512-qdGXCtoBrwqk1BT6r2+1Wcvl583ZVkuSZ3or7Y1O2w5AvWtlvvxwjGhmz5DdPJS9xqRdDlgTJ/38ehWnEi0tFA==}
+  /vue-component-type-helpers@2.0.7:
+    resolution: {integrity: sha512-7e12Evdll7JcTIocojgnCgwocX4WzIYStGClBQ+QuWPinZo/vQolv2EMq4a3lg16TKfwWafLimG77bxb56UauA==}
     dev: true
 
   /vue-demi@0.13.11(vue@3.4.19):

--- a/ui/src/locales/en.yaml
+++ b/ui/src/locales/en.yaml
@@ -1462,6 +1462,16 @@ core:
     editor_provider_selector:
       tooltips:
         disallow: The content format is different and cannot be switched
+    uppy:
+      image_editor:
+        revert: "Revert"
+        rotate: "Rotate"
+        zoom_in: "Zoom in"
+        zoom_out: "Zoom out"
+        flip_horizontal: "Flip horizontal"
+        aspect_ratio_square: "Crop square"
+        aspect_ratio_landscape: "Crop landscape (16:9)"
+        aspect_ratio_portrait: "Crop portrait (9:16)"
   composables:
     content_cache:
       toast_recovered: Recovered unsaved content from cache

--- a/ui/src/locales/zh-CN.yaml
+++ b/ui/src/locales/zh-CN.yaml
@@ -1408,6 +1408,16 @@ core:
     editor_provider_selector:
       tooltips:
         disallow: 内容格式不同，无法切换
+    uppy:
+      image_editor:
+        revert: "恢复"
+        rotate: "旋转"
+        zoom_in: "放大"
+        zoom_out: "缩小"
+        flip_horizontal: "水平翻转"
+        aspect_ratio_square: "裁剪为正方形"
+        aspect_ratio_landscape: "裁剪为横向 (16:9)"
+        aspect_ratio_portrait: "裁剪为纵向 (9:16)"
   composables:
     content_cache:
       toast_recovered: 已从缓存中恢复未保存的内容

--- a/ui/src/locales/zh-TW.yaml
+++ b/ui/src/locales/zh-TW.yaml
@@ -1374,6 +1374,16 @@ core:
     editor_provider_selector:
       tooltips:
         disallow: 內容格式不同，無法切換
+    uppy:
+      image_editor:
+        revert: "還原"
+        rotate: "旋轉"
+        zoom_in: "放大"
+        zoom_out: "縮小"
+        flip_horizontal: "水平翻轉"
+        aspect_ratio_square: "裁剪為正方形"
+        aspect_ratio_landscape: "裁剪為橫向 (16:9)"
+        aspect_ratio_portrait: "裁剪為縱向 (9:16)"
   composables:
     content_cache:
       toast_recovered: 已從緩存中恢復未保存的內容


### PR DESCRIPTION
#### What type of PR is this?

/area ui
/kind feature
/milestone 2.14.x

#### What this PR does / why we need it:

为上传附件的组件添加基本的图片编辑功能。

<img width="747" alt="image" src="https://github.com/halo-dev/halo/assets/21301288/6816e045-ae4a-4d26-b3a4-23494fb39d5f">

#### Which issue(s) this PR fixes:

Fixes #5583 


#### Does this PR introduce a user-facing change?

```release-note
为上传附件的组件添加基本的图片编辑功能。
```
