### PR TITLE
Improve timezone information in login notification

### DIFF
--- a/application/src/main/java/run/halo/app/security/device/NewDeviceLoginListener.java
+++ b/application/src/main/java/run/halo/app/security/device/NewDeviceLoginListener.java
@@ -1,5 +1,7 @@
 package run.halo.app.security.device;
 
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.ApplicationListener;
 import org.springframework.lang.NonNull;
@@ -25,6 +27,8 @@ import run.halo.app.notification.UserIdentity;
 @RequiredArgsConstructor
 public class NewDeviceLoginListener implements ApplicationListener<NewDeviceLoginEvent> {
     static final String REASON_TYPE = "new-device-login";
+    private static final DateTimeFormatter DATE_TIME_FORMATTER =
+        DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss O").withZone(ZoneOffset.systemDefault());
     private final NotificationCenter notificationCenter;
     private final NotificationReasonEmitter notificationReasonEmitter;
 
@@ -43,7 +47,8 @@ public class NewDeviceLoginListener implements ApplicationListener<NewDeviceLogi
             attributes.put("os", device.getStatus().getOs());
             attributes.put("browser", device.getStatus().getBrowser());
             attributes.put("ipAddress", device.getSpec().getIpAddress());
-            attributes.put("loginTime", device.getSpec().getLastAuthenticatedTime());
+            attributes.put("loginTime",
+                DATE_TIME_FORMATTER.format(device.getSpec().getLastAuthenticatedTime()));
             builder.attributes(attributes)
                 .author(UserIdentity.of(device.getSpec().getPrincipalName()))
                 .subject(Reason.Subject.builder()

--- a/application/src/main/java/run/halo/app/security/device/NewDeviceLoginListener.java
+++ b/application/src/main/java/run/halo/app/security/device/NewDeviceLoginListener.java
@@ -1,5 +1,7 @@
 package run.halo.app.security.device;
 
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.ApplicationListener;
 import org.springframework.lang.NonNull;
@@ -25,6 +27,8 @@ import run.halo.app.notification.UserIdentity;
 @RequiredArgsConstructor
 public class NewDeviceLoginListener implements ApplicationListener<NewDeviceLoginEvent> {
     static final String REASON_TYPE = "new-device-login";
+    private static final DateTimeFormatter DATE_TIME_FORMATTER
+        = DateTimeFormatter.ofPattern("yyyy/MM/dd hh:mm:ss").withZone(ZoneOffset.systemDefault());
     private final NotificationCenter notificationCenter;
     private final NotificationReasonEmitter notificationReasonEmitter;
 
@@ -43,7 +47,8 @@ public class NewDeviceLoginListener implements ApplicationListener<NewDeviceLogi
             attributes.put("os", device.getStatus().getOs());
             attributes.put("browser", device.getStatus().getBrowser());
             attributes.put("ipAddress", device.getSpec().getIpAddress());
-            attributes.put("loginTime", device.getSpec().getLastAuthenticatedTime());
+            var lastLogin = device.getSpec().getLastAuthenticatedTime();
+            attributes.put("loginTime", DATE_TIME_FORMATTER.format(lastLogin));
             builder.attributes(attributes)
                 .author(UserIdentity.of(device.getSpec().getPrincipalName()))
                 .subject(Reason.Subject.builder()

--- a/application/src/main/java/run/halo/app/security/device/NewDeviceLoginListener.java
+++ b/application/src/main/java/run/halo/app/security/device/NewDeviceLoginListener.java
@@ -28,7 +28,7 @@ import run.halo.app.notification.UserIdentity;
 public class NewDeviceLoginListener implements ApplicationListener<NewDeviceLoginEvent> {
     static final String REASON_TYPE = "new-device-login";
     private static final DateTimeFormatter DATE_TIME_FORMATTER
-        = DateTimeFormatter.ofPattern("yyyy/MM/dd hh:mm:ss").withZone(ZoneOffset.systemDefault());
+        = DateTimeFormatter.ofPattern("yyyy/MM/dd hh:mm:ss ").withZone(ZoneOffset.systemDefault());
     private final NotificationCenter notificationCenter;
     private final NotificationReasonEmitter notificationReasonEmitter;
 
@@ -48,7 +48,8 @@ public class NewDeviceLoginListener implements ApplicationListener<NewDeviceLogi
             attributes.put("browser", device.getStatus().getBrowser());
             attributes.put("ipAddress", device.getSpec().getIpAddress());
             var lastLogin = device.getSpec().getLastAuthenticatedTime();
-            attributes.put("loginTime", DATE_TIME_FORMATTER.format(lastLogin));
+            attributes.put("loginTime",
+                DATE_TIME_FORMATTER.format(lastLogin) + ZoneOffset.systemDefault());
             builder.attributes(attributes)
                 .author(UserIdentity.of(device.getSpec().getPrincipalName()))
                 .subject(Reason.Subject.builder()

--- a/application/src/main/java/run/halo/app/security/device/NewDeviceLoginListener.java
+++ b/application/src/main/java/run/halo/app/security/device/NewDeviceLoginListener.java
@@ -1,7 +1,5 @@
 package run.halo.app.security.device;
 
-import java.time.ZoneOffset;
-import java.time.format.DateTimeFormatter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.ApplicationListener;
 import org.springframework.lang.NonNull;
@@ -27,8 +25,6 @@ import run.halo.app.notification.UserIdentity;
 @RequiredArgsConstructor
 public class NewDeviceLoginListener implements ApplicationListener<NewDeviceLoginEvent> {
     static final String REASON_TYPE = "new-device-login";
-    private static final DateTimeFormatter DATE_TIME_FORMATTER
-        = DateTimeFormatter.ofPattern("yyyy/MM/dd hh:mm:ss ").withZone(ZoneOffset.systemDefault());
     private final NotificationCenter notificationCenter;
     private final NotificationReasonEmitter notificationReasonEmitter;
 
@@ -47,9 +43,7 @@ public class NewDeviceLoginListener implements ApplicationListener<NewDeviceLogi
             attributes.put("os", device.getStatus().getOs());
             attributes.put("browser", device.getStatus().getBrowser());
             attributes.put("ipAddress", device.getSpec().getIpAddress());
-            var lastLogin = device.getSpec().getLastAuthenticatedTime();
-            attributes.put("loginTime",
-                DATE_TIME_FORMATTER.format(lastLogin) + ZoneOffset.systemDefault());
+            attributes.put("loginTime", device.getSpec().getLastAuthenticatedTime());
             builder.attributes(attributes)
                 .author(UserIdentity.of(device.getSpec().getPrincipalName()))
                 .subject(Reason.Subject.builder()

--- a/application/src/main/resources/extensions/notification-templates.yaml
+++ b/application/src/main/resources/extensions/notification-templates.yaml
@@ -168,7 +168,7 @@ spec:
       [(${subscriber.displayName})] 你好：
 
         你的 [(${site.title})] 账号被用于在 [(${os})] 的 [(${browser})] 上登录。
-        时间：[(${#temporals.format(loginTime, 'yyyy/MM/dd HH:mm:ss')})] UTC
+        时间：[(${#temporals.format(loginTime, 'yyyy/MM/dd HH:mm:ss O')})]
         IP 地址：[(${ipAddress})] 
         如果你知悉上述信息，请忽略此电子邮件。
         如果你最近没有使用你的 Halo 账号登录并相信有人可能访问了你的账户，请尽快重设你的密码。
@@ -180,7 +180,7 @@ spec:
         <div class="body">
           <p th:text="|你的 ${site.title} 账号被用于在 ${os} 的 ${browser} 上登录：|"></p>
           <div class="device-info">
-            <p th:text="|时间： ${#temporals.format(loginTime, 'yyyy/MM/dd HH:mm:ss')} UTC|"></p>
+            <p th:text="|时间： ${#temporals.format(loginTime, 'yyyy/MM/dd HH:mm:ss O')}|"></p>
             <p th:text="|IP 地址： ${ipAddress}|"></p>
           </div>
           <p>如果你知悉上述信息，请忽略此电子邮件。</p>

--- a/application/src/main/resources/extensions/notification-templates.yaml
+++ b/application/src/main/resources/extensions/notification-templates.yaml
@@ -168,7 +168,7 @@ spec:
       [(${subscriber.displayName})] 你好：
 
         你的 [(${site.title})] 账号被用于在 [(${os})] 的 [(${browser})] 上登录。
-        时间：[(${#temporals.format(loginTime, 'yyyy/MM/dd HH:mm:ss O')})]
+        时间：[(${loginTime})]
         IP 地址：[(${ipAddress})] 
         如果你知悉上述信息，请忽略此电子邮件。
         如果你最近没有使用你的 Halo 账号登录并相信有人可能访问了你的账户，请尽快重设你的密码。
@@ -180,7 +180,7 @@ spec:
         <div class="body">
           <p th:text="|你的 ${site.title} 账号被用于在 ${os} 的 ${browser} 上登录：|"></p>
           <div class="device-info">
-            <p th:text="|时间： ${#temporals.format(loginTime, 'yyyy/MM/dd HH:mm:ss O')}|"></p>
+            <p th:text="|时间： ${loginTime}|"></p>
             <p th:text="|IP 地址： ${ipAddress}|"></p>
           </div>
           <p>如果你知悉上述信息，请忽略此电子邮件。</p>

--- a/application/src/main/resources/extensions/notification-templates.yaml
+++ b/application/src/main/resources/extensions/notification-templates.yaml
@@ -168,7 +168,7 @@ spec:
       [(${subscriber.displayName})] 你好：
 
         你的 [(${site.title})] 账号被用于在 [(${os})] 的 [(${browser})] 上登录。
-        时间：[(${loginTime})] 
+        时间：[(${#temporals.format(loginTime, 'yyyy/MM/dd HH:mm:ss')})] UTC
         IP 地址：[(${ipAddress})] 
         如果你知悉上述信息，请忽略此电子邮件。
         如果你最近没有使用你的 Halo 账号登录并相信有人可能访问了你的账户，请尽快重设你的密码。
@@ -180,8 +180,8 @@ spec:
         <div class="body">
           <p th:text="|你的 ${site.title} 账号被用于在 ${os} 的 ${browser} 上登录：|"></p>
           <div class="device-info">
-            <p th:text="|时间： ${loginTime}。|"></p>
-            <p th:text="|IP 地址： ${ipAddress}。|"></p>
+            <p th:text="|时间： ${#temporals.format(loginTime, 'yyyy/MM/dd HH:mm:ss')} UTC|"></p>
+            <p th:text="|IP 地址： ${ipAddress}|"></p>
           </div>
           <p>如果你知悉上述信息，请忽略此电子邮件。</p>
           <p th:text="|如果你最近没有使用你的 ${site.title} 账号登录并相信有人可能访问了你的账户，请尽快重设你的密码。|"></p>

--- a/application/src/test/java/run/halo/app/security/device/DeviceServiceImplTest.java
+++ b/application/src/test/java/run/halo/app/security/device/DeviceServiceImplTest.java
@@ -3,9 +3,6 @@ package run.halo.app.security.device;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import org.junit.jupiter.api.Test;
-import java.time.Instant;
-import java.time.ZoneOffset;
-import java.time.format.DateTimeFormatter;
 
 /**
  * Tests for {@link DeviceServiceImpl}.
@@ -24,13 +21,4 @@ class DeviceServiceImplTest {
         assertThat(info.browser()).isEqualTo("Chrome 126.0");
     }
 
-    @Test
-    void instantFormatTest() {
-        var instant = Instant.parse("2024-07-10T00:30:00.00Z");
-        assertThat(instant.toString()).isEqualTo("2024-07-10T00:30:00Z");
-        var dateTimeFormatter = DateTimeFormatter.ofPattern("yyyy/MM/dd hh:mm:ss")
-            .withZone(ZoneOffset.systemDefault());
-        var format = dateTimeFormatter.format(instant);
-        assertThat(format).isEqualTo("2024/07/10 08:30:00");
-    }
 }

--- a/application/src/test/java/run/halo/app/security/device/DeviceServiceImplTest.java
+++ b/application/src/test/java/run/halo/app/security/device/DeviceServiceImplTest.java
@@ -3,6 +3,9 @@ package run.halo.app.security.device;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import org.junit.jupiter.api.Test;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
 
 /**
  * Tests for {@link DeviceServiceImpl}.
@@ -21,4 +24,13 @@ class DeviceServiceImplTest {
         assertThat(info.browser()).isEqualTo("Chrome 126.0");
     }
 
+    @Test
+    void test() {
+        var instant = Instant.parse("2024-07-10T00:30:00.00Z");
+        assertThat(instant.toString()).isEqualTo("2024-07-10T00:30:00Z");
+        var dateTimeFormatter = DateTimeFormatter.ofPattern("yyyy/MM/dd hh:mm:ss")
+            .withZone(ZoneOffset.systemDefault());
+        var format = dateTimeFormatter.format(instant);
+        assertThat(format).isEqualTo("2024/07/10 08:30:00");
+    }
 }

--- a/application/src/test/java/run/halo/app/security/device/DeviceServiceImplTest.java
+++ b/application/src/test/java/run/halo/app/security/device/DeviceServiceImplTest.java
@@ -25,7 +25,7 @@ class DeviceServiceImplTest {
     }
 
     @Test
-    void test() {
+    void instantFormatTest() {
         var instant = Instant.parse("2024-07-10T00:30:00.00Z");
         assertThat(instant.toString()).isEqualTo("2024-07-10T00:30:00Z");
         var dateTimeFormatter = DateTimeFormatter.ofPattern("yyyy/MM/dd hh:mm:ss")


### PR DESCRIPTION
/area core
/kind improvement

Fixes #6256 

```release-note
格式化新设备登录邮件通知内的登录时间为系统时区
```
