### PR TITLE
Prevent null role while getting permissions

### DIFF
--- a/application/src/main/java/run/halo/app/core/extension/endpoint/UserEndpoint.java
+++ b/application/src/main/java/run/halo/app/core/extension/endpoint/UserEndpoint.java
@@ -771,7 +771,11 @@ public class UserEndpoint implements CustomEndpoint {
                             .map(user -> {
                                 var username = user.getMetadata().getName();
                                 var roles = Optional.ofNullable(usernameRolesMap.get(username))
-                                    .map(roleNames -> roleNames.stream().map(roleMap::get).toList())
+                                    .map(roleNames -> roleNames.stream()
+                                        .map(roleMap::get)
+                                        .filter(Objects::nonNull)
+                                        .toList()
+                                    )
                                     .orElseGet(List::of);
                                 return new ListedUser(user, roles);
                             })

--- a/application/src/main/java/run/halo/app/core/extension/service/UserServiceImpl.java
+++ b/application/src/main/java/run/halo/app/core/extension/service/UserServiceImpl.java
@@ -133,6 +133,7 @@ public class UserServiceImpl implements UserService {
                         var mutableRoles = new HashSet<>(roles);
                         mutableRoles.removeAll(existingRoles);
                         return mutableRoles.stream()
+                            .filter(StringUtils::hasText)
                             .map(roleName -> RoleBinding.create(username, roleName));
                     }).flatMap(client::create))
                     .then(Mono.defer(() -> {


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/area core
/milestone 2.20.x

#### What this PR does / why we need it:

This PR filters blank role name while granting roles for an user to prevent null role in permissions.

#### Which issue(s) this PR fixes:

Fixes https://github.com/halo-dev/halo/issues/6604

#### Does this PR introduce a user-facing change?

```release-note
修复取消用户角色后无法正常渲染用户列表的问题
```
