### PR TITLE
feat: add an API to invalidate theme template cache

### DIFF
--- a/api-docs/openapi/v3_0/aggregated.json
+++ b/api-docs/openapi/v3_0/aggregated.json
@@ -4220,6 +4220,30 @@
         ]
       }
     },
+    "/apis/api.console.halo.run/v1alpha1/themes/{name}/invalidate-cache": {
+      "put": {
+        "description": "Invalidate theme template cache.",
+        "operationId": "InvalidateCache",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "name",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "No Content"
+          }
+        },
+        "tags": [
+          "api.console.halo.run/v1alpha1/Theme"
+        ]
+      }
+    },
     "/apis/api.console.halo.run/v1alpha1/themes/{name}/reload": {
       "put": {
         "description": "Reload theme setting.",

--- a/application/src/main/resources/extensions/role-template-theme.yaml
+++ b/application/src/main/resources/extensions/role-template-theme.yaml
@@ -16,7 +16,7 @@ rules:
     verbs: [ "*" ]
   - apiGroups: [ "api.console.halo.run" ]
     resources: [ "themes", "themes/reload", "themes/resetconfig", "themes/config", "themes/activation",
-                 "themes/install-from-uri", "themes/upgrade-from-uri" ]
+                 "themes/install-from-uri", "themes/upgrade-from-uri", "themes/invalidate-cache" ]
     verbs: [ "*" ]
   - nonResourceURLs: [ "/apis/api.console.halo.run/themes/install" ]
     verbs: [ "create" ]

--- a/ui/console-src/modules/interface/themes/ThemeDetail.vue
+++ b/ui/console-src/modules/interface/themes/ThemeDetail.vue
@@ -32,6 +32,27 @@ const themesModal = inject<Ref<boolean>>("themesModal");
 const { isActivated, getFailedMessage, handleResetSettingConfig } =
   useThemeLifeCycle(selectedTheme);
 
+async function handleClearCache() {
+  Dialog.warning({
+    title: t("core.theme.operations.clear_templates_cache.title"),
+    description: t("core.theme.operations.clear_templates_cache.description"),
+    confirmText: t("core.common.buttons.confirm"),
+    cancelText: t("core.common.buttons.cancel"),
+    async onConfirm() {
+      if (!selectedTheme.value) {
+        console.error("No selected or activated theme");
+        return;
+      }
+
+      await apiClient.theme.invalidateCache({
+        name: selectedTheme.value?.metadata.name,
+      });
+
+      Toast.success(t("core.common.toast.operation_success"));
+    },
+  });
+}
+
 const handleReloadTheme = async () => {
   Dialog.warning({
     title: t("core.theme.operations.reload.title"),
@@ -108,6 +129,9 @@ const handleReloadTheme = async () => {
               <VDropdownDivider />
               <VDropdownItem type="danger" @click="handleReloadTheme">
                 {{ $t("core.theme.operations.reload.button") }}
+              </VDropdownItem>
+              <VDropdownItem type="danger" @click="handleClearCache">
+                {{ $t("core.theme.operations.clear_templates_cache.button") }}
               </VDropdownItem>
               <VDropdownItem type="danger" @click="handleResetSettingConfig">
                 {{ $t("core.common.buttons.reset") }}

--- a/ui/packages/api-client/src/api/api-console-halo-run-v1alpha1-theme-api.ts
+++ b/ui/packages/api-client/src/api/api-console-halo-run-v1alpha1-theme-api.ts
@@ -280,6 +280,47 @@ export const ApiConsoleHaloRunV1alpha1ThemeApiAxiosParamCreator = function (conf
             };
         },
         /**
+         * Invalidate theme template cache.
+         * @param {string} name 
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        invalidateCache: async (name: string, options: RawAxiosRequestConfig = {}): Promise<RequestArgs> => {
+            // verify required parameter 'name' is not null or undefined
+            assertParamExists('invalidateCache', 'name', name)
+            const localVarPath = `/apis/api.console.halo.run/v1alpha1/themes/{name}/invalidate-cache`
+                .replace(`{${"name"}}`, encodeURIComponent(String(name)));
+            // use dummy base URL string because the URL constructor only accepts absolute URLs.
+            const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
+            let baseOptions;
+            if (configuration) {
+                baseOptions = configuration.baseOptions;
+            }
+
+            const localVarRequestOptions = { method: 'PUT', ...baseOptions, ...options};
+            const localVarHeaderParameter = {} as any;
+            const localVarQueryParameter = {} as any;
+
+            // authentication BasicAuth required
+            // http basic authentication required
+            setBasicAuthToObject(localVarRequestOptions, configuration)
+
+            // authentication BearerAuth required
+            // http bearer authentication required
+            await setBearerAuthToObject(localVarHeaderParameter, configuration)
+
+
+    
+            setSearchParams(localVarUrlObj, localVarQueryParameter);
+            let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+
+            return {
+                url: toPathString(localVarUrlObj),
+                options: localVarRequestOptions,
+            };
+        },
+        /**
          * List themes.
          * @param {number} [page] Page number. Default is 0.
          * @param {number} [size] Size number. Default is 0.
@@ -650,6 +691,18 @@ export const ApiConsoleHaloRunV1alpha1ThemeApiFp = function(configuration?: Conf
             return (axios, basePath) => createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration)(axios, localVarOperationServerBasePath || basePath);
         },
         /**
+         * Invalidate theme template cache.
+         * @param {string} name 
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        async invalidateCache(name: string, options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.invalidateCache(name, options);
+            const localVarOperationServerIndex = configuration?.serverIndex ?? 0;
+            const localVarOperationServerBasePath = operationServerMap['ApiConsoleHaloRunV1alpha1ThemeApi.invalidateCache']?.[localVarOperationServerIndex]?.url;
+            return (axios, basePath) => createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration)(axios, localVarOperationServerBasePath || basePath);
+        },
+        /**
          * List themes.
          * @param {number} [page] Page number. Default is 0.
          * @param {number} [size] Size number. Default is 0.
@@ -791,6 +844,15 @@ export const ApiConsoleHaloRunV1alpha1ThemeApiFactory = function (configuration?
             return localVarFp.installThemeFromUri(requestParameters.installFromUriRequest, options).then((request) => request(axios, basePath));
         },
         /**
+         * Invalidate theme template cache.
+         * @param {ApiConsoleHaloRunV1alpha1ThemeApiInvalidateCacheRequest} requestParameters Request parameters.
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        invalidateCache(requestParameters: ApiConsoleHaloRunV1alpha1ThemeApiInvalidateCacheRequest, options?: RawAxiosRequestConfig): AxiosPromise<void> {
+            return localVarFp.invalidateCache(requestParameters.name, options).then((request) => request(axios, basePath));
+        },
+        /**
          * List themes.
          * @param {ApiConsoleHaloRunV1alpha1ThemeApiListThemesRequest} requestParameters Request parameters.
          * @param {*} [options] Override http request option.
@@ -901,6 +963,20 @@ export interface ApiConsoleHaloRunV1alpha1ThemeApiInstallThemeFromUriRequest {
      * @memberof ApiConsoleHaloRunV1alpha1ThemeApiInstallThemeFromUri
      */
     readonly installFromUriRequest: InstallFromUriRequest
+}
+
+/**
+ * Request parameters for invalidateCache operation in ApiConsoleHaloRunV1alpha1ThemeApi.
+ * @export
+ * @interface ApiConsoleHaloRunV1alpha1ThemeApiInvalidateCacheRequest
+ */
+export interface ApiConsoleHaloRunV1alpha1ThemeApiInvalidateCacheRequest {
+    /**
+     * 
+     * @type {string}
+     * @memberof ApiConsoleHaloRunV1alpha1ThemeApiInvalidateCache
+     */
+    readonly name: string
 }
 
 /**
@@ -1105,6 +1181,17 @@ export class ApiConsoleHaloRunV1alpha1ThemeApi extends BaseAPI {
      */
     public installThemeFromUri(requestParameters: ApiConsoleHaloRunV1alpha1ThemeApiInstallThemeFromUriRequest, options?: RawAxiosRequestConfig) {
         return ApiConsoleHaloRunV1alpha1ThemeApiFp(this.configuration).installThemeFromUri(requestParameters.installFromUriRequest, options).then((request) => request(this.axios, this.basePath));
+    }
+
+    /**
+     * Invalidate theme template cache.
+     * @param {ApiConsoleHaloRunV1alpha1ThemeApiInvalidateCacheRequest} requestParameters Request parameters.
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     * @memberof ApiConsoleHaloRunV1alpha1ThemeApi
+     */
+    public invalidateCache(requestParameters: ApiConsoleHaloRunV1alpha1ThemeApiInvalidateCacheRequest, options?: RawAxiosRequestConfig) {
+        return ApiConsoleHaloRunV1alpha1ThemeApiFp(this.configuration).invalidateCache(requestParameters.name, options).then((request) => request(this.axios, this.basePath));
     }
 
     /**

--- a/ui/src/locales/en.yaml
+++ b/ui/src/locales/en.yaml
@@ -701,6 +701,12 @@ core:
       existed_during_installation:
         title: The theme already exists.
         description: The currently installed theme already exists, do you want to upgrade?
+      clear_templates_cache:
+        button: Clear templates cache
+        title: Clear templates cache
+        description: >-
+          This feature allows you to refresh the cache to view the latest web
+          results after modifying template files at runtime.
     list_modal:
       tabs:
         installed: Installed

--- a/ui/src/locales/zh-CN.yaml
+++ b/ui/src/locales/zh-CN.yaml
@@ -673,6 +673,10 @@ core:
       existed_during_installation:
         title: 主题已存在
         description: 当前安装的主题已存在，是否升级？
+      clear_templates_cache:
+        button: 清理模板缓存
+        title: 清除模板缓存
+        description: 此功能适用于在运行时修改模板文件后，刷新缓存以查看最新网页结果。
     list_modal:
       tabs:
         installed: 已安装

--- a/ui/src/locales/zh-TW.yaml
+++ b/ui/src/locales/zh-TW.yaml
@@ -653,6 +653,10 @@ core:
       existed_during_installation:
         title: 主題已存在
         description: 當前安裝的主題已存在，是否升級？
+      clear_templates_cache:
+        button: 清除模板快取
+        title: 清除模板快取
+        description: 此功能適用於在運行時修改模板檔案後，刷新快取以查看最新網頁結果。
     list_modal:
       tabs:
         installed: 已安裝


### PR DESCRIPTION
#### What type of PR is this?
/kind feature
/area core
/area theme
/milestone 2.16.x

#### What this PR does / why we need it:
为主题管理增加在线清理缓存功能

#### Which issue(s) this PR fixes:
Fixes #5440

#### Does this PR introduce a user-facing change?
```release-note
为主题管理增加在线清理缓存功能
```
