### PR TITLE
refactor: preserve original image if smaller than requested thumbnail size

### DIFF
--- a/application/src/main/java/run/halo/app/core/attachment/ThumbnailGenerator.java
+++ b/application/src/main/java/run/halo/app/core/attachment/ThumbnailGenerator.java
@@ -1,5 +1,7 @@
 package run.halo.app.core.attachment;
 
+import static java.nio.file.StandardCopyOption.REPLACE_EXISTING;
+
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
@@ -74,10 +76,14 @@ public class ThumbnailGenerator {
             throw new UnsupportedOperationException(
                 "Unsupported image format for: " + formatNameOpt.orElse("unknown"));
         }
-        var thumbnail = Scalr.resize(img, Scalr.Method.AUTOMATIC, Scalr.Mode.FIT_TO_WIDTH,
-            size.getWidth());
         var formatName = formatNameOpt.orElse("jpg");
         var thumbnailFile = getThumbnailFile(formatName);
+        if (img.getWidth() <= size.getWidth()) {
+            Files.copy(tempImagePath, thumbnailFile.toPath(), REPLACE_EXISTING);
+            return;
+        }
+        var thumbnail = Scalr.resize(img, Scalr.Method.AUTOMATIC, Scalr.Mode.FIT_TO_WIDTH,
+            size.getWidth());
         ImageIO.write(thumbnail, formatName, thumbnailFile);
     }
 


### PR DESCRIPTION
#### What type of PR is this?
/kind improvement
/area core
/milestone 2.20.x

#### What this PR does / why we need it:
当生成缩略图时如果原图尺寸小于请求尺寸则返回原图以保持其质量

#### Which issue(s) this PR fixes:
Fixes #6579

#### Does this PR introduce a user-facing change?
```release-note
当生成缩略图时如果原图尺寸小于请求尺寸则返回原图以保持其质量
```
