### PR TITLE
fix: prevent anonymous extensions from being filtered due to duplicate names

### DIFF
--- a/ui/src/components/editor/DefaultEditor.vue
+++ b/ui/src/components/editor/DefaultEditor.vue
@@ -254,6 +254,7 @@ const presetExtensions = [
   ExtensionColor,
   ExtensionIndent,
   Extension.create({
+    name: "custom-heading-extension",
     addGlobalAttributes() {
       return [
         {
@@ -268,6 +269,7 @@ const presetExtensions = [
     },
   }),
   Extension.create({
+    name: "custom-attachment-extension",
     addOptions() {
       // If user has no permission to view attachments, return
       if (!currentUserHasPermission(["system:attachments:view"])) {
@@ -342,6 +344,7 @@ const presetExtensions = [
   ExtensionNodeSelected,
   ExtensionTrailingNode,
   Extension.create({
+    name: "get-heading-id-extension",
     addProseMirrorPlugins() {
       return [
         new Plugin({


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/area editor
/milestone 2.19.x

#### What this PR does / why we need it:

为匿名的 `Extension` 添加 name 值，解决由于匿名的 `Extension` name 相同而导致被过滤的问题。

#### How to test it?

测试默认编辑器附件库是否可以被打开。

#### Does this PR introduce a user-facing change?
```release-note
解决默认编辑器附件库无法被打开的问题
```
