### PR TITLE
chore: revert @uppy/xhr-upload version to 3.6.0

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -70,7 +70,7 @@
     "@uppy/progress-bar": "^3.1.1",
     "@uppy/status-bar": "^3.3.3",
     "@uppy/vue": "^1.1.2",
-    "@uppy/xhr-upload": "^3.6.7",
+    "@uppy/xhr-upload": "3.6.0",
     "@vueuse/components": "^10.9.0",
     "@vueuse/core": "^10.9.0",
     "@vueuse/integrations": "^10.9.0",

--- a/ui/pnpm-lock.yaml
+++ b/ui/pnpm-lock.yaml
@@ -105,8 +105,8 @@ importers:
         specifier: ^1.1.2
         version: 1.1.2(@uppy/core@3.11.3)(@uppy/dashboard@3.8.3(@uppy/core@3.11.3))(@uppy/drag-drop@3.1.0(@uppy/core@3.11.3))(@uppy/file-input@3.1.2(@uppy/core@3.11.3))(@uppy/progress-bar@3.1.1(@uppy/core@3.11.3))(@uppy/status-bar@3.3.3(@uppy/core@3.11.3))(vue@3.4.27(typescript@5.3.3))
       '@uppy/xhr-upload':
-        specifier: ^3.6.7
-        version: 3.6.7(@uppy/core@3.11.3)
+        specifier: 3.6.0
+        version: 3.6.0(@uppy/core@3.11.3)
       '@vueuse/components':
         specifier: ^10.9.0
         version: 10.9.0(vue@3.4.27(typescript@5.3.3))
@@ -4243,10 +4243,10 @@ packages:
       '@uppy/status-bar':
         optional: true
 
-  '@uppy/xhr-upload@3.6.7':
-    resolution: {integrity: sha512-xd8PA6gz8/usm7wpI6w8zOjnw5KnE/Yt7fWknFubMFCbP0yutWbStgeFAj5AMdLjLQpGveGb/OVWHhBfy2LwlA==}
+  '@uppy/xhr-upload@3.6.0':
+    resolution: {integrity: sha512-HgWr+CvJzJXAp639AiZatdEWmRdhhN5LrjTZurAkvm9nPQarpi1bo0DChO+1bpkXWOR/1VarBbZOr8lNecEn7Q==}
     peerDependencies:
-      '@uppy/core': ^3.11.3
+      '@uppy/core': ^3.8.0
 
   '@vitejs/plugin-vue-jsx@3.1.0':
     resolution: {integrity: sha512-w9M6F3LSEU5kszVb9An2/MmXNxocAnUb3WhRr8bHlimhDrXNt6n6D2nJQR3UXpGlZHh/EsgouOHCsM8V3Ln+WA==}
@@ -15451,11 +15451,12 @@ snapshots:
       '@uppy/progress-bar': 3.1.1(@uppy/core@3.11.3)
       '@uppy/status-bar': 3.3.3(@uppy/core@3.11.3)
 
-  '@uppy/xhr-upload@3.6.7(@uppy/core@3.11.3)':
+  '@uppy/xhr-upload@3.6.0(@uppy/core@3.11.3)':
     dependencies:
       '@uppy/companion-client': 3.8.1(@uppy/core@3.11.3)
       '@uppy/core': 3.11.3
       '@uppy/utils': 5.9.0
+      nanoid: 4.0.0
 
   '@vitejs/plugin-vue-jsx@3.1.0(vite@5.2.11(@types/node@18.13.0)(less@4.2.0)(sass@1.60.0)(terser@5.31.0))(vue@3.4.27(typescript@5.3.3))':
     dependencies:


### PR DESCRIPTION
#### What type of PR is this?

/area ui
/kind bug
/milestone 2.16.x

#### What this PR does / why we need it:

回退 `@uppy/xhr-upload` 的版本至 3.6.0，因为最新版本的 `@uppy/xhr-upload` 添加了重试机制和修改了错误异常的结构，并且当前重试参数并没有体现在文档和 API 中，所以暂时先回退至 3.6.0 以解决 https://github.com/halo-dev/halo/issues/6014

https://github.com/transloadit/uppy/blame/31cc47f3fb7513c82b887b429aa5f2a36eb4d593/packages/%40uppy/utils/src/fetcher.ts#L26

#### Which issue(s) this PR fixes:

Fixes https://github.com/halo-dev/halo/issues/6014

#### Special notes for your reviewer:

需要测试：

1. 附件上传功能
2. 上传已安装的插件或者主题，观察是否有提示升级。

#### Does this PR introduce a user-facing change?

```release-note
None
```
