### PR TITLE
Fix the problem of enabling 2FA unexpectedly

### DIFF
--- a/application/src/main/java/run/halo/app/security/DefaultUserDetailService.java
+++ b/application/src/main/java/run/halo/app/security/DefaultUserDetailService.java
@@ -22,6 +22,7 @@ import run.halo.app.core.extension.service.UserService;
 import run.halo.app.extension.GroupKind;
 import run.halo.app.infra.exception.UserNotFoundException;
 import run.halo.app.security.authentication.login.HaloUser;
+import run.halo.app.security.authentication.twofactor.TwoFactorUtils;
 
 public class DefaultUserDetailService
     implements ReactiveUserDetailsService, ReactiveUserDetailsPasswordService {
@@ -63,10 +64,9 @@ public class DefaultUserDetailService
                     .doOnNext(userBuilder::authorities);
 
                 return setAuthorities.then(Mono.fromSupplier(() -> {
-                    var twoFactorAuthEnabled =
-                        requireNonNullElse(user.getSpec().getTwoFactorAuthEnabled(), false);
+                    var twoFactorAuthSettings = TwoFactorUtils.getTwoFactorAuthSettings(user);
                     return new HaloUser.Builder(userBuilder.build())
-                        .twoFactorAuthEnabled(twoFactorAuthEnabled)
+                        .twoFactorAuthEnabled(twoFactorAuthSettings.isAvailable())
                         .totpEncryptedSecret(user.getSpec().getTotpEncryptedSecret())
                         .build();
                 }));


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/area core
/milestone 2.17.x

#### What this PR does / why we need it:

Some users encountered 2FA required issue after upgrading Halo 2.16, because they enabled 2FA but didn't configure TOTP before. The issue was introduced by <https://github.com/halo-dev/halo/pull/6005>.

This PR checks if TOTP configured to determine whether 2FA is required.

#### Does this PR introduce a user-facing change?

```release-note
修复在没有配置 TOTP 验证器的情况下仍被要求二步验证的问题
```
