### PR TITLE
Upgrade SpringDoc to 2.6.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,5 +6,5 @@ plugins {
     id "io.freefair.lombok" version "8.6" apply false
     id 'org.gradle.crypto.checksum' version '1.4.0' apply false
     id "com.github.node-gradle.node" version "7.0.2" apply false
-    id "org.springdoc.openapi-gradle-plugin" version "1.8.0" apply false
+    id "org.springdoc.openapi-gradle-plugin" version "1.9.0" apply false
 }

--- a/platform/application/build.gradle
+++ b/platform/application/build.gradle
@@ -18,7 +18,7 @@ ext {
     guava = "32.0.1-jre"
     jsoup = '1.15.3'
     jsonPatch = "1.13"
-    springDocOpenAPI = "2.5.0"
+    springDocOpenAPI = "2.6.0"
     lucene = "9.11.1"
     resilience4jVersion = "2.2.0"
     twoFactorAuth = "1.3"


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup
/area core
/milestone 2.17.0

#### What this PR does / why we need it:

This PR upgrades SpringDoc to 2.6.0 and its gradle plugin to 1.9.0.
See https://github.com/springdoc/springdoc-openapi/releases/tag/v2.6.0 and https://github.com/springdoc/springdoc-openapi-gradle-plugin/releases/tag/1.9.0 for more.

#### Does this PR introduce a user-facing change?

```release-note
升级 SpringDoc 至 2.6.0
```
