### PR TITLE
refactor: email notifications are now sent only to verified email addresses

### DIFF
--- a/application/src/main/java/run/halo/app/notification/DefaultSubscriberEmailResolver.java
+++ b/application/src/main/java/run/halo/app/notification/DefaultSubscriberEmailResolver.java
@@ -30,6 +30,7 @@ public class DefaultSubscriberEmailResolver implements SubscriberEmailResolver {
             return Mono.fromSupplier(() -> getEmail(subscriber));
         }
         return client.fetch(User.class, subscriber.getName())
+            .filter(user -> user.getSpec().isEmailVerified())
             .mapNotNull(user -> user.getSpec().getEmail());
     }
 

--- a/application/src/test/java/run/halo/app/notification/DefaultSubscriberEmailResolverTest.java
+++ b/application/src/test/java/run/halo/app/notification/DefaultSubscriberEmailResolverTest.java
@@ -50,6 +50,15 @@ class DefaultSubscriberEmailResolverTest {
         user.getMetadata().setName("fake-user");
         user.setSpec(new User.UserSpec());
         user.getSpec().setEmail("test@halo.run");
+        user.getSpec().setEmailVerified(false);
+        when(client.fetch(eq(User.class), eq("fake-user"))).thenReturn(Mono.just(user));
+
+        subscriber.setName("fake-user");
+        subscriberEmailResolver.resolve(subscriber)
+            .as(StepVerifier::create)
+            .verifyComplete();
+
+        user.getSpec().setEmailVerified(true);
         when(client.fetch(eq(User.class), eq("fake-user"))).thenReturn(Mono.just(user));
 
         subscriber.setName("fake-user");


### PR DESCRIPTION
#### What type of PR is this?
/kind improvement
/area core
/milestone 2.16.x

#### What this PR does / why we need it:
邮件通知功能现在只向经过验证的邮箱地址发送通知匿名用户除外

#### Which issue(s) this PR fixes:
Fixes #5722

#### Does this PR introduce a user-facing change?
```release-note
邮件通知功能现在只向经过验证的邮箱地址发送通知匿名用户除外
```
