### PR TITLE
fix: missing default values for system settings

### DIFF
--- a/application/src/main/resources/extensions/system-configurable-configmap.yaml
+++ b/application/src/main/resources/extensions/system-configurable-configmap.yaml
@@ -6,7 +6,8 @@ data:
   user: |
     {
       "allowRegistration": false,
-      "defaultRole": "",
+      "mustVerifyEmailOnRegistration": false,
+      "defaultRole": "guest",
       "avatarPolicy": "default-policy"
     }
   theme: |


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/area core
/milestone 2.16.x

#### What this PR does / why we need it:

补充缺失的系统设置默认值。

#### Does this PR introduce a user-facing change?

```release-note
修复系统设置未保存导致无法正常注册的问题
```
