### PR TITLE
pref: default code block indentation from Tab to 2 Spaces in editor

### DIFF
--- a/ui/packages/editor/src/extensions/code-block/code-block.ts
+++ b/ui/packages/editor/src/extensions/code-block/code-block.ts
@@ -50,7 +50,7 @@ const updateIndent = (tr: Transaction, type: IndentType): Transaction => {
   const { from, to } = selection;
   doc.nodesBetween(from, to, (node, pos) => {
     if (from - to == 0 && type === "indent") {
-      tr.insertText("\t", from, to);
+      tr.insertText("  ", from, to);
       return false;
     }
 
@@ -60,17 +60,17 @@ const updateIndent = (tr: Transaction, type: IndentType): Transaction => {
       precedeLineBreakPos === -1 ? pos + 1 : pos + precedeLineBreakPos + 1;
     const text = doc.textBetween(startBetWeenIndex, to, "\n");
     if (type === "indent") {
-      let replacedStr = text.replace(/\n/g, "\n\t");
+      let replacedStr = text.replace(/\n/g, "\n  ");
       if (startBetWeenIndex === pos + 1) {
-        replacedStr = "\t" + replacedStr;
+        replacedStr = "  " + replacedStr;
       }
       tr.insertText(replacedStr, startBetWeenIndex, to);
     } else {
-      let replacedStr = text.replace(/\n\t/g, "\n");
+      let replacedStr = text.replace(/\n {2}/g, "\n");
       if (startBetWeenIndex === pos + 1) {
-        const firstNewLineIndex = replacedStr.indexOf("\t");
+        const firstNewLineIndex = replacedStr.indexOf("  ");
         if (firstNewLineIndex == 0) {
-          replacedStr = replacedStr.replace("\t", "");
+          replacedStr = replacedStr.replace("  ", "");
         }
       }
       tr.insertText(replacedStr, startBetWeenIndex, to);


### PR DESCRIPTION
#### What type of PR is this?

/kind improvement
/area editor
/milestone 2.17.x

#### What this PR does / why we need it:

将默认编辑器中代码块的缩进由一个制表符(\t)，更改为两个空格` {2}`。

#### How to test it?

测试使用 `Tab` 即 `Shift + Tab` 缩进时，是否每次缩进两个空格而不是一个制表符。

#### Does this PR introduce a user-facing change?
```release-note
优化默认编辑器代码块缩进为两个空格。
```
