### PR TITLE
docs: add documentation for formkit select allowCreate property

### DIFF
--- a/ui/docs/custom-formkit-input/README.md
+++ b/ui/docs/custom-formkit-input/README.md
@@ -65,7 +65,7 @@
     4. `remote`：标识当前是否由用户自定义的远程数据源。
     5. `remoteOption`：当 `remote` 为 `true` 时，此配置项必须存在，用于为 Select 组件提供处理搜索及查询键值对的方法。
     6. `remoteOptimize`：是否开启远程数据源优化，默认为 `true`。开启后，将会对远程数据源进行优化，减少请求次数。仅在动态数据源下有效。
-    7. `allowCreate`：是否允许创建新选项，默认为 `false`。仅在静态数据源下有效。
+    7. `allowCreate`：是否允许创建新选项，默认为 `false`。仅在静态数据源下有效，需要同时开启 `searchable`。
     8. `clearable`：是否允许清空选项，默认为 `false`。
     9. `multiple`：是否多选，默认为 `false`。
     10. `maxCount`：多选时最大可选数量，默认为 `Infinity`。仅在多选时有效。


### PR DESCRIPTION
#### What type of PR is this?

/kind documentation
/area docs

#### What this PR does / why we need it:

补充 formkit select 组件中关于 allowCreate 属性的文档

#### Which issue(s) this PR fixes:

Fixes halo-dev/docs#408 

#### Does this PR introduce a user-facing change?
```release-note
None
```
