### PR TITLE
fix: remove close button for reserved alert in role detail page

### DIFF
--- a/ui/console-src/modules/system/roles/RoleDetail.vue
+++ b/ui/console-src/modules/system/roles/RoleDetail.vue
@@ -102,6 +102,7 @@ const handleUpdateRole = async () => {
   await handleCreateOrUpdate();
   await refetch();
 };
+const isShow = ref(true);
 </script>
 <template>
   <VPageHeader :title="$t('core.role.detail.title')">
@@ -169,7 +170,7 @@ const handleUpdateRole = async () => {
       </div>
 
       <div v-if="tabActiveId === 'permissions'">
-        <div v-if="isSystemReserved" class="px-4 py-5">
+        <div v-if="isSystemReserved && isShow" class="px-4 py-5">
           <VAlert
             :title="$t('core.common.text.tip')"
             :description="
@@ -178,6 +179,7 @@ const handleUpdateRole = async () => {
               )
             "
             class="w-full sm:w-1/4"
+            @close="isShow = false"
           />
         </div>
 

--- a/ui/console-src/modules/system/roles/RoleDetail.vue
+++ b/ui/console-src/modules/system/roles/RoleDetail.vue
@@ -102,7 +102,6 @@ const handleUpdateRole = async () => {
   await handleCreateOrUpdate();
   await refetch();
 };
-const isShow = ref(true);
 </script>
 <template>
   <VPageHeader :title="$t('core.role.detail.title')">
@@ -170,7 +169,7 @@ const isShow = ref(true);
       </div>
 
       <div v-if="tabActiveId === 'permissions'">
-        <div v-if="isSystemReserved && isShow" class="px-4 py-5">
+        <div v-if="isSystemReserved" class="px-4 py-5">
           <VAlert
             :title="$t('core.common.text.tip')"
             :description="
@@ -179,7 +178,7 @@ const isShow = ref(true);
               )
             "
             class="w-full sm:w-1/4"
-            @close="isShow = false"
+            :closable="false"
           />
         </div>
 


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/area core
/area ui

#### What this PR does / why we need it:
用户角色详情页面，权限设置提示框关闭按钮不能关闭，增加对应关闭事件！
![image](https://github.com/halo-dev/halo/assets/81747598/2aa93550-8f97-413d-8b88-0d6731587ca7)

#### Does this PR introduce a user-facing change?


```release-note
用户-角色设置-权限设置提示框关闭按钮
```
