### PR TITLE
chore: update reviewers for OWNERS file

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -2,9 +2,7 @@ reviewers:
 - ruibaby
 - guqing
 - JohnNiang
-- lan-yonghui
 - wan92hen
-- minliacom
 - LIlGG
 
 approvers:


### PR DESCRIPTION
#### What this PR does / why we need it:
更新 Prow 的 OWNERS 中关于 reviewers 的配置

#### Does this PR introduce a user-facing change?
```release-note
None
```
