### PR TITLE
refactor: remove padding style from editor column block

### DIFF
--- a/ui/packages/editor/src/extensions/columns/column.ts
+++ b/ui/packages/editor/src/extensions/columns/column.ts
@@ -21,7 +21,7 @@ const Column = Node.create({
         parseHTML: (element) => element.getAttribute("index"),
       },
       style: {
-        default: "min-width: 0;padding: 12px;flex: 1 1;box-sizing: border-box;",
+        default: "min-width: 0;flex: 1 1;box-sizing: border-box;",
         parseHTML: (element) => element.getAttribute("style"),
       },
     };

--- a/ui/packages/editor/src/extensions/columns/columns.ts
+++ b/ui/packages/editor/src/extensions/columns/columns.ts
@@ -322,7 +322,7 @@ const Columns = Node.create({
         parseHTML: (element) => element.getAttribute("cols"),
       },
       style: {
-        default: "display: flex;width: 100%;grid-gap: 8px;gap: 8px;",
+        default: "display: flex;width: 100%;gap: 1em;",
         parseHTML: (element) => element.getAttribute("style"),
       },
     };

--- a/ui/packages/editor/src/styles/columns.scss
+++ b/ui/packages/editor/src/styles/columns.scss
@@ -7,6 +7,7 @@
         border: 1px solid #e7e9e8;
         border-radius: 6px;
         position: relative;
+        padding: 16px;
       }
     }
   }


### PR DESCRIPTION
#### What type of PR is this?

/area editor
/kind improvement
/milestone 2.18.x

#### What this PR does / why we need it:

移除编辑器 Column 的默认 padding 样式。

See https://github.com/halo-dev/halo/issues/6377#issue-2428912807

#### Which issue(s) this PR fixes:

Fixes #6377 

#### Does this PR introduce a user-facing change?

```release-note
移除编辑器分栏卡片的默认 padding 样式。
```
