### PR TITLE
Expose search service for plugin

### DIFF
--- a/api/src/main/java/run/halo/app/search/SearchService.java
+++ b/api/src/main/java/run/halo/app/search/SearchService.java
@@ -1,0 +1,21 @@
+package run.halo.app.search;
+
+import reactor.core.publisher.Mono;
+
+/**
+ * Search service is used to search content.
+ *
+ * @author johnniang
+ * @since 2.17.0
+ */
+public interface SearchService {
+
+    /**
+     * Perform search.
+     *
+     * @param option search option must not be null
+     * @return search result
+     */
+    Mono<SearchResult> search(SearchOption option);
+
+}

--- a/application/src/main/java/run/halo/app/plugin/DefaultPluginApplicationContextFactory.java
+++ b/application/src/main/java/run/halo/app/plugin/DefaultPluginApplicationContextFactory.java
@@ -38,6 +38,7 @@ import run.halo.app.plugin.event.HaloPluginStoppedEvent;
 import run.halo.app.plugin.event.SpringPluginStartedEvent;
 import run.halo.app.plugin.event.SpringPluginStoppedEvent;
 import run.halo.app.plugin.event.SpringPluginStoppingEvent;
+import run.halo.app.search.SearchService;
 import run.halo.app.theme.DefaultTemplateNameResolver;
 import run.halo.app.theme.ViewNameResolver;
 import run.halo.app.theme.finders.FinderRegistry;
@@ -135,6 +136,11 @@ public class DefaultPluginApplicationContextFactory implements PluginApplication
                     pluginRouterFunctionManager
                 );
             });
+
+        rootContext.getBeanProvider(SearchService.class)
+            .ifUnique(searchService ->
+                beanFactory.registerSingleton("searchService", searchService)
+            );
 
         sw.stop();
 

--- a/application/src/main/java/run/halo/app/plugin/PluginAutoConfiguration.java
+++ b/application/src/main/java/run/halo/app/plugin/PluginAutoConfiguration.java
@@ -43,7 +43,7 @@ public class PluginAutoConfiguration {
     }
 
     @Bean
-    public PluginManager pluginManager(ApplicationContext context,
+    public SpringPluginManager pluginManager(ApplicationContext context,
         SystemVersionSupplier systemVersionSupplier,
         PluginProperties pluginProperties) {
         return new HaloPluginManager(context, pluginProperties, systemVersionSupplier);

--- a/application/src/main/java/run/halo/app/search/SearchServiceImpl.java
+++ b/application/src/main/java/run/halo/app/search/SearchServiceImpl.java
@@ -1,0 +1,36 @@
+package run.halo.app.search;
+
+import org.springframework.stereotype.Service;
+import org.springframework.validation.Validator;
+import reactor.core.publisher.Mono;
+import reactor.core.scheduler.Schedulers;
+import run.halo.app.infra.exception.RequestBodyValidationException;
+import run.halo.app.plugin.extensionpoint.ExtensionGetter;
+
+@Service
+public class SearchServiceImpl implements SearchService {
+
+    private final Validator validator;
+
+    private final ExtensionGetter extensionGetter;
+
+    public SearchServiceImpl(Validator validator, ExtensionGetter extensionGetter) {
+        this.validator = validator;
+        this.extensionGetter = extensionGetter;
+    }
+
+    @Override
+    public Mono<SearchResult> search(SearchOption option) {
+        // validate the option
+        var errors = validator.validateObject(option);
+        if (errors.hasErrors()) {
+            return Mono.error(new RequestBodyValidationException(errors));
+        }
+        return extensionGetter.getEnabledExtension(SearchEngine.class)
+            .filter(SearchEngine::available)
+            .switchIfEmpty(Mono.error(SearchEngineUnavailableException::new))
+            .flatMap(searchEngine -> Mono.fromSupplier(() ->
+                searchEngine.search(option)
+            ).subscribeOn(Schedulers.boundedElastic()));
+    }
+}

--- a/application/src/test/java/run/halo/app/plugin/DefaultPluginApplicationContextFactoryTest.java
+++ b/application/src/test/java/run/halo/app/plugin/DefaultPluginApplicationContextFactoryTest.java
@@ -1,0 +1,47 @@
+package run.halo.app.plugin;
+
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.pf4j.PluginWrapper;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.SpyBean;
+import run.halo.app.search.SearchService;
+
+@SpringBootTest
+class DefaultPluginApplicationContextFactoryTest {
+
+    @SpyBean
+    SpringPluginManager pluginManager;
+
+    DefaultPluginApplicationContextFactory factory;
+
+    @BeforeEach
+    void setUp() {
+        factory = new DefaultPluginApplicationContextFactory((SpringPluginManager) pluginManager);
+    }
+
+    @Test
+    void shouldCreateCorrectly() {
+        var pw = mock(PluginWrapper.class);
+        when(pw.getPluginClassLoader()).thenReturn(this.getClass().getClassLoader());
+        var sp = mock(SpringPlugin.class);
+        var pluginContext = new PluginContext.PluginContextBuilder()
+            .name("fake-plugin")
+            .version("1.0.0")
+            .build();
+        when(sp.getPluginContext()).thenReturn(pluginContext);
+        when(pw.getPlugin()).thenReturn(sp);
+        when(pluginManager.getPlugin("fake-plugin")).thenReturn(pw);
+        var context = factory.create("fake-plugin");
+
+        assertInstanceOf(PluginApplicationContext.class, context);
+        assertNotNull(context.getBeanProvider(SearchService.class).getIfUnique());
+        // TODO Add more assertions here.
+    }
+
+}

--- a/application/src/test/java/run/halo/app/search/SearchServiceImplTest.java
+++ b/application/src/test/java/run/halo/app/search/SearchServiceImplTest.java
@@ -1,0 +1,106 @@
+package run.halo.app.search;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.validation.Errors;
+import org.springframework.validation.Validator;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+import run.halo.app.infra.exception.RequestBodyValidationException;
+import run.halo.app.plugin.extensionpoint.ExtensionGetter;
+
+@ExtendWith(MockitoExtension.class)
+class SearchServiceImplTest {
+
+    @Mock
+    Validator validator;
+
+    @Mock
+    ExtensionGetter extensionGetter;
+
+    @InjectMocks
+    SearchServiceImpl searchService;
+
+    @Test
+    void shouldThrowValidationErrorIfOptionIsInvalid() {
+        var option = new SearchOption();
+        option.setKeyword("halo");
+
+        var errors = mock(Errors.class);
+        when(errors.hasErrors()).thenReturn(true);
+        when(validator.validateObject(option)).thenReturn(errors);
+
+        searchService.search(option)
+            .as(StepVerifier::create)
+            .expectError(RequestBodyValidationException.class)
+            .verify();
+    }
+
+    @Test
+    void shouldThrowSearchEngineUnavailableExceptionIfNoSearchEngineFound() {
+        var option = new SearchOption();
+        option.setKeyword("halo");
+
+        var errors = mock(Errors.class);
+        when(errors.hasErrors()).thenReturn(false);
+        when(validator.validateObject(option)).thenReturn(errors);
+
+        when(extensionGetter.getEnabledExtension(SearchEngine.class)).thenReturn(Mono.empty());
+
+        searchService.search(option)
+            .as(StepVerifier::create)
+            .expectError(SearchEngineUnavailableException.class)
+            .verify();
+    }
+
+    @Test
+    void shouldThrowSearchEngineUnavailableExceptionIfNoSearchEngineAvailable() {
+        var option = new SearchOption();
+        option.setKeyword("halo");
+
+        var errors = mock(Errors.class);
+        when(errors.hasErrors()).thenReturn(false);
+        when(validator.validateObject(option)).thenReturn(errors);
+
+        when(extensionGetter.getEnabledExtension(SearchEngine.class))
+            .thenAnswer(invocation -> Mono.fromSupplier(() -> {
+                var searchEngine = mock(SearchEngine.class);
+                when(searchEngine.available()).thenReturn(false);
+                return searchEngine;
+            }));
+
+        searchService.search(option)
+            .as(StepVerifier::create)
+            .expectError(SearchEngineUnavailableException.class);
+    }
+
+    @Test
+    void shouldSearch() {
+        var option = new SearchOption();
+        option.setKeyword("halo");
+
+        var errors = mock(Errors.class);
+        when(errors.hasErrors()).thenReturn(false);
+        when(validator.validateObject(option)).thenReturn(errors);
+
+        var searchResult = mock(SearchResult.class);
+        when(extensionGetter.getEnabledExtension(SearchEngine.class))
+            .thenAnswer(invocation -> Mono.fromSupplier(() -> {
+                var searchEngine = mock(SearchEngine.class);
+                when(searchEngine.available()).thenReturn(true);
+                when(searchEngine.search(option)).thenReturn(searchResult);
+                return searchEngine;
+            }));
+
+        searchService.search(option)
+            .as(StepVerifier::create)
+            .expectNext(searchResult)
+            .verifyComplete();
+    }
+}


### PR DESCRIPTION
#### What type of PR is this?

/kind feature
/kind api-change
/area core
/area plugin
/milestone 2.17.0

#### What this PR does / why we need it:

This PR creates a SearchService and makes it invokable for plugins.

#### Special notes for your reviewer:

1. Create a plugin
2. Publish all publication into Maven local repository by executing `./gradlew publishAllPublicationsToMavenLocalRepository`
3. Use `2.17.0-SNAPSHOT` as dependency version and refresh dependencies
4. Try to use the SearchService to search something.

#### Does this PR introduce a user-facing change?

```release-note
为插件提供全文搜索服务
```
