### PR TITLE
Fix the problem of not being able to autowire settingFetcher bean in plugin

### DIFF
--- a/application/src/main/java/run/halo/app/plugin/DefaultPluginApplicationContextFactory.java
+++ b/application/src/main/java/run/halo/app/plugin/DefaultPluginApplicationContextFactory.java
@@ -1,6 +1,5 @@
 package run.halo.app.plugin;
 
-import static org.springframework.beans.factory.config.BeanDefinition.SCOPE_SINGLETON;
 import static org.springframework.util.ResourceUtils.CLASSPATH_URL_PREFIX;
 
 import java.io.IOException;
@@ -102,9 +101,8 @@ public class DefaultPluginApplicationContextFactory implements PluginApplication
 
         rootContext.getBeanProvider(ReactiveExtensionClient.class)
             .ifUnique(client -> {
-                context.registerBean("reactiveSettingFetcher",
-                    DefaultReactiveSettingFetcher.class, bhd -> bhd.setScope(SCOPE_SINGLETON));
-                beanFactory.registerSingleton("settingFetcher", DefaultSettingFetcher.class);
+                context.registerBean("reactiveSettingFetcher", DefaultReactiveSettingFetcher.class);
+                context.registerBean("settingFetcher", DefaultSettingFetcher.class);
             });
 
         rootContext.getBeanProvider(PluginRequestMappingHandlerMapping.class)


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/area core
/area plugin

#### What this PR does / why we need it:

The problem was introduced by PR <https://github.com/halo-dev/halo/pull/6141>. That PR wrongly registered `settingFetcher` singleton bean.

#### Which issue(s) this PR fixes:

<img width="1920" alt="image" src="https://github.com/halo-dev/halo/assets/16865714/ecc67064-3506-49b8-8114-a145da549126">

#### Does this PR introduce a user-facing change?

```release-note
None
```
