### PR TITLE
chore: update display name of default attachment policy

### DIFF
--- a/application/src/main/resources/extensions/attachment-local-policy.yaml
+++ b/application/src/main/resources/extensions/attachment-local-policy.yaml
@@ -3,7 +3,7 @@ kind: PolicyTemplate
 metadata:
   name: local
 spec:
-  displayName: Local Storage
+  displayName: 本地存储
   settingName: local-policy-template-setting
 ---
 apiVersion: storage.halo.run/v1alpha1


### PR DESCRIPTION
#### What type of PR is this?

/area core
/kind improvement
/milestone 2.14.0

#### What this PR does / why we need it:

在 Halo 完成动态数据的 i18n 之前，使用中文描述存储策略名称。

Ref https://github.com/halo-dev/plugin-s3/pull/128

#### Does this PR introduce a user-facing change?

```release-note
将默认存储策略模板的显示名称改为中文
```
