### PR TITLE
chore: mark deprecated constructor for base plugin

### DIFF
--- a/api/src/main/java/run/halo/app/plugin/BasePlugin.java
+++ b/api/src/main/java/run/halo/app/plugin/BasePlugin.java
@@ -27,7 +27,7 @@ public class BasePlugin extends Plugin {
         this.context = pluginContext;
     }
 
-    @Deprecated
+    @Deprecated(since = "2.7.0", forRemoval = true)
     public BasePlugin(PluginWrapper wrapper) {
         super(wrapper);
         log.warn("Deprecated constructor 'BasePlugin(PluginWrapper wrapper)' called, please use "

--- a/api/src/main/java/run/halo/app/plugin/BasePlugin.java
+++ b/api/src/main/java/run/halo/app/plugin/BasePlugin.java
@@ -3,6 +3,7 @@ package run.halo.app.plugin;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import org.pf4j.Plugin;
+import org.pf4j.PluginWrapper;
 
 /**
  * This class will be extended by all plugins and serve as the common class between a plugin and
@@ -24,6 +25,15 @@ public class BasePlugin extends Plugin {
      */
     public BasePlugin(PluginContext pluginContext) {
         this.context = pluginContext;
+    }
+
+    @Deprecated
+    public BasePlugin(PluginWrapper wrapper) {
+        super(wrapper);
+        log.warn("Deprecated constructor 'BasePlugin(PluginWrapper wrapper)' called, please use "
+                + "'BasePlugin(PluginContext pluginContext)' instead for plugin '{}',This "
+                + "constructor will be removed in 2.19.0",
+            wrapper.getPluginId());
     }
 
     public BasePlugin() {


### PR DESCRIPTION
#### What type of PR is this?
/milestone 2.18.x

#### What this PR does / why we need it:
将 BasePlugin 的 PluginWrapper 构造函数标记为过时并输出警告日志提示

#### Does this PR introduce a user-facing change?
```release-note
在 BasePlugin 的 PluginWrapper 构造函数输出过时警告日志以提醒开发者尽快适配
```
