### PR TITLE
feat: support setting rendering templates for related posts on category

### DIFF
--- a/api-docs/openapi/v3_0/aggregated.json
+++ b/api-docs/openapi/v3_0/aggregated.json
@@ -13499,6 +13499,10 @@
             "minLength": 1,
             "type": "string"
           },
+          "postTemplate": {
+            "maxLength": 255,
+            "type": "string"
+          },
           "priority": {
             "type": "integer",
             "format": "int32",
@@ -13509,6 +13513,7 @@
             "type": "string"
           },
           "template": {
+            "maxLength": 255,
             "type": "string"
           }
         }
@@ -17446,12 +17451,12 @@
           },
           "visible": {
             "type": "string",
+            "default": "PUBLIC",
             "enum": [
               "PUBLIC",
               "INTERNAL",
               "PRIVATE"
-            ],
-            "default": "PUBLIC"
+            ]
           }
         }
       },
@@ -19101,12 +19106,12 @@
           },
           "visible": {
             "type": "string",
+            "default": "PUBLIC",
             "enum": [
               "PUBLIC",
               "INTERNAL",
               "PRIVATE"
-            ],
-            "default": "PUBLIC"
+            ]
           }
         }
       },

--- a/api/src/main/java/run/halo/app/core/extension/content/Category.java
+++ b/api/src/main/java/run/halo/app/core/extension/content/Category.java
@@ -1,5 +1,6 @@
 package run.halo.app.core.extension.content;
 
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.NOT_REQUIRED;
 import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
 import static run.halo.app.core.extension.content.Category.KIND;
 
@@ -53,7 +54,16 @@ public class Category extends AbstractExtension {
 
         private String cover;
 
+        @Schema(requiredMode = NOT_REQUIRED, maxLength = 255)
         private String template;
+
+        /**
+         * <p>Used to specify the template for the posts associated with the category.</p>
+         * <p>The priority is not as high as that of the post.</p>
+         * <p>If the post also specifies a template, the post's template will prevail.</p>
+         */
+        @Schema(requiredMode = NOT_REQUIRED, maxLength = 255)
+        private String postTemplate;
 
         @Schema(requiredMode = REQUIRED, defaultValue = "0")
         private Integer priority;

--- a/ui/console-src/modules/contents/posts/categories/components/CategoryEditingModal.vue
+++ b/ui/console-src/modules/contents/posts/categories/components/CategoryEditingModal.vue
@@ -51,6 +51,7 @@ const formState = ref<Category>({
     description: "",
     cover: "",
     template: "",
+    postTemplate: "",
     priority: 0,
     children: [],
   },
@@ -160,6 +161,7 @@ onMounted(() => {
 
 // custom templates
 const { templates } = useThemeCustomTemplates("category");
+const { templates: postTemplates } = useThemeCustomTemplates("post");
 
 // slug
 const { handleGenerateSlug } = useSlugify(
@@ -243,8 +245,25 @@ const { handleGenerateSlug } = useSlugify(
               :label="
                 $t('core.post_category.editing_modal.fields.template.label')
               "
+              :help="
+                $t('core.post_category.editing_modal.fields.template.help')
+              "
               type="select"
               name="template"
+            ></FormKit>
+            <FormKit
+              v-model="formState.spec.postTemplate"
+              :options="postTemplates"
+              :label="
+                $t(
+                  'core.post_category.editing_modal.fields.post_template.label'
+                )
+              "
+              :help="
+                $t('core.post_category.editing_modal.fields.post_template.help')
+              "
+              type="select"
+              name="postTemplate"
             ></FormKit>
             <FormKit
               v-model="formState.spec.cover"

--- a/ui/packages/api-client/src/models/category-spec.ts
+++ b/ui/packages/api-client/src/models/category-spec.ts
@@ -46,6 +46,12 @@ export interface CategorySpec {
     'displayName': string;
     /**
      * 
+     * @type {string}
+     * @memberof CategorySpec
+     */
+    'postTemplate'?: string;
+    /**
+     * 
      * @type {number}
      * @memberof CategorySpec
      */

--- a/ui/src/locales/en.yaml
+++ b/ui/src/locales/en.yaml
@@ -366,12 +366,20 @@ core:
           refresh_message: Regenerate slug based on display name.
         template:
           label: Custom template
+          help: >-
+            Customize the rendering template of the category archive page, which
+            requires support from the theme
         cover:
           label: Cover
           help: Theme adaptation is required to support
         description:
           label: Description
           help: Theme adaptation is required to support
+        post_template:
+          label: Custom post template
+          help: >-
+            Customize the rendering template of posts in the current category,
+            which requires support from the theme
   page:
     title: Pages
     actions:
@@ -728,9 +736,9 @@ core:
         version_mismatch:
           title: Version mismatch
           description: >-
-            The imported configuration file version does not match the 
-            current theme version, which may lead to compatibility issues.
-            Do you want to continue importing?
+            The imported configuration file version does not match the  current
+            theme version, which may lead to compatibility issues. Do you want
+            to continue importing?
         invalid_format: Invalid theme configuration file
         mismatched_theme: Configuration file does not match the selected theme
     list_modal:

--- a/ui/src/locales/zh-CN.yaml
+++ b/ui/src/locales/zh-CN.yaml
@@ -366,12 +366,16 @@ core:
           refresh_message: 根据名称重新生成别名
         template:
           label: 自定义模板
+          help: 自定义分类归档页面的渲染模版，需要主题提供支持
         cover:
           label: 封面图
           help: 需要主题适配以支持
         description:
           label: 描述
           help: 需要主题适配以支持
+        post_template:
+          label: 自定义文章模板
+          help: 自定义当前分类下文章的渲染模版，需要主题提供支持
   page:
     title: 页面
     actions:

--- a/ui/src/locales/zh-TW.yaml
+++ b/ui/src/locales/zh-TW.yaml
@@ -346,12 +346,16 @@ core:
           refresh_message: 根據名稱重新生成別名
         template:
           label: 自定義模板
+          help: 自定義分類歸檔頁面的渲染模板，需要主題提供支持
         cover:
           label: 封面圖
           help: 需要主題適配以支持
         description:
           label: 描述
           help: 需要主題適配以支持
+        post_template:
+          label: 自定義文章模板
+          help: 自定義當前分類下文章的渲染模板，需要主題提供支持
   page:
     title: 頁面
     actions:


### PR DESCRIPTION
#### What type of PR is this?
/kind feature
/area core
/milestone 2.17.x

#### What this PR does / why we need it:
支持在分类上为关联的文章统一设置渲染模板

现在文章的模板生效顺序为：
1. 文章关联的分类上设置的文章模板，如果有多个则选择第一个
2. 文章上设置的自定义模板
3. 文章的默认模板

#### Which issue(s) this PR fixes:
Fixes #6101

#### Does this PR introduce a user-facing change?
```release-note
支持在分类上为关联的文章统一设置渲染模板
```
