### PR TITLE
refactor: logic of theme management modal

### DIFF
--- a/ui/console-src/modules/interface/themes/components/list-tabs/InstalledThemes.vue
+++ b/ui/console-src/modules/interface/themes/components/list-tabs/InstalledThemes.vue
@@ -3,12 +3,12 @@ import {
   IconAddCircle,
   VButton,
   VEmpty,
-  VSpace,
   VLoading,
+  VSpace,
 } from "@halo-dev/components";
 import ThemePreviewModal from "../preview/ThemePreviewModal.vue";
 import ThemeListItem from "../ThemeListItem.vue";
-import { ref, inject, type Ref } from "vue";
+import { inject, ref, type Ref } from "vue";
 import type { Theme } from "@halo-dev/api-client";
 import { apiClient } from "@/utils/api-client";
 import { useQuery } from "@tanstack/vue-query";
@@ -48,11 +48,11 @@ const {
     });
   },
   refetchInterval(data) {
-    const deletingThemes = data?.filter(
+    const hasDeletingTheme = data?.some(
       (theme) => !!theme.metadata.deletionTimestamp
     );
 
-    return deletingThemes?.length ? 1000 : false;
+    return hasDeletingTheme ? 1000 : false;
   },
 });
 

--- a/ui/console-src/modules/interface/themes/layouts/ThemeLayout.vue
+++ b/ui/console-src/modules/interface/themes/layouts/ThemeLayout.vue
@@ -1,7 +1,14 @@
 <script lang="ts" setup>
 // core libs
-import { nextTick, onMounted, type Ref, computed, watch } from "vue";
-import { provide, ref } from "vue";
+import {
+  computed,
+  nextTick,
+  onMounted,
+  provide,
+  type Ref,
+  ref,
+  watch,
+} from "vue";
 import { useRoute, useRouter } from "vue-router";
 
 // libs
@@ -14,18 +21,18 @@ import BasicLayout from "@console/layouts/BasicLayout.vue";
 
 // components
 import {
+  Dialog,
   IconExchange,
   IconEye,
+  IconListSettings,
   IconPalette,
   VButton,
   VCard,
   VEmpty,
+  VLoading,
   VPageHeader,
   VSpace,
   VTabbar,
-  VLoading,
-  Dialog,
-  IconListSettings,
 } from "@halo-dev/components";
 import ThemeListModal from "../components/ThemeListModal.vue";
 import ThemePreviewModal from "../components/preview/ThemePreviewModal.vue";
@@ -268,7 +275,11 @@ onMounted(() => {
       </div>
     </div>
 
-    <ThemeListModal v-model:visible="themesModal" @select="onSelectTheme" />
+    <ThemeListModal
+      v-if="themesModal"
+      @close="themesModal = false"
+      @select="onSelectTheme"
+    />
     <ThemePreviewModal
       v-if="previewModal"
       :theme="selectedTheme"


### PR DESCRIPTION
#### What type of PR is this?

/area ui
/kind improvement
/milestone 2.16.x

#### What this PR does / why we need it:

优化主题管理弹窗的显示逻辑，改为在未打开弹窗组件的时候不渲染组件，减少不必要的请求。

before:

<img width="1656" alt="image" src="https://github.com/halo-dev/halo/assets/21301288/96cfe2f0-4fef-4140-a014-1a96efb0e2c0">

after:

<img width="1660" alt="image" src="https://github.com/halo-dev/halo/assets/21301288/9624561f-ae94-43c9-8e05-32134ebb4091">

#### Which issue(s) this PR fixes:

#### Does this PR introduce a user-facing change?

```release-note
优化主题管理弹窗的显示逻辑，减少不必要的请求。
```
