### PR TITLE
feat: restrict deletion of the primary menu

### DIFF
--- a/ui/console-src/modules/interface/menus/components/MenuList.vue
+++ b/ui/console-src/modules/interface/menus/components/MenuList.vue
@@ -236,13 +236,20 @@ const handleSetPrimaryMenu = async (menu: Menu) => {
               v-if="currentUserHasPermission(['system:menus:manage'])"
               #dropdownItems
             >
-              <VDropdownItem @click="handleSetPrimaryMenu(menu)">
+              <VDropdownItem
+                v-if="primaryMenuName !== menu.metadata.name"
+                @click="handleSetPrimaryMenu(menu)"
+              >
                 {{ $t("core.menu.operations.set_primary.button") }}
               </VDropdownItem>
               <VDropdownItem @click="handleOpenEditingModal(menu)">
                 {{ $t("core.common.buttons.edit") }}
               </VDropdownItem>
-              <VDropdownItem type="danger" @click="handleDeleteMenu(menu)">
+              <VDropdownItem
+                :disabled="primaryMenuName === menu.metadata.name"
+                type="danger"
+                @click="handleDeleteMenu(menu)"
+              >
                 {{ $t("core.common.buttons.delete") }}
               </VDropdownItem>
             </template>


### PR DESCRIPTION
#### What type of PR is this?

/area ui
/kind improvement
/milestone 2.17.x

#### What this PR does / why we need it:

添加对菜单的限制，不能删除已经设置为主菜单的菜单。

#### Which issue(s) this PR fixes:

Fixes https://github.com/halo-dev/halo/issues/4956

#### Does this PR introduce a user-facing change?

```release-note
None
```
