### PR TITLE
Make slug of single page be not unique

### DIFF
--- a/application/src/main/java/run/halo/app/infra/SchemeInitializer.java
+++ b/application/src/main/java/run/halo/app/infra/SchemeInitializer.java
@@ -490,7 +490,7 @@ public class SchemeInitializer implements ApplicationListener<ApplicationContext
             );
             is.add(new IndexSpec()
                 .setName("spec.slug")
-                .setUnique(true)
+                .setUnique(false)
                 .setIndexFunc(
                     simpleAttribute(SinglePage.class, page -> Optional.ofNullable(page.getSpec())
                         .map(SinglePage.SinglePageSpec::getSlug)


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup
/area core
/milestone 2.19.0

#### What this PR does / why we need it:

For backward compatibility, the slug of single page should not be unique.

BTW, the problem was introduced by <https://github.com/halo-dev/halo/pull/6540>.

#### Does this PR introduce a user-facing change?

```release-note
None
```
