### PR TITLE
Ignore includeSubdomains for hsts header

### DIFF
--- a/application/src/main/java/run/halo/app/config/WebServerSecurityConfig.java
+++ b/application/src/main/java/run/halo/app/config/WebServerSecurityConfig.java
@@ -92,6 +92,7 @@ public class WebServerSecurityConfig {
                     .build();
                 oauth2.authenticationManagerResolver(authManagerResolver);
             })
+            .headers(headerSpec -> headerSpec.hsts(hstsSpec -> hstsSpec.includeSubdomains(false)))
         ;
 
         // Integrate with other configurers separately
@@ -126,6 +127,7 @@ public class WebServerSecurityConfig {
                         haloProperties.getSecurity().getReferrerOptions().getPolicy());
                 })
                 .cache(ServerHttpSecurity.HeaderSpec.CacheSpec::disable)
+                .hsts(hstsSpec -> hstsSpec.includeSubdomains(false))
             )
             .anonymous(spec -> spec.authenticationFilter(
                 new HaloAnonymousAuthenticationWebFilter("portal", AnonymousUserConst.PRINCIPAL,

--- a/application/src/test/java/run/halo/app/config/SecurityConfigTest.java
+++ b/application/src/test/java/run/halo/app/config/SecurityConfigTest.java
@@ -1,0 +1,39 @@
+package run.halo.app.config;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.springframework.security.web.server.header.StrictTransportSecurityServerHttpHeadersWriter.STRICT_TRANSPORT_SECURITY;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.reactive.AutoConfigureWebTestClient;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.reactive.server.WebTestClient;
+
+@SpringBootTest
+@AutoConfigureWebTestClient
+class SecurityConfigTest {
+
+    @Autowired
+    WebTestClient webClient;
+
+    @Test
+    void shouldNotIncludeSubdomainForHstsHeader() {
+        webClient.get()
+            .uri(builder -> builder.scheme("https").path("/fake").build())
+            .accept(MediaType.TEXT_HTML)
+            .exchange()
+            .expectHeader()
+            .value(STRICT_TRANSPORT_SECURITY,
+                hsts -> assertFalse(hsts.contains("includeSubDomains")));
+
+        webClient.get()
+            .uri(builder -> builder.scheme("https").path("/apis/fake").build())
+            .accept(MediaType.APPLICATION_JSON)
+            .exchange()
+            .expectHeader()
+            .value(STRICT_TRANSPORT_SECURITY,
+                hsts -> assertFalse(hsts.contains("includeSubDomains")));
+    }
+
+}


### PR DESCRIPTION
#### What type of PR is this?

/kind improvement
/area core
/milestone 2.16.x

#### What this PR does / why we need it:

This PR ignores `includeSubdomains` for HSTS header. See https://github.com/halo-dev/halo/issues/4943 for more.

#### Which issue(s) this PR fixes:

Fixes https://github.com/halo-dev/halo/issues/4943

#### Does this PR introduce a user-facing change?

```release-note
修复开启 HSTS 可能会导致未开启 HSTS 的子域名站点无法访问的问题
```
