### PR TITLE
fix: deleting selected text in a list with the backspace key causes the list to revert

### DIFF
--- a/ui/packages/editor/src/extensions/indent/index.ts
+++ b/ui/packages/editor/src/extensions/indent/index.ts
@@ -4,8 +4,8 @@ import {
   type KeyboardShortcutCommand,
   Extension,
   isList,
-  Editor,
-} from "@/tiptap/vue-3";
+  CoreEditor,
+} from "@/tiptap";
 import { TextSelection, Transaction } from "@/tiptap/pm";
 
 declare module "@/tiptap" {
@@ -104,7 +104,6 @@ const Indent = Extension.create<IndentOptions, never>({
     return {
       Tab: getIndent(),
       "Shift-Tab": getOutdent(false),
-      Backspace: getOutdent(true),
       "Mod-]": getIndent(),
       "Mod-[": getOutdent(false),
     };
@@ -196,7 +195,7 @@ const isTextIndent = (tr: Transaction, currNodePos: number) => {
   return false;
 };
 
-const isListActive = (editor: Editor) => {
+const isListActive = (editor: CoreEditor) => {
   return (
     editor.isActive("bulletList") ||
     editor.isActive("orderedList") ||
@@ -204,7 +203,7 @@ const isListActive = (editor: Editor) => {
   );
 };
 
-const isFilterActive = (editor: Editor) => {
+const isFilterActive = (editor: CoreEditor) => {
   return editor.isActive("table") || editor.isActive("columns");
 };
 
@@ -232,11 +231,11 @@ export const getOutdent: (
     if (outdentOnlyAtHead && editor.state.selection.$head.parentOffset > 0) {
       return false;
     }
-    // @ts-ignore
+
     if (isFilterActive(editor)) {
       return false;
     }
-    // @ts-ignore
+
     if (isListActive(editor)) {
       const name = editor.can().liftListItem("listItem")
         ? "listItem"

--- a/ui/packages/editor/src/styles/base.scss
+++ b/ui/packages/editor/src/styles/base.scss
@@ -73,7 +73,7 @@
       }
 
       ul {
-        @apply list-disc;
+        list-style-type: revert-layer;
       }
 
       code br {


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/area editor
/milestone 2.16.x

#### What this PR does / why we need it:

移除使用 `Backspace` 进行缩进的功能。此功能会导致选中无序列表文本至起始位置时，按 `Backspace` 快捷键会导致无序列表解除当前层级。

#### How to test it?

测试从后往前选中无序列表文本至文本起始位置，然后按下 `Backspace` 快捷键。此时应当只删除文本而不会调整无序列表层级。

#### Which issue(s) this PR fixes:

Fixes #5925 

#### Does this PR introduce a user-facing change?
```release-note
修复默认编辑器中列表使用 Backspace 快捷键删除选中文本的错误行为
```
