### PR TITLE
fix: formkit selector not listening to data after defaulting to first option

### DIFF
--- a/ui/src/formkit/inputs/select/SelectMain.vue
+++ b/ui/src/formkit/inputs/select/SelectMain.vue
@@ -576,9 +576,15 @@ watch(
   }
 );
 
+const handleSelectedUpdate = (
+  value: Array<{ label: string; value: string }>
+) => {
+  stopSelectedWatch();
+  handleUpdate(value);
+};
+
 const handleUpdate = (value: Array<{ label: string; value: string }>) => {
   const values = value.map((item) => item.value);
-  stopSelectedWatch();
   selectOptions.value = value;
   if (selectProps.multiple) {
     props.context.node.input(values);
@@ -714,7 +720,7 @@ const handleNextPage = async () => {
     :clearable="selectProps.clearable"
     :searchable="selectProps.searchable"
     :auto-select="selectProps.autoSelect"
-    @update="handleUpdate"
+    @update="handleSelectedUpdate"
     @search="handleSearch"
     @load-more="handleNextPage"
   />


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/area ui
/milestone 2.20.x

#### What this PR does / why we need it:

当 formkit 选择器初始没有值的情况下，会默认选择第一项，但这同时会导致监听器取消监听，进而无法监听到后续的 value 值变更。

此 PR 将选择值的逻辑与自动选择第一项分开，用于解决此问题。

#### How to test it?

测试当选择器不存在初始值时，后续通过 v-model 传入的值是否还会使当前选项进行变更。

#### Does this PR introduce a user-facing change?
```release-note
解决 formkit 选择器回显数据异常的问题
```
