### PR TITLE
fix: wrong router navigation when redirect to /uc

### DIFF
--- a/ui/console-src/router/guards/auth-check.ts
+++ b/ui/console-src/router/guards/auth-check.ts
@@ -52,7 +52,7 @@ export function setupAuthCheckGuard(router: Router) {
         return;
       }
 
-      if (whiteList.includes(to.name)) {
+      if (to.name && whiteList.includes(to.name as string)) {
         next();
         return;
       }

--- a/ui/console-src/router/guards/auth-check.ts
+++ b/ui/console-src/router/guards/auth-check.ts
@@ -2,7 +2,7 @@ import { rbacAnnotations } from "@/constants/annotations";
 import { useUserStore } from "@/stores/user";
 import type { Router } from "vue-router";
 
-const whiteList = ["Setup", "Login", "Binding", "ResetPassword"];
+const whiteList = ["Setup", "Login", "Binding", "ResetPassword", "Redirect"];
 
 export function setupAuthCheckGuard(router: Router) {
   router.beforeEach((to, from, next) => {
@@ -52,7 +52,7 @@ export function setupAuthCheckGuard(router: Router) {
         return;
       }
 
-      if (to.name === "whiteList") {
+      if (whiteList.includes(to.name)) {
         next();
         return;
       }


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/area ui

#### What this PR does / why we need it:

修复当角色勾选禁止访问 Console 后，redirect_uri 参数无效的问题

#### How to test it?

测试角色禁止访问 console 时，当链接中携带 redirect_uri 参数，能否正常跳转

#### Which issue(s) this PR fixes:

Fixes #5417 

#### Does this PR introduce a user-facing change?
```release-note
修复当角色禁止访问 Console 后，redirect_uri 参数无效的问题
```
