### PR TITLE
chore: add types path to ui-plugin-bunlder-kit package.json

### DIFF
--- a/ui/packages/ui-plugin-bundler-kit/package.json
+++ b/ui/packages/ui-plugin-bundler-kit/package.json
@@ -15,7 +15,8 @@
   "exports": {
     ".": {
       "import": "./dist/index.mjs",
-      "require": "./dist/index.cjs"
+      "require": "./dist/index.cjs",
+      "types": "./dist/index.d.ts"
     }
   },
   "main": "./dist/index.cjs",


### PR DESCRIPTION
#### What type of PR is this?

/kind improvement
/area ui
/milestone 2.17.x

#### What this PR does / why we need it:

补充 `@halo-dev/ui-plugin-bunlder-kit` 包的 types 地址定义。

#### Does this PR introduce a user-facing change?

```release-note
None
```
