### PR TITLE
pref: limit the datetime year of the post or page to four digits

### DIFF
--- a/ui/console-src/modules/contents/pages/components/SinglePageSettingModal.vue
+++ b/ui/console-src/modules/contents/pages/components/SinglePageSettingModal.vue
@@ -421,6 +421,8 @@ const { handleGenerateSlug } = useSlugify(
               :label="$t('core.page.settings.fields.publish_time.label')"
               type="datetime-local"
               name="publishTime"
+              min="0000-01-01T00:00"
+              max="9999-12-31T23:59"
             ></FormKit>
             <FormKit
               v-model="formState.spec.template"

--- a/ui/console-src/modules/contents/posts/components/PostSettingModal.vue
+++ b/ui/console-src/modules/contents/posts/components/PostSettingModal.vue
@@ -395,6 +395,8 @@ const { handleGenerateSlug } = useSlugify(
               v-model="publishTime"
               :label="$t('core.post.settings.fields.publish_time.label')"
               type="datetime-local"
+              min="0000-01-01T00:00"
+              max="9999-12-31T23:59"
             ></FormKit>
             <FormKit
               v-model="formState.spec.template"

--- a/ui/uc-src/modules/contents/posts/components/PostSettingForm.vue
+++ b/ui/uc-src/modules/contents/posts/components/PostSettingForm.vue
@@ -187,6 +187,8 @@ const { handleGenerateSlug } = useSlugify(
             name="publishTime"
             :label="$t('core.post.settings.fields.publish_time.label')"
             type="datetime-local"
+            min="0000-01-01T00:00"
+            max="9999-12-31T23:59"
           ></FormKit>
           <HasPermission :permissions="['system:attachments:view']">
             <FormKit


### PR DESCRIPTION
#### What type of PR is this?

/kind improvement
/area ui

#### What this PR does / why we need it:

限定文章或页面中的发布日期中的年份为四位数，方便用户输入四位年份之后自定跳转至月份。

#### How to test it?

测试在 `chrome` 上输入四位年份之后，是否会自动跳转至月份。

#### Which issue(s) this PR fixes:

Fixes #5630 

#### Does this PR introduce a user-facing change?
```release-note
限定文章或页面中的发布日期中的年份为四位数
```
