### PR TITLE
feat: share ExtensionGetter Bean with plugins for extension retrieval

### DIFF
--- a/api/src/main/java/run/halo/app/plugin/extensionpoint/ExtensionGetter.java
+++ b/api/src/main/java/run/halo/app/plugin/extensionpoint/ExtensionGetter.java
@@ -16,13 +16,13 @@ public interface ExtensionGetter {
     <T extends ExtensionPoint> Mono<T> getEnabledExtension(Class<T> extensionPoint);
 
     /**
-     * Get the extension(s) according to the {@link ExtensionPointDefinition} queried
+     * Get the extension(s) according to the {@code ExtensionPointDefinition} queried
      * by incoming extension point class.
      *
      * @param extensionPoint extension point class
      * @return implementations of the corresponding extension point.
      * @throws IllegalArgumentException if the incoming extension point class does not have
-     *                                  the {@link ExtensionPointDefinition}.
+     *                                  the {@code ExtensionPointDefinition}.
      */
     <T extends ExtensionPoint> Flux<T> getEnabledExtensions(Class<T> extensionPoint);
 

--- a/application/src/main/java/run/halo/app/plugin/SharedApplicationContextFactory.java
+++ b/application/src/main/java/run/halo/app/plugin/SharedApplicationContextFactory.java
@@ -14,6 +14,7 @@ import run.halo.app.infra.ExternalLinkProcessor;
 import run.halo.app.infra.ExternalUrlSupplier;
 import run.halo.app.notification.NotificationCenter;
 import run.halo.app.notification.NotificationReasonEmitter;
+import run.halo.app.plugin.extensionpoint.ExtensionGetter;
 import run.halo.app.security.LoginHandlerEnhancer;
 
 /**
@@ -66,6 +67,8 @@ public enum SharedApplicationContextFactory {
             .ifUnique(pluginsRootGetter ->
                 beanFactory.registerSingleton("pluginsRootGetter", pluginsRootGetter)
             );
+        beanFactory.registerSingleton("extensionGetter",
+            rootContext.getBean(ExtensionGetter.class));
         // TODO add more shared instance here
 
         sharedContext.refresh();


### PR DESCRIPTION
#### What type of PR is this?

/kind improvement
/area core
/milestone 2.18.x

#### What this PR does / why we need it:

通过将 ExtensionGetter Bean 共享到给插件的 ApplicationContext，插件能够方便地使用该 Bean 来获取扩展。此更改确保插件具有可靠的扩展访问方式，从而促进系统内更好的模块化和可扩展性。

#### Which issue(s) this PR fixes:

Fixes #6357 

#### Does this PR introduce a user-facing change?
```release-note
将 ExtensionGetter Bean 共享给插件使用，以便插件可以通过它来获取扩展
```
