### PR TITLE
fix: cursor misalignment when scrolling through the table

### DIFF
--- a/ui/packages/editor/src/extensions/table/index.ts
+++ b/ui/packages/editor/src/extensions/table/index.ts
@@ -136,21 +136,12 @@ class TableView implements NodeView {
       return this.handleHorizontalWheel(this.containerDOM, e);
     });
 
-    let mouseX = 0;
-    let mouseY = 0;
-    document.addEventListener("mousemove", function (event) {
-      mouseX = event.clientX;
-      mouseY = event.clientY;
-    });
-
     this.containerDOM.addEventListener("scroll", () => {
       if (!editor) {
         return false;
       }
       const { view } = editor;
-      const coords = { left: mouseX, top: mouseY };
-      const pos = view.posAtCoords(coords);
-      editor.commands.setTextSelection(pos?.pos || 0);
+      view.dispatch(view.state.tr);
     });
 
     this.scrollDom = document.createElement("div");


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/area editor
/milestone 2.16.x

#### What this PR does / why we need it:

目前表格在监听到滚动时，会重新设置 `TextSelection` 用于阴影的显示。
本 PR 将设置 `TextSelection` 更改为重新执行一次 `Transaction` 。这样可以解决在滚动时光标错位的问题。

#### How to test it?

编写表格时，测试当编写内容出现滚动条时，是否会导致文本错位。
测试滚动表格时，光标位置是否会发生改变。

#### Which issue(s) this PR fixes:

Fixes #5924 

#### Does this PR introduce a user-facing change?
```release-note
解决默认编辑器中滚动表格时会导致光标变换的问题
```
