### PR TITLE
pref: block-level content actively sets fakeSelection

### DIFF
--- a/ui/packages/editor/src/extensions/audio/index.ts
+++ b/ui/packages/editor/src/extensions/audio/index.ts
@@ -35,6 +35,7 @@ declare module "@/tiptap" {
 
 const Audio = Node.create<ExtensionOptions>({
   name: "audio",
+  fakeSelection: true,
 
   inline() {
     return true;

--- a/ui/packages/editor/src/extensions/code-block/code-block.ts
+++ b/ui/packages/editor/src/extensions/code-block/code-block.ts
@@ -104,6 +104,7 @@ export default CodeBlockLowlight.extend<
   // It needs to have a higher priority than range-selection,
   // otherwise the Mod-a shortcut key will be overridden.
   priority: 110,
+  fakeSelection: true,
   addCommands() {
     return {
       ...this.parent?.(),

--- a/ui/packages/editor/src/extensions/columns/column.ts
+++ b/ui/packages/editor/src/extensions/columns/column.ts
@@ -4,6 +4,7 @@ const Column = Node.create({
   name: "column",
   content: "block+",
   isolating: true,
+  fakeSelection: true,
 
   addOptions() {
     return {

--- a/ui/packages/editor/src/extensions/iframe/index.ts
+++ b/ui/packages/editor/src/extensions/iframe/index.ts
@@ -44,6 +44,7 @@ declare module "@/tiptap" {
 
 const Iframe = Node.create<ExtensionOptions>({
   name: "iframe",
+  fakeSelection: true,
 
   inline() {
     return true;

--- a/ui/packages/editor/src/extensions/image/index.ts
+++ b/ui/packages/editor/src/extensions/image/index.ts
@@ -30,6 +30,8 @@ import BubbleItemImageSize from "./BubbleItemImageSize.vue";
 import ImageView from "./ImageView.vue";
 
 const Image = TiptapImage.extend<ExtensionOptions & ImageOptions>({
+  fakeSelection: true,
+
   inline() {
     return true;
   },

--- a/ui/packages/editor/src/extensions/range-selection/index.ts
+++ b/ui/packages/editor/src/extensions/range-selection/index.ts
@@ -61,16 +61,13 @@ const ExtensionRangeSelection = Extension.create({
               if (node.isText || node.type.name === "paragraph") {
                 return;
               }
-              let className = "no-selection";
               if (node.type.spec.fakeSelection) {
-                className = className + " range-fake-selection";
+                decorations.push(
+                  Decoration.node(pos, pos + node.nodeSize, {
+                    class: "no-selection range-fake-selection",
+                  })
+                );
               }
-
-              decorations.push(
-                Decoration.node(pos, pos + node.nodeSize, {
-                  class: className,
-                })
-              );
             });
             return DecorationSet.create(doc, decorations);
           },
@@ -155,7 +152,7 @@ const ExtensionRangeSelection = Extension.create({
     return {
       fakeSelection:
         callOrReturn(getExtensionField(extension, "fakeSelection", context)) ??
-        true,
+        false,
     };
   },
 });

--- a/ui/packages/editor/src/extensions/table/index.ts
+++ b/ui/packages/editor/src/extensions/table/index.ts
@@ -209,7 +209,6 @@ class TableView implements NodeView {
 
 const Table = TiptapTable.extend<ExtensionOptions & TableOptions>({
   allowGapCursor: true,
-  fakeSelection: false,
 
   addExtensions() {
     return [TableCell, TableRow, TableHeader];

--- a/ui/packages/editor/src/extensions/table/table-cell.ts
+++ b/ui/packages/editor/src/extensions/table/table-cell.ts
@@ -27,6 +27,7 @@ const TableCell = Node.create<TableCellOptions>({
   content: "block+",
   tableRole: "cell",
   isolating: true,
+  fakeSelection: true,
 
   addOptions() {
     return {

--- a/ui/packages/editor/src/extensions/table/table-header.ts
+++ b/ui/packages/editor/src/extensions/table/table-header.ts
@@ -21,6 +21,7 @@ const TableHeader = Node.create<TableCellOptions>({
   content: "block+",
   tableRole: "header_cell",
   isolating: true,
+  fakeSelection: true,
 
   addOptions() {
     return {

--- a/ui/packages/editor/src/extensions/table/table-row.ts
+++ b/ui/packages/editor/src/extensions/table/table-row.ts
@@ -2,7 +2,6 @@ import { TableRow as BuiltInTableRow } from "@tiptap/extension-table-row";
 
 const TableRow = BuiltInTableRow.extend({
   allowGapCursor: false,
-  fakeSelection: false,
 
   addAttributes() {
     return {

--- a/ui/packages/editor/src/extensions/video/index.ts
+++ b/ui/packages/editor/src/extensions/video/index.ts
@@ -44,6 +44,7 @@ declare module "@/tiptap" {
 
 const Video = Node.create<ExtensionOptions>({
   name: "video",
+  fakeSelection: true,
 
   inline() {
     return true;


### PR DESCRIPTION
#### What type of PR is this?

/kind improvement
/area editor
/milestone 2.17.x

#### What this PR does / why we need it:

由于 RangeSelection 可能将一些并不想展示为模拟选中效果的节点进行了转换，因此将 RangeSelection 中模拟选中的效果，由默认的自动设置为 true，变为 false。

之后需要由节点自行设置 `fakeSelection: true` 后才会展示为模拟选中的效果，否则保持原本的选择样式。

#### How to test it?

测试使用 Mod-a 全选后，listItem 等节点是否会展示为模拟选中的效果。

#### Does this PR introduce a user-facing change?
```release-note
None
```
