### PR TITLE
fix: comment and reply observed version for status

### DIFF
--- a/application/src/main/java/run/halo/app/core/extension/reconciler/CommentReconciler.java
+++ b/application/src/main/java/run/halo/app/core/extension/reconciler/CommentReconciler.java
@@ -80,6 +80,11 @@ public class CommentReconciler implements Reconciler<Reconciler.Request> {
                 updateUnReplyCountIfNecessary(comment);
                 updateSameSubjectRefCommentCounter(comment);
 
+                // version + 1 is required to truly equal version
+                // as a version will be incremented after the update
+                comment.getStatusOrDefault()
+                    .setObservedVersion(comment.getMetadata().getVersion() + 1);
+
                 client.update(comment);
             });
         return new Result(false, null);

--- a/application/src/main/java/run/halo/app/core/extension/reconciler/ReplyReconciler.java
+++ b/application/src/main/java/run/halo/app/core/extension/reconciler/ReplyReconciler.java
@@ -57,6 +57,11 @@ public class ReplyReconciler implements Reconciler<Reconciler.Request> {
                         )
                     );
                 }
+
+                // version + 1 is required to truly equal version
+                // as a version will be incremented after the update
+                reply.getStatus().setObservedVersion(reply.getMetadata().getVersion() + 1);
+
                 client.update(reply);
 
                 replyNotificationSubscriptionHelper.subscribeNewReplyReasonForReply(reply);


### PR DESCRIPTION
#### What type of PR is this?
/kind bug
/area core
/milestone 2.15.x

#### What this PR does / why we need it:
修复由于没有更新 observed version 导致评论和回复的 reconciler 执行次数控制没有生效的问题

#### Does this PR introduce a user-facing change?
```release-note
None
```
