### PR TITLE
Build and run using IntelliJ IDEA after building ui

### DIFF
--- a/application/build.gradle
+++ b/application/build.gradle
@@ -7,6 +7,7 @@ plugins {
     id "com.gorylenko.gradle-git-properties"
     id "checkstyle"
     id 'java'
+    id 'idea'
     id 'jacoco'
     id "de.undercouch.download"
     id "io.freefair.lombok"
@@ -21,6 +22,12 @@ compileTestJava.options.encoding = 'UTF-8'
 java {
     sourceCompatibility = JavaVersion.VERSION_17
     targetCompatibility = JavaVersion.VERSION_17
+}
+
+idea {
+    module {
+        resourceDirs += file("../ui/build/dist/")
+    }
 }
 
 checkstyle {


### PR DESCRIPTION
#### What type of PR is this?

/kind improvement
/area core
/milestone 2.18.x

#### What this PR does / why we need it:

This PR treats `ui/build/dist` as resource dir for application module to adapt building and running using IntelliJ IDEA.

How to use?

1. Build ui project by executing command `./gradlew :ui:build -x :ui:check`.
1. Create a `Run/Debug Configuration` with arguments `--spring.profiles.active=dev --halo.console.proxy.enabled=false --halo.uc.proxy.enabled=false`.
1. Go to `Settings | Build, Execution, Deployment | Build Tools | Gradle` and select `IntelliJ IDEA` for `Build and run using:`
1. Run/Debug the configuration 

#### Does this PR introduce a user-facing change?

```release-note
None
```
