### PR TITLE
fix: backspace on empty line doesn’t return to previous list item

### DIFF
--- a/ui/packages/editor/src/extensions/paragraph/index.ts
+++ b/ui/packages/editor/src/extensions/paragraph/index.ts
@@ -147,7 +147,7 @@ export function deleteCurrentNodeAndSetSelection(
   const { tr } = state;
   if (deleteNodeByPos($from)(tr) && dispatch) {
     if (beforePos !== 0) {
-      tr.setSelection(TextSelection.create(tr.doc, beforePos - 1));
+      tr.setSelection(TextSelection.near(tr.doc.resolve(beforePos - 1), -1));
     }
     dispatch(tr);
     return true;


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/area editor
/milestone 2.19.x

#### What this PR does / why we need it:

修复默认编辑器中，当在列表的下一空白行使用退格键时，会导致无法回退至列表项中的问题。

#### How to test it?

1. 在编辑器中增加一个列表项。
2. 按两次回车跳出列表编辑器。
3. 按退格键。

查看退格键是否按一次就可以回到列表项，并且再次按时执行列表项的删除。

#### Which issue(s) this PR fixes:

Fixes #6263

#### Does this PR introduce a user-facing change?
```release-note
解决默认编辑器中在空白行中按退格键无法回退到列表项中的问题
```
