### PR TITLE
fix: style issue of dialog component icon

### DIFF
--- a/ui/packages/components/src/components/dialog/Dialog.vue
+++ b/ui/packages/components/src/components/dialog/Dialog.vue
@@ -109,7 +109,7 @@ const handleClose = () => {
         <component
           :is="icons[type].icon"
           :class="`text-${icons[type].color}-500`"
-          class="w-6 h-6"
+          class="w-6 h-6 flex-none"
         ></component>
         <div class="text-base text-gray-900 font-bold">{{ title }}</div>
       </div>


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/area core
/area ui

#### What this PR does / why we need it:

dialog 组件在标题内容过多的时候，icon 会很小，样式出现错位！

#### Does this PR introduce a user-facing change?

```release-note
修复当 Dialog 标题过长时，提示图标的样式问题。
```
