### PR TITLE
fix: dropdown component auto-destruction issue

### DIFF
--- a/ui/packages/components/src/components/dropdown/Dropdown.vue
+++ b/ui/packages/components/src/components/dropdown/Dropdown.vue
@@ -41,11 +41,12 @@ defineExpose({
 </script>
 
 <template>
+  <!-- @vue-ignore -->
   <FloatingDropdown
     ref="dropdownRef"
     :placement="placement"
     :triggers="triggers"
-    :dispose-timeout="0"
+    :dispose-timeout="null"
     @show="emit('show')"
   >
     <slot />


### PR DESCRIPTION
#### What type of PR is this?

/area ui
/kind bug
/milestone 2.16.x

#### What this PR does / why we need it:

修复 Dropdown 组件自动销毁的问题，这可能导致部分插件在 Dropdown 中的组件无法正常渲染。

#### Does this PR introduce a user-facing change?

```release-note
None 
```
