### PR TITLE
refactor: simplify the plugin startup logic

### DIFF
--- a/ui/console-src/modules/system/plugins/components/installation-tabs/LocalUpload.vue
+++ b/ui/console-src/modules/system/plugins/components/installation-tabs/LocalUpload.vue
@@ -64,15 +64,11 @@ const handleShowActiveModalAfterInstall = (plugin: Plugin) => {
     cancelText: t("core.common.buttons.cancel"),
     onConfirm: async () => {
       try {
-        const { data: pluginToUpdate } =
-          await apiClient.extension.plugin.getPluginHaloRunV1alpha1Plugin({
-            name: plugin.metadata.name,
-          });
-        pluginToUpdate.spec.enabled = true;
-
-        await apiClient.extension.plugin.updatePluginHaloRunV1alpha1Plugin({
-          name: pluginToUpdate.metadata.name,
-          plugin: pluginToUpdate,
+        await apiClient.plugin.changePluginRunningState({
+          name: plugin.metadata.name,
+          pluginRunningStateRequest: {
+            enable: true,
+          },
         });
 
         window.location.reload();

--- a/ui/console-src/modules/system/plugins/components/installation-tabs/RemoteDownload.vue
+++ b/ui/console-src/modules/system/plugins/components/installation-tabs/RemoteDownload.vue
@@ -80,15 +80,11 @@ const handleShowActiveModalAfterInstall = (plugin: Plugin) => {
     cancelText: t("core.common.buttons.cancel"),
     onConfirm: async () => {
       try {
-        const { data: pluginToUpdate } =
-          await apiClient.extension.plugin.getPluginHaloRunV1alpha1Plugin({
-            name: plugin.metadata.name,
-          });
-        pluginToUpdate.spec.enabled = true;
-
-        await apiClient.extension.plugin.updatePluginHaloRunV1alpha1Plugin({
-          name: pluginToUpdate.metadata.name,
-          plugin: pluginToUpdate,
+        await apiClient.plugin.changePluginRunningState({
+          name: plugin.metadata.name,
+          pluginRunningStateRequest: {
+            enable: true,
+          },
         });
 
         window.location.reload();

--- a/ui/console-src/modules/system/plugins/composables/use-plugin.ts
+++ b/ui/console-src/modules/system/plugins/composables/use-plugin.ts
@@ -1,7 +1,6 @@
 import type { ComputedRef, Ref } from "vue";
 import { computed } from "vue";
 import { type Plugin, PluginStatusPhaseEnum } from "@halo-dev/api-client";
-import { cloneDeep } from "lodash-es";
 import { apiClient } from "@/utils/api-client";
 import { Dialog, Toast } from "@halo-dev/components";
 import { useI18n } from "vue-i18n";
@@ -117,14 +116,12 @@ export function usePluginLifeCycle(
         if (!plugin.value) return;
 
         try {
-          if (enabled) {
-            const pluginToUpdate = cloneDeep(plugin.value);
-            pluginToUpdate.spec.enabled = false;
-            await apiClient.extension.plugin.updatePluginHaloRunV1alpha1Plugin({
-              name: pluginToUpdate.metadata.name,
-              plugin: pluginToUpdate,
-            });
-          }
+          await apiClient.plugin.changePluginRunningState({
+            name: plugin.value.metadata.name,
+            pluginRunningStateRequest: {
+              enable: false,
+            },
+          });
 
           await apiClient.extension.plugin.deletePluginHaloRunV1alpha1Plugin({
             name: plugin.value.metadata.name,


### PR DESCRIPTION
#### What type of PR is this?

/area ui
/kind improvement
/milestone 2.17.x

#### What this PR does / why we need it:

简化插件启动的接口，改为之前单独提供的修改插件状态的接口，而不是修改 `spec.enabled`。

#### Special notes for your reviewer:

需要测试：

1. 手动安装插件之后，启动插件。

#### Does this PR introduce a user-facing change?

```release-note
None
```
