### PR TITLE
chore: add support for X-Forwarded-Proto and X-Forwarded-Host headers in IpAddressUtils

### DIFF
--- a/application/src/main/java/run/halo/app/infra/utils/IpAddressUtils.java
+++ b/application/src/main/java/run/halo/app/infra/utils/IpAddressUtils.java
@@ -27,6 +27,8 @@ public class IpAddressUtils {
         "HTTP_FORWARDED",
         "HTTP_VIA",
         "REMOTE_ADDR",
+        "X-Forwarded-Proto",
+        "X-Forwarded-Host"
     };
 
     /**


### PR DESCRIPTION
#### What type of PR is this?
/kind improvement
/area core
/milestone 2.18.x

#### What this PR does / why we need it:
在 IpAddressUtils 中增加对 X-Forwarded-Proto 和 X-Forwarded-Host 请求头的支持

#### Which issue(s) this PR fixes:
Fixes #6255

#### Does this PR introduce a user-facing change?
```release-note
None
```
