### PR TITLE
fix: causing API to be pending when plugin startup encounters an error

### DIFF
--- a/application/src/main/java/run/halo/app/core/extension/reconciler/PluginReconciler.java
+++ b/application/src/main/java/run/halo/app/core/extension/reconciler/PluginReconciler.java
@@ -158,7 +158,7 @@ public class PluginReconciler implements Reconciler<Request> {
                         }
                     }
                     return result;
-                } catch (Exception e) {
+                } catch (Throwable e) {
                     status.getConditions().addAndEvictFIFO(Condition.builder()
                         .type(ConditionType.READY)
                         .status(ConditionStatus.FALSE)
@@ -313,7 +313,7 @@ public class PluginReconciler implements Reconciler<Request> {
                     Failed to start plugin %s(%s).\
                     """.formatted(pluginName, pluginState));
             }
-        } catch (Exception e) {
+        } catch (Throwable e) {
             conditions.addAndEvictFIFO(Condition.builder()
                 .type(ConditionType.READY)
                 .status(ConditionStatus.FALSE)
@@ -365,7 +365,7 @@ public class PluginReconciler implements Reconciler<Request> {
             }
             try {
                 pluginManager.disablePlugin(pluginName);
-            } catch (Exception e) {
+            } catch (Throwable e) {
                 conditions.addAndEvictFIFO(Condition.builder()
                     .type(ConditionType.READY)
                     .status(ConditionStatus.FALSE)


### PR DESCRIPTION
#### What type of PR is this?
/kind improvement
/area core
/area plugin

#### What this PR does / why we need it:
修复当启动插件遇到 Error 级别的错误时会导致 API 被挂起无法终止的问题

```
- Throwable
    - Error
    - Exception
```
see #6192 for more details

#### Which issue(s) this PR fixes:
Fixes #6192

#### Does this PR introduce a user-facing change?
```release-note
修复当启动插件遇到 Error 级别的错误时会导致 API 被挂起无法终止的问题
```
