### PR TITLE
Respond 409 for operation conflict instead of 500

### DIFF
--- a/application/src/main/resources/config/i18n/messages.properties
+++ b/application/src/main/resources/config/i18n/messages.properties
@@ -28,6 +28,7 @@ problemDetail.title.run.halo.app.infra.exception.PluginDependencyException$Wrong
 problemDetail.title.run.halo.app.infra.exception.PluginDependentsNotDisabledException=Dependents Not Disabled
 problemDetail.title.run.halo.app.infra.exception.PluginDependenciesNotEnabledException=Dependencies Not Enabled
 problemDetail.title.internalServerError=Internal Server Error
+problemDetail.title.conflict=Conflict
 
 # Detail definitions
 problemDetail.org.springframework.web.server.UnsupportedMediaTypeStatusException=Content type {0} is not supported. Supported media types: {1}.
@@ -72,6 +73,7 @@ problemDetail.directoryTraversal=Directory traversal detected. Base path is {0},
 problemDetail.plugin.version.unsatisfied.requires=Plugin requires a minimum system version of {0}, but the current version is {1}.
 problemDetail.plugin.missingManifest=Missing plugin manifest file "plugin.yaml" or manifest file does not conform to the specification.
 problemDetail.internalServerError=Something went wrong, please try again later.
+problemDetail.conflict=Conflict detected, please check the data and retry.
 problemDetail.migration.backup.notFound=The backup file does not exist or has been deleted.
 
 title.visibility.identification.private=(Private)

--- a/application/src/main/resources/config/i18n/messages_zh.properties
+++ b/application/src/main/resources/config/i18n/messages_zh.properties
@@ -16,6 +16,7 @@ problemDetail.title.run.halo.app.infra.exception.PluginDependencyException$Wrong
 problemDetail.title.run.halo.app.infra.exception.PluginDependentsNotDisabledException=子插件未禁用
 problemDetail.title.run.halo.app.infra.exception.PluginDependenciesNotEnabledException=依赖未启用
 problemDetail.title.internalServerError=服务器内部错误
+problemDetail.title.conflict=冲突
 
 problemDetail.org.springframework.security.authentication.BadCredentialsException=用户名或密码错误。
 problemDetail.run.halo.app.infra.exception.AttachmentAlreadyExistsException=文件 {0} 已存在，建议更名后重试。
@@ -44,6 +45,7 @@ problemDetail.theme.version.unsatisfied.requires=主题要求一个最小的系�
 problemDetail.theme.install.missingManifest=缺少 theme.yaml 配置文件或配置文件不符合规范。
 problemDetail.theme.install.alreadyExists=主题 {0} 已存在。
 problemDetail.internalServerError=服务器内部发生错误，请稍候再试。
+problemDetail.conflict=检测到冲突，请检查数据后重试。
 problemDetail.migration.backup.notFound=备份文件不存在或已删除。
 
 title.visibility.identification.private=（私有）

--- a/application/src/test/resources/application.yaml
+++ b/application/src/test/resources/application.yaml
@@ -12,7 +12,7 @@ spring:
       mode: always
       platform: h2
   messages:
-      basename: config.i18n.messages
+    basename: config.i18n.messages
 
 halo:
   work-dir: ${user.home}/halo-next-test

--- a/application/src/test/resources/config/i18n/messages.properties
+++ b/application/src/test/resources/config/i18n/messages.properties
@@ -4,3 +4,6 @@ problemDetail.internalServerError=Something went wrong, please try again later.
 problemDetail.run.halo.app.infra.exception.handlers.I18nExceptionTest$ErrorResponseException=Message argument is {0}.
 error.somethingWentWrong=Something went wrong, argument is {0}.
 problemDetail.title.internalServerError=Internal Server Error
+
+problemDetail.title.conflict=Conflict
+problemDetail.conflict=Conflict detected.


### PR DESCRIPTION
#### What type of PR is this?

/kind improvement
/area core
/kind api-change
/milestone 2.18.x

#### What this PR does / why we need it:

This PR makes ConcurrencyFailureException respond http status code 409 instead of 500.

#### Which issue(s) this PR fixes:

Fixes #6254 

#### Does this PR introduce a user-facing change?

```release-note
None
```
