### PR TITLE
fix: excel tables copied into editor become images

### DIFF
--- a/ui/src/components/editor/extensions/upload/index.ts
+++ b/ui/src/components/editor/extensions/upload/index.ts
@@ -25,6 +25,11 @@ export const Upload = Extension.create({
               return false;
             }
 
+            const types = event.clipboardData.types;
+            if (types.includes("text/plain") || types.includes("text/html")) {
+              return false;
+            }
+
             const files = Array.from(event.clipboardData.files);
 
             if (files.length) {

--- a/ui/src/components/editor/extensions/upload/index.ts
+++ b/ui/src/components/editor/extensions/upload/index.ts
@@ -26,7 +26,7 @@ export const Upload = Extension.create({
             }
 
             const types = event.clipboardData.types;
-            if (types.includes("text/plain") || types.includes("text/html")) {
+            if (!(types.length === 1 && types[0].toLowerCase() === "files")) {
               return false;
             }
 


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/area ui
/area editor

#### What this PR does / why we need it:

在进行图片上传的前置处理中，将剪切板属性中的 `text/plain` 类型与 `text/html` 类型进行过滤，用于解决将 Excel 表格粘贴至默认编辑器时，会导致其变为了图片而不是表格。

#### How to test it?

从 Excel 中复制一个表格，在默认编辑器中使用粘贴，查看其是否成功粘贴为表格而不是图片。

#### Which issue(s) this PR fixes:

Fixes #5761 

#### Does this PR introduce a user-facing change?
```release-note
解决 Excel 表格粘贴至默认编辑器后会变为图片的问题。
```
