### PR TITLE
Fix the problem of not being able to initialize preset plugins

### DIFF
--- a/application/src/main/java/run/halo/app/plugin/SpringPlugin.java
+++ b/application/src/main/java/run/halo/app/plugin/SpringPlugin.java
@@ -25,25 +25,36 @@ public class SpringPlugin extends Plugin {
 
     @Override
     public void start() {
+        log.info("Preparing starting plugin {}", pluginContext.getName());
+        var pluginId = pluginContext.getName();
         try {
             // initialize context
-            var pluginId = pluginContext.getName();
             this.context = contextFactory.create(pluginId);
+            log.info("Application context {} for plugin {} is created", this.context, pluginId);
 
             var pluginOpt = context.getBeanProvider(Plugin.class)
                 .stream()
                 .findFirst();
+            log.info("Before publishing plugin starting event for plugin {}", pluginId);
             context.publishEvent(new SpringPluginStartingEvent(this, this));
+            log.info("After publishing plugin starting event for plugin {}", pluginId);
             if (pluginOpt.isPresent()) {
                 this.delegate = pluginOpt.get();
                 if (this.delegate instanceof BasePlugin basePlugin) {
                     basePlugin.setContext(pluginContext);
                 }
+                log.info("Starting {} for plugin {}", this.delegate, pluginId);
                 this.delegate.start();
+                log.info("Started {} for plugin {}", this.delegate, pluginId);
             }
+            log.info("Before publishing plugin started event for plugin {}", pluginId);
             context.publishEvent(new SpringPluginStartedEvent(this, this));
+            log.info("After publishing plugin started event for plugin {}", pluginId);
         } catch (Throwable t) {
             // try to stop plugin for cleaning resources if something went wrong
+            log.error(
+                "Cleaning up plugin resources for plugin {} due to not being able to start plugin.",
+                pluginId);
             this.stop();
             // propagate exception to invoker.
             throw t;
@@ -54,16 +65,25 @@ public class SpringPlugin extends Plugin {
     public void stop() {
         try {
             if (context != null) {
+                log.info("Before publishing plugin stopping event for plugin {}",
+                    pluginContext.getName());
                 context.publishEvent(new SpringPluginStoppingEvent(this, this));
+                log.info("After publishing plugin stopping event for plugin {}",
+                    pluginContext.getName());
             }
             if (this.delegate != null) {
+                log.info("Stopping {} for plugin {}", this.delegate, pluginContext.getName());
                 this.delegate.stop();
+                log.info("Stopped {} for plugin {}", this.delegate, pluginContext.getName());
             }
         } finally {
             if (context instanceof ConfigurableApplicationContext configurableContext) {
+                log.info("Closing plugin context for plugin {}", pluginContext.getName());
                 configurableContext.close();
+                log.info("Closed plugin context for plugin {}", pluginContext.getName());
             }
             // reset application context
+            log.info("Reset plugin context for plugin {}", pluginContext.getName());
             context = null;
         }
     }

--- a/application/src/test/java/run/halo/app/core/extension/endpoint/PluginEndpointTest.java
+++ b/application/src/test/java/run/halo/app/core/extension/endpoint/PluginEndpointTest.java
@@ -2,6 +2,8 @@ package run.halo.app.core.extension.endpoint;
 
 import static java.util.Objects.requireNonNull;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.argThat;
@@ -9,6 +11,7 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isA;
 import static org.mockito.ArgumentMatchers.same;
 import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.reactive.server.WebTestClient.bindToRouterFunction;
@@ -472,6 +475,72 @@ class PluginEndpointTest {
                     }
                 })
                 .verifyComplete();
+        }
+    }
+
+    @Nested
+    class PluginStateChangeTest {
+
+        WebTestClient webClient;
+
+        @BeforeEach
+        void setUp() {
+            webClient = WebTestClient.bindToRouterFunction(endpoint.endpoint())
+                .build();
+        }
+
+        @Test
+        void shouldEnablePluginIfPluginWasNotStarted() {
+            var plugin = createPlugin("fake-plugin");
+            plugin.getSpec().setEnabled(false);
+            plugin.statusNonNull().setPhase(Plugin.Phase.RESOLVED);
+
+            when(client.get(Plugin.class, "fake-plugin")).thenReturn(Mono.just(plugin))
+                .thenReturn(Mono.fromSupplier(() -> {
+                    plugin.statusNonNull().setPhase(Plugin.Phase.STARTED);
+                    return plugin;
+                }));
+            when(client.update(plugin)).thenReturn(Mono.just(plugin));
+
+            var requestBody = new PluginEndpoint.RunningStateRequest();
+            requestBody.setEnable(true);
+            requestBody.setAsync(false);
+            webClient.put().uri("/plugins/fake-plugin/plugin-state")
+                .bodyValue(requestBody)
+                .exchange()
+                .expectStatus().isOk()
+                .expectBody(Plugin.class)
+                .value(p -> assertTrue(p.getSpec().getEnabled()));
+
+            verify(client, times(2)).get(Plugin.class, "fake-plugin");
+            verify(client).update(plugin);
+        }
+
+        @Test
+        void shouldDisablePluginIfAlreadyStarted() {
+            var plugin = createPlugin("fake-plugin");
+            plugin.getSpec().setEnabled(true);
+            plugin.statusNonNull().setPhase(Plugin.Phase.STARTED);
+
+            when(client.get(Plugin.class, "fake-plugin")).thenReturn(Mono.just(plugin))
+                .thenReturn(Mono.fromSupplier(() -> {
+                    plugin.getStatus().setPhase(Plugin.Phase.STOPPED);
+                    return plugin;
+                }));
+            when(client.update(plugin)).thenReturn(Mono.just(plugin));
+
+            var requestBody = new PluginEndpoint.RunningStateRequest();
+            requestBody.setEnable(false);
+            requestBody.setAsync(false);
+            webClient.put().uri("/plugins/fake-plugin/plugin-state")
+                .bodyValue(requestBody)
+                .exchange()
+                .expectStatus().isOk()
+                .expectBody(Plugin.class)
+                .value(p -> assertFalse(p.getSpec().getEnabled()));
+
+            verify(client, times(2)).get(Plugin.class, "fake-plugin");
+            verify(client).update(plugin);
         }
     }
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/area core
/area plugin
/milestone 2.16.x

#### What this PR does / why we need it:

This PR refactors plugin running state change method to resolve the problem of not being able to initialize preset plugins due to too small gap between installation and enabling.

#### Which issue(s) this PR fixes:

Fixes https://github.com/halo-dev/halo/issues/5867

#### Does this PR introduce a user-facing change?

```release-note
解决初始化时无法正常启用插件的问题
```
