### PR TITLE
Fix the problem that return empty result while listing users

### DIFF
--- a/application/src/main/java/run/halo/app/core/extension/service/DefaultRoleService.java
+++ b/application/src/main/java/run/halo/app/core/extension/service/DefaultRoleService.java
@@ -72,7 +72,7 @@ public class DefaultRoleService implements RoleService {
     @Override
     public Mono<Map<String, Collection<String>>> getRolesByUsernames(Collection<String> usernames) {
         if (CollectionUtils.isEmpty(usernames)) {
-            return Mono.empty();
+            return Mono.just(Map.of());
         }
         var subjects = usernames.stream().map(DefaultRoleService::toUserSubject)
             .map(Object::toString)

--- a/application/src/test/java/run/halo/app/core/extension/service/DefaultRoleServiceTest.java
+++ b/application/src/test/java/run/halo/app/core/extension/service/DefaultRoleServiceTest.java
@@ -8,6 +8,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -18,6 +19,8 @@ import org.assertj.core.api.AssertionsForInterfaceTypes;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -44,6 +47,19 @@ class DefaultRoleServiceTest {
 
     @InjectMocks
     private DefaultRoleService roleService;
+
+    @ParameterizedTest
+    @MethodSource("usernamesProvider")
+    void shouldReturnEmptyMapIfNoUsernamesProvided(Collection<String> usernames) {
+        roleService.getRolesByUsernames(usernames)
+            .as(StepVerifier::create)
+            .expectNext(Map.of())
+            .verifyComplete();
+    }
+
+    static Stream<Collection<String>> usernamesProvider() {
+        return Stream.of(null, List.of(), Set.of());
+    }
 
     @Nested
     class ListDependenciesTest {


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/area core
/milestone 2.19.0

#### What this PR does / why we need it:

This PR makes the return value of method `DefaultRoleService#getRolesByUsernames` never be `Mono#empty`.

See https://github.com/halo-dev/halo/issues/6528 for more.

#### Which issue(s) this PR fixes:

Fixes https://github.com/halo-dev/halo/issues/6528 

#### Special notes for your reviewer:

1. Try to execute command `http -a admin:admin http://127.0.0.1:8090/apis/api.console.halo.run/v1alpha1/users?keyword=xyz`.
2. See the output

#### Does this PR introduce a user-facing change?

```release-note
修复获取用户列表时可能返回空结果的问题
```
