### PR TITLE
refactor: simplify post settings form fields

### DIFF
--- a/ui/console-src/modules/contents/pages/components/SinglePageSettingModal.vue
+++ b/ui/console-src/modules/contents/pages/components/SinglePageSettingModal.vue
@@ -328,15 +328,11 @@ const { handleGenerateSlug } = useSlugify(
             </FormKit>
             <FormKit
               v-model="formState.spec.excerpt.autoGenerate"
-              :options="[
-                { label: $t('core.common.radio.yes'), value: true },
-                { label: $t('core.common.radio.no'), value: false },
-              ]"
               name="autoGenerate"
               :label="
                 $t('core.page.settings.fields.auto_generate_excerpt.label')
               "
-              type="radio"
+              type="checkbox"
             >
             </FormKit>
             <FormKit
@@ -366,23 +362,15 @@ const { handleGenerateSlug } = useSlugify(
           <div class="mt-5 divide-y divide-gray-100 md:col-span-3 md:mt-0">
             <FormKit
               v-model="formState.spec.allowComment"
-              :options="[
-                { label: $t('core.common.radio.yes'), value: true },
-                { label: $t('core.common.radio.no'), value: false },
-              ]"
               name="allowComment"
               :label="$t('core.page.settings.fields.allow_comment.label')"
-              type="radio"
+              type="checkbox"
             ></FormKit>
             <FormKit
               v-model="formState.spec.pinned"
-              :options="[
-                { label: $t('core.common.radio.yes'), value: true },
-                { label: $t('core.common.radio.no'), value: false },
-              ]"
               :label="$t('core.page.settings.fields.pinned.label')"
               name="pinned"
-              type="radio"
+              type="checkbox"
             ></FormKit>
             <FormKit
               v-model="formState.spec.visible"

--- a/ui/console-src/modules/contents/posts/components/PostSettingModal.vue
+++ b/ui/console-src/modules/contents/posts/components/PostSettingModal.vue
@@ -355,15 +355,11 @@ const showCancelPublishButton = computed(() => {
             />
             <FormKit
               v-model="formState.spec.excerpt.autoGenerate"
-              :options="[
-                { label: $t('core.common.radio.yes'), value: true },
-                { label: $t('core.common.radio.no'), value: false },
-              ]"
               name="autoGenerate"
               :label="
                 $t('core.post.settings.fields.auto_generate_excerpt.label')
               "
-              type="radio"
+              type="checkbox"
             >
             </FormKit>
             <FormKit
@@ -398,22 +394,14 @@ const showCancelPublishButton = computed(() => {
             ></FormKit>
             <FormKit
               v-model="formState.spec.allowComment"
-              :options="[
-                { label: $t('core.common.radio.yes'), value: true },
-                { label: $t('core.common.radio.no'), value: false },
-              ]"
               :label="$t('core.post.settings.fields.allow_comment.label')"
-              type="radio"
+              type="checkbox"
             ></FormKit>
             <FormKit
               v-model="formState.spec.pinned"
-              :options="[
-                { label: $t('core.common.radio.yes'), value: true },
-                { label: $t('core.common.radio.no'), value: false },
-              ]"
               :label="$t('core.post.settings.fields.pinned.label')"
               name="pinned"
-              type="radio"
+              type="checkbox"
             ></FormKit>
             <FormKit
               v-model="formState.spec.visible"

--- a/ui/uc-src/modules/contents/posts/components/PostSettingForm.vue
+++ b/ui/uc-src/modules/contents/posts/components/PostSettingForm.vue
@@ -135,13 +135,9 @@ const publishTimeHelp = computed(() => {
           />
           <FormKit
             :value="true"
-            :options="[
-              { label: $t('core.common.radio.yes'), value: true },
-              { label: $t('core.common.radio.no'), value: false },
-            ]"
             name="excerptAutoGenerate"
             :label="$t('core.post.settings.fields.auto_generate_excerpt.label')"
-            type="radio"
+            type="checkbox"
           >
           </FormKit>
           <FormKit
@@ -170,21 +166,13 @@ const publishTimeHelp = computed(() => {
         <div class="mt-5 divide-y divide-gray-100 md:col-span-3 md:mt-0">
           <FormKit
             name="allowComment"
-            :options="[
-              { label: $t('core.common.radio.yes'), value: true },
-              { label: $t('core.common.radio.no'), value: false },
-            ]"
             :label="$t('core.post.settings.fields.allow_comment.label')"
-            type="radio"
+            type="checkbox"
           ></FormKit>
           <FormKit
-            :options="[
-              { label: $t('core.common.radio.yes'), value: true },
-              { label: $t('core.common.radio.no'), value: false },
-            ]"
             :label="$t('core.post.settings.fields.pinned.label')"
             name="pinned"
-            type="radio"
+            type="checkbox"
           ></FormKit>
           <FormKit
             :options="[


### PR DESCRIPTION
#### What type of PR is this?

/area ui
/kind improvement
/milestone 2.19.0

#### What this PR does / why we need it:

简化文章设置表单的部分表单项。

<img width="760" alt="image" src="https://github.com/user-attachments/assets/337a728e-8cc6-4c9e-aa85-dc4c64b72de5">


#### Does this PR introduce a user-facing change?

```release-note
简化文章设置表单的部分表单项。
```
