### PR TITLE
chore: compatibility for deprecated buildParametersFromType method with deprecation log

### DIFF
--- a/api/src/main/java/run/halo/app/extension/router/QueryParamBuildUtil.java
+++ b/api/src/main/java/run/halo/app/extension/router/QueryParamBuildUtil.java
@@ -30,6 +30,7 @@ public class QueryParamBuildUtil {
     public static void buildParametersFromType(Builder operationBuilder, Type queryParamType) {
         log.warn(
             "Deprecated method QueryParamBuildUtil.buildParametersFromType is called, please use "
-                + "'org.springdoc.core.fn.builders.operation.Builder#parameter' method instead.");
+                + "'org.springdoc.core.fn.builders.operation.Builder#parameter' method instead."
+                + "This method will be removed in Halo 2.20.0 version.");
     }
 }

--- a/api/src/main/java/run/halo/app/extension/router/QueryParamBuildUtil.java
+++ b/api/src/main/java/run/halo/app/extension/router/QueryParamBuildUtil.java
@@ -5,8 +5,12 @@ import static org.springdoc.core.fn.builders.parameter.Builder.parameterBuilder;
 import static org.springdoc.core.fn.builders.schema.Builder.schemaBuilder;
 
 import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import java.lang.reflect.Type;
 import lombok.experimental.UtilityClass;
+import lombok.extern.slf4j.Slf4j;
+import org.springdoc.core.fn.builders.operation.Builder;
 
+@Slf4j
 @UtilityClass
 public class QueryParamBuildUtil {
 
@@ -20,5 +24,12 @@ public class QueryParamBuildUtil {
                 Default sort order is ascending. Multiple sort criteria are supported.\
                 """)
             .array(arraySchemaBuilder().schema(schemaBuilder().type("string")));
+    }
+
+    @Deprecated(since = "2.15.0")
+    public static void buildParametersFromType(Builder operationBuilder, Type queryParamType) {
+        log.warn(
+            "Deprecated method QueryParamBuildUtil.buildParametersFromType is called, please use "
+                + "'org.springdoc.core.fn.builders.operation.Builder#parameter' method instead.");
     }
 }


### PR DESCRIPTION
#### What type of PR is this?
/kind improvement
/area core
/milestone 2.18.x

#### What this PR does / why we need it:
在 https://github.com/halo-dev/halo/pull/6244 中移除了过时的 `QueryParamBuildUtil.buildParametersFromType` 方法，但是由于留给插件适配的时间不够，很多官方提供的插件也要和 2.18 一起发版这样会导致使用了此方法的插件无法启动，因此留下方法声明并输出日志等到后续版本在删除，这样可以给出一些时间给用户先升级插件而不是挂掉。

#### Does this PR introduce a user-facing change?
```release-note
None
```
