### PR TITLE
fix: ensure pasted content auto-generates title id

### DIFF
--- a/ui/packages/editor/src/extensions/heading/index.ts
+++ b/ui/packages/editor/src/extensions/heading/index.ts
@@ -290,6 +290,9 @@ const Blockquote = TiptapHeading.extend<ExtensionOptions & HeadingOptions>({
               return true;
             }
             if (transaction.docChanged) {
+              if (transaction.getMeta("paste")) {
+                return true;
+              }
               beforeComposition = composition;
               const selection = transaction.selection;
               const { $from } = selection;


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/area editor
/milestone 2.17.x

#### What this PR does / why we need it:

当前在编辑器中粘贴内容后，如果不修改任意标题或新增标题，则无法为当前标题自动生成标题 ID，进而导致锚点失效。

本 PR 将在编辑器触发内容更改后，如果是粘贴的内容，则直接触发生成标题 ID。

#### How to test it?

新建一篇文章并粘贴一段带标题的内容后直接发布。

查看发布后的文章是否可以在主题端使用锚点跳转。

#### Which issue(s) this PR fixes:

Fixes #6056 

#### Does this PR introduce a user-facing change?
```release-note
解决在默认编辑器中粘贴的内容无法生成标题 ID 的问题
```
