### PR TITLE
refactor: change the number of queried attachments in the selector modal

### DIFF
--- a/ui/console-src/modules/contents/attachments/components/selector-providers/CoreSelectorProvider.vue
+++ b/ui/console-src/modules/contents/attachments/components/selector-providers/CoreSelectorProvider.vue
@@ -45,7 +45,7 @@ const emit = defineEmits<{
 
 const selectedGroup = ref();
 const page = ref(1);
-const size = ref(60);
+const size = ref(20);
 
 const {
   attachments,
@@ -138,7 +138,7 @@ function onGroupSelect(group: Group) {
   </VEmpty>
   <div
     v-else
-    class="mt-2 grid grid-cols-3 gap-x-2 gap-y-3 sm:grid-cols-3 md:grid-cols-6 xl:grid-cols-8 2xl:grid-cols-10"
+    class="mt-2 grid grid-cols-3 gap-x-2 gap-y-3 sm:grid-cols-3 md:grid-cols-5"
     role="list"
   >
     <VCard
@@ -218,7 +218,7 @@ function onGroupSelect(group: Group) {
         $t('core.components.pagination.total_label', { total: total })
       "
       :total="total"
-      :size-options="[60, 120, 200]"
+      :size-options="[20, 50, 100]"
     />
   </div>
   <AttachmentUploadModal v-if="uploadVisible" @close="onUploadModalClose" />


### PR DESCRIPTION
#### What type of PR is this?

/area ui
/kind improvement
/milestone 2.18.x

#### What this PR does / why we need it:

修改附件选择组件的默认显示数量，以解决因为图片数量过多或者图片过大导致的卡顿问题。

#### Which issue(s) this PR fixes:

Ref https://github.com/halo-dev/halo/issues/6352

#### Does this PR introduce a user-facing change?

```release-note
修改附件选择组件的默认显示数量，以解决因为图片数量过多或者图片过大导致的卡顿问题。
```
