### PR TITLE
refactor: trigger plugin config updated event at startup

### DIFF
--- a/application/src/main/java/run/halo/app/plugin/DefaultReactiveSettingFetcher.java
+++ b/application/src/main/java/run/halo/app/plugin/DefaultReactiveSettingFetcher.java
@@ -18,13 +18,13 @@ import org.springframework.lang.NonNull;
 import org.springframework.lang.Nullable;
 import reactor.core.publisher.Mono;
 import run.halo.app.extension.ConfigMap;
-import run.halo.app.extension.DefaultExtensionMatcher;
 import run.halo.app.extension.ExtensionClient;
+import run.halo.app.extension.ExtensionMatcher;
+import run.halo.app.extension.ListOptions;
 import run.halo.app.extension.ReactiveExtensionClient;
 import run.halo.app.extension.controller.Controller;
 import run.halo.app.extension.controller.ControllerBuilder;
 import run.halo.app.extension.controller.Reconciler;
-import run.halo.app.extension.router.selector.FieldSelector;
 import run.halo.app.infra.utils.JsonParseException;
 import run.halo.app.infra.utils.JsonUtils;
 
@@ -185,16 +185,17 @@ public class DefaultReactiveSettingFetcher
 
     @Override
     public Controller setupWith(ControllerBuilder builder) {
-        var configMap = new ConfigMap();
-        var extensionMatcher =
-            DefaultExtensionMatcher.builder(blockingClient, configMap.groupVersionKind())
-                .fieldSelector(FieldSelector.of(equal("metadata.name", configMapName)))
-                .build();
+        ExtensionMatcher matcher =
+            extension -> configMapName.equals(extension.getMetadata().getName());
         return builder
-            .extension(configMap)
-            .syncAllOnStart(false)
-            .onAddMatcher(extensionMatcher)
-            .onUpdateMatcher(extensionMatcher)
+            .extension(new ConfigMap())
+            .syncAllOnStart(true)
+            .syncAllListOptions(ListOptions.builder()
+                .fieldQuery(equal("metadata.name", configMapName))
+                .build())
+            .onAddMatcher(matcher)
+            .onUpdateMatcher(matcher)
+            .onDeleteMatcher(matcher)
             .build();
     }
 


### PR DESCRIPTION
#### What type of PR is this?
/kind improvement
/area core
/milestone 2.18.x

#### What this PR does / why we need it:
插件启动时触发一次插件配置更新事件以便进行资源初始化操作

之前配置插件完后重启/升级插件无法监听到事件则不方便初始化资源需要通过再次监听插件启动事件来实现，现在改为插件启动时可以监听到

#### Does this PR introduce a user-facing change?
```release-note
插件启动时触发一次插件配置更新事件以便进行资源初始化操作
```
