### PR TITLE
Fix the problem of fetching old value from plugin setting fetcher

### DIFF
--- a/application/src/main/java/run/halo/app/plugin/DefaultReactiveSettingFetcher.java
+++ b/application/src/main/java/run/halo/app/plugin/DefaultReactiveSettingFetcher.java
@@ -162,13 +162,13 @@ public class DefaultReactiveSettingFetcher
                 if (configMapData != null) {
                     configMapData.forEach((key, value) -> result.put(key, readTree(value)));
                 }
+                // update cache
+                cache.put(pluginName, result);
                 applicationContext.publishEvent(PluginConfigUpdatedEvent.builder()
                     .source(this)
                     .oldConfig(existData)
                     .newConfig(result)
                     .build());
-                // update cache
-                cache.put(pluginName, result);
             });
         return Result.doNotRetry();
     }


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/area core
/area plugin
/milestone 2.17.x

#### What this PR does / why we need it:

This PR  makes sure the method `cache#put` is called before the event is published to avoid the event listener to fetch the old value from the cache.

The problem was introduced by <https://github.com/halo-dev/halo/pull/6141>.

#### Which issue(s) this PR fixes:

Fixes #6213 

#### Does this PR introduce a user-facing change?

```release-note
修复在插件配置变更监听器中始终获取到旧数据的问题
```
