### PR TITLE
chore: remove transactional annotation

### DIFF
--- a/application/src/main/java/run/halo/app/core/extension/service/UserServiceImpl.java
+++ b/application/src/main/java/run/halo/app/core/extension/service/UserServiceImpl.java
@@ -18,7 +18,6 @@ import org.springframework.dao.OptimisticLockingFailureException;
 import org.springframework.data.domain.Sort;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.Assert;
 import org.springframework.util.CollectionUtils;
 import org.springframework.util.StringUtils;
@@ -147,7 +146,6 @@ public class UserServiceImpl implements UserService {
     }
 
     @Override
-    @Transactional
     public Mono<User> signUp(User user, String password) {
         if (!StringUtils.hasText(password)) {
             throw new IllegalArgumentException("Password must not be blank");

--- a/application/src/main/java/run/halo/app/extension/store/ReactiveExtensionStoreClientImpl.java
+++ b/application/src/main/java/run/halo/app/extension/store/ReactiveExtensionStoreClientImpl.java
@@ -8,7 +8,6 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Component;
-import org.springframework.transaction.annotation.Transactional;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import run.halo.app.infra.exception.DuplicateNameException;
@@ -61,7 +60,6 @@ public class ReactiveExtensionStoreClientImpl implements ReactiveExtensionStoreC
     }
 
     @Override
-    @Transactional
     public Mono<ExtensionStore> delete(String name, Long version) {
         return repository.findById(name)
             .flatMap(extensionStore -> {

--- a/application/src/main/java/run/halo/app/migration/impl/MigrationServiceImpl.java
+++ b/application/src/main/java/run/halo/app/migration/impl/MigrationServiceImpl.java
@@ -29,7 +29,6 @@ import org.springframework.core.io.FileSystemResource;
 import org.springframework.core.io.Resource;
 import org.springframework.core.io.buffer.DataBuffer;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.StringUtils;
 import org.springframework.web.server.ServerWebInputException;
 import reactor.core.Exceptions;
@@ -136,7 +135,6 @@ public class MigrationServiceImpl implements MigrationService, InitializingBean 
     }
 
     @Override
-    @Transactional
     public Mono<Void> restore(Publisher<DataBuffer> content) {
         return Mono.usingWhen(
             createTempDir("halo-restore-", scheduler),


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup
/area core
/milestone 2.19.x

#### What this PR does / why we need it:
移除事务注解避免对索引创建产生影响，原因参考改动中的方法注释

**其中一点特别注意：**
在执行 `client.create(name, data)` 方法后，会尝试进行 `indexer.indexRecord` 操作。但 indexRecord 可能会因唯一索引中存在重复键而导致 indexRecord 失败，索引创建也会随之失败。为确保索引与数据的一致性，此时应回滚由 `client.create(name, data)` 对数据产生的影响，因此除非找到更佳的一致性问题解决方案，否则暂时不能移除此处的手动事务操作。

```java
 return client.create(name, version, data)
                .map(updated -> converter.convertFrom(type, updated))
                .doOnNext(extension -> indexer.indexRecord(convertToRealExtension(extension)))
                .as(transactionalOperator::transactional);
```
将变更传递给 extension watcher 是在 `doCreate` 或 `doUpdate` 成功之后才会被处理，因此这里的事务回滚不会对 watcher 造成影响

#### Does this PR introduce a user-facing change?
```release-note
None
```
