### PR TITLE
feat: add default selection option to formkit select component

### DIFF
--- a/ui/console-src/modules/system/settings/tabs/Setting.vue
+++ b/ui/console-src/modules/system/settings/tabs/Setting.vue
@@ -79,6 +79,7 @@ const handleSaveConfigMap = async () => {
         type="form"
         @submit="handleSaveConfigMap"
       >
+        <FormKit type="userSelect"> </FormKit>
         <FormKitSchema
           :schema="toRaw(formSchema)"
           :data="configMapFormData[group]"

--- a/ui/console-src/modules/system/settings/tabs/Setting.vue
+++ b/ui/console-src/modules/system/settings/tabs/Setting.vue
@@ -79,7 +79,6 @@ const handleSaveConfigMap = async () => {
         type="form"
         @submit="handleSaveConfigMap"
       >
-        <FormKit type="userSelect"> </FormKit>
         <FormKitSchema
           :schema="toRaw(formSchema)"
           :data="configMapFormData[group]"

--- a/ui/docs/custom-formkit-input/README.md
+++ b/ui/docs/custom-formkit-input/README.md
@@ -71,6 +71,7 @@
     10. `maxCount`：多选时最大可选数量，默认为 `Infinity`。仅在多选时有效。
     11. `sortable`：是否支持拖动排序，默认为 `false`。仅在多选时有效。
     12. `searchable`：是否支持搜索内容，默认为 `false`。
+    13. `autoSelect`：当 value 不存在时，是否自动选择第一个选项，默认为 `true`。仅在单选时有效。
 
 在 Vue 单组件中使用：
 
@@ -120,16 +121,16 @@ select 是一个选择器类型的输入组件，使用者可以从一批待选�
     multiple
     searchable
     :options="[
-      { label: "China", value: "China" },
-      { label: "USA", value: "USA" },
-      { label: "Japan", value: "Japan" },
-      { label: "Korea", value: "Korea" },
-      { label: "France", value: "France" },
-      { label: "Italy", value: "Italy" },
-      { label: "Germany", value: "Germany" },
-      { label: "UK", value: "UK" },
-      { label: "Canada", value: "Canada" },
-      { label: "Australia", value: "Australia" },
+      { label: 'China', value: 'China' },
+      { label: 'USA', value: 'USA' },
+      { label: 'Japan', value: 'Japan' },
+      { label: 'Korea', value: 'Korea' },
+      { label: 'France', value: 'France' },
+      { label: 'Italy', value: 'Italy' },
+      { label: 'Germany', value: 'Germany' },
+      { label: 'UK', value: 'UK' },
+      { label: 'Canada', value: 'Canada' },
+      { label: 'Australia', value: 'Australia' },
     ]"
     help="Don’t worry, you can’t get this one wrong."
   />
@@ -196,6 +197,8 @@ const handleSelectPostAuthorRemote = {
   clearable: true
   placeholder: Select a country
   options:
+    - label: China
+      value: cn
     - label: France
       value: fr
     - label: Germany
@@ -231,7 +234,7 @@ const handleSelectPostAuthorRemote = {
 ```
 
 > [!NOTE]
-> 当远程数据具有分页时，可能会出现默认选项不在第一页的情况，此时 Select 组件将会发送另一个查询请求，以获取默认选项的数据。此接口会携带如下参数 `labelSelector: ${requestOption.valueField}=in(value1,value2,value3)`。
+> 当远程数据具有分页时，可能会出现默认选项不在第一页的情况，此时 Select 组件将会发送另一个查询请求，以获取默认选项的数据。此接口会携带如下参数 `fieldSelector: ${requestOption.valueField}=(value1,value2,value3)`。
 
 > 其中，value1, value2, value3 为默认选项的值。返回值与查询一致，通过 `requestOption` 解析。
 

--- a/ui/src/formkit/inputs/attachment-group-select.ts
+++ b/ui/src/formkit/inputs/attachment-group-select.ts
@@ -22,7 +22,6 @@ function optionsHandler(node: FormKitNode) {
 
 export const attachmentGroupSelect: FormKitTypeDefinition = {
   ...select,
-  props: ["placeholder"],
   forceTypeProp: "select",
   features: [optionsHandler],
 };

--- a/ui/src/formkit/inputs/attachment-policy-select.ts
+++ b/ui/src/formkit/inputs/attachment-policy-select.ts
@@ -19,7 +19,6 @@ function optionsHandler(node: FormKitNode) {
 
 export const attachmentPolicySelect: FormKitTypeDefinition = {
   ...select,
-  props: ["placeholder"],
   forceTypeProp: "select",
   features: [optionsHandler],
 };

--- a/ui/src/formkit/inputs/menu-item-select.ts
+++ b/ui/src/formkit/inputs/menu-item-select.ts
@@ -21,7 +21,7 @@ function optionsHandler(node: FormKitNode) {
 
 export const menuItemSelect: FormKitTypeDefinition = {
   ...select,
-  props: ["placeholder", "menuItems"],
+  props: ["menuItems", ...(select.props as string[])],
   forceTypeProp: "select",
   features: [optionsHandler],
 };

--- a/ui/src/formkit/inputs/post-select.ts
+++ b/ui/src/formkit/inputs/post-select.ts
@@ -59,7 +59,6 @@ function optionsHandler(node: FormKitNode) {
 
 export const postSelect: FormKitTypeDefinition = {
   ...select,
-  props: ["placeholder"],
   forceTypeProp: "select",
   features: [optionsHandler],
 };

--- a/ui/src/formkit/inputs/post-select.ts
+++ b/ui/src/formkit/inputs/post-select.ts
@@ -53,6 +53,7 @@ function optionsHandler(node: FormKitNode) {
         search,
         findOptionsByValues,
       },
+      searchable: true,
     };
   });
 }

--- a/ui/src/formkit/inputs/role-select.ts
+++ b/ui/src/formkit/inputs/role-select.ts
@@ -37,7 +37,6 @@ function optionsHandler(node: FormKitNode) {
 
 export const roleSelect: FormKitTypeDefinition = {
   ...select,
-  props: ["placeholder"],
-  forceTypeProp: "nativeSelect",
+  forceTypeProp: "select",
   features: [optionsHandler],
 };

--- a/ui/src/formkit/inputs/select/SelectContainer.vue
+++ b/ui/src/formkit/inputs/select/SelectContainer.vue
@@ -78,6 +78,10 @@ const props = defineProps({
     type: Boolean,
     default: false,
   },
+  autoSelect: {
+    type: Boolean,
+    default: true,
+  },
 });
 
 const emit = defineEmits<{
@@ -221,7 +225,11 @@ const clearAllSelectedOptions = () => {
   if (!hasClearable.value) {
     return;
   }
-  selectedOptions.value = [];
+  if (props.autoSelect && props.options.length > 0) {
+    selectedOptions.value = [props.options[0]];
+  } else {
+    selectedOptions.value = [];
+  }
   clearInputValue();
 };
 

--- a/ui/src/formkit/inputs/select/SelectContainer.vue
+++ b/ui/src/formkit/inputs/select/SelectContainer.vue
@@ -225,11 +225,8 @@ const clearAllSelectedOptions = () => {
   if (!hasClearable.value) {
     return;
   }
-  if (props.autoSelect && props.options.length > 0) {
-    selectedOptions.value = [props.options[0]];
-  } else {
-    selectedOptions.value = [];
-  }
+
+  selectedOptions.value = [];
   clearInputValue();
 };
 

--- a/ui/src/formkit/inputs/select/SelectMain.vue
+++ b/ui/src/formkit/inputs/select/SelectMain.vue
@@ -77,6 +77,11 @@ export interface SelectProps {
    * Whether to enable search, default is false.
    */
   searchable?: boolean;
+
+  /**
+   * Whether to automatically select the first option. default is true.
+   */
+  autoSelect?: boolean;
 }
 
 export interface SelectResponse {
@@ -214,6 +219,7 @@ const initSelectProps = () => {
   selectProps.allowCreate = !isFalse(nodeProps.allowCreate);
   selectProps.clearable = !isFalse(nodeProps.clearable);
   selectProps.searchable = !isFalse(nodeProps.searchable);
+  selectProps.autoSelect = !isFalse(nodeProps.autoSelect) || true;
   if (selectProps.remote) {
     if (!nodeProps.remoteOption) {
       throw new Error("remoteOption is required when remote is true.");
@@ -513,7 +519,11 @@ const stopSelectedWatch = watch(
   async () => {
     if (options.value) {
       const selectedOption = await fetchSelectedOptions();
-      selectOptions.value = selectedOption;
+      if (selectedOption) {
+        selectOptions.value = selectedOption;
+      } else if (selectProps.autoSelect && options.value.length > 0) {
+        selectOptions.value = [options.value[0]];
+      }
     }
   },
   {
@@ -669,6 +679,7 @@ const handleNextPage = async () => {
     :remote="isRemote"
     :clearable="selectProps.clearable"
     :searchable="selectProps.searchable"
+    :auto-select="selectProps.autoSelect"
     @update="handleUpdate"
     @search="handleSearch"
     @load-more="handleNextPage"

--- a/ui/src/formkit/inputs/select/SelectMain.vue
+++ b/ui/src/formkit/inputs/select/SelectMain.vue
@@ -516,6 +516,23 @@ onMounted(async () => {
   }
 });
 
+const getAutoSelectedOption = ():
+  | {
+      label: string;
+      value: string;
+    }
+  | undefined => {
+  if (!options.value || options.value.length === 0) {
+    return;
+  }
+
+  // Find the first option that is not disabled.
+  return options.value.find((option) => {
+    const attrs = option.attrs as Record<string, unknown>;
+    return isFalse(attrs?.disabled as string | boolean | undefined);
+  });
+};
+
 const stopSelectedWatch = watch(
   () => [options.value, props.context.value],
   async () => {
@@ -525,14 +542,17 @@ const stopSelectedWatch = watch(
         selectOptions.value = selectedOption;
         return;
       }
-      if (
+      const isAutoSelect =
         selectProps.autoSelect &&
-        options.value.length > 0 &&
-        !selectProps.multiple
-      ) {
+        !selectProps.multiple &&
+        !selectProps.placeholder;
+
+      if (isAutoSelect) {
         // Automatically select the first option when the selected value is empty.
-        selectOptions.value = [options.value[0]];
-        return;
+        const autoSelectedOption = getAutoSelectedOption();
+        if (autoSelectedOption) {
+          selectOptions.value = [autoSelectedOption];
+        }
       }
     }
   },

--- a/ui/src/formkit/inputs/select/SelectMain.vue
+++ b/ui/src/formkit/inputs/select/SelectMain.vue
@@ -80,6 +80,8 @@ export interface SelectProps {
 
   /**
    * Whether to automatically select the first option. default is true.
+   *
+   * Only valid when `multiple` is false.
    */
   autoSelect?: boolean;
 }
@@ -521,8 +523,16 @@ const stopSelectedWatch = watch(
       const selectedOption = await fetchSelectedOptions();
       if (selectedOption) {
         selectOptions.value = selectedOption;
-      } else if (selectProps.autoSelect && options.value.length > 0) {
+        return;
+      }
+      if (
+        selectProps.autoSelect &&
+        options.value.length > 0 &&
+        !selectProps.multiple
+      ) {
+        // Automatically select the first option when the selected value is empty.
         selectOptions.value = [options.value[0]];
+        return;
       }
     }
   },

--- a/ui/src/formkit/inputs/select/SelectMain.vue
+++ b/ui/src/formkit/inputs/select/SelectMain.vue
@@ -373,6 +373,9 @@ const fetchSelectedOptions = async (): Promise<
     )
     .filter(Boolean);
   if (unmappedSelectValues.length === 0) {
+    if (!currentOptions || currentOptions.length === 0) {
+      return;
+    }
     return currentOptions?.sort((a, b) =>
       selectedValues.indexOf(a.value) > selectedValues.indexOf(b.value) ? 1 : -1
     );

--- a/ui/src/formkit/inputs/select/SelectMain.vue
+++ b/ui/src/formkit/inputs/select/SelectMain.vue
@@ -545,19 +545,18 @@ const stopSelectedWatch = watch(
       const isAutoSelect =
         selectProps.autoSelect &&
         !selectProps.multiple &&
-        !selectProps.placeholder;
+        !selectProps.placeholder &&
+        !props.context.node.value;
 
       if (isAutoSelect) {
         // Automatically select the first option when the selected value is empty.
         const autoSelectedOption = getAutoSelectedOption();
         if (autoSelectedOption) {
           selectOptions.value = [autoSelectedOption];
+          handleUpdate(selectOptions.value);
         }
       }
     }
-  },
-  {
-    immediate: true,
   }
 );
 

--- a/ui/src/formkit/inputs/select/SelectMain.vue
+++ b/ui/src/formkit/inputs/select/SelectMain.vue
@@ -349,29 +349,29 @@ const fetchSelectedOptions = async (): Promise<
 > => {
   const node = props.context.node;
   const value = node.value;
-  if (!value) {
-    return undefined;
-  }
 
-  const selectedValues: string[] = [];
+  const selectedValues: Array<unknown> = [];
   if (Array.isArray(value)) {
     selectedValues.push(...value);
   } else if (
     typeof value === "string" ||
     typeof value === "number" ||
-    typeof value === "boolean"
+    typeof value === "boolean" ||
+    value === void 0
   ) {
-    selectedValues.push(value.toString());
+    selectedValues.push(value);
   }
 
   const currentOptions = options.value?.filter((option) =>
-    selectedValues.includes(option.value.toString())
+    selectedValues.includes(option.value)
   );
 
   // Get options that are not yet mapped.
-  const unmappedSelectValues = selectedValues.filter(
-    (value) => !currentOptions?.find((option) => option.value === value)
-  );
+  const unmappedSelectValues = selectedValues
+    .filter(
+      (value) => !currentOptions?.find((option) => option.value === value)
+    )
+    .filter(Boolean);
   if (unmappedSelectValues.length === 0) {
     return currentOptions?.sort((a, b) =>
       selectedValues.indexOf(a.value) > selectedValues.indexOf(b.value) ? 1 : -1
@@ -379,7 +379,9 @@ const fetchSelectedOptions = async (): Promise<
   }
 
   // Map the unresolved options to label and value format.
-  const mappedSelectOptions = await mapUnresolvedOptions(unmappedSelectValues);
+  const mappedSelectOptions = await mapUnresolvedOptions(
+    unmappedSelectValues.map(String)
+  );
   // Merge currentOptions and mappedSelectOptions, then sort them according to selectValues order.
   return [...(currentOptions || []), ...mappedSelectOptions].sort((a, b) =>
     selectedValues.indexOf(a.value) > selectedValues.indexOf(b.value) ? 1 : -1

--- a/ui/src/formkit/inputs/select/index.ts
+++ b/ui/src/formkit/inputs/select/index.ts
@@ -52,6 +52,7 @@ export const select: FormKitTypeDefinition = {
     "allowCreate",
     "remoteOptimize",
     "searchable",
+    "autoSelect",
   ],
 
   library: {

--- a/ui/src/formkit/inputs/singlePage-select.ts
+++ b/ui/src/formkit/inputs/singlePage-select.ts
@@ -59,7 +59,6 @@ function optionsHandler(node: FormKitNode) {
 
 export const singlePageSelect: FormKitTypeDefinition = {
   ...select,
-  props: ["placeholder"],
-  forceTypeProp: "nativeSelect",
+  forceTypeProp: "select",
   features: [optionsHandler, selects, defaultIcon("select", "select")],
 };

--- a/ui/src/formkit/inputs/singlePage-select.ts
+++ b/ui/src/formkit/inputs/singlePage-select.ts
@@ -53,6 +53,7 @@ function optionsHandler(node: FormKitNode) {
         search,
         findOptionsByValues,
       },
+      searchable: true,
     };
   });
 }

--- a/ui/src/formkit/inputs/singlePage-select.ts
+++ b/ui/src/formkit/inputs/singlePage-select.ts
@@ -1,7 +1,7 @@
 import { singlePageLabels } from "@/constants/labels";
 import type { FormKitNode, FormKitTypeDefinition } from "@formkit/core";
-import { defaultIcon, select, selects } from "@formkit/inputs";
 import { consoleApiClient } from "@halo-dev/api-client";
+import { select } from "./select";
 
 async function search({ page, size, keyword }) {
   const { data } = await consoleApiClient.content.singlePage.listSinglePages({
@@ -60,5 +60,5 @@ function optionsHandler(node: FormKitNode) {
 export const singlePageSelect: FormKitTypeDefinition = {
   ...select,
   forceTypeProp: "select",
-  features: [optionsHandler, selects, defaultIcon("select", "select")],
+  features: [optionsHandler],
 };

--- a/ui/src/formkit/inputs/user-select.ts
+++ b/ui/src/formkit/inputs/user-select.ts
@@ -57,7 +57,6 @@ function optionsHandler(node: FormKitNode) {
 
 export const userSelect: FormKitTypeDefinition = {
   ...select,
-  props: ["placeholder"],
   forceTypeProp: "select",
   features: [optionsHandler],
 };


### PR DESCRIPTION
#### What type of PR is this?

/kind improvement
/area ui
/milestone 2.19.x

#### What this PR does / why we need it:

为 formkit select 增加属性 `autoSelect`。

这个属性仅会作用于单选，且目的是为了初始化数据所用。当 value 或者 placeholder 存在时，此属性无效。

会查找第一个 option 不为 disabled 的数据。

#### Does this PR introduce a user-facing change?
```release-note
None
```
