### PR TITLE
refactor: improve conditions for determining if a plugin needs to be reloaded

### DIFF
--- a/ui/console-src/modules/system/plugins/components/entity-fields/ReloadField.vue
+++ b/ui/console-src/modules/system/plugins/components/entity-fields/ReloadField.vue
@@ -18,6 +18,10 @@ const currentJsModuleInfo = enabledJsModulesInfo.find((jsModuleInfo) => {
 });
 
 const needsReloadWindow = computed(() => {
+  if (!currentJsModuleInfo) {
+    return false;
+  }
+
   const { version } = props.plugin.spec;
   const { phase } = props.plugin.status || {};
 


### PR DESCRIPTION
#### What type of PR is this?

/area ui
/kind improvement
/milestone 2.19.x

#### What this PR does / why we need it:

优化插件是否需要重载页面的判断条件，否则从低版本升级到 2.19 时，所有插件都会提示需要重载。

因为在 https://github.com/halo-dev/halo/pull/6470 中修改了 bundle.js 的结构，但升级到 2.19 之后可能并不会及时抛弃 bundle.js 的缓存，因为插件本身的 version 并没有改变，bundle.js 的 hash 参数也不会改变。

#### Does this PR introduce a user-facing change?

```release-note
None
```
