### PR TITLE
Rectify role templates about PAT and 2FA endpoints

### DIFF
--- a/application/src/main/resources/extensions/role-template-authenticated.yaml
+++ b/application/src/main/resources/extensions/role-template-authenticated.yaml
@@ -110,10 +110,10 @@ metadata:
     halo.run/role-template: "true"
     halo.run/hidden: "true"
 rules:
-  - apiGroups: [ "api.security.halo.run" ]
+  - apiGroups: [ "uc.api.security.halo.run" ]
     resources: [ "personalaccesstokens" ]
     verbs: [ "*" ]
-  - apiGroups: [ "api.security.halo.run" ]
+  - apiGroups: [ "uc.api.security.halo.run" ]
     resources: [ "personalaccesstokens/actions" ]
     verbs: [ "update" ]
 
@@ -126,7 +126,7 @@ metadata:
     halo.run/role-template: "true"
     halo.run/hidden: "true"
 rules:
-  - apiGroups: [ "api.security.halo.run" ]
+  - apiGroups: [ "uc.api.security.halo.run" ]
     resources: [ "authentications", "authentications/totp", "authentications/settings" ]
     verbs: [ "*" ]
   - apiGroups: [ "uc.api.security.halo.run" ]


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/area core
/milestone 2.17.x

#### What this PR does / why we need it:

In PR <https://github.com/halo-dev/halo/pull/6130>, I changed the api group of PAT and 2FA endpoints, but I forgot to change the corresponding role templates. So other users except admin will encounter 403 error like <https://github.com/halo-dev/halo/issues/6199>.

#### Which issue(s) this PR fixes:

Fixes https://github.com/halo-dev/halo/issues/6199

#### Does this PR introduce a user-facing change?

```release-note
None
```
