### PR TITLE
refactor: add warning alert for H2 database on data initialization page

### DIFF
--- a/ui/console-src/views/system/Setup.vue
+++ b/ui/console-src/views/system/Setup.vue
@@ -1,5 +1,4 @@
 <script lang="ts" setup>
-import H2WarningAlert from "@/components/alerts/H2WarningAlert.vue";
 import LocaleChange from "@/components/common/LocaleChange.vue";
 import { useGlobalInfoStore } from "@/stores/global-info";
 import type { SystemInitializationRequest } from "@halo-dev/api-client";
@@ -51,8 +50,6 @@ const inputClasses = {
     <IconLogo class="mb-8 flex-none" />
 
     <div class="flex w-72 flex-col">
-      <H2WarningAlert class="mb-3" />
-
       <FormKit
         id="setup-form"
         v-model="formState"

--- a/ui/console-src/views/system/SetupInitialData.vue
+++ b/ui/console-src/views/system/SetupInitialData.vue
@@ -186,7 +186,7 @@ onMounted(async () => {
       <H2WarningAlert class="max-w-md">
         <template #actions>
           <VButton type="secondary" size="sm" @click="setupInitialData()">
-            {{ $t("core.setup.operations.continue.button") }}
+            {{ $t("core.common.buttons.continue") }}
           </VButton>
         </template>
       </H2WarningAlert>

--- a/ui/src/components/alerts/H2WarningAlert.vue
+++ b/ui/src/components/alerts/H2WarningAlert.vue
@@ -26,5 +26,8 @@ const { data: info } = useQuery<Info>({
     <template #description>
       {{ $t("core.components.h2_warning_alert.description") }}
     </template>
+    <template #actions>
+      <slot name="actions" />
+    </template>
   </VAlert>
 </template>

--- a/ui/src/locales/en.yaml
+++ b/ui/src/locales/en.yaml
@@ -1508,6 +1508,8 @@ core:
         toast_success: Setup successfully
       setup_initial_data:
         loading: Initializing data, please wait...
+      continue:
+        button: Continue
     fields:
       site_title:
         label: Site title

--- a/ui/src/locales/en.yaml
+++ b/ui/src/locales/en.yaml
@@ -1508,8 +1508,6 @@ core:
         toast_success: Setup successfully
       setup_initial_data:
         loading: Initializing data, please wait...
-      continue:
-        button: Continue
     fields:
       site_title:
         label: Site title
@@ -1787,6 +1785,7 @@ core:
       revoke: Revoke
       disable: Disable
       enable: Enable
+      continue: Continue
     radio:
       "yes": "Yes"
       "no": "No"

--- a/ui/src/locales/zh-CN.yaml
+++ b/ui/src/locales/zh-CN.yaml
@@ -1402,8 +1402,6 @@ core:
         toast_success: 初始化成功
       setup_initial_data:
         loading: 正在初始化数据，请稍后...
-      continue:
-        button: 继续初始化
     fields:
       site_title:
         label: 站点名称
@@ -1696,6 +1694,7 @@ core:
       revoke: 撤销
       disable: 禁用
       enable: 启用
+      continue: 继续
     radio:
       "yes": 是
       "no": 否

--- a/ui/src/locales/zh-CN.yaml
+++ b/ui/src/locales/zh-CN.yaml
@@ -1402,6 +1402,8 @@ core:
         toast_success: 初始化成功
       setup_initial_data:
         loading: 正在初始化数据，请稍后...
+      continue:
+        button: 继续初始化
     fields:
       site_title:
         label: 站点名称

--- a/ui/src/locales/zh-TW.yaml
+++ b/ui/src/locales/zh-TW.yaml
@@ -1381,8 +1381,6 @@ core:
         toast_success: 初始化成功
       setup_initial_data:
         loading: 正在初始化資料，請稍後...
-      continue:
-        button: 繼續初始化
     fields:
       site_title:
         label: 站點名稱
@@ -1653,6 +1651,7 @@ core:
       revoke: 撤銷
       disable: 禁用
       enable: 启用
+      continue: 繼續
     radio:
       "yes": 是
       "no": 否

--- a/ui/src/locales/zh-TW.yaml
+++ b/ui/src/locales/zh-TW.yaml
@@ -1381,6 +1381,8 @@ core:
         toast_success: 初始化成功
       setup_initial_data:
         loading: 正在初始化資料，請稍後...
+      continue:
+        button: 繼續初始化
     fields:
       site_title:
         label: 站點名稱


### PR DESCRIPTION
#### What type of PR is this?

/area ui
/kind improvement
/milestone 2.19.0

#### What this PR does / why we need it:

将 H2 数据库使用警告放置在数据初始化页面，之前放在初始化表单页面无法正确判断，因为没有登录，无法调用 /actuator/info 接口获取数据库数据。

<img width="638" alt="image" src="https://github.com/user-attachments/assets/18868104-321a-4146-a893-5babf4573146">

Fixes https://github.com/halo-dev/halo/issues/6561

#### Special notes for your reviewer:

需要使用此 PR 测试使用 H2 数据库全新安装，观察是否在数据初始化页面有 H2 数据库的使用提示。

#### Does this PR introduce a user-facing change?

```release-note
None
```
