### PR TITLE
feat: add tab shortcut function to the default editor table

### DIFF
--- a/ui/packages/editor/src/extensions/table/index.ts
+++ b/ui/packages/editor/src/extensions/table/index.ts
@@ -16,6 +16,7 @@ import {
   type NodeView,
   type EditorState,
   type DOMOutputSpec,
+  TextSelection,
 } from "@/tiptap/pm";
 import TableCell from "./table-cell";
 import TableRow from "./table-row";
@@ -38,6 +39,8 @@ import { i18n } from "@/locales";
 import type { ExtensionOptions, NodeBubbleMenu } from "@/types";
 import { BlockActionSeparator, ToolboxItem } from "@/components";
 import {
+  findNextCell,
+  findPreviousCell,
   hasTableBefore,
   isCellSelection,
   isTableSelected,
@@ -520,6 +523,60 @@ const Table = TiptapTable.extend<ExtensionOptions & TableOptions>({
           return false;
         }
         editor.commands.setNodeSelection(cellNodePos.pos);
+        return true;
+      },
+      Tab: ({ editor }) => {
+        const { selection } = editor.state;
+        if (!isActive(editor.state, Table.name)) {
+          return false;
+        }
+        let nextView = editor.view;
+        let nextTr = editor.state.tr;
+        let nextCell = findNextCell(selection);
+        if (!nextCell) {
+          // If it is the last cell, create a new line and jump to the first cell of the new line.
+          editor
+            .chain()
+            .addRowAfter()
+            .command(({ tr, view }) => {
+              nextView = view;
+              nextTr = tr;
+              const { selection } = tr;
+              nextCell = findNextCell(selection);
+              return true;
+            });
+        }
+        if (nextCell) {
+          nextTr.setSelection(
+            new TextSelection(
+              nextTr.doc.resolve(nextCell.start),
+              nextTr.doc.resolve(
+                nextCell.start + (nextCell.node?.nodeSize || 0) - 4
+              )
+            )
+          );
+          nextView.dispatch(nextTr);
+          return true;
+        }
+        return false;
+      },
+      "Shift-Tab": ({ editor }) => {
+        const { selection, tr } = editor.state;
+        if (!isActive(editor.state, Table.name)) {
+          return false;
+        }
+        const previousCell = findPreviousCell(selection);
+        if (previousCell) {
+          tr.setSelection(
+            new TextSelection(
+              tr.doc.resolve(previousCell.start),
+              tr.doc.resolve(
+                previousCell.start + (previousCell.node?.nodeSize || 0) - 4
+              )
+            )
+          );
+          editor.view.dispatch(tr);
+        }
         return true;
       },
     };

--- a/ui/packages/editor/src/extensions/table/index.ts
+++ b/ui/packages/editor/src/extensions/table/index.ts
@@ -526,23 +526,23 @@ const Table = TiptapTable.extend<ExtensionOptions & TableOptions>({
         return true;
       },
       Tab: ({ editor }) => {
-        const { selection } = editor.state;
+        const { state } = editor;
         if (!isActive(editor.state, Table.name)) {
           return false;
         }
         let nextView = editor.view;
         let nextTr = editor.state.tr;
-        let nextCell = findNextCell(selection);
+
+        let nextCell = findNextCell(state);
         if (!nextCell) {
           // If it is the last cell, create a new line and jump to the first cell of the new line.
           editor
             .chain()
             .addRowAfter()
-            .command(({ tr, view }) => {
+            .command(({ tr, view, state }) => {
               nextView = view;
               nextTr = tr;
-              const { selection } = tr;
-              nextCell = findNextCell(selection);
+              nextCell = findNextCell(state);
               return true;
             });
         }
@@ -555,17 +555,18 @@ const Table = TiptapTable.extend<ExtensionOptions & TableOptions>({
               )
             )
           );
+          nextTr.scrollIntoView();
           nextView.dispatch(nextTr);
           return true;
         }
         return false;
       },
       "Shift-Tab": ({ editor }) => {
-        const { selection, tr } = editor.state;
+        const { tr } = editor.state;
         if (!isActive(editor.state, Table.name)) {
           return false;
         }
-        const previousCell = findPreviousCell(selection);
+        const previousCell = findPreviousCell(editor.state);
         if (previousCell) {
           tr.setSelection(
             new TextSelection(
@@ -575,6 +576,7 @@ const Table = TiptapTable.extend<ExtensionOptions & TableOptions>({
               )
             )
           );
+          tr.scrollIntoView();
           editor.view.dispatch(tr);
         }
         return true;


### PR DESCRIPTION
#### What type of PR is this?

/kind feature
/area editor

#### What this PR does / why we need it:

为默认编辑器表格增加 `Tab` 与 `Shift-Tab` 切换至上一个单元格或下一个单元格。具体功能如下：

1. 使用 Tab 快捷键从左向右切换至下一个单元格，当光标在最后一个单元格时，使用 Tab 键新建一行并跳转至新一行的第一个单元格。
2. 使用 Shift + Tab 快捷键从右向左来切换至上一个单元格。

#### How to test it?

测试在默认编辑器中 `Tab` 快捷键切换单元格是否生效。
测试在合并单元格等各种表格操作下，切换单元格是否生效。

#### Which issue(s) this PR fixes:

Fixes #5771 

#### Does this PR introduce a user-facing change?
```release-note
为默认编辑器表格增加 Tab 快捷键切换单元格的功能
```
