### PR TITLE
Fix the problem where extensions were not changed but still updated

### DIFF
--- a/application/src/main/java/run/halo/app/extension/ReactiveExtensionClientImpl.java
+++ b/application/src/main/java/run/halo/app/extension/ReactiveExtensionClientImpl.java
@@ -215,6 +215,11 @@ public class ReactiveExtensionClientImpl implements ReactiveExtensionClient {
             newMetadata.setCreationTimestamp(oldMetadata.getCreationTimestamp());
             newMetadata.setGenerateName(oldMetadata.getGenerateName());
 
+            // If the extension is an unstructured, the version type may be integer instead of long.
+            // reset metadata.version for long type.
+            oldMetadata.setVersion(oldMetadata.getVersion());
+            newMetadata.setVersion(newMetadata.getVersion());
+
             if (Objects.equals(oldJsonExt, newJsonExt)) {
                 // skip updating if not data changed.
                 return Mono.just(extension);


### PR DESCRIPTION
#### What type of PR is this?

/kind improvement
/area core
/milestone 2.16.x

#### What this PR does / why we need it:

This PR fixes the problem where extensions were not changed but still updated. What we want is to not update the extension if it has not changed.

Before that, we update the version of extension manually while getting the latest extension, this will lead to change the type of metadata.version from int to long.See the code snippet below:

https://github.com/halo-dev/halo/blob/a629961e8de4c086490e821248b6fa9964caecdd/application/src/main/java/run/halo/app/extension/JSONExtensionConverter.java#L83

Now, we force update the versions using type Long.

#### Does this PR introduce a user-facing change?

```release-note
None
```
