### PR TITLE
refactor: add list options for sync all synchronizer

### DIFF
--- a/api/src/main/java/run/halo/app/extension/ExtensionMatcher.java
+++ b/api/src/main/java/run/halo/app/extension/ExtensionMatcher.java
@@ -4,11 +4,20 @@ import run.halo.app.extension.router.selector.FieldSelector;
 import run.halo.app.extension.router.selector.LabelSelector;
 
 public interface ExtensionMatcher {
-    GroupVersionKind getGvk();
+    @Deprecated(since = "2.17.0", forRemoval = true)
+    default GroupVersionKind getGvk() {
+        return null;
+    }
 
-    LabelSelector getLabelSelector();
+    @Deprecated(since = "2.17.0", forRemoval = true)
+    default LabelSelector getLabelSelector() {
+        return null;
+    }
 
-    FieldSelector getFieldSelector();
+    @Deprecated(since = "2.17.0", forRemoval = true)
+    default FieldSelector getFieldSelector() {
+        return null;
+    }
 
     boolean match(Extension extension);
 }

--- a/api/src/main/java/run/halo/app/extension/WatcherExtensionMatchers.java
+++ b/api/src/main/java/run/halo/app/extension/WatcherExtensionMatchers.java
@@ -4,6 +4,8 @@ import java.util.Objects;
 import lombok.Builder;
 import lombok.Getter;
 import org.springframework.util.Assert;
+import run.halo.app.extension.router.selector.FieldSelector;
+import run.halo.app.extension.router.selector.LabelSelector;
 
 public class WatcherExtensionMatchers {
     @Getter
@@ -38,15 +40,15 @@ public class WatcherExtensionMatchers {
     }
 
     public ExtensionMatcher onAddMatcher() {
-        return this.onAddMatcher;
+        return delegateExtensionMatcher(this.onAddMatcher);
     }
 
     public ExtensionMatcher onUpdateMatcher() {
-        return this.onUpdateMatcher;
+        return delegateExtensionMatcher(this.onUpdateMatcher);
     }
 
     public ExtensionMatcher onDeleteMatcher() {
-        return this.onDeleteMatcher;
+        return delegateExtensionMatcher(this.onDeleteMatcher);
     }
 
     public static WatcherExtensionMatchersBuilder builder(ExtensionClient client,
@@ -57,5 +59,33 @@ public class WatcherExtensionMatchers {
     static ExtensionMatcher emptyMatcher(ExtensionClient client,
         GroupVersionKind gvk) {
         return DefaultExtensionMatcher.builder(client, gvk).build();
+    }
+
+    /**
+     * Remove this method when the deprecated methods are removed.
+     */
+    ExtensionMatcher delegateExtensionMatcher(ExtensionMatcher matcher) {
+        return new ExtensionMatcher() {
+
+            @Override
+            public GroupVersionKind getGvk() {
+                return matcher.getGvk();
+            }
+
+            @Override
+            public LabelSelector getLabelSelector() {
+                return matcher.getLabelSelector();
+            }
+
+            @Override
+            public FieldSelector getFieldSelector() {
+                return matcher.getFieldSelector();
+            }
+
+            @Override
+            public boolean match(Extension extension) {
+                return extension.groupVersionKind().equals(gvk) && matcher.match(extension);
+            }
+        };
     }
 }

--- a/api/src/main/java/run/halo/app/extension/controller/RequestSynchronizer.java
+++ b/api/src/main/java/run/halo/app/extension/controller/RequestSynchronizer.java
@@ -5,7 +5,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Sort;
 import run.halo.app.extension.Extension;
 import run.halo.app.extension.ExtensionClient;
-import run.halo.app.extension.ExtensionMatcher;
 import run.halo.app.extension.GroupVersionKind;
 import run.halo.app.extension.ListOptions;
 import run.halo.app.extension.Watcher;
@@ -27,7 +26,7 @@ public class RequestSynchronizer implements Synchronizer<Request> {
 
     private final Watcher watcher;
 
-    private final ExtensionMatcher listMatcher;
+    private final ListOptions listOptions;
 
     @Getter
     private volatile boolean started = false;
@@ -36,13 +35,13 @@ public class RequestSynchronizer implements Synchronizer<Request> {
         ExtensionClient client,
         Extension extension,
         Watcher watcher,
-        ExtensionMatcher listMatcher) {
+        ListOptions listOptions) {
         this.syncAllOnStart = syncAllOnStart;
         this.client = client;
         this.type = extension.groupVersionKind();
         this.watcher = watcher;
         this.indexedQueryEngine = client.indexedQueryEngine();
-        this.listMatcher = listMatcher;
+        this.listOptions = listOptions;
     }
 
     @Override
@@ -54,11 +53,6 @@ public class RequestSynchronizer implements Synchronizer<Request> {
         started = true;
 
         if (syncAllOnStart) {
-            var listOptions = new ListOptions();
-            if (listMatcher != null) {
-                listOptions.setFieldSelector(listMatcher.getFieldSelector());
-                listOptions.setLabelSelector(listMatcher.getLabelSelector());
-            }
             indexedQueryEngine.retrieveAll(type, listOptions, Sort.by("metadata.creationTimestamp"))
                 .forEach(name -> watcher.onAdd(new Request(name)));
         }

--- a/api/src/test/java/run/halo/app/extension/controller/RequestSynchronizerTest.java
+++ b/api/src/test/java/run/halo/app/extension/controller/RequestSynchronizerTest.java
@@ -18,7 +18,6 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.data.domain.Sort;
 import run.halo.app.extension.ExtensionClient;
-import run.halo.app.extension.ExtensionMatcher;
 import run.halo.app.extension.FakeExtension;
 import run.halo.app.extension.GroupVersionKind;
 import run.halo.app.extension.ListOptions;
@@ -37,16 +36,13 @@ class RequestSynchronizerTest {
     @Mock
     Watcher watcher;
 
-    @Mock
-    ExtensionMatcher listMatcher;
-
     RequestSynchronizer synchronizer;
 
     @BeforeEach
     void setUp() {
         when(client.indexedQueryEngine()).thenReturn(indexedQueryEngine);
         synchronizer =
-            new RequestSynchronizer(true, client, new FakeExtension(), watcher, listMatcher);
+            new RequestSynchronizer(true, client, new FakeExtension(), watcher, new ListOptions());
         assertFalse(synchronizer.isDisposed());
         assertFalse(synchronizer.isStarted());
     }
@@ -71,7 +67,7 @@ class RequestSynchronizerTest {
     @Test
     void shouldStartCorrectlyWhenNotSyncingAllOnStart() {
         synchronizer =
-            new RequestSynchronizer(false, client, new FakeExtension(), watcher, listMatcher);
+            new RequestSynchronizer(false, client, new FakeExtension(), watcher, new ListOptions());
         assertFalse(synchronizer.isDisposed());
         assertFalse(synchronizer.isStarted());
 


### PR DESCRIPTION
#### What type of PR is this?
/kind improvement
/area core
/milestone 2.17.x

#### What this PR does / why we need it:
为启动时同步添加 ListOptions 选项为后续保持 ExtensionMatcher 的纯粹做准备，后续将移除 ExtensionMatcher 中多余的方法声明，只保留 match 方法,最终的结果希望是
```java
@FunctionalInterface
public interface ExtensionMatcher {
    boolean match(Extension extension);
}
```
以前构建 Controller 的写法
```java
public Controller setupWith(ControllerBuilder builder) {
         return builder
            .extension(new Post())
            .onAddMatcher(DefaultExtensionMatcher.builder(client, Post.GVK)
                .fieldSelector(FieldSelector.of(
                    equal(Post.REQUIRE_SYNC_ON_STARTUP_INDEX_NAME, TRUE))
                )
                .build()
            )
           .build();
}
```
现在的写法
```java
public Controller setupWith(ControllerBuilder builder) {
        var post = new Post();
        return builder
            .extension(post)
            // 当有新数据添加时
            .onAddMatcher(extension -> "fake-post".equals(extension.getMetadata().getName()))
            // 使用 syncAllListOptions 作为启动时同步的查询条件过滤不需要的数据
            .syncAllListOptions(ListOptions.builder()
                .fieldQuery(equal(Post.REQUIRE_SYNC_ON_STARTUP_INDEX_NAME, TRUE))
                .build()
            )
            .build();
    }
```

#### Does this PR introduce a user-facing change?
```release-note
开发者相关：重构 ControllerBuilder 的匹配条件并增加 syncAllListOptions 作为启动时同步的查询条件
```
