### PR TITLE
Use top-level interface of session repository

### DIFF
--- a/application/src/main/java/run/halo/app/security/device/DeviceEndpoint.java
+++ b/application/src/main/java/run/halo/app/security/device/DeviceEndpoint.java
@@ -19,6 +19,7 @@ import org.springframework.data.domain.Sort;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.core.context.ReactiveSecurityContextHolder;
 import org.springframework.security.core.context.SecurityContext;
+import org.springframework.session.ReactiveFindByIndexNameSessionRepository;
 import org.springframework.session.Session;
 import org.springframework.stereotype.Component;
 import org.springframework.web.reactive.function.server.RouterFunction;
@@ -31,7 +32,6 @@ import run.halo.app.extension.GroupVersion;
 import run.halo.app.extension.ListOptions;
 import run.halo.app.extension.ReactiveExtensionClient;
 import run.halo.app.extension.router.selector.FieldSelector;
-import run.halo.app.security.session.ReactiveIndexedSessionRepository;
 
 /**
  * Device endpoint for user profile,every user can only manage their own devices.
@@ -43,7 +43,7 @@ import run.halo.app.security.session.ReactiveIndexedSessionRepository;
 @RequiredArgsConstructor
 public class DeviceEndpoint implements CustomEndpoint {
     private final ReactiveExtensionClient client;
-    private final ReactiveIndexedSessionRepository<?> sessionRepository;
+    private final ReactiveFindByIndexNameSessionRepository<?> sessionRepository;
     private final DeviceService deviceService;
 
     @Override


### PR DESCRIPTION
#### What type of PR is this?

/kind improvement
/area core
/milestone 2.17.x

#### What this PR does / why we need it:

Use top-level interface `org.springframework.session.ReactiveFindByIndexNameSessionRepository` for being compatible with other session repositories.

#### Which issue(s) this PR fixes:

Fixes https://github.com/halo-dev/halo/issues/6159

#### Does this PR introduce a user-facing change?

```release-note
None
```
