### PR TITLE
Fix the problem where automatic login using remember-me token could fail

### DIFF
--- a/application/src/main/java/run/halo/app/security/authentication/rememberme/PersistentTokenBasedRememberMeServices.java
+++ b/application/src/main/java/run/halo/app/security/authentication/rememberme/PersistentTokenBasedRememberMeServices.java
@@ -112,7 +112,7 @@ public class PersistentTokenBasedRememberMeServices extends TokenBasedRememberMe
                 log.debug("Refreshing persistent login token for user '{}', series '{}'",
                     token.getUsername(), token.getSeries());
                 var newToken = new PersistentRememberMeToken(token.getUsername(), token.getSeries(),
-                    generateTokenData(), new Date());
+                    token.getTokenValue(), new Date());
                 return Mono.just(newToken);
             })
             .flatMap(newToken -> updateToken(newToken)


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/area core
/milestone 2.18.x

#### What this PR does / why we need it:

This PR prevent remember-me token from updating after auto login.

#### Which issue(s) this PR fixes:

Fixes #6290 

#### Does this PR introduce a user-facing change?

```release-note
修复“保持登录会话”可能失效的问题
```
