### PR TITLE
Respond 404 for non-exist theme resources instead of 500

### DIFF
--- a/application/src/main/java/run/halo/app/theme/config/ThemeWebFluxConfigurer.java
+++ b/application/src/main/java/run/halo/app/theme/config/ThemeWebFluxConfigurer.java
@@ -80,6 +80,9 @@ public class ThemeWebFluxConfigurer implements WebFluxConfigurer {
             var assetsPath = themeRoot.resolve(themeName + "/templates/assets/" + resourcePaths);
             FileUtils.checkDirectoryTraversal(themeRoot, assetsPath);
             var location = new FileSystemResource(assetsPath);
+            if (!location.isReadable()) {
+                return Mono.empty();
+            }
             return Mono.just(location);
         }
 

--- a/application/src/test/java/run/halo/app/config/WebFluxConfigTest.java
+++ b/application/src/test/java/run/halo/app/config/WebFluxConfigTest.java
@@ -144,4 +144,14 @@ class WebFluxConfigTest {
         }
     }
 
+    @Nested
+    class StaticResourcesTest {
+
+        @Test
+        void shouldRespond404WhenThemeResourceNotFound() {
+            webClient.get().uri("/themes/fake-theme/assets/favicon.ico")
+                .exchange()
+                .expectStatus().isNotFound();
+        }
+    }
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/area core
/milestone 2.18.x

#### What this PR does / why we need it:

This PR checks readable of theme resources while getting resources to prevent Halo from throwing FileNotFoundException.

#### Which issue(s) this PR fixes:

Fixes #6338 

#### Special notes for your reviewer:

1. Try to request <https://www.halo.run/themes/fake-theme/assets/favicons/favicon-32x32.png>
2. See the result

#### Does this PR introduce a user-facing change?

```release-note
修复访问不存在的主题资源时出现服务器异常的问题
```
