### PR TITLE
feat: hide registration-related options when allowRegistration is disabled

### DIFF
--- a/application/src/main/resources/extensions/system-setting.yaml
+++ b/application/src/main/resources/extensions/system-setting.yaml
@@ -104,6 +104,7 @@ spec:
         - $formkit: checkbox
           name: mustVerifyEmailOnRegistration
           label: "注册需验证邮箱"
+          if: "$get(allowRegistration).value === true"
           help: "需要确保已经正确配置邮件通知器"
           value: false
         - $formkit: roleSelect

--- a/application/src/main/resources/extensions/system-setting.yaml
+++ b/application/src/main/resources/extensions/system-setting.yaml
@@ -97,6 +97,8 @@ spec:
       formSchema:
         - $formkit: checkbox
           name: allowRegistration
+          id: allowRegistration
+          key: allowRegistration
           label: "开放注册"
           value: false
         - $formkit: checkbox
@@ -107,6 +109,8 @@ spec:
         - $formkit: roleSelect
           name: defaultRole
           label: "默认角色"
+          validation: 'required'
+          if: "$get(allowRegistration).value === true"
           help: 用户注册之后默认为用户分配的角色
         - $formkit: attachmentPolicySelect
           name: avatarPolicy


### PR DESCRIPTION
#### What type of PR is this?

/kind improvement
/area core

#### Which issue(s) this PR fixes:

Fixes #5688 

```release-note
当未开启允许注册选项时，隐藏注册相关的其他选项。
```
