### PR TITLE
refactor: hide move group button when no attachment groups are present

### DIFF
--- a/ui/console-src/modules/contents/attachments/AttachmentList.vue
+++ b/ui/console-src/modules/contents/attachments/AttachmentList.vue
@@ -1,9 +1,9 @@
 <script lang="ts" setup>
 import UserFilterDropdown from "@/components/filter/UserFilterDropdown.vue";
 import LazyImage from "@/components/image/LazyImage.vue";
-import { coreApiClient } from "@halo-dev/api-client";
 import { isImage } from "@/utils/image";
 import type { Attachment, Group } from "@halo-dev/api-client";
+import { coreApiClient } from "@halo-dev/api-client";
 import {
   IconArrowLeft,
   IconArrowRight,
@@ -323,7 +323,7 @@ onMounted(() => {
                         $t("core.attachment.operations.deselect_items.button")
                       }}
                     </VButton>
-                    <VDropdown>
+                    <VDropdown v-if="groups?.length">
                       <VButton>
                         {{ $t("core.attachment.operations.move.button") }}
                       </VButton>


### PR DESCRIPTION
#### What type of PR is this?

/area ui
/kind improvement
/milestone 2.17.x

#### What this PR does / why we need it:

选择附件时，如果当前没有分组，改为不显示移动按钮。

<img width="385" alt="image" src="https://github.com/halo-dev/halo/assets/21301288/2d805f29-ecea-4469-b305-e217bd17db8b">

<img width="497" alt="image" src="https://github.com/halo-dev/halo/assets/21301288/34800eb1-8fae-42fa-b875-929a3d912967">


#### Which issue(s) this PR fixes:

Fixes #6124 

#### Does this PR introduce a user-facing change?

```release-note
None
```
