### PR TITLE
Fix the problem that some plugins could not be used after upgrading dependent plugin

### DIFF
--- a/application/src/main/java/run/halo/app/plugin/SpringPluginManager.java
+++ b/application/src/main/java/run/halo/app/plugin/SpringPluginManager.java
@@ -1,6 +1,9 @@
 package run.halo.app.plugin;
 
+import java.nio.file.Path;
+import java.util.List;
 import org.pf4j.PluginManager;
+import org.pf4j.PluginWrapper;
 import org.springframework.context.ApplicationContext;
 
 public interface SpringPluginManager extends PluginManager {
@@ -9,4 +12,21 @@ public interface SpringPluginManager extends PluginManager {
 
     ApplicationContext getSharedContext();
 
+    /**
+     * Reload the plugin and the plugins that depend on it.
+     *
+     * @param pluginId plugin id
+     * @param loadLocation new load location
+     * @return true if reload successfully, otherwise false
+     */
+    boolean reloadPlugin(String pluginId, Path loadLocation);
+
+    /**
+     * Get all dependents recursively.
+     *
+     * @param pluginId plugin id
+     * @return a list of plugin wrapper. The order of the list is from the farthest dependent to
+     * the nearest dependent.
+     */
+    List<PluginWrapper> getDependents(String pluginId);
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/area plugin
/area core

#### What this PR does / why we need it:

This PR resolves the problem that some plugins could not be used after upgrading dependent plugin.

#### Which issue(s) this PR fixes:

Fixes https://github.com/halo-dev/halo/issues/5615

#### Special notes for your reviewer:

1. Install plugin [app-store](https://www.halo.run/store/apps/app-VYJbF)
2. Install plugin [backup](https://www.halo.run/store/apps/app-dHakX) and activate it
3. Disable plugin app-store
4. Check the features of plugin backup
5. Enable plugin app-store
6. Check the features of plugin backup
7. Upgrade plugin app-store with the any versions
8. Check the features of plugin backup

#### Does this PR introduce a user-facing change?

```release-note
修复因升级应用市场插件导致部分插件意外停止的问题
```
