### PR TITLE
fix: enter key causing focus loss in default editor title during composition input

### DIFF
--- a/ui/src/components/editor/DefaultEditor.vue
+++ b/ui/src/components/editor/DefaultEditor.vue
@@ -451,6 +451,13 @@ const currentLocale = i18n.global.locale.value as
 function onTitleInput(event: Event) {
   emit("update:title", (event.target as HTMLInputElement).value);
 }
+
+function handleFocusEditor(event) {
+  if (event.isComposing) {
+    return;
+  }
+  editor.value?.commands.focus("start");
+}
 </script>
 
 <template>
@@ -470,7 +477,7 @@ function onTitleInput(event: Event) {
           :placeholder="$t('core.components.default_editor.title_placeholder')"
           class="w-full border-x-0 !border-b border-t-0 !border-solid !border-gray-100 p-0 !py-2 text-4xl font-semibold placeholder:text-gray-300"
           @input="onTitleInput"
-          @keydown.enter="() => editor?.commands.focus('start')"
+          @keydown.enter="handleFocusEditor"
         />
       </template>
       <template v-if="showSidebar" #extra>


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/area editor
/milestone 2.18.x

#### What this PR does / why we need it:

使用组合输入时，按下回车键不再执行编辑器获取焦点的事件。

#### Which issue(s) this PR fixes:

Fixes #6345 

#### Does this PR introduce a user-facing change?
```release-note
解决默认编辑器标题在使用组合输入时，按下回车键会导致其失去焦点的问题。
```
