### PR TITLE
Update attachment permalink only when handler is available

### DIFF
--- a/application/src/main/java/run/halo/app/core/attachment/reconciler/AttachmentReconciler.java
+++ b/application/src/main/java/run/halo/app/core/attachment/reconciler/AttachmentReconciler.java
@@ -14,7 +14,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.stereotype.Component;
 import reactor.core.publisher.Flux;
-import reactor.core.publisher.Mono;
 import run.halo.app.core.attachment.AttachmentUtils;
 import run.halo.app.core.attachment.ThumbnailService;
 import run.halo.app.core.attachment.ThumbnailSize;
@@ -28,6 +27,7 @@ import run.halo.app.extension.controller.Controller;
 import run.halo.app.extension.controller.ControllerBuilder;
 import run.halo.app.extension.controller.Reconciler;
 import run.halo.app.extension.controller.Reconciler.Request;
+import run.halo.app.extension.controller.RequeueException;
 
 @Slf4j
 @Component
@@ -57,18 +57,15 @@ public class AttachmentReconciler implements Reconciler<Request> {
 
             var annotations = attachment.getMetadata().getAnnotations();
             if (annotations != null) {
-                attachmentService.getPermalink(attachment)
+                var permalink = attachmentService.getPermalink(attachment)
                     .map(URI::toASCIIString)
-                    .switchIfEmpty(Mono.fromSupplier(() -> {
-                        // Only for back-compatibility
-                        return annotations.get(Constant.EXTERNAL_LINK_ANNO_KEY);
-                    }))
-                    .doOnNext(permalink -> {
-                        log.debug("Set permalink {} for attachment {}", permalink, request.name());
-                        var status = nullSafeStatus(attachment);
-                        status.setPermalink(permalink);
-                    })
-                    .blockOptional();
+                    .blockOptional()
+                    .orElseThrow(() -> new RequeueException(new Result(true, null),
+                        "Attachment handler is unavailable, requeue the request"
+                    ));
+                log.debug("Set permalink {} for attachment {}", permalink, request.name());
+                var status = nullSafeStatus(attachment);
+                status.setPermalink(permalink);
             }
             var permalink = nullSafeStatus(attachment).getPermalink();
             if (StringUtils.isNotBlank(permalink) && AttachmentUtils.isImage(attachment)) {


### PR DESCRIPTION
#### What type of PR is this?

/kind improvement
/area core
/area plugin

#### What this PR does / why we need it:

This PR removes deprecated code that was for backward compatibility and lets reconciler requeue if attachment handler is unavailable.

#### Which issue(s) this PR fixes:

Fixes https://github.com/halo-dev/halo/issues/4439

#### Does this PR introduce a user-facing change?

```release-note
解决重启后可能无法更新附件链接的问题
```
