### PR TITLE
fix: bubble menu not appearing when crossing lines in editor

### DIFF
--- a/ui/packages/editor/src/extensions/text/index.ts
+++ b/ui/packages/editor/src/extensions/text/index.ts
@@ -1,6 +1,7 @@
 import ColorBubbleItem from "@/extensions/color/ColorBubbleItem.vue";
 import HighlightBubbleItem from "@/extensions/highlight/HighlightBubbleItem.vue";
 import LinkBubbleButton from "@/extensions/link/LinkBubbleButton.vue";
+import { RangeSelection } from "@/extensions/range-selection";
 import { i18n } from "@/locales";
 import type { EditorState } from "@/tiptap/pm";
 import { isActive, isTextSelection } from "@/tiptap/vue-3";
@@ -56,7 +57,10 @@ const Text = TiptapText.extend<ExtensionOptions>({
               return false;
             }
 
-            if (!isTextSelection(selection)) {
+            if (
+              !isTextSelection(selection) &&
+              !(selection instanceof RangeSelection)
+            ) {
               return false;
             }
 


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/area editor
/milestone 2.18.x

#### What this PR does / why we need it:

在默认编辑器中，选中一个跨多个节点的 text 时，selection 会变为 RangeSelection，此时冒泡菜单将不会出现。

此 RP 将 RangeSelection 添加至 text 的冒泡菜单验证中，使得冒泡菜单可以出现。

#### How to test it?

测试跨行选中多个无序列表时，是否出现冒泡菜单。

#### Which issue(s) this PR fixes:

Fixes #6267 

#### Does this PR introduce a user-facing change?
```release-note
修复默认编辑器中跨行选择节点时冒泡菜单无法出现的问题
```
