### PR TITLE
Fix the problem of resolving locale context by language parameter

### DIFF
--- a/application/src/main/java/run/halo/app/theme/ThemeLocaleContextResolver.java
+++ b/application/src/main/java/run/halo/app/theme/ThemeLocaleContextResolver.java
@@ -51,7 +51,7 @@ public class ThemeLocaleContextResolver extends AcceptHeaderLocaleContextResolve
 
         Locale locale;
         if (StringUtils.isNotBlank(language)) {
-            locale = new Locale(language);
+            locale = Locale.forLanguageTag(language);
         } else if (exchange.getAttribute(LOCALE_REQUEST_ATTRIBUTE_NAME) != null) {
             locale = exchange.getAttribute(LOCALE_REQUEST_ATTRIBUTE_NAME);
         } else {

--- a/application/src/test/java/run/halo/app/theme/ThemeLocaleContextResolverTest.java
+++ b/application/src/test/java/run/halo/app/theme/ThemeLocaleContextResolverTest.java
@@ -62,6 +62,10 @@ class ThemeLocaleContextResolverTest {
             .isEqualTo(ENGLISH);
         assertThat(this.resolver.resolveLocaleContext(exchangeForParam("zh")).getLocale())
             .isEqualTo(CHINESE);
+        assertThat(this.resolver.resolveLocaleContext(exchangeForParam("zh-CN")).getLocale())
+            .isEqualTo(CHINA);
+        assertThat(this.resolver.resolveLocaleContext(exchangeForParam("zh-cn")).getLocale())
+            .isEqualTo(CHINA);
     }
 
     @Test


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/area theme
/milestone 2.20.x

#### What this PR does / why we need it:

If we pass a query `language` while requesting index page, we will get the wrong header `Content-Language`. Please see the result below:

```bash
http https://www.halo.run/\?language\=zh-CN -p h

HTTP/1.1 200 OK
Content-Language: und
...
```

After fixing, we will get the right header `Content-Language`.

```bash
http http://localhost:8090/\?language\=zh-CN -p h

HTTP/1.1 200 OK
Content-Language: zh-CN
...
```

#### Does this PR introduce a user-facing change?

```release-note
修复主题端区域和语言解析错误的问题
```
