### PR TITLE
refactor: redirect to original image if thumbnail is inaccessible

### DIFF
--- a/application/src/main/java/run/halo/app/core/attachment/impl/LocalThumbnailServiceImpl.java
+++ b/application/src/main/java/run/halo/app/core/attachment/impl/LocalThumbnailServiceImpl.java
@@ -45,6 +45,7 @@ import run.halo.app.extension.Metadata;
 import run.halo.app.extension.PageRequestImpl;
 import run.halo.app.extension.ReactiveExtensionClient;
 import run.halo.app.infra.ExternalUrlSupplier;
+import run.halo.app.infra.exception.NotFoundException;
 
 @Slf4j
 @Component
@@ -76,7 +77,8 @@ public class LocalThumbnailServiceImpl implements LocalThumbnailService {
     @Override
     public Mono<URI> getOriginalImageUri(URI thumbnailUri) {
         return fetchThumbnail(thumbnailUri)
-            .map(local -> URI.create(local.getSpec().getImageUri()));
+            .map(local -> URI.create(local.getSpec().getImageUri()))
+            .switchIfEmpty(Mono.error(() -> new NotFoundException("Resource not found.")));
     }
 
     @Override

--- a/application/src/test/java/run/halo/app/theme/endpoint/ThumbnailEndpointTest.java
+++ b/application/src/test/java/run/halo/app/theme/endpoint/ThumbnailEndpointTest.java
@@ -1,0 +1,51 @@
+package run.halo.app.theme.endpoint;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+import java.net.URI;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.web.reactive.server.WebTestClient;
+import reactor.core.publisher.Mono;
+import run.halo.app.core.attachment.ThumbnailService;
+
+/**
+ * Tests for {@link ThumbnailEndpoint}.
+ *
+ * @author guqing
+ * @since 2.19.0
+ */
+@ExtendWith(MockitoExtension.class)
+class ThumbnailEndpointTest {
+
+    WebTestClient webClient;
+
+    @Mock
+    private ThumbnailService thumbnailService;
+
+    @InjectMocks
+    private ThumbnailEndpoint endpoint;
+
+    @BeforeEach
+    void setUp() {
+        webClient = WebTestClient.bindToRouterFunction(endpoint.endpoint())
+            .build();
+    }
+
+    @Test
+    void thumbnailUriNotAccessible() {
+        when(thumbnailService.generate(any(), any()))
+            .thenReturn(Mono.just(URI.create("/thumbnail-not-found.png")));
+        webClient.get()
+            .uri("/thumbnails/-/via-uri?size=l&uri=/myavatar.png")
+            .exchange()
+            .expectAll(responseSpec -> responseSpec.expectHeader().location("/myavatar.png"))
+            .expectStatus()
+            .is3xxRedirection();
+    }
+}


### PR DESCRIPTION
#### What type of PR is this?
/kind improvement
/area core
/milestone 2.19.x

#### What this PR does / why we need it:
获取缩略图时检查缩略图链接是否可访问否则重定向到原图链接

#### Does this PR introduce a user-facing change?
```release-note
获取缩略图时检查缩略图链接是否可访问否则重定向到原图链接
```
