### PR TITLE
Fix the problem that bundle files are not changed in development mode

### DIFF
--- a/application/src/test/java/run/halo/app/core/extension/service/impl/PluginServiceImplTest.java
+++ b/application/src/test/java/run/halo/app/core/extension/service/impl/PluginServiceImplTest.java
@@ -23,6 +23,9 @@ import java.net.URISyntaxException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.ExecutionException;
@@ -249,7 +252,6 @@ class PluginServiceImplTest {
 
     }
 
-
     @Test
     void generateBundleVersionTest() {
         var plugin1 = mock(PluginWrapper.class);
@@ -295,6 +297,19 @@ class PluginServiceImplTest {
             .verifyComplete();
 
         assertThat(result).isNotEqualTo(result2);
+    }
+
+    @Test
+    void shouldGenerateRandomBundleVersionInDevelopment() {
+        var clock = Clock.fixed(Instant.now(), ZoneId.systemDefault());
+        pluginService.setClock(clock);
+        when(pluginManager.isDevelopment()).thenReturn(true);
+        pluginService.generateBundleVersion()
+            .as(StepVerifier::create)
+            .expectNext(String.valueOf(clock.instant().toEpochMilli()))
+            .verifyComplete();
+
+        verify(pluginManager, never()).getStartedPlugins();
     }
 
     @Nested


### PR DESCRIPTION
#### What type of PR is this?

/kind regression
/area plugin
/milestone 2.17.x

#### What this PR does / why we need it:

This PR reverts changes of generating bundle resource version in <https://github.com/halo-dev/halo/pull/6028>.

Because the changes were adapted realtime change of bundle files for plugin developers in plugin development runtime mode, but I ignored it.

#### Special notes for your reviewer:

1. Try to start Halo in plugin development mode
2. Change and rebuild ui resources
3. Refresh console and check the result

#### Does this PR introduce a user-facing change?

```release-note
None
```
