### PR TITLE
Trigger attachment status update on storage policy config change

### DIFF
--- a/api/src/main/java/run/halo/app/core/extension/attachment/Policy.java
+++ b/api/src/main/java/run/halo/app/core/extension/attachment/Policy.java
@@ -16,6 +16,7 @@ import run.halo.app.extension.GVK;
 @GVK(group = Constant.GROUP, version = Constant.VERSION, kind = KIND,
     plural = "policies", singular = "policy")
 public class Policy extends AbstractExtension {
+    public static final String POLICY_OWNER_LABEL = "storage.halo.run/policy-owner";
 
     public static final String KIND = "Policy";
 

--- a/application/src/main/java/run/halo/app/core/attachment/PolicyConfigChangeDetector.java
+++ b/application/src/main/java/run/halo/app/core/attachment/PolicyConfigChangeDetector.java
@@ -1,0 +1,115 @@
+package run.halo.app.core.attachment;
+
+import static run.halo.app.extension.index.query.QueryFactory.equal;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Optional;
+import java.util.function.Consumer;
+import lombok.RequiredArgsConstructor;
+import org.springframework.dao.OptimisticLockingFailureException;
+import org.springframework.data.domain.Sort;
+import org.springframework.stereotype.Component;
+import reactor.core.publisher.Mono;
+import reactor.util.retry.Retry;
+import run.halo.app.core.extension.attachment.Attachment;
+import run.halo.app.core.extension.attachment.Policy;
+import run.halo.app.extension.ConfigMap;
+import run.halo.app.extension.ExtensionMatcher;
+import run.halo.app.extension.GroupVersionKind;
+import run.halo.app.extension.ListOptions;
+import run.halo.app.extension.MetadataUtil;
+import run.halo.app.extension.ReactiveExtensionClient;
+import run.halo.app.extension.controller.Controller;
+import run.halo.app.extension.controller.ControllerBuilder;
+import run.halo.app.extension.controller.Reconciler;
+import run.halo.app.infra.ReactiveExtensionPaginatedOperator;
+
+/**
+ * <p>Detects changes to {@link ConfigMap} that are referenced by {@link Policy} and updates the
+ * {@link Attachment} with the {@link Policy} reference to reflect the change.</p>
+ * <p>Without this, the link to the attachment corresponding to the storage policy configuration
+ * change may not be correctly updated and only the service can be restarted.</p>
+ *
+ * @author guqing
+ * @since 2.20.0
+ */
+@Component
+@RequiredArgsConstructor
+public class PolicyConfigChangeDetector implements Reconciler<Reconciler.Request> {
+    static final String POLICY_UPDATED_AT = "storage.halo.run/policy-updated-at";
+    private final GroupVersionKind policyGvk = GroupVersionKind.fromExtension(Policy.class);
+    private final ReactiveExtensionClient client;
+    private final ReactiveExtensionPaginatedOperator paginatedOperator;
+
+    @Override
+    public Result reconcile(Request request) {
+        var policyNameOpt = lookupPolicyReference(request.name());
+        if (policyNameOpt.isEmpty()) {
+            return Result.doNotRetry();
+        }
+        paginatedOperator.list(Attachment.class, ListOptions.builder()
+                .andQuery(equal("spec.policyName", policyNameOpt.get()))
+                .build()
+            )
+            .flatMap(this::updateAnnotation)
+            .then()
+            .block();
+        return Result.doNotRetry();
+    }
+
+    protected Mono<Attachment> updateAnnotation(Attachment attachment) {
+        var updatedAt = Instant.now().toString();
+        populatePolicyUpdatedAt(attachment, updatedAt);
+        return client.update(attachment)
+            .onErrorResume(OptimisticLockingFailureException.class,
+                e -> updateAttachmentWithRetry(
+                    attachment.getMetadata().getName(),
+                    a -> populatePolicyUpdatedAt(a, updatedAt)
+                )
+            );
+    }
+
+    private Mono<Attachment> updateAttachmentWithRetry(String name, Consumer<Attachment> consumer) {
+        return Mono.defer(() -> client.get(Attachment.class, name)
+                .doOnNext(consumer)
+                .flatMap(client::update)
+            )
+            .retryWhen(Retry.backoff(5, Duration.ofMillis(100))
+                .filter(OptimisticLockingFailureException.class::isInstance));
+    }
+
+    private void populatePolicyUpdatedAt(Attachment attachment, String value) {
+        var annotations = MetadataUtil.nullSafeAnnotations(attachment);
+        annotations.put(POLICY_UPDATED_AT, value);
+    }
+
+    @Override
+    public Controller setupWith(ControllerBuilder builder) {
+        ExtensionMatcher matcher = extension -> {
+            var configMap = (ConfigMap) extension;
+            var labels = configMap.getMetadata().getLabels();
+            return labels != null && labels.containsKey(Policy.POLICY_OWNER_LABEL);
+        };
+        return builder
+            .extension(new ConfigMap())
+            .syncAllOnStart(false)
+            .onAddMatcher(matcher)
+            .onUpdateMatcher(matcher)
+            .onDeleteMatcher(matcher)
+            .build();
+    }
+
+    /**
+     * Lookup the {@link Policy} that references the specified {@link ConfigMap} by its name.
+     */
+    protected Optional<String> lookupPolicyReference(String configMapName) {
+        return client.indexedQueryEngine()
+            .retrieveAll(policyGvk, ListOptions.builder()
+                .fieldQuery(equal("spec.configMapName", configMapName))
+                .build(), Sort.unsorted()
+            )
+            .stream()
+            .findFirst();
+    }
+}

--- a/application/src/main/java/run/halo/app/core/attachment/reconciler/PolicyReconciler.java
+++ b/application/src/main/java/run/halo/app/core/attachment/reconciler/PolicyReconciler.java
@@ -3,8 +3,6 @@ package run.halo.app.core.attachment.reconciler;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 import run.halo.app.core.extension.attachment.Policy;
-import run.halo.app.core.extension.attachment.PolicyTemplate;
-import run.halo.app.extension.AbstractExtension;
 import run.halo.app.extension.ConfigMap;
 import run.halo.app.extension.ExtensionClient;
 import run.halo.app.extension.MetadataUtil;
@@ -29,21 +27,10 @@ public class PolicyReconciler implements Reconciler<Reconciler.Request> {
         var configMapName = policy.getSpec().getConfigMapName();
         client.fetch(ConfigMap.class, configMapName)
             .ifPresent(configMap -> {
-                populateOwnerLabel(configMap, policyName);
+                var labels = MetadataUtil.nullSafeLabels(configMap);
+                labels.put(Policy.POLICY_OWNER_LABEL, policyName);
                 client.update(configMap);
             });
-
-        var templateName = policy.getSpec().getTemplateName();
-        client.fetch(PolicyTemplate.class, templateName)
-            .ifPresent(policyTemplate -> {
-                populateOwnerLabel(policyTemplate, policyName);
-                client.update(policyTemplate);
-            });
-    }
-
-    private static void populateOwnerLabel(AbstractExtension extension, String policyName) {
-        var labels = MetadataUtil.nullSafeLabels(extension);
-        labels.put(Policy.POLICY_OWNER_LABEL, policyName);
     }
 
     @Override

--- a/application/src/main/java/run/halo/app/core/attachment/reconciler/PolicyReconciler.java
+++ b/application/src/main/java/run/halo/app/core/attachment/reconciler/PolicyReconciler.java
@@ -1,0 +1,57 @@
+package run.halo.app.core.attachment.reconciler;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import run.halo.app.core.extension.attachment.Policy;
+import run.halo.app.core.extension.attachment.PolicyTemplate;
+import run.halo.app.extension.AbstractExtension;
+import run.halo.app.extension.ConfigMap;
+import run.halo.app.extension.ExtensionClient;
+import run.halo.app.extension.MetadataUtil;
+import run.halo.app.extension.controller.Controller;
+import run.halo.app.extension.controller.ControllerBuilder;
+import run.halo.app.extension.controller.Reconciler;
+
+@Component
+@RequiredArgsConstructor
+public class PolicyReconciler implements Reconciler<Reconciler.Request> {
+    private final ExtensionClient client;
+
+    @Override
+    public Result reconcile(Request request) {
+        client.fetch(Policy.class, request.name())
+            .ifPresent(this::checkOwnerLabel);
+        return Result.doNotRetry();
+    }
+
+    private void checkOwnerLabel(Policy policy) {
+        var policyName = policy.getMetadata().getName();
+        var configMapName = policy.getSpec().getConfigMapName();
+        client.fetch(ConfigMap.class, configMapName)
+            .ifPresent(configMap -> {
+                populateOwnerLabel(configMap, policyName);
+                client.update(configMap);
+            });
+
+        var templateName = policy.getSpec().getTemplateName();
+        client.fetch(PolicyTemplate.class, templateName)
+            .ifPresent(policyTemplate -> {
+                populateOwnerLabel(policyTemplate, policyName);
+                client.update(policyTemplate);
+            });
+    }
+
+    private static void populateOwnerLabel(AbstractExtension extension, String policyName) {
+        var labels = MetadataUtil.nullSafeLabels(extension);
+        labels.put(Policy.POLICY_OWNER_LABEL, policyName);
+    }
+
+    @Override
+    public Controller setupWith(ControllerBuilder builder) {
+        return builder
+            .extension(new Policy())
+            // sync on start for compatible with previous data
+            .syncAllOnStart(true)
+            .build();
+    }
+}

--- a/application/src/main/java/run/halo/app/infra/SchemeInitializer.java
+++ b/application/src/main/java/run/halo/app/infra/SchemeInitializer.java
@@ -551,13 +551,7 @@ public class SchemeInitializer implements ApplicationListener<ApplicationContext
         });
         // storage.halo.run
         schemeManager.register(Group.class);
-        schemeManager.register(Policy.class, indexSpecs -> {
-            indexSpecs.add(new IndexSpec()
-                .setName("spec.configMapName")
-                .setIndexFunc(simpleAttribute(Policy.class,
-                    policy -> policy.getSpec().getConfigMapName()))
-            );
-        });
+        schemeManager.register(Policy.class);
         schemeManager.register(Attachment.class, indexSpecs -> {
             indexSpecs.add(new IndexSpec()
                 .setName("spec.displayName")

--- a/application/src/main/java/run/halo/app/infra/SchemeInitializer.java
+++ b/application/src/main/java/run/halo/app/infra/SchemeInitializer.java
@@ -551,7 +551,13 @@ public class SchemeInitializer implements ApplicationListener<ApplicationContext
         });
         // storage.halo.run
         schemeManager.register(Group.class);
-        schemeManager.register(Policy.class);
+        schemeManager.register(Policy.class, indexSpecs -> {
+            indexSpecs.add(new IndexSpec()
+                .setName("spec.configMapName")
+                .setIndexFunc(simpleAttribute(Policy.class,
+                    policy -> policy.getSpec().getConfigMapName()))
+            );
+        });
         schemeManager.register(Attachment.class, indexSpecs -> {
             indexSpecs.add(new IndexSpec()
                 .setName("spec.displayName")

--- a/application/src/main/resources/extensions/attachment-local-policy.yaml
+++ b/application/src/main/resources/extensions/attachment-local-policy.yaml
@@ -28,8 +28,6 @@ apiVersion: v1alpha1
 kind: Setting
 metadata:
   name: local-policy-template-setting
-  labels:
-    storage.halo.run/policy-owner: default-policy
 spec:
   forms:
     - group: default
@@ -42,7 +40,7 @@ spec:
         - $formkit: text
           name: maxFileSize
           label: 最大单文件大小
-          validation: [['matches', '/^(0|[1-9]\d*)(?:[KMG]B)?$/']]
+          validation: [ [ 'matches', '/^(0|[1-9]\d*)(?:[KMG]B)?$/' ] ]
           validation-visibility: "live"
           validation-messages:
             matches: "输入格式错误，遵循：整数 + 大写的单位（KB, MB, GB）"

--- a/application/src/main/resources/extensions/attachment-local-policy.yaml
+++ b/application/src/main/resources/extensions/attachment-local-policy.yaml
@@ -19,6 +19,8 @@ apiVersion: v1alpha1
 kind: ConfigMap
 metadata:
   name: default-policy-config
+  labels:
+    storage.halo.run/policy-owner: default-policy
 data:
   default: "{\"location\":\"\"}"
 ---
@@ -26,6 +28,8 @@ apiVersion: v1alpha1
 kind: Setting
 metadata:
   name: local-policy-template-setting
+  labels:
+    storage.halo.run/policy-owner: default-policy
 spec:
   forms:
     - group: default

--- a/application/src/test/java/run/halo/app/core/attachment/PolicyConfigChangeDetectorTest.java
+++ b/application/src/test/java/run/halo/app/core/attachment/PolicyConfigChangeDetectorTest.java
@@ -1,0 +1,65 @@
+package run.halo.app.core.attachment;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.assertArg;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+import run.halo.app.core.extension.attachment.Attachment;
+import run.halo.app.extension.Metadata;
+import run.halo.app.extension.ReactiveExtensionClient;
+import run.halo.app.extension.controller.Reconciler;
+import run.halo.app.infra.ReactiveExtensionPaginatedOperator;
+
+/**
+ * Tests for {@link PolicyConfigChangeDetector}.
+ *
+ * @author guqing
+ * @since 2.20.0
+ */
+@ExtendWith(MockitoExtension.class)
+class PolicyConfigChangeDetectorTest {
+
+    @Mock
+    private ReactiveExtensionPaginatedOperator paginatedOperator;
+
+    @Mock
+    private ReactiveExtensionClient client;
+
+    @InjectMocks
+    private PolicyConfigChangeDetector policyConfigChangeDetector;
+
+    @Test
+    void reconcileTest() {
+        var spyDetector = spy(policyConfigChangeDetector);
+
+        doReturn(Optional.of("fake-policy")).when(spyDetector)
+            .lookupPolicyReference(eq("fake-config"));
+
+        var attachment = new Attachment();
+        attachment.setMetadata(new Metadata());
+        attachment.getMetadata().setName("fake-attachment");
+        attachment.setSpec(new Attachment.AttachmentSpec());
+        when(paginatedOperator.list(eq(Attachment.class), any()))
+            .thenReturn(Flux.just(attachment));
+        when(client.update(any())).thenReturn(Mono.empty());
+
+        spyDetector.reconcile(new Reconciler.Request("fake-config"));
+
+        verify(spyDetector).updateAnnotation(eq(attachment));
+        verify(client).update(assertArg(a -> assertThat(a.getMetadata().getAnnotations())
+            .containsKey(PolicyConfigChangeDetector.POLICY_UPDATED_AT)));
+    }
+}


### PR DESCRIPTION
#### What type of PR is this?
/kind improvement
/area core
/milestone 2.20.x

#### What this PR does / why we need it:
当存储策略的配置变更后自动触发关联附件的状态更新

#### Which issue(s) this PR fixes:
Fixes #6636

#### Does this PR introduce a user-facing change?
```release-note
当存储策略的配置变更后自动触发关联附件的状态（如访问链接等）更新
```
