### PR TITLE
fix: resolve potential exception during bulk image upload in post creation

### DIFF
--- a/ui/console-src/modules/contents/pages/SinglePageEditor.vue
+++ b/ui/console-src/modules/contents/pages/SinglePageEditor.vue
@@ -431,9 +431,6 @@ async function handleUploadImage(file: File, options?: AxiosRequestConfig) {
   if (!currentUserHasPermission(["uc:attachments:manage"])) {
     return;
   }
-  if (!isUpdateMode.value) {
-    await handleSave();
-  }
 
   const { data } = await ucApiClient.storage.attachment.createAttachmentForPost(
     {

--- a/ui/console-src/modules/contents/posts/PostEditor.vue
+++ b/ui/console-src/modules/contents/posts/PostEditor.vue
@@ -456,10 +456,6 @@ async function handleUploadImage(file: File, options?: AxiosRequestConfig) {
     return;
   }
 
-  if (!isUpdateMode.value) {
-    await handleSave();
-  }
-
   const { data } = await ucApiClient.storage.attachment.createAttachmentForPost(
     {
       file,

--- a/ui/uc-src/modules/contents/posts/PostEditor.vue
+++ b/ui/uc-src/modules/contents/posts/PostEditor.vue
@@ -422,9 +422,6 @@ async function handleUploadImage(file: File, options?: AxiosRequestConfig) {
   if (!currentUserHasPermission(["uc:attachments:manage"])) {
     return;
   }
-  if (!isUpdateMode.value) {
-    await handleCreate();
-  }
 
   const { data } = await ucApiClient.storage.attachment.createAttachmentForPost(
     {


### PR DESCRIPTION
#### What type of PR is this?

/area ui
/kind bug
/milestone 2.18.x

#### What this PR does / why we need it:

修复创建文章前批量上传图片可能出现异常的问题。

目前解决方案为：移除上传前创建文章的逻辑，因为在上传前已经确定了文章的 metadata.name。

#### Does this PR introduce a user-facing change?

```release-note
修复创建文章前批量上传图片可能出现异常的问题。
```
