### PR TITLE
Support excluding node_modules for idea IDE

### DIFF
--- a/ui/build.gradle
+++ b/ui/build.gradle
@@ -1,5 +1,18 @@
 plugins {
-  id "com.github.node-gradle.node"
+  id 'idea'
+  id 'com.github.node-gradle.node'
+}
+
+idea {
+  module {
+    excludeDirs += file('node_modules/')
+    excludeDirs += file('packages').listFiles().collect {
+      file(it.path + '/node_modules/')
+    }
+    excludeDirs += file('packages').listFiles().collect {
+      file(it.path + '/dist/')
+    }
+  }
 }
 
 tasks.register('clean', Delete) {


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup
/area core

#### What this PR does / why we need it:

There are too many unrelated results from node_modules folders when we try to search in files using IDEA IDE. This PR adapts the IDEA IDE using Gradle plugin `idea` to reduce search results.

Before:

<img width="700" alt="image" src="https://github.com/halo-dev/halo/assets/16865714/0e730896-6327-445c-b30e-0b0773f1743d">

After:

<img width="686" alt="image" src="https://github.com/halo-dev/halo/assets/16865714/2fc080cd-939c-4658-9309-e066e143bc30">

#### Does this PR introduce a user-facing change?

```release-note
None
```
