### PR TITLE
fix: solving the issue of the default editor format brush being incorectly filtered

### DIFF
--- a/ui/packages/editor/src/extensions/clear-format/index.ts
+++ b/ui/packages/editor/src/extensions/clear-format/index.ts
@@ -7,6 +7,8 @@ import { markRaw } from "vue";
 import MdiEraser from "~icons/mdi/eraser";
 
 const clearFormat = Extension.create<ExtensionOptions>({
+  name: "clearFormat",
+
   addOptions() {
     return {
       getToolbarItems({ editor }: { editor: Editor }) {

--- a/ui/packages/editor/src/extensions/format-brush/index.ts
+++ b/ui/packages/editor/src/extensions/format-brush/index.ts
@@ -20,6 +20,8 @@ export interface FormatBrushStore {
 }
 
 const formatBrush = Extension.create<any, FormatBrushStore>({
+  name: "formatBrush",
+
   addOptions() {
     return {
       ...this.parent?.(),


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/area editor
/milestone 2.19.x

#### What this PR does / why we need it:

为默认编辑器格式刷及清除格式扩展增加 name，用于解决其重名而导致被错误过滤的问题

Fixes #6562 

#### How to test it?

查看默认编辑中格式刷及清除格式功能是否存在且运行正常。

#### Does this PR introduce a user-facing change?
```release-note
解决默认编辑器格式刷及清除格式功能不存在的问题
```
