### PR TITLE
refactor: hide the custom annotations form by defaults

### DIFF
--- a/ui/src/components/form/AnnotationsForm.vue
+++ b/ui/src/components/form/AnnotationsForm.vue
@@ -1,11 +1,14 @@
 <script lang="ts" setup>
 import {
-  reset,
-  submitForm,
   type FormKitNode,
   type FormKitSchemaCondition,
   type FormKitSchemaNode,
+  reset,
+  submitForm,
 } from "@formkit/core";
+
+import { IconArrowRight } from "@halo-dev/components";
+
 import { computed, nextTick, onMounted, ref, watch } from "vue";
 import { apiClient } from "@/utils/api-client";
 import type { AnnotationSetting } from "@halo-dev/api-client";
@@ -13,6 +16,7 @@ import { cloneDeep } from "lodash-es";
 import { getValidationMessages } from "@formkit/validation";
 import { useThemeStore } from "@console/stores/theme";
 import { randomUUID } from "@/utils/id";
+import { useSessionStorage } from "@vueuse/core";
 
 const themeStore = useThemeStore();
 
@@ -196,6 +200,12 @@ defineExpose({
   annotations,
   customAnnotations,
 });
+
+const showCustomForm = useSessionStorage("annotations-show-custom-form", false);
+
+function onCustomFormToggle(e: Event) {
+  showCustomForm.value = (e.target as HTMLDetailsElement).open;
+}
 </script>
 
 <template>
@@ -219,34 +229,67 @@ defineExpose({
         />
       </template>
     </FormKit>
-    <FormKit
-      v-if="annotations"
-      :id="customFormId"
-      type="form"
-      :preserve="true"
-      :form-class="`${avaliableAnnotationSettings.length ? 'py-4' : ''}`"
-      @submit-invalid="onCustomFormSubmitCheck"
-      @submit="customFormInvalid = false"
+
+    <details
+      :open="showCustomForm"
+      class="flex cursor-pointer space-y-4 py-4 transition-all first:pt-0"
+      @toggle="onCustomFormToggle"
     >
+      <summary class="group flex items-center justify-between">
+        <div class="block text-sm font-medium text-gray-700">
+          {{ $t("core.common.buttons.view_more") }}
+        </div>
+        <div
+          class="-mr-1 inline-flex items-center justify-center rounded-full p-1 group-hover:bg-gray-100"
+          :class="{ 'bg-gray-100': showCustomForm }"
+        >
+          <IconArrowRight
+            :class="{ 'rotate-90 !text-gray-900': showCustomForm }"
+            class="text-gray-600 transition-all"
+          />
+        </div>
+      </summary>
+
       <FormKit
-        v-model="customAnnotationsState"
-        type="repeater"
-        :label="$t('core.components.annotations_form.custom_fields.label')"
+        v-if="annotations"
+        :id="customFormId"
+        type="form"
+        :preserve="true"
+        :form-class="`${avaliableAnnotationSettings.length ? 'py-4' : ''}`"
+        @submit-invalid="onCustomFormSubmitCheck"
+        @submit="customFormInvalid = false"
       >
         <FormKit
-          type="text"
-          label="Key"
-          name="key"
-          validation="required:trim|keyValidationRule"
-          :validation-rules="{ keyValidationRule }"
-          :validation-messages="{
-            keyValidationRule: $t(
-              'core.components.annotations_form.custom_fields.validation'
-            ),
-          }"
-        ></FormKit>
-        <FormKit type="text" label="Value" name="value" value=""></FormKit>
+          v-model="customAnnotationsState"
+          type="repeater"
+          :label="$t('core.components.annotations_form.custom_fields.label')"
+        >
+          <FormKit
+            type="text"
+            label="Key"
+            name="key"
+            validation="required:trim|keyValidationRule"
+            :validation-rules="{ keyValidationRule }"
+            :validation-messages="{
+              keyValidationRule: $t(
+                'core.components.annotations_form.custom_fields.validation'
+              ),
+            }"
+          ></FormKit>
+          <FormKit type="text" label="Value" name="value" value=""></FormKit>
+        </FormKit>
       </FormKit>
-    </FormKit>
+    </details>
   </div>
 </template>
+
+<style scoped>
+details > summary {
+  list-style: none;
+}
+
+/** Hide the default marker **/
+details > summary::-webkit-details-marker {
+  display: none;
+}
+</style>

--- a/ui/src/components/form/AnnotationsForm.vue
+++ b/ui/src/components/form/AnnotationsForm.vue
@@ -16,7 +16,6 @@ import { cloneDeep } from "lodash-es";
 import { getValidationMessages } from "@formkit/validation";
 import { useThemeStore } from "@console/stores/theme";
 import { randomUUID } from "@/utils/id";
-import { useSessionStorage } from "@vueuse/core";
 
 const themeStore = useThemeStore();
 
@@ -201,7 +200,7 @@ defineExpose({
   customAnnotations,
 });
 
-const showCustomForm = useSessionStorage("annotations-show-custom-form", false);
+const showCustomForm = ref(false);
 
 function onCustomFormToggle(e: Event) {
   showCustomForm.value = (e.target as HTMLDetailsElement).open;
@@ -237,7 +236,13 @@ function onCustomFormToggle(e: Event) {
     >
       <summary class="group flex items-center justify-between">
         <div class="block text-sm font-medium text-gray-700">
-          {{ $t("core.common.buttons.view_more") }}
+          {{
+            $t(
+              showCustomForm
+                ? "core.components.annotations_form.buttons.collapse"
+                : "core.components.annotations_form.buttons.expand"
+            )
+          }}
         </div>
         <div
           class="-mr-1 inline-flex items-center justify-center rounded-full p-1 group-hover:bg-gray-100"

--- a/ui/src/locales/en.yaml
+++ b/ui/src/locales/en.yaml
@@ -1464,14 +1464,14 @@ core:
         disallow: The content format is different and cannot be switched
     uppy:
       image_editor:
-        revert: "Revert"
-        rotate: "Rotate"
-        zoom_in: "Zoom in"
-        zoom_out: "Zoom out"
-        flip_horizontal: "Flip horizontal"
-        aspect_ratio_square: "Crop square"
-        aspect_ratio_landscape: "Crop landscape (16:9)"
-        aspect_ratio_portrait: "Crop portrait (9:16)"
+        revert: Revert
+        rotate: Rotate
+        zoom_in: Zoom in
+        zoom_out: Zoom out
+        flip_horizontal: Flip horizontal
+        aspect_ratio_square: Crop square
+        aspect_ratio_landscape: Crop landscape (16:9)
+        aspect_ratio_portrait: Crop portrait (9:16)
   composables:
     content_cache:
       toast_recovered: Recovered unsaved content from cache
@@ -1524,6 +1524,7 @@ core:
       verify: Verify
       modify: Modify
       access: Access
+      view_more: View more
     radio:
       "yes": "Yes"
       "no": "No"

--- a/ui/src/locales/en.yaml
+++ b/ui/src/locales/en.yaml
@@ -1381,6 +1381,9 @@ core:
       custom_fields:
         label: Custom
         validation: The current Key is already in use
+      buttons:
+        expand: View more
+        collapse: Collapse
     default_editor:
       tabs:
         toc:
@@ -1524,7 +1527,6 @@ core:
       verify: Verify
       modify: Modify
       access: Access
-      view_more: View more
     radio:
       "yes": "Yes"
       "no": "No"

--- a/ui/src/locales/zh-CN.yaml
+++ b/ui/src/locales/zh-CN.yaml
@@ -1329,6 +1329,9 @@ core:
       custom_fields:
         label: 自定义
         validation: 当前 Key 已被占用
+      buttons:
+        expand: 查看更多
+        collapse: 收起
     default_editor:
       tabs:
         toc:
@@ -1470,7 +1473,6 @@ core:
       verify: 验证
       modify: 修改
       access: 访问
-      view_more: 查看更多
     radio:
       "yes": 是
       "no": 否

--- a/ui/src/locales/zh-CN.yaml
+++ b/ui/src/locales/zh-CN.yaml
@@ -1410,14 +1410,14 @@ core:
         disallow: 内容格式不同，无法切换
     uppy:
       image_editor:
-        revert: "恢复"
-        rotate: "旋转"
-        zoom_in: "放大"
-        zoom_out: "缩小"
-        flip_horizontal: "水平翻转"
-        aspect_ratio_square: "裁剪为正方形"
-        aspect_ratio_landscape: "裁剪为横向 (16:9)"
-        aspect_ratio_portrait: "裁剪为纵向 (9:16)"
+        revert: 恢复
+        rotate: 旋转
+        zoom_in: 放大
+        zoom_out: 缩小
+        flip_horizontal: 水平翻转
+        aspect_ratio_square: 裁剪为正方形
+        aspect_ratio_landscape: 裁剪为横向 (16:9)
+        aspect_ratio_portrait: 裁剪为纵向 (9:16)
   composables:
     content_cache:
       toast_recovered: 已从缓存中恢复未保存的内容
@@ -1470,6 +1470,7 @@ core:
       verify: 验证
       modify: 修改
       access: 访问
+      view_more: 查看更多
     radio:
       "yes": 是
       "no": 否

--- a/ui/src/locales/zh-TW.yaml
+++ b/ui/src/locales/zh-TW.yaml
@@ -1376,14 +1376,14 @@ core:
         disallow: 內容格式不同，無法切換
     uppy:
       image_editor:
-        revert: "還原"
-        rotate: "旋轉"
-        zoom_in: "放大"
-        zoom_out: "縮小"
-        flip_horizontal: "水平翻轉"
-        aspect_ratio_square: "裁剪為正方形"
-        aspect_ratio_landscape: "裁剪為橫向 (16:9)"
-        aspect_ratio_portrait: "裁剪為縱向 (9:16)"
+        revert: 還原
+        rotate: 旋轉
+        zoom_in: 放大
+        zoom_out: 縮小
+        flip_horizontal: 水平翻轉
+        aspect_ratio_square: 裁剪為正方形
+        aspect_ratio_landscape: 裁剪為橫向 (16:9)
+        aspect_ratio_portrait: 裁剪為縱向 (9:16)
   composables:
     content_cache:
       toast_recovered: 已從緩存中恢復未保存的內容
@@ -1436,6 +1436,7 @@ core:
       modify: 修改
       verify: 驗證
       access: 訪問
+      view_more: 查看更多
     radio:
       "yes": 是
       "no": 否

--- a/ui/src/locales/zh-TW.yaml
+++ b/ui/src/locales/zh-TW.yaml
@@ -1295,6 +1295,9 @@ core:
       custom_fields:
         label: 自定義
         validation: 當前 Key 已被占用
+      buttons:
+        expand: 查看更多
+        collapse: 收起
     default_editor:
       tabs:
         toc:
@@ -1436,7 +1439,6 @@ core:
       modify: 修改
       verify: 驗證
       access: 訪問
-      view_more: 查看更多
     radio:
       "yes": 是
       "no": 否


### PR DESCRIPTION
#### What type of PR is this?

/area ui
/kind improvement
/milestone 2.14.x

#### What this PR does / why we need it:

默认隐藏自定义元数据表单，通常这不会让用户自行修改，默认显示反而会给使用者造成心智负担。

<img width="807" alt="image" src="https://github.com/halo-dev/halo/assets/21301288/f80813e2-00c8-483e-bb16-fe4671c5450e">

#### Which issue(s) this PR fixes:

Fixes https://github.com/halo-dev/halo/issues/5439

#### Does this PR introduce a user-facing change?

```release-note
默认隐藏文章设置等界面的自定义元数据表单。
```
