### PR TITLE
feat: add version for themes and plugins when copying overview information

### DIFF
--- a/ui/console-src/modules/system/overview/Overview.vue
+++ b/ui/console-src/modules/system/overview/Overview.vue
@@ -1,28 +1,28 @@
 <script lang="ts" setup>
-import {
-  IconTerminalBoxLine,
-  IconClipboardLine,
-  VAlert,
-  VPageHeader,
-  VCard,
-  VButton,
-  Toast,
-  VDescription,
-  VDescriptionItem,
-  VTag,
-  VLoading,
-} from "@halo-dev/components";
-import { computed } from "vue";
-import type { Info, GlobalInfo, Startup } from "@/types";
-import axios from "axios";
+import type { GlobalInfo, Info, Startup } from "@/types";
+import { apiClient } from "@/utils/api-client";
 import { formatDatetime } from "@/utils/date";
-import { useClipboard } from "@vueuse/core";
-import { useI18n } from "vue-i18n";
+import { usePermission } from "@/utils/permission";
 import { useThemeStore } from "@console/stores/theme";
 import type { Plugin } from "@halo-dev/api-client";
-import { apiClient } from "@/utils/api-client";
+import {
+  IconClipboardLine,
+  IconTerminalBoxLine,
+  Toast,
+  VAlert,
+  VButton,
+  VCard,
+  VDescription,
+  VDescriptionItem,
+  VLoading,
+  VPageHeader,
+  VTag,
+} from "@halo-dev/components";
 import { useQuery } from "@tanstack/vue-query";
-import { usePermission } from "@/utils/permission";
+import { useClipboard } from "@vueuse/core";
+import axios from "axios";
+import { computed } from "vue";
+import { useI18n } from "vue-i18n";
 
 const { t } = useI18n();
 const themeStore = useThemeStore();
@@ -159,7 +159,7 @@ const handleCopy = () => {
     },
     {
       label: t("core.overview.fields.activated_theme"),
-      value: themeStore.activatedTheme?.spec.displayName || "",
+      value: `${themeStore.activatedTheme?.spec.displayName} ${themeStore.activatedTheme?.spec.version}`,
       href:
         themeStore.activatedTheme?.spec.repo ||
         themeStore.activatedTheme?.spec.homepage,
@@ -167,7 +167,7 @@ const handleCopy = () => {
     {
       label: t("core.overview.fields.enabled_plugins"),
       children: plugins.value?.map((plugin) => ({
-        value: plugin.spec.displayName,
+        value: `${plugin.spec.displayName} ${plugin.spec.version}`,
         href: plugin.spec.repo || plugin.spec.homepage,
       })) as CopyItem[],
     },


### PR DESCRIPTION
#### What type of PR is this?

/area ui
/kind feature
/milestone 2.16.x

#### What this PR does / why we need it:

在概览页面复制信息时，为主题和插件添加版本号。

示例：

```
- 外部访问地址: 
- 启动时间: 2024-05-29 15:51
- 版本: 2.16.0-SNAPSHOT
- 构建时间: 2024-05-29 15:51
- Git Commit: 6204472
- Java: OpenJDK Runtime Environment / 17.0.11+0
- 数据库: PostgreSQL / 15.2 (Debian 15.2-1.pgdg110+1)
- 操作系统: Mac OS X / 14.5
- 已激活主题: [Earth 1.8.0](https://github.com/halo-dev/theme-earth.git)
- 已启动插件:
  - [静态网页服务 1.0.0-alpha.2](https://github.com/ruibaby/plugin-static-pages)
  - [评论组件 2.10.0-SNAPSHOT](https://github.com/halo-dev/plugin-comment-widget)
  - [OAuth2 认证 1.1.1](https://github.com/halo-sigs/plugin-oauth2)
  - [增强备份（Backup IMproved） 1.0.0-SNAPSHOT](https://www.halo.run/store/apps/app-dHakX)
  - [图库管理 1.3.0](https://github.com/halo-sigs/plugin-photos)
  - [Markdown / HTML 内容块 1.2.0](https://github.com/halo-dev/plugin-hybrid-edit-block)
  - AI 助手 1.0.0-alpha.2
  - [对象存储（Amazon S3 协议） 1.9.1](https://github.com/halo-dev/plugin-s3)
  - [链接管理 1.3.3](https://github.com/halo-sigs/plugin-links)
  - [Docsme 1.0.0-alpha.5](https://github.com/f2ccloud/plugin-docsme)
  - [ByteMD 1.4.0](https://github.com/ruibaby/plugin-bytemd)
  - [StackEdit 1.1.1](https://github.com/halo-sigs/plugin-stackedit)
  - [应用市场 1.3.0](https://www.halo.run/store/apps/app-VYJbF)
```

#### Does this PR introduce a user-facing change?

```release-note
在概览页面复制信息时，为主题和插件添加版本号。
```
