### PR TITLE
fix: correct boolean value display issue in formkit selector component

### DIFF
--- a/ui/src/formkit/inputs/select/SelectMain.vue
+++ b/ui/src/formkit/inputs/select/SelectMain.vue
@@ -555,6 +555,22 @@ watch(
   }
 );
 
+const enableAutoSelect = () => {
+  if (!selectProps.autoSelect) {
+    return false;
+  }
+  if (selectProps.multiple || selectProps.placeholder) {
+    return false;
+  }
+
+  const value = props.context.node.value;
+  if (value === void 0 || value === null) {
+    return true;
+  }
+
+  return false;
+};
+
 watch(
   () => options.value,
   async (newOptions) => {
@@ -563,13 +579,8 @@ watch(
       if (selectedOption) {
         selectOptions.value = selectedOption;
       }
-      const isAutoSelect =
-        selectProps.autoSelect &&
-        !selectProps.multiple &&
-        !selectProps.placeholder &&
-        !props.context.node.value;
 
-      if (isAutoSelect) {
+      if (enableAutoSelect()) {
         // Automatically select the first option when the selected value is empty.
         const autoSelectedOption = getAutoSelectedOption();
         if (autoSelectedOption) {


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/area ui
/milestone 2.20.x

#### What this PR does / why we need it:

解决 Formkit Selector 在值为布尔或者数字类型时，回显时内容不正常的问题。

#### How to test it?

测试当 FormKit Select 组件的值为布尔或者数字时，回显的内容是否正常。 

#### Does this PR introduce a user-facing change?
```release-note
修复 FormKit Select 组件中布尔值的显示问题。
```
