### PR TITLE
feat: add method to find path of a specified node in a category tree

### DIFF
--- a/application/src/main/java/run/halo/app/theme/finders/CategoryFinder.java
+++ b/application/src/main/java/run/halo/app/theme/finders/CategoryFinder.java
@@ -30,4 +30,6 @@ public interface CategoryFinder {
     Flux<CategoryTreeVo> listAsTree(String name);
 
     Mono<CategoryVo> getParentByName(String name);
+
+    Flux<CategoryVo> getBreadcrumbs(String name);
 }

--- a/application/src/main/java/run/halo/app/theme/finders/vo/CategoryTreeVo.java
+++ b/application/src/main/java/run/halo/app/theme/finders/vo/CategoryTreeVo.java
@@ -51,6 +51,19 @@ public class CategoryTreeVo implements VisualizableTreeNode<CategoryTreeVo>, Ext
             .build();
     }
 
+    /**
+     * Convert {@link CategoryTreeVo} to {@link CategoryVo}.
+     */
+    public static CategoryVo toCategoryVo(CategoryTreeVo categoryTreeVo) {
+        Assert.notNull(categoryTreeVo, "The category tree vo must not be null");
+        return CategoryVo.builder()
+            .metadata(categoryTreeVo.getMetadata())
+            .spec(categoryTreeVo.getSpec())
+            .status(categoryTreeVo.getStatus())
+            .postCount(categoryTreeVo.getPostCount())
+            .build();
+    }
+
     @Override
     public String nodeText() {
         return String.format("%s (%s)%s", getSpec().getDisplayName(), getPostCount(),


### PR DESCRIPTION
#### What type of PR is this?
/kind feature
/area core
/milestone 2.17.x

#### What this PR does / why we need it:
为分类 Finder 提供获取指定节点的面包屑路径方法

#### Which issue(s) this PR fixes:
Fixes #3374

#### Does this PR introduce a user-facing change?
```release-note
为分类 Finder 提供获取指定节点的面包屑路径方法
```
