### PR TITLE
[release-2.17] chore: mark deprecated constructor for base plugin

### DIFF
--- a/api/src/main/java/run/halo/app/plugin/BasePlugin.java
+++ b/api/src/main/java/run/halo/app/plugin/BasePlugin.java
@@ -18,10 +18,13 @@ public class BasePlugin extends Plugin {
 
     protected PluginContext context;
 
-    @Deprecated
+    @Deprecated(since = "2.7.0", forRemoval = true)
     public BasePlugin(PluginWrapper wrapper) {
         super(wrapper);
-        log.info("Initialized plugin {}", wrapper.getPluginId());
+        log.warn("Deprecated constructor 'BasePlugin(PluginWrapper wrapper)' called, please use "
+                + "'BasePlugin(PluginContext pluginContext)' instead for plugin '{}',This "
+                + "constructor will be removed in 2.19.0",
+            wrapper.getPluginId());
     }
 
     /**


### PR DESCRIPTION
#### What type of PR is this?
/milestone 2.17.x

#### What this PR does / why we need it:
将 BasePlugin 的 PluginWrapper 构造函数标记为过时并输出警告日志提示

#### Does this PR introduce a user-facing change?
```release-note
在 BasePlugin 的 PluginWrapper 构造函数输出过时警告日志以提醒开发者尽快适配
```
