### PR TITLE
Fix "Missing exception attribute in ServerWebExchange" error after upgrading Spring Boot 3.3.3

### DIFF
--- a/application/src/main/java/run/halo/app/infra/exception/handlers/ProblemDetailErrorAttributes.java
+++ b/application/src/main/java/run/halo/app/infra/exception/handlers/ProblemDetailErrorAttributes.java
@@ -2,24 +2,18 @@ package run.halo.app.infra.exception.handlers;
 
 import static run.halo.app.infra.exception.Exceptions.createErrorResponse;
 
-import java.util.LinkedHashMap;
 import java.util.Map;
 import org.springframework.boot.web.error.ErrorAttributeOptions;
 import org.springframework.boot.web.reactive.error.DefaultErrorAttributes;
-import org.springframework.boot.web.reactive.error.ErrorAttributes;
 import org.springframework.context.MessageSource;
 import org.springframework.web.reactive.function.server.ServerRequest;
-import org.springframework.web.server.ServerWebExchange;
 
 /**
  * See {@link DefaultErrorAttributes} for more.
  *
  * @author johnn
  */
-public class ProblemDetailErrorAttributes implements ErrorAttributes {
-
-    private static final String ERROR_INTERNAL_ATTRIBUTE =
-        ProblemDetailErrorAttributes.class.getName() + ".ERROR";
+public class ProblemDetailErrorAttributes extends DefaultErrorAttributes {
 
     private final MessageSource messageSource;
 
@@ -30,25 +24,11 @@ public class ProblemDetailErrorAttributes implements ErrorAttributes {
     @Override
     public Map<String, Object> getErrorAttributes(ServerRequest request,
         ErrorAttributeOptions options) {
-        final var errAttributes = new LinkedHashMap<String, Object>();
+        final var errAttributes = super.getErrorAttributes(request, options);
         var error = getError(request);
         var errorResponse = createErrorResponse(error, null, request.exchange(), messageSource);
         errAttributes.put("error", errorResponse.getBody());
         return errAttributes;
     }
-
-    @Override
-    public Throwable getError(ServerRequest request) {
-        return (Throwable) request.attribute(ERROR_INTERNAL_ATTRIBUTE).stream()
-            .findFirst()
-            .orElseThrow(() -> new IllegalStateException(
-                "Missing exception attribute in ServerWebExchange"));
-    }
-
-    @Override
-    public void storeErrorInformation(Throwable error, ServerWebExchange exchange) {
-        exchange.getAttributes().putIfAbsent(ERROR_INTERNAL_ATTRIBUTE, error);
-    }
-
 
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/area core
/milestone 2.19.0

#### What this PR does / why we need it:

After merging https://github.com/halo-dev/halo/pull/6512 and https://github.com/halo-dev/halo/pull/6511, unit tests fail due to the changes of <https://github.com/spring-projects/spring-boot/commit/05b73ceeecd940843a34b9026ce73ba408a7aaa2>.

This PR fixes the problem by letting `run.halo.app.infra.exception.handlers.ProblemDetailErrorAttributes` extend  `org.springframework.boot.web.reactive.error.DefaultErrorAttributes`.

#### Does this PR introduce a user-facing change?

```release-note
None
```
