### PR TITLE
fix: resolve issue with disabled property in options not working

### DIFF
--- a/ui/src/formkit/inputs/select/SelectMain.vue
+++ b/ui/src/formkit/inputs/select/SelectMain.vue
@@ -1,5 +1,10 @@
 <script lang="ts" setup>
 import type { FormKitFrameworkContext } from "@formkit/core";
+import { axiosInstance } from "@halo-dev/api-client";
+import { useDebounceFn } from "@vueuse/core";
+import { useFuse } from "@vueuse/integrations/useFuse";
+import type { AxiosRequestConfig } from "axios";
+import { get, has, type PropertyPath } from "lodash-es";
 import {
   computed,
   onMounted,
@@ -9,12 +14,8 @@ import {
   watch,
   type PropType,
 } from "vue";
+import { isFalse } from "./isFalse";
 import SelectContainer from "./SelectContainer.vue";
-import { axiosInstance } from "@halo-dev/api-client";
-import { get, has, type PropertyPath } from "lodash-es";
-import { useDebounceFn } from "@vueuse/core";
-import { useFuse } from "@vueuse/integrations/useFuse";
-import type { AxiosRequestConfig } from "axios";
 
 export interface SelectProps {
   /**
@@ -228,10 +229,6 @@ const initSelectProps = () => {
     }
     selectProps.remoteOption = nodeProps.remoteOption;
   }
-};
-
-const isFalse = (value: string | boolean | undefined | null) => {
-  return [undefined, null, "false", false].includes(value);
 };
 
 const isLoading = ref(false);

--- a/ui/src/formkit/inputs/select/SelectOption.vue
+++ b/ui/src/formkit/inputs/select/SelectOption.vue
@@ -4,6 +4,7 @@ import { vScroll } from "@vueuse/components";
 import { useEventListener, type UseScrollReturn } from "@vueuse/core";
 import { computed, ref, watch } from "vue";
 import SelectOptionItem from "./SelectOptionItem.vue";
+import { isFalse } from "./isFalse";
 
 const props = defineProps<{
   options: Array<Record<string, unknown> & { label: string; value: string }>;
@@ -81,7 +82,7 @@ const handleSelected = (index: number) => {
     }
   }
   selectedIndex.value = index;
-  if (option) {
+  if (option && !isDisabled(option)) {
     emit("selected", option);
   }
 };
@@ -112,11 +113,15 @@ const reachMaximumLimit = computed(() => {
   return false;
 });
 
-const isDisabled = (option: { label: string; value: string }) => {
+const isDisabled = (
+  option: Record<string, unknown> & { label: string; value: string }
+) => {
+  const attrs = option.attrs as Record<string, unknown>;
   return (
-    reachMaximumLimit.value &&
-    selectedValues.value &&
-    !selectedValues.value.includes(option.value)
+    (reachMaximumLimit.value &&
+      selectedValues.value &&
+      !selectedValues.value.includes(option.value)) ||
+    !isFalse(attrs?.disabled as string | boolean | undefined)
   );
 };
 

--- a/ui/src/formkit/inputs/select/isFalse.ts
+++ b/ui/src/formkit/inputs/select/isFalse.ts
@@ -1,0 +1,3 @@
+export const isFalse = (value: string | boolean | undefined | null) => {
+  return [undefined, null, "false", false].includes(value);
+};


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/area ui

#### What this PR does / why we need it:

解决 formkit select 组件中，option 使用 `attrs: { disabled: true }` 无效的问题。

#### How to test it?

测试在 formkit select 组件中，option 设置 disabled 属性是否有效。

#### Which issue(s) this PR fixes:

Fixed #6592 

#### Does this PR introduce a user-facing change?
```release-note
解决 formkit select 组件的 Option 设置 disabled 无效的问题
```
