### PR TITLE
chore: bump mariadb driver to 1.2.1 to fix crash issue

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,2 @@
 version=2.17.0-SNAPSHOT
+r2dbc-mariadb.version=1.2.1

--- a/platform/application/build.gradle
+++ b/platform/application/build.gradle
@@ -54,8 +54,6 @@ dependencies {
         api "io.github.resilience4j:resilience4j-spring-boot3:$resilience4jVersion"
         api "io.github.resilience4j:resilience4j-reactor:$resilience4jVersion"
         api "com.j256.two-factor-auth:two-factor-auth:$twoFactorAuth"
-
-        runtime 'org.mariadb:r2dbc-mariadb:1.1.4'
     }
 
 }


### PR DESCRIPTION
#### What type of PR is this?

/area core
/kind bug
/milestone 2.17.x

#### What this PR does / why we need it:

升级 MariaDB 的原生驱动版本至 [1.2.1](https://github.com/mariadb-corporation/mariadb-connector-r2dbc/releases/tag/1.2.1)，以解决无法正常部署的问题。

#### Which issue(s) this PR fixes:

Fixes https://github.com/halo-dev/halo/issues/5534

#### Special notes for your reviewer:

测试方式：

```shell
./gradlew clean build -x check -x test --refresh-dependencies
```

```shell
docker build -t halohub/halo:mariadb-fix .
```

```yaml
services:
  halo:
    image: halohub/halo:mariadb-fix
    restart: on-failure:3
    networks:
      halo_network:
    volumes:
      - ./halo2:/root/.halo2
    ports:
      - "8090:8090"
    healthcheck:
      test: ["CMD", "curl", "-f", "http://localhost:8090/actuator/health/readiness"]
      interval: 30s
      timeout: 5s
      retries: 5
      start_period: 30s
    command:
      - --spring.r2dbc.url=r2dbc:pool:mariadb://halodb:3306/halo
      - --spring.r2dbc.username=root
      - --spring.r2dbc.password=jzm3h9t9jggo6ww
      - --spring.sql.init.platform=mariadb
      - --halo.external-url=http://localhost:8090/

  halodb:
    image: mariadb:latest
    container_name: mariadb
    restart: always
    networks:
      halo_network:
    environment:
      MYSQL_ROOT_PASSWORD: jzm3h9t9jggo6ww
      MYSQL_DATABASE: halo
    volumes:
      - ./db:/var/lib/mysql
networks:
  halo_network:
```

```shell
docker compose up
```

#### Does this PR introduce a user-facing change?

```release-note
升级 MariaDB 的原生驱动版本至 [1.2.1](https://github.com/mariadb-corporation/mariadb-connector-r2dbc/releases/tag/1.2.1)，以解决使用 MariaDB 无法正常部署的问题。
```
