### PR TITLE
feat: add extension points for user detail tab

### DIFF
--- a/ui/console-src/modules/system/users/tabs/Detail.vue
+++ b/ui/console-src/modules/system/users/tabs/Detail.vue
@@ -5,13 +5,13 @@ import {
   VDescriptionItem,
   VTag,
 } from "@halo-dev/components";
-import type { Ref } from "vue";
-import { inject } from "vue";
 import type { DetailedUser } from "@halo-dev/api-client";
 import { rbacAnnotations } from "@/constants/annotations";
 import { formatDatetime } from "@/utils/date";
 
-const user = inject<Ref<DetailedUser | undefined>>("user");
+withDefaults(defineProps<{ user?: DetailedUser }>(), {
+  user: undefined,
+});
 </script>
 <template>
   <div class="border-t border-gray-100">

--- a/ui/packages/shared/src/index.ts
+++ b/ui/packages/shared/src/index.ts
@@ -11,3 +11,4 @@ export * from "./states/plugin-installation-tabs";
 export * from "./states/entity";
 export * from "./states/theme-list-tabs";
 export * from "./states/operation";
+export * from "./states/user-tab";

--- a/ui/packages/shared/src/states/user-tab.ts
+++ b/ui/packages/shared/src/states/user-tab.ts
@@ -1,0 +1,17 @@
+import type { Component, Raw } from "vue";
+
+export interface UserTab {
+  id: string;
+  label: string;
+  component: Raw<Component>;
+  permissions?: string[];
+  priority: number;
+}
+
+export interface UserProfileTab {
+  id: string;
+  label: string;
+  component: Raw<Component>;
+  permissions?: string[];
+  priority: number;
+}

--- a/ui/packages/shared/src/types/plugin.ts
+++ b/ui/packages/shared/src/types/plugin.ts
@@ -1,5 +1,5 @@
 import type { Component, Ref } from "vue";
-import type { RouteRecordRaw, RouteRecordName } from "vue-router";
+import type { RouteRecordName, RouteRecordRaw } from "vue-router";
 import type { FunctionalPage } from "../states/pages";
 import type { AttachmentSelectProvider } from "../states/attachment-selector";
 import type { EditorProvider, PluginTab } from "..";
@@ -17,6 +17,7 @@ import type {
   Plugin,
   Theme,
 } from "@halo-dev/api-client";
+import type { UserProfileTab, UserTab } from "@/states/user-tab";
 
 export interface RouteRecordAppend {
   parentName: RouteRecordName;
@@ -76,6 +77,12 @@ export interface ExtensionPoint {
   "theme:list-item:operation:create"?: (
     theme: Ref<Theme>
   ) => OperationItem<Theme>[] | Promise<OperationItem<Theme>[]>;
+
+  "user:detail:tabs:create"?: () => UserTab[] | Promise<UserTab[]>;
+
+  "uc:user:profile:tabs:create"?: () =>
+    | UserProfileTab[]
+    | Promise<UserProfileTab[]>;
 }
 
 export interface PluginModule {

--- a/ui/uc-src/modules/profile/tabs/Detail.vue
+++ b/ui/uc-src/modules/profile/tabs/Detail.vue
@@ -8,8 +8,7 @@ import {
   VDescriptionItem,
   VTag,
 } from "@halo-dev/components";
-import type { Ref } from "vue";
-import { inject, computed } from "vue";
+import { computed, ref } from "vue";
 import type { DetailedUser, ListedAuthProvider } from "@halo-dev/api-client";
 import { rbacAnnotations } from "@/constants/annotations";
 import { formatDatetime } from "@/utils/date";
@@ -18,9 +17,8 @@ import { apiClient } from "@/utils/api-client";
 import axios from "axios";
 import { useI18n } from "vue-i18n";
 import EmailVerifyModal from "../components/EmailVerifyModal.vue";
-import { ref } from "vue";
 
-const user = inject<Ref<DetailedUser | undefined>>("user");
+withDefaults(defineProps<{ user?: DetailedUser }>(), { user: undefined });
 
 const { t } = useI18n();
 

--- a/ui/uc-src/modules/profile/tabs/NotificationPreferences.vue
+++ b/ui/uc-src/modules/profile/tabs/NotificationPreferences.vue
@@ -1,34 +1,36 @@
 <script lang="ts" setup>
 import { apiClient } from "@/utils/api-client";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/vue-query";
-import type { DetailedUser } from "@halo-dev/api-client";
+import type {
+  DetailedUser,
+  ReasonTypeNotifierRequest,
+} from "@halo-dev/api-client";
 import { VLoading, VSwitch } from "@halo-dev/components";
-import type { Ref } from "vue";
 import { computed } from "vue";
-import { inject } from "vue";
 import { cloneDeep } from "lodash-es";
-import type { ReasonTypeNotifierRequest } from "@halo-dev/api-client";
 import HasPermission from "@/components/permission/HasPermission.vue";
 
-const queryClient = useQueryClient();
+const props = withDefaults(defineProps<{ user?: DetailedUser }>(), {
+  user: undefined,
+});
 
-const user = inject<Ref<DetailedUser | undefined>>("user");
+const queryClient = useQueryClient();
 
 const { data, isLoading } = useQuery({
   queryKey: ["notification-preferences"],
   queryFn: async () => {
-    if (!user?.value) {
-      return;
+    if (!props.user) {
+      return null;
     }
 
     const { data } =
       await apiClient.notification.listUserNotificationPreferences({
-        username: user?.value?.user.metadata.name,
+        username: props.user?.user.metadata.name,
       });
 
     return data;
   },
-  enabled: computed(() => !!user?.value),
+  enabled: computed(() => !!props.user),
 });
 
 const {
@@ -48,7 +50,7 @@ const {
   }) => {
     const preferences = cloneDeep(data.value);
 
-    if (!user?.value || !preferences) {
+    if (!props.user || !preferences) {
       return;
     }
 
@@ -78,7 +80,7 @@ const {
       .filter(Boolean) as Array<ReasonTypeNotifierRequest>;
 
     return await apiClient.notification.saveUserNotificationPreferences({
-      username: user?.value?.user.metadata.name,
+      username: props.user.user.metadata.name,
       reasonTypeNotifierCollectionRequest: {
         reasonTypeNotifiers,
       },


### PR DESCRIPTION
#### What type of PR is this?

/area ui
/kind feature
/milestone 2.15.x

#### What this PR does / why we need it:

为 Console 的用户详情页面的选项卡和个人中心的个人资料页面选项卡添加扩展点，支持通过插件扩展选项卡。

todo:

- [x] 完善 docs.halo.run 的开发文档 https://github.com/halo-dev/docs/pull/340

#### Which issue(s) this PR fixes:

Fixes https://github.com/halo-dev/halo/issues/5745

#### Special notes for your reviewer:

可以使用 [plugin-starter-1.3.2-SNAPSHOT.jar.zip](https://github.com/halo-dev/halo/files/15059291/plugin-starter-1.3.2-SNAPSHOT.jar.zip) 进行测试。

#### Does this PR introduce a user-facing change?

```release-note
为 Console 的用户详情页面的选项卡和个人中心的个人资料页面选项卡添加扩展点
```
