### PR TITLE
chore: specify expose port in dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,4 +23,6 @@ ENV JVM_OPTS="-Xmx256m -Xms256m" \
 RUN ln -sf /usr/share/zoneinfo/$TZ /etc/localtime \
     && echo $TZ > /etc/timezone
 
+Expose 8090
+
 ENTRYPOINT ["sh", "-c", "java ${JVM_OPTS} org.springframework.boot.loader.launch.JarLauncher ${0} ${@}"]


### PR DESCRIPTION
#### What type of PR is this?
/kind improvement

#### What this PR does / why we need it:

When traefik is used, the host cannot be accessed to 8090 by default after being configured. Therefore, you need to configure loadbalance. The process is complicated, so specify the expose port

当使用 traefik 时， 配置完 host 后无法直接的访问到对应的服务， 需要额外的配置service， loadbalance.port 才能， 所以建议增加一个 expose port， 指定下默认的服务端口
#### Which issue(s) this PR fixes:


#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
None
```
