### PR TITLE
fix: the post admin does not have tag list permissions

### DIFF
--- a/application/src/main/resources/extensions/role-template-tag.yaml
+++ b/application/src/main/resources/extensions/role-template-tag.yaml
@@ -23,3 +23,6 @@ rules:
   - apiGroups: [ "content.halo.run" ]
     resources: [ "tags" ]
     verbs: [ "get", "list" ]
+  - apiGroups: [ "api.console.halo.run" ]
+    resources: [ "tags" ]
+    verbs: [ "get", "list" ]


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/area ui

#### What this PR does / why we need it:

补充 #5593 中缺少的 `api.console.halo.run` 权限。用于解决具有文章列表权限的用户，访问标签列表时提示无权限的问题

#### How to test it?

创建一个具有文章列表查看权限的用户，是否能够访问到标签列表。

#### Which issue(s) this PR fixes:

Fixes #5814

#### Does this PR introduce a user-facing change?
```release-note
None
```
