### PR TITLE
refactor: unread status not shown after admin replies

### DIFF
--- a/application/src/main/java/run/halo/app/content/comment/CommentService.java
+++ b/application/src/main/java/run/halo/app/content/comment/CommentService.java
@@ -19,4 +19,6 @@ public interface CommentService {
     Mono<Comment> create(Comment comment);
 
     Mono<Void> removeBySubject(@NonNull Ref subjectRef);
+
+    Mono<Void> markRepliesAsRead(String commentName);
 }

--- a/application/src/main/java/run/halo/app/core/extension/endpoint/CommentEndpoint.java
+++ b/application/src/main/java/run/halo/app/core/extension/endpoint/CommentEndpoint.java
@@ -125,9 +125,12 @@ public class CommentEndpoint implements CustomEndpoint {
                 if (reply.getSpec().getHidden() == null) {
                     reply.getSpec().setHidden(false);
                 }
-                return replyService.create(commentName, reply);
+                return replyService.create(commentName, reply)
+                    .flatMap(created -> commentService.markRepliesAsRead(commentName)
+                        .thenReturn(created)
+                    );
             })
-            .flatMap(comment -> ServerResponse.ok().bodyValue(comment));
+            .flatMap(reply -> ServerResponse.ok().bodyValue(reply));
     }
 
 }


### PR DESCRIPTION
#### What type of PR is this?
/kind improvement
/area core
/milestone 2.16.x

#### What this PR does / why we need it:
管理员回复后不再显示有未读回复的状态


#### Does this PR introduce a user-facing change?
```release-note
管理员回复后不再显示有未读回复的状态
```
