### PR TITLE
fix: content offset caused by empty slot

### DIFF
--- a/ui/packages/components/src/components/tag/Tag.vue
+++ b/ui/packages/components/src/components/tag/Tag.vue
@@ -51,7 +51,8 @@ const classes = computed(() => {
   h-5
   text-xs
   border
-  border-solid;
+  border-solid
+  px-1;
 
   &.tag-default {
     border: 1px solid #d9d9d9;
@@ -81,14 +82,6 @@ const classes = computed(() => {
 
   .tag-content {
     @apply px-1;
-  }
-
-  .tag-left-icon {
-    @apply pl-1;
-  }
-
-  .tag-right-icon {
-    @apply pr-1;
   }
 }
 </style>


### PR DESCRIPTION
#### What type of PR is this?

/area ui
/kind improvement

#### Which issue(s) this PR fixes:

Fixes #5877 

```release-note
修复Tag Icon为空时，后台文章的Tag内容不居中
```
