### PR TITLE
Add support for serializing HaloUser and 2FA

### DIFF
--- a/application/src/main/java/run/halo/app/security/HaloUserDetails.java
+++ b/application/src/main/java/run/halo/app/security/HaloUserDetails.java
@@ -1,0 +1,21 @@
+package run.halo.app.security;
+
+import org.springframework.security.core.userdetails.UserDetails;
+
+public interface HaloUserDetails extends UserDetails {
+
+    /**
+     * Checks if two-factor authentication is enabled.
+     *
+     * @return true if two-factor authentication is enabled, false otherwise.
+     */
+    boolean isTwoFactorAuthEnabled();
+
+    /**
+     * Gets the encrypted secret of TOTP.
+     *
+     * @return encrypted secret of TOTP.
+     */
+    String getTotpEncryptedSecret();
+
+}

--- a/application/src/main/java/run/halo/app/security/authentication/login/UsernamePasswordDelegatingAuthenticationManager.java
+++ b/application/src/main/java/run/halo/app/security/authentication/login/UsernamePasswordDelegatingAuthenticationManager.java
@@ -6,8 +6,8 @@ import org.springframework.security.core.Authentication;
 import org.springframework.security.core.AuthenticationException;
 import reactor.core.publisher.Mono;
 import run.halo.app.plugin.extensionpoint.ExtensionGetter;
+import run.halo.app.security.HaloUserDetails;
 import run.halo.app.security.authentication.twofactor.TwoFactorAuthentication;
-import run.halo.app.security.authentication.twofactor.TwoFactorUtils;
 
 @Slf4j
 public class UsernamePasswordDelegatingAuthenticationManager
@@ -43,12 +43,9 @@ public class UsernamePasswordDelegatingAuthenticationManager
             )
             // check if MFA is enabled after authenticated
             .map(a -> {
-                if (a.getPrincipal() instanceof HaloUser user) {
-                    var twoFactorAuthSettings =
-                        TwoFactorUtils.getTwoFactorAuthSettings(user.getDelegate());
-                    if (twoFactorAuthSettings.isAvailable()) {
-                        a = new TwoFactorAuthentication(a);
-                    }
+                if (a.getPrincipal() instanceof HaloUserDetails user
+                    && user.isTwoFactorAuthEnabled()) {
+                    a = new TwoFactorAuthentication(a);
                 }
                 return a;
             });

--- a/application/src/main/java/run/halo/app/security/authentication/twofactor/TwoFactorAuthSecurityConfigurer.java
+++ b/application/src/main/java/run/halo/app/security/authentication/twofactor/TwoFactorAuthSecurityConfigurer.java
@@ -15,6 +15,7 @@ import run.halo.app.security.authentication.twofactor.totp.TotpAuthenticationFil
 public class TwoFactorAuthSecurityConfigurer implements SecurityConfigurer {
 
     private final ServerSecurityContextRepository securityContextRepository;
+
     private final TotpAuthService totpAuthService;
 
     private final ServerResponse.Context context;
@@ -25,8 +26,11 @@ public class TwoFactorAuthSecurityConfigurer implements SecurityConfigurer {
 
     public TwoFactorAuthSecurityConfigurer(
         ServerSecurityContextRepository securityContextRepository,
-        TotpAuthService totpAuthService, ServerResponse.Context context,
-        MessageSource messageSource, RememberMeServices rememberMeServices) {
+        TotpAuthService totpAuthService,
+        ServerResponse.Context context,
+        MessageSource messageSource,
+        RememberMeServices rememberMeServices
+    ) {
         this.securityContextRepository = securityContextRepository;
         this.totpAuthService = totpAuthService;
         this.context = context;

--- a/application/src/main/java/run/halo/app/security/authentication/twofactor/TwoFactorAuthentication.java
+++ b/application/src/main/java/run/halo/app/security/authentication/twofactor/TwoFactorAuthentication.java
@@ -7,6 +7,11 @@ import org.springframework.security.authentication.AbstractAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 
+/**
+ * Authentication token for two-factor authentication.
+ *
+ * @author johnniang
+ */
 public class TwoFactorAuthentication extends AbstractAuthenticationToken {
 
     private final Authentication previous;
@@ -33,10 +38,12 @@ public class TwoFactorAuthentication extends AbstractAuthenticationToken {
 
     @Override
     public boolean isAuthenticated() {
+        // return true for accessing anonymous resources
         return true;
     }
 
     public Authentication getPrevious() {
         return previous;
     }
+
 }

--- a/application/src/main/java/run/halo/app/security/jackson2/HaloSecurityJackson2Module.java
+++ b/application/src/main/java/run/halo/app/security/jackson2/HaloSecurityJackson2Module.java
@@ -1,0 +1,28 @@
+package run.halo.app.security.jackson2;
+
+import com.fasterxml.jackson.core.Version;
+import com.fasterxml.jackson.databind.module.SimpleModule;
+import org.springframework.security.jackson2.SecurityJackson2Modules;
+import run.halo.app.security.authentication.login.HaloUser;
+import run.halo.app.security.authentication.twofactor.TwoFactorAuthentication;
+
+/**
+ * Halo security Jackson2 module.
+ *
+ * @author johnniang
+ */
+public class HaloSecurityJackson2Module extends SimpleModule {
+
+    public HaloSecurityJackson2Module() {
+        super(HaloSecurityJackson2Module.class.getName(), new Version(1, 0, 0, null, null, null));
+    }
+
+    @Override
+    public void setupModule(SetupContext context) {
+        SecurityJackson2Modules.enableDefaultTyping(context.getOwner());
+        context.setMixInAnnotations(HaloUser.class, HaloUserMixin.class);
+        context.setMixInAnnotations(TwoFactorAuthentication.class,
+            TwoFactorAuthenticationMixin.class);
+    }
+
+}

--- a/application/src/main/java/run/halo/app/security/jackson2/HaloUserMixin.java
+++ b/application/src/main/java/run/halo/app/security/jackson2/HaloUserMixin.java
@@ -1,0 +1,20 @@
+package run.halo.app.security.jackson2;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import org.springframework.security.core.userdetails.UserDetails;
+
+@JsonTypeInfo(use = JsonTypeInfo.Id.CLASS)
+@JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.ANY, getterVisibility =
+    JsonAutoDetect.Visibility.NONE, isGetterVisibility = JsonAutoDetect.Visibility.NONE)
+@JsonIgnoreProperties(ignoreUnknown = true)
+abstract class HaloUserMixin {
+
+    HaloUserMixin(@JsonProperty("delegate") UserDetails delegate,
+        @JsonProperty("twoFactorAuthEnabled") boolean twoFactorAuthEnabled,
+        @JsonProperty("totpEncryptedSecret") String totpEncryptedSecret) {
+    }
+
+}

--- a/application/src/main/java/run/halo/app/security/jackson2/TwoFactorAuthenticationMixin.java
+++ b/application/src/main/java/run/halo/app/security/jackson2/TwoFactorAuthenticationMixin.java
@@ -1,0 +1,25 @@
+package run.halo.app.security.jackson2;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import org.springframework.security.core.Authentication;
+
+/**
+ * This mixin class is used to serialize/deserialize TwoFactorAuthentication.
+ *
+ * @author johnniang
+ */
+@JsonTypeInfo(use = JsonTypeInfo.Id.CLASS)
+@JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.ANY,
+    getterVisibility = JsonAutoDetect.Visibility.NONE,
+    isGetterVisibility = JsonAutoDetect.Visibility.NONE)
+@JsonIgnoreProperties(ignoreUnknown = true)
+abstract class TwoFactorAuthenticationMixin {
+
+    @JsonCreator
+    TwoFactorAuthenticationMixin(@JsonProperty("previous") Authentication previous) {
+    }
+}

--- a/application/src/test/java/run/halo/app/security/jackson2/HaloSecurityJacksonModuleTest.java
+++ b/application/src/test/java/run/halo/app/security/jackson2/HaloSecurityJacksonModuleTest.java
@@ -1,0 +1,66 @@
+package run.halo.app.security.jackson2;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.function.Function;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.converter.json.Jackson2ObjectMapperBuilder;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextImpl;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.jackson2.SecurityJackson2Modules;
+import run.halo.app.security.authentication.login.HaloUser;
+import run.halo.app.security.authentication.twofactor.TwoFactorAuthentication;
+
+class HaloSecurityJacksonModuleTest {
+
+    ObjectMapper objectMapper;
+
+    @BeforeEach
+    void setUp() {
+        this.objectMapper = Jackson2ObjectMapperBuilder.json()
+            .modules(SecurityJackson2Modules.getModules(this.getClass().getClassLoader()))
+            .modules(modules -> modules.add(new HaloSecurityJackson2Module()))
+            .indentOutput(true)
+            .build();
+    }
+
+    @Test
+    void codecHaloUserTest() throws JsonProcessingException {
+        codecAssert(haloUser -> UsernamePasswordAuthenticationToken.authenticated(haloUser,
+            haloUser.getPassword(),
+            haloUser.getAuthorities()));
+    }
+
+    @Test
+    void codecTwoFactorAuthenticationTokenTest() throws JsonProcessingException {
+        codecAssert(haloUser -> new TwoFactorAuthentication(
+            UsernamePasswordAuthenticationToken.authenticated(haloUser,
+                haloUser.getPassword(),
+                haloUser.getAuthorities())));
+    }
+
+    void codecAssert(Function<HaloUser, Authentication> authenticationConverter)
+        throws JsonProcessingException {
+        var userDetails = User.withUsername("faker")
+            .password("123456")
+            .authorities("ROLE_USER")
+            .build();
+        var haloUser = new HaloUser(userDetails, true, "fake-encrypted-secret");
+
+        var authentication = authenticationConverter.apply(haloUser);
+
+        var securityContext = new SecurityContextImpl(authentication);
+        var securityContextJson = objectMapper.writeValueAsString(securityContext);
+
+        var deserializedSecurityContext =
+            objectMapper.readValue(securityContextJson, SecurityContext.class);
+
+        assertEquals(deserializedSecurityContext, securityContext);
+    }
+}


### PR DESCRIPTION
#### What type of PR is this?

/kind improvement
/area core
/milestone 2.16.x

#### What this PR does / why we need it:

This PR adds support for serializing HaloUser and 2FA.

1. Refactor delegate of HaloUser using `org.springframework.security.core.userdetails.User`.
2. Add `HaloSecurityJackson2Module` to enable serialization/deserialization of Halo security module.

Below is code snippet of integration:

```java
        this.objectMapper = Jackson2ObjectMapperBuilder.json()
            .modules(SecurityJackson2Modules.getModules(this.getClass().getClassLoader()))
            .modules(modules -> modules.add(new HaloSecurityJackson2Module()))
            .indentOutput(true)
            .build();
```

#### Does this PR introduce a user-facing change?

```release-note
None
```
