### PR TITLE
feat: enable asynchronous resolving for UI extension points

### DIFF
--- a/ui/packages/shared/src/types/plugin.ts
+++ b/ui/packages/shared/src/types/plugin.ts
@@ -1,15 +1,10 @@
-import type { Component, Ref } from "vue";
-import type { RouteRecordName, RouteRecordRaw } from "vue-router";
-import type { FunctionalPage } from "../states/pages";
-import type { AttachmentSelectProvider } from "../states/attachment-selector";
-import type { EditorProvider, PluginTab } from "..";
-import type { AnyExtension } from "@halo-dev/richtext-editor";
-import type { CommentSubjectRefProvider } from "@/states/comment-subject-ref";
 import type { BackupTab } from "@/states/backup";
-import type { PluginInstallationTab } from "@/states/plugin-installation-tabs";
+import type { CommentSubjectRefProvider } from "@/states/comment-subject-ref";
 import type { EntityFieldItem } from "@/states/entity";
 import type { OperationItem } from "@/states/operation";
+import type { PluginInstallationTab } from "@/states/plugin-installation-tabs";
 import type { ThemeListTab } from "@/states/theme-list-tabs";
+import type { UserProfileTab, UserTab } from "@/states/user-tab";
 import type {
   Attachment,
   Backup,
@@ -17,7 +12,12 @@ import type {
   Plugin,
   Theme,
 } from "@halo-dev/api-client";
-import type { UserProfileTab, UserTab } from "@/states/user-tab";
+import type { AnyExtension } from "@halo-dev/richtext-editor";
+import type { Component, Ref } from "vue";
+import type { RouteRecordName, RouteRecordRaw } from "vue-router";
+import type { EditorProvider, PluginTab } from "..";
+import type { AttachmentSelectProvider } from "../states/attachment-selector";
+import type { FunctionalPage } from "../states/pages";
 
 export interface RouteRecordAppend {
   parentName: RouteRecordName;
@@ -50,33 +50,29 @@ export interface ExtensionPoint {
 
   "post:list-item:operation:create"?: (
     post: Ref<ListedPost>
-  ) => OperationItem<ListedPost>[] | Promise<OperationItem<ListedPost>[]>;
+  ) => OperationItem<ListedPost>[];
 
   "plugin:list-item:operation:create"?: (
     plugin: Ref<Plugin>
-  ) => OperationItem<Plugin>[] | Promise<OperationItem<Plugin>[]>;
+  ) => OperationItem<Plugin>[];
 
   "backup:list-item:operation:create"?: (
     backup: Ref<Backup>
-  ) => OperationItem<Backup>[] | Promise<OperationItem<Backup>[]>;
+  ) => OperationItem<Backup>[];
 
   "attachment:list-item:operation:create"?: (
     attachment: Ref<Attachment>
-  ) => OperationItem<Attachment>[] | Promise<OperationItem<Attachment>[]>;
+  ) => OperationItem<Attachment>[];
 
-  "plugin:list-item:field:create"?: (
-    plugin: Ref<Plugin>
-  ) => EntityFieldItem[] | Promise<EntityFieldItem[]>;
+  "plugin:list-item:field:create"?: (plugin: Ref<Plugin>) => EntityFieldItem[];
 
-  "post:list-item:field:create"?: (
-    post: Ref<ListedPost>
-  ) => EntityFieldItem[] | Promise<EntityFieldItem[]>;
+  "post:list-item:field:create"?: (post: Ref<ListedPost>) => EntityFieldItem[];
 
   "theme:list:tabs:create"?: () => ThemeListTab[] | Promise<ThemeListTab[]>;
 
   "theme:list-item:operation:create"?: (
     theme: Ref<Theme>
-  ) => OperationItem<Theme>[] | Promise<OperationItem<Theme>[]>;
+  ) => OperationItem<Theme>[];
 
   "user:detail:tabs:create"?: () => UserTab[] | Promise<UserTab[]>;
 


### PR DESCRIPTION
#### What type of PR is this?

/area ui
/kind feature
/milestone 2.16.x

#### What this PR does / why we need it:

优化 UI 部分的扩展点获取实现，让部分扩展点支持异步获取，之前的实现与文档不符。

比如：

```ts
import { definePlugin } from "@halo-dev/console-shared";
import axios from "axios";

export default definePlugin({
  components: {},
  routes: [],
  extensionPoints: {
    "attachment:selector:create": async () => {
      const { data } = await axios.get(
        "/apis/v1alpha1/fake.halo.run/attachments/selectors"
      );

      return data;
    },
  },
});
```

#### Which issue(s) this PR fixes:

Fixes https://github.com/halo-dev/halo/issues/6008

#### Does this PR introduce a user-facing change?

```release-note
优化 UI 部分的扩展点获取实现，让部分扩展点支持异步获取。
```
