### PR TITLE
fix: incorrect column width calculation after merging cells in the table

### DIFF
--- a/ui/packages/editor/src/extensions/table/table-cell.ts
+++ b/ui/packages/editor/src/extensions/table/table-cell.ts
@@ -58,7 +58,9 @@ const TableCell = Node.create<TableCellOptions>({
         default: [100],
         parseHTML: (element) => {
           const colwidth = element.getAttribute("colwidth");
-          const value = colwidth ? [parseInt(colwidth, 10)] : null;
+          const value = colwidth
+            ? colwidth.split(",").map((width) => parseInt(width, 10))
+            : null;
           return value;
         },
       },

--- a/ui/packages/editor/src/extensions/table/table-header.ts
+++ b/ui/packages/editor/src/extensions/table/table-header.ts
@@ -41,8 +41,9 @@ const TableHeader = Node.create<TableCellOptions>({
         default: [100],
         parseHTML: (element) => {
           const colwidth = element.getAttribute("colwidth");
-          const value = colwidth ? [parseInt(colwidth, 10)] : null;
-
+          const value = colwidth
+            ? colwidth.split(",").map((width) => parseInt(width, 10))
+            : null;
           return value;
         },
       },


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/area editor
/milestone 2.16.x

#### What this PR does / why we need it:

默认编辑器中的表格**首行被合并单元格**之后，将会出现当前表在刷新之后宽度被重置为默认。此 PR 改正了计算宽度，使其首次刷新时，也能返回正确的数组。

#### How to test it?

1. 将表格首行使用合并单元格之后，改变表格宽度。
2. 刷新表格，查看表格宽度是否不再变为默认宽度。

#### Which issue(s) this PR fixes:

Fixes #5767 

#### Does this PR introduce a user-facing change?
```release-note
解决默认编辑器中的表格首行合并单元格后会出现宽度重置的问题
```
