### PR TITLE
Refactor attachment moving using the patch api

### DIFF
--- a/ui/console-src/modules/contents/attachments/AttachmentList.vue
+++ b/ui/console-src/modules/contents/attachments/AttachmentList.vue
@@ -27,7 +27,6 @@ import {
 } from "@halo-dev/components";
 import { useLocalStorage } from "@vueuse/core";
 import { useRouteQuery } from "@vueuse/router";
-import { cloneDeep } from "lodash-es";
 import type { Ref } from "vue";
 import { computed, onMounted, provide, ref, watch } from "vue";
 import { useI18n } from "vue-i18n";
@@ -130,12 +129,16 @@ provide<Ref<Set<Attachment>>>("selectedAttachments", selectedAttachments);
 const handleMove = async (group: Group) => {
   try {
     const promises = Array.from(selectedAttachments.value).map((attachment) => {
-      const attachmentToUpdate = cloneDeep(attachment);
-      attachmentToUpdate.spec.groupName = group.metadata.name;
-      return apiClient.extension.storage.attachment.updateStorageHaloRunV1alpha1Attachment(
+      return apiClient.extension.storage.attachment.patchStorageHaloRunV1alpha1Attachment(
         {
           name: attachment.metadata.name,
-          attachment: attachmentToUpdate,
+          jsonPatchInner: [
+            {
+              op: "add",
+              path: "/spec/groupName",
+              value: group.metadata.name,
+            },
+          ],
         }
       );
     });

--- a/ui/console-src/modules/contents/attachments/components/AttachmentGroupBadge.vue
+++ b/ui/console-src/modules/contents/attachments/components/AttachmentGroupBadge.vue
@@ -61,11 +61,15 @@ const handleDelete = () => {
 
       // move attachments to none group
       const moveToUnGroupRequests = data.items.map((attachment) => {
-        attachment.spec.groupName = undefined;
-        return apiClient.extension.storage.attachment.updateStorageHaloRunV1alpha1Attachment(
+        return apiClient.extension.storage.attachment.patchStorageHaloRunV1alpha1Attachment(
           {
             name: attachment.metadata.name,
-            attachment: attachment,
+            jsonPatchInner: [
+              {
+                op: "remove",
+                path: "/spec/groupName",
+              },
+            ],
           }
         );
       });


### PR DESCRIPTION
#### What type of PR is this?

/area ui
/kind improvement
/milestone 2.17.x

#### What this PR does / why we need it:

使用新的 [patch](https://github.com/halo-dev/halo/pull/6031) 接口重构附件的移动功能。

#### Special notes for your reviewer:

1. 测试附件移动至其他分组的功能是否正常。
2. 测试删除附件分组，选择 **删除并将附件移动至未分组** 选项，观察删除分组之后，其中的附件是否已经移动到未分组。

#### Does this PR introduce a user-facing change?

```release-note
None
```
