### PR TITLE
feat: tag and category add save and continue button

### DIFF
--- a/ui/console-src/modules/contents/posts/categories/components/CategoryEditingModal.vue
+++ b/ui/console-src/modules/contents/posts/categories/components/CategoryEditingModal.vue
@@ -21,6 +21,7 @@ import {
 import { useQueryClient } from "@tanstack/vue-query";
 import { cloneDeep } from "lodash-es";
 import { useI18n } from "vue-i18n";
+import { submitForm, reset } from "@formkit/core";
 
 const props = withDefaults(
   defineProps<{
@@ -65,6 +66,7 @@ const formState = ref<Category>({
 const selectedParentCategory = ref();
 const saving = ref(false);
 const modal = ref<InstanceType<typeof VModal> | null>(null);
+const keepAddingSubmit = ref(false);
 
 const isUpdateMode = !!props.category;
 
@@ -133,7 +135,11 @@ const handleSaveCategory = async () => {
       }
     }
 
-    modal.value?.close();
+    if (keepAddingSubmit.value) {
+      reset("category-form");
+    } else {
+      modal.value?.close();
+    }
 
     queryClient.invalidateQueries({ queryKey: ["post-categories"] });
 
@@ -143,6 +149,11 @@ const handleSaveCategory = async () => {
   } finally {
     saving.value = false;
   }
+};
+
+const handleSubmit = (keepAdding = false) => {
+  keepAddingSubmit.value = keepAdding;
+  submitForm("category-form");
 };
 
 onMounted(() => {
@@ -345,11 +356,19 @@ const { handleGenerateSlug } = useSlugify(
           :loading="saving"
           type="secondary"
           :text="$t('core.common.buttons.submit')"
-          @submit="$formkit.submit('category-form')"
+          @submit="handleSubmit"
         >
         </SubmitButton>
         <VButton @click="modal?.close()">
           {{ $t("core.common.buttons.cancel_and_shortcut") }}
+        </VButton>
+        <VButton
+          v-if="!isUpdateMode"
+          :loading="saving"
+          :keep="true"
+          @click="handleSubmit(true)"
+        >
+          {{ $t("core.common.buttons.save_and_continue") }}
         </VButton>
       </VSpace>
     </template>

--- a/ui/console-src/modules/contents/posts/categories/components/CategoryEditingModal.vue
+++ b/ui/console-src/modules/contents/posts/categories/components/CategoryEditingModal.vue
@@ -351,26 +351,29 @@ const { handleGenerateSlug } = useSlugify(
     </div>
 
     <template #footer>
-      <VSpace>
-        <SubmitButton
-          :loading="saving"
-          type="secondary"
-          :text="$t('core.common.buttons.submit')"
-          @submit="handleSubmit"
-        >
-        </SubmitButton>
+      <div class="flex justify-between">
+        <VSpace>
+          <SubmitButton
+            :loading="saving && !keepAddingSubmit"
+            :disabled="saving && keepAddingSubmit"
+            type="secondary"
+            :text="$t('core.common.buttons.submit')"
+            @submit="handleSubmit"
+          >
+          </SubmitButton>
+          <VButton
+            v-if="!isUpdateMode"
+            :loading="saving && keepAddingSubmit"
+            :disabled="saving && !keepAddingSubmit"
+            @click="handleSubmit(true)"
+          >
+            {{ $t("core.common.buttons.save_and_continue") }}
+          </VButton>
+        </VSpace>
         <VButton @click="modal?.close()">
           {{ $t("core.common.buttons.cancel_and_shortcut") }}
         </VButton>
-        <VButton
-          v-if="!isUpdateMode"
-          :loading="saving"
-          :keep="true"
-          @click="handleSubmit(true)"
-        >
-          {{ $t("core.common.buttons.save_and_continue") }}
-        </VButton>
-      </VSpace>
+      </div>
     </template>
   </VModal>
 </template>

--- a/ui/console-src/modules/contents/posts/tags/components/TagEditingModal.vue
+++ b/ui/console-src/modules/contents/posts/tags/components/TagEditingModal.vue
@@ -26,6 +26,7 @@ import useSlugify from "@console/composables/use-slugify";
 import { cloneDeep } from "lodash-es";
 import { onMounted } from "vue";
 import { useI18n } from "vue-i18n";
+import { submitForm, reset } from "@formkit/core";
 
 const props = withDefaults(
   defineProps<{
@@ -62,6 +63,8 @@ const formState = ref<Tag>({
 const modal = ref<InstanceType<typeof VModal> | null>(null);
 
 const saving = ref(false);
+
+const keepAddingSubmit = ref(false);
 
 const isUpdateMode = computed(() => !!props.tag);
 
@@ -101,7 +104,11 @@ const handleSaveTag = async () => {
       });
     }
 
-    modal.value?.close();
+    if (keepAddingSubmit.value) {
+      reset("tag-form");
+    } else {
+      modal.value?.close();
+    }
 
     Toast.success(t("core.common.toast.save_success"));
   } catch (e) {
@@ -109,6 +116,11 @@ const handleSaveTag = async () => {
   } finally {
     saving.value = false;
   }
+};
+
+const handleSubmit = (keepAdding = false) => {
+  keepAddingSubmit.value = keepAdding;
+  submitForm("tag-form");
 };
 
 onMounted(() => {
@@ -255,11 +267,19 @@ const { handleGenerateSlug } = useSlugify(
           :loading="saving"
           type="secondary"
           :text="$t('core.common.buttons.submit')"
-          @submit="$formkit.submit('tag-form')"
+          @submit="handleSubmit"
         >
         </SubmitButton>
         <VButton @click="modal?.close()">
           {{ $t("core.common.buttons.cancel_and_shortcut") }}
+        </VButton>
+        <VButton
+          v-if="!isUpdateMode"
+          :loading="saving"
+          :keep="true"
+          @click="handleSubmit(true)"
+        >
+          {{ $t("core.common.buttons.save_and_continue") }}
         </VButton>
       </VSpace>
     </template>

--- a/ui/console-src/modules/contents/posts/tags/components/TagEditingModal.vue
+++ b/ui/console-src/modules/contents/posts/tags/components/TagEditingModal.vue
@@ -262,26 +262,29 @@ const { handleGenerateSlug } = useSlugify(
     </div>
 
     <template #footer>
-      <VSpace>
-        <SubmitButton
-          :loading="saving"
-          type="secondary"
-          :text="$t('core.common.buttons.submit')"
-          @submit="handleSubmit"
-        >
-        </SubmitButton>
+      <div class="flex justify-between">
+        <VSpace>
+          <SubmitButton
+            :loading="saving && !keepAddingSubmit"
+            :disabled="saving && keepAddingSubmit"
+            type="secondary"
+            :text="$t('core.common.buttons.submit')"
+            @submit="handleSubmit"
+          >
+          </SubmitButton>
+          <VButton
+            v-if="!isUpdateMode"
+            :loading="saving && keepAddingSubmit"
+            :disabled="saving && !keepAddingSubmit"
+            @click="handleSubmit(true)"
+          >
+            {{ $t("core.common.buttons.save_and_continue") }}
+          </VButton>
+        </VSpace>
         <VButton @click="modal?.close()">
           {{ $t("core.common.buttons.cancel_and_shortcut") }}
         </VButton>
-        <VButton
-          v-if="!isUpdateMode"
-          :loading="saving"
-          :keep="true"
-          @click="handleSubmit(true)"
-        >
-          {{ $t("core.common.buttons.save_and_continue") }}
-        </VButton>
-      </VSpace>
+      </div>
     </template>
   </VModal>
 </template>

--- a/ui/src/locales/en.yaml
+++ b/ui/src/locales/en.yaml
@@ -1671,6 +1671,7 @@ core:
     buttons:
       save: Save
       close: Close
+      save_and_continue: Save and keep adding
       close_and_shortcut: Close (Esc)
       delete: Delete
       setting: Setting

--- a/ui/src/locales/es.yaml
+++ b/ui/src/locales/es.yaml
@@ -1308,6 +1308,7 @@ core:
     buttons:
       save: Guardar
       close: Cerrar
+      save_and_continue: Guardar y seguir añadiendo
       close_and_shortcut: Cerrar (Esc)
       delete: Borrar
       setting: Configuración

--- a/ui/src/locales/zh-CN.yaml
+++ b/ui/src/locales/zh-CN.yaml
@@ -1588,6 +1588,7 @@ core:
     buttons:
       save: 保存
       close: 关闭
+      save_and_continue: 保存并继续添加
       close_and_shortcut: 关闭（Esc）
       delete: 删除
       setting: 设置

--- a/ui/src/locales/zh-TW.yaml
+++ b/ui/src/locales/zh-TW.yaml
@@ -1545,6 +1545,7 @@ core:
     buttons:
       save: 保存
       close: 關閉
+      save_and_continue: 保存並繼續添加
       close_and_shortcut: 關閉（Esc）
       delete: 刪除
       setting: 設置


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

文章分类和标签 Modal 添加 ”保存并继续添加” 按钮，便于连续添加。

#### Which issue(s) this PR fixes:

Fixes https://github.com/halo-dev/halo/issues/6127

#### Special notes for your reviewer:

![image](https://github.com/halo-dev/halo/assets/111493458/4debe13e-4002-48a8-827b-58cb74b4b074)


#### Does this PR introduce a user-facing change?

```release-note
文章分类和标签页添加 "保存并继续添加" 按钮。
```
