### PR TITLE
fix: vue injection warn

### DIFF
--- a/ui/packages/components/src/components/avatar/Avatar.vue
+++ b/ui/packages/components/src/components/avatar/Avatar.vue
@@ -8,7 +8,7 @@ const props = withDefaults(defineProps<AvatarProps>(), {
   circle: false,
 });
 
-const groupProps = inject(AvatarGroupContextInjectionKey);
+const groupProps = inject(AvatarGroupContextInjectionKey, undefined);
 
 const size = computed(() => groupProps?.size || props.size);
 const circle = computed(() => groupProps?.circle || props.circle);


### PR DESCRIPTION
#### What type of PR is this?

/area ui
/kind bug
/milestone 2.17.x

#### What this PR does / why we need it:

Fix the vue injection warn in browser console

<img width="559" alt="image" src="https://github.com/halo-dev/halo/assets/21301288/4160cbe4-fe8b-4b30-a1db-57d35d78e4f9">

#### Does this PR introduce a user-facing change?

```release-note
None 
```
