### PR TITLE
Fix the problem that Lucene lock is held by VM

### DIFF
--- a/application/src/main/java/run/halo/app/search/lucene/LuceneSearchEngine.java
+++ b/application/src/main/java/run/halo/app/search/lucene/LuceneSearchEngine.java
@@ -84,7 +84,7 @@ public class LuceneSearchEngine implements SearchEngine, InitializingBean, Dispo
 
     private Directory directory;
 
-    public LuceneSearchEngine(Path indexRootDir) throws IOException {
+    public LuceneSearchEngine(Path indexRootDir) {
         this.indexRootDir = indexRootDir;
     }
 
@@ -106,12 +106,14 @@ public class LuceneSearchEngine implements SearchEngine, InitializingBean, Dispo
 
         var writerConfig = new IndexWriterConfig(this.analyzer)
             .setOpenMode(CREATE_OR_APPEND);
-        try (var indexWriter = new IndexWriter(this.directory, writerConfig)) {
-            indexWriter.updateDocuments(deleteQuery, docs);
-        } catch (IOException e) {
-            throw Exceptions.propagate(e);
-        } finally {
-            this.refreshSearcherManager();
+        synchronized (this) {
+            try (var indexWriter = new IndexWriter(this.directory, writerConfig)) {
+                indexWriter.updateDocuments(deleteQuery, docs);
+            } catch (IOException e) {
+                throw Exceptions.propagate(e);
+            } finally {
+                this.refreshSearcherManager();
+            }
         }
     }
 
@@ -122,12 +124,14 @@ public class LuceneSearchEngine implements SearchEngine, InitializingBean, Dispo
         var deleteQuery = new TermInSetQuery("id", terms);
         var writerConfig = new IndexWriterConfig(this.analyzer)
             .setOpenMode(CREATE_OR_APPEND);
-        try (var indexWriter = new IndexWriter(this.directory, writerConfig)) {
-            indexWriter.deleteDocuments(deleteQuery);
-        } catch (IOException e) {
-            throw Exceptions.propagate(e);
-        } finally {
-            this.refreshSearcherManager();
+        synchronized (this) {
+            try (var indexWriter = new IndexWriter(this.directory, writerConfig)) {
+                indexWriter.deleteDocuments(deleteQuery);
+            } catch (IOException e) {
+                throw Exceptions.propagate(e);
+            } finally {
+                this.refreshSearcherManager();
+            }
         }
     }
 
@@ -135,12 +139,14 @@ public class LuceneSearchEngine implements SearchEngine, InitializingBean, Dispo
     public void deleteAll() {
         var writerConfig = new IndexWriterConfig(this.analyzer)
             .setOpenMode(CREATE_OR_APPEND);
-        try (var indexWriter = new IndexWriter(this.directory, writerConfig)) {
-            indexWriter.deleteAll();
-        } catch (IOException e) {
-            throw Exceptions.propagate(e);
-        } finally {
-            this.refreshSearcherManager();
+        synchronized (this) {
+            try (var indexWriter = new IndexWriter(this.directory, writerConfig)) {
+                indexWriter.deleteAll();
+            } catch (IOException e) {
+                throw Exceptions.propagate(e);
+            } finally {
+                this.refreshSearcherManager();
+            }
         }
     }
 


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/area core
/milestone 2.20.x

#### What this PR does / why we need it:

This PR add keyword synchronized for methods `addOrUpdateDocuments`, `deleteDocuments` and `deleteAll` to ensure the write lock of Lucene is obtained only by one IndexWriter at the same time.

#### Which issue(s) this PR fixes:

Fixes #6569 

#### Does this PR introduce a user-facing change?

```release-note
修复重启后无法搜索部分文档的问题
```
