### PR TITLE
fix: formkit select component not emitting event or updating selection on value change

### DIFF
--- a/ui/src/formkit/inputs/select/SelectContainer.vue
+++ b/ui/src/formkit/inputs/select/SelectContainer.vue
@@ -2,18 +2,18 @@
 import { IconArrowDownLine, IconCloseCircle } from "@halo-dev/components";
 import {
   computed,
+  defineEmits,
   nextTick,
   onMounted,
-  ref,
-  defineEmits,
-  type PropType,
   onUnmounted,
+  ref,
+  type PropType,
 } from "vue";
 
-import SelectSelector from "./SelectSelector.vue";
+import { Dropdown } from "floating-vue";
 import MultipleSelectSelector from "./MultipleSelectSelector.vue";
 import SelectDropdownContainer from "./SelectDropdownContainer.vue";
-import { Dropdown } from "floating-vue";
+import SelectSelector from "./SelectSelector.vue";
 
 const props = defineProps({
   multiple: {
@@ -95,7 +95,7 @@ const inputRef = ref<HTMLInputElement | null>();
 const searchKeyword = ref<string>("");
 const isDropdownVisible = ref<boolean>(false);
 const selectedOptions = computed({
-  get: () => props.selected,
+  get: () => [...props.selected],
   set: (value) => {
     emit("update", value);
   },

--- a/ui/src/formkit/inputs/select/SelectMain.vue
+++ b/ui/src/formkit/inputs/select/SelectMain.vue
@@ -591,7 +591,7 @@ watch(
   }
 );
 
-const handleUpdate = (value: Array<{ label: string; value: string }>) => {
+const handleUpdate = async (value: Array<{ label: string; value: string }>) => {
   const oldSelectValue = selectOptions.value;
   if (
     oldSelectValue &&
@@ -607,6 +607,7 @@ const handleUpdate = (value: Array<{ label: string; value: string }>) => {
     };
   });
   handleSetNodeValue(newValue);
+  await props.context.node.settled;
   props.context.attrs.onChange?.(newValue);
 };
 


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/area ui
/milestone 2.20.x

#### What this PR does / why we need it:

重新修改 formkit select 初始化值的监听方式，用于当 value 发生变化时，使选项值可以发生变化。

另外在更新数据时，如果数据发生变化，则发出 `onChange` 事件。

> 需要注意的是，通过 v-modal 传入默认值，再将此值改为 `undefined` 时无法触发 `watch` 及 formkit 的 `input` 事件，原因暂时未知，将此值设置为 `""` 即可正常触发。

#### How to test it?

由于此 PR 改动了初始化的方式，因此需要全量测试所有使用 `Select` 组件的位置。包括多选与单选，本地源与远程源。确保功能符合预期。

#### Which issue(s) this PR fixes:

Fixes #6594 

#### Does this PR introduce a user-facing change?
```release-note
解决 Formkit Select 组件在值变更时不会发出事件及修改选项值的问题。
```
