### PR TITLE
pref: use whitelist for allowed href values

### DIFF
--- a/ui/packages/editor/src/extensions/link/index.ts
+++ b/ui/packages/editor/src/extensions/link/index.ts
@@ -1,4 +1,3 @@
-import { mergeAttributes } from "@/tiptap/vue-3";
 import type { ExtensionOptions } from "@/types";
 import type { LinkOptions } from "@tiptap/extension-link";
 import TiptapLink from "@tiptap/extension-link";
@@ -18,28 +17,6 @@ const Link = TiptapLink.extend<ExtensionOptions & LinkOptions>({
   addPasteRules() {
     // Remove the function of pasted text parsing as a link
     return [];
-  },
-
-  renderHTML({ HTMLAttributes }) {
-    const href = HTMLAttributes.href;
-    // False positive; we're explicitly checking for javascript: links to ignore them
-    // eslint-disable-next-line no-script-url
-    if (href?.toString().startsWith("javascript:")) {
-      // strip out the href
-      return [
-        "a",
-        mergeAttributes(this.options.HTMLAttributes, {
-          ...HTMLAttributes,
-          href: "",
-        }),
-        0,
-      ];
-    }
-    return [
-      "a",
-      mergeAttributes(this.options.HTMLAttributes, HTMLAttributes),
-      0,
-    ];
   },
 });
 


### PR DESCRIPTION
#### What type of PR is this?

/kind improvement
/area editor
/milestone 2.19.x

#### What this PR does / why we need it:

使用白名单校验替换原有的黑名单校验，解决 a 标签潜在的安全问题。

移除自定义的解决方案，使用 Tiptap 所提供的白名单方案。

#### How to test it?

测试 a 标签的 href 链接是否会受到 xss 的影响。

同时测试 #5479 的情况是否还会发生。即默认富文本编辑器中当链接为纯数字时是否还会报错。

#### Does this PR introduce a user-facing change?
```release-note
使用白名单校验 a 标签的 href 用于解决潜在的安全问题。
```
