### PR TITLE
fix: selecting the previous post leads to a negative page

### DIFF
--- a/ui/console-src/modules/contents/posts/PostList.vue
+++ b/ui/console-src/modules/contents/posts/PostList.vue
@@ -197,7 +197,7 @@ const handleSelectPrevious = async () => {
     selectedPost.value = previousPost;
     return;
   }
-  if (index === 0 && hasPrevious) {
+  if (index === 0 && hasPrevious.value) {
     page.value--;
     await refetch();
     selectedPost.value = posts.value[posts.value.length - 1].post;


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/area ui

#### What this PR does / why we need it:

修复当选中首个文章设置时，点击上一个还可以继续修改 `page` 的问题。

#### How to test it?

测试选中首个文章设置之后，点击上一个是否不再修改 `page` 值

#### Which issue(s) this PR fixes:

Fixes #5475 

#### Does this PR introduce a user-facing change?
```release-note
修复在文章列表设置中可以无限点击上一个的问题
```
