### PR TITLE
fix: not remembering the selected attachment policy in upload modal

### DIFF
--- a/ui/console-src/modules/contents/attachments/components/AttachmentUploadModal.vue
+++ b/ui/console-src/modules/contents/attachments/components/AttachmentUploadModal.vue
@@ -8,7 +8,7 @@ import {
   VModal,
 } from "@halo-dev/components";
 import { useLocalStorage } from "@vueuse/core";
-import { ref, watch } from "vue";
+import { onMounted, ref } from "vue";
 import { useFetchAttachmentGroup } from "../composables/use-attachment-group";
 import {
   useFetchAttachmentPolicy,
@@ -32,35 +32,11 @@ const selectedPolicyName = useLocalStorage("attachment-upload-policy", "");
 const policyEditingModal = ref(false);
 const policyTemplateNameToCreate = ref();
 
-watch(
-  () => groups.value,
-  () => {
-    if (selectedGroupName.value === "") return;
-
-    const group = groups.value?.find(
-      (group) => group.metadata.name === selectedGroupName.value
-    );
-    if (!group) {
-      selectedGroupName.value = groups.value?.length
-        ? groups.value[0].metadata.name
-        : "";
-    }
+onMounted(() => {
+  if (!selectedPolicyName.value) {
+    selectedPolicyName.value = policies.value?.[0].metadata.name;
   }
-);
-
-watch(
-  () => policies.value,
-  () => {
-    const policy = policies.value?.find(
-      (policy) => policy.metadata.name === selectedPolicyName.value
-    );
-    if (!policy) {
-      selectedPolicyName.value = policies.value?.length
-        ? policies.value[0].metadata.name
-        : "";
-    }
-  }
-);
+});
 
 const handleOpenCreateNewPolicyModal = (policyTemplate: PolicyTemplate) => {
   policyTemplateNameToCreate.value = policyTemplate.metadata.name;


### PR DESCRIPTION
#### What type of PR is this?

/area ui
/kind bug
/milestone 2.17.x

#### What this PR does / why we need it:

修复首次上传附件时，没有默认选择第一个存储策略的问题。

#### Which issue(s) this PR fixes:

Fixes https://github.com/halo-dev/halo/issues/6094

#### Does this PR introduce a user-facing change?

```release-note
修复首次上传附件时，没有默认选择第一个存储策略的问题。
```
