### PR TITLE
fix: post list sorting parameter not working

### DIFF
--- a/application/src/main/java/run/halo/app/theme/finders/impl/PostFinderImpl.java
+++ b/application/src/main/java/run/halo/app/theme/finders/impl/PostFinderImpl.java
@@ -85,7 +85,7 @@ public class PostFinderImpl implements PostFinder {
         return Sort.by(Sort.Order.desc("spec.pinned"),
             Sort.Order.desc("spec.priority"),
             Sort.Order.desc("spec.publishTime"),
-            Sort.Order.desc("metadata.name")
+            Sort.Order.asc("metadata.name")
         );
     }
 
@@ -337,11 +337,8 @@ public class PostFinderImpl implements PostFinder {
         }
 
         public PageRequest toPageRequest() {
-            var resolvedSort = Optional.of(SortUtils.resolve(sort))
-                .filter(Sort::isUnsorted)
-                .orElse(defaultSort());
             return PageRequestImpl.of(pageNullSafe(getPage()),
-                sizeNullSafe(getSize()), resolvedSort);
+                sizeNullSafe(getSize()), SortUtils.resolve(sort).and(defaultSort()));
         }
     }
 }

--- a/application/src/test/java/run/halo/app/theme/finders/impl/PostFinderImplTest.java
+++ b/application/src/test/java/run/halo/app/theme/finders/impl/PostFinderImplTest.java
@@ -10,11 +10,13 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Predicate;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Sort;
 import reactor.core.publisher.Mono;
 import run.halo.app.content.PostService;
 import run.halo.app.core.extension.content.Post;
@@ -213,5 +215,22 @@ class PostFinderImplTest {
         postStatus.setExcerpt("hello world!");
         post.setStatus(postStatus);
         return post;
+    }
+
+    @Nested
+    class PostQueryTest {
+
+        @Test
+        void toPageRequestTest() {
+            var query = new PostFinderImpl.PostQuery();
+            var result = query.toPageRequest();
+            assertThat(result.getSort()).isEqualTo(PostFinderImpl.defaultSort());
+
+            query.setSort(List.of("spec.publishTime,desc"));
+            result = query.toPageRequest();
+            assertThat(result.getSort())
+                .isEqualTo(Sort.by(Sort.Order.desc("spec.publishTime"))
+                    .and(PostFinderImpl.defaultSort()));
+        }
     }
 }


### PR DESCRIPTION
#### What type of PR is this?
/kind bug
/area core
/milestone 2.19.x

#### What this PR does / why we need it:
修复 postFinder 的 list 排序参数不生效的问题

此问题由于 https://github.com/halo-dev/halo/pull/6531 导致

#### Which issue(s) this PR fixes:
Fixes #6534

#### Does this PR introduce a user-facing change?
```release-note
None
```
