### PR TITLE
Support changing locale

### DIFF
--- a/application/src/main/java/run/halo/app/theme/config/ThemeWebFluxConfigurer.java
+++ b/application/src/main/java/run/halo/app/theme/config/ThemeWebFluxConfigurer.java
@@ -1,21 +1,36 @@
 package run.halo.app.theme.config;
 
+import static org.springframework.web.reactive.function.server.RequestPredicates.contentType;
+
+import java.net.URI;
 import java.nio.file.Path;
+import java.time.Duration;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
+import java.util.Optional;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.boot.autoconfigure.web.WebProperties;
+import org.springframework.context.annotation.Bean;
 import org.springframework.core.io.FileSystemResource;
 import org.springframework.core.io.Resource;
 import org.springframework.http.CacheControl;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseCookie;
 import org.springframework.stereotype.Component;
 import org.springframework.web.reactive.HandlerMapping;
 import org.springframework.web.reactive.config.ResourceHandlerRegistry;
 import org.springframework.web.reactive.config.WebFluxConfigurer;
+import org.springframework.web.reactive.function.server.RouterFunction;
+import org.springframework.web.reactive.function.server.RouterFunctions;
+import org.springframework.web.reactive.function.server.ServerResponse;
 import org.springframework.web.reactive.resource.AbstractResourceResolver;
 import org.springframework.web.reactive.resource.EncodedResourceResolver;
 import org.springframework.web.reactive.resource.ResourceResolverChain;
 import org.springframework.web.server.ServerWebExchange;
+import org.springframework.web.server.ServerWebInputException;
 import reactor.core.publisher.Mono;
 import run.halo.app.infra.ThemeRootGetter;
 import run.halo.app.infra.utils.FileUtils;
@@ -46,6 +61,41 @@ public class ThemeWebFluxConfigurer implements WebFluxConfigurer {
             .resourceChain(true)
             .addResolver(new EncodedResourceResolver())
             .addResolver(new ThemePathResourceResolver(themeRootGetter.get()));
+    }
+
+    @Bean
+    RouterFunction<ServerResponse> localeRoute() {
+        return RouterFunctions.route()
+            .POST(
+                "/locale",
+                contentType(MediaType.APPLICATION_FORM_URLENCODED),
+                request -> {
+                    var location =
+                        Optional.ofNullable(request.headers().firstHeader(HttpHeaders.REFERER))
+                            .filter(StringUtils::isNotBlank)
+                            .map(URI::create)
+                            .orElseGet(() -> URI.create("/"));
+                    return request.formData()
+                        .flatMap(formData -> Optional.ofNullable(formData.getFirst("language"))
+                            .filter(StringUtils::isNotBlank)
+                            .map(Locale::forLanguageTag)
+                            .map(locale -> ServerResponse.status(HttpStatus.FOUND)
+                                .location(location)
+                                .cookie(ResponseCookie.from("language", locale.toLanguageTag())
+                                    .maxAge(Duration.ofDays(365))
+                                    .httpOnly(false)
+                                    .path("/")
+                                    .build()
+                                )
+                                .build()
+                            )
+                            .orElseGet(
+                                () -> Mono.error(
+                                    new ServerWebInputException("Invalid language tag"))
+                            )
+                        );
+                })
+            .build();
     }
 
     /**

--- a/application/src/test/java/run/halo/app/theme/config/ChangeLocaleTest.java
+++ b/application/src/test/java/run/halo/app/theme/config/ChangeLocaleTest.java
@@ -1,0 +1,78 @@
+package run.halo.app.theme.config;
+
+import static org.springframework.security.test.web.reactive.server.SecurityMockServerConfigurers.csrf;
+import static run.halo.app.theme.ThemeLocaleContextResolver.LANGUAGE_COOKIE_NAME;
+
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.reactive.AutoConfigureWebTestClient;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.reactive.server.WebTestClient;
+import org.springframework.util.LinkedMultiValueMap;
+
+@SpringBootTest
+@AutoConfigureWebTestClient
+class ChangeLocaleTest {
+
+    @Autowired
+    WebTestClient webClient;
+
+    @Test
+    void shouldRedirectToIndexIfNoRefererHeader() {
+        var formData = new LinkedMultiValueMap<String, String>();
+        formData.put("language", List.of("zh-CN"));
+        webClient.mutate().apply(csrf()).build()
+            .post().uri("/locale")
+            .contentType(MediaType.APPLICATION_FORM_URLENCODED)
+            .bodyValue(formData)
+            .exchange()
+            .expectStatus().isFound()
+            .expectHeader().location("/")
+            .expectCookie().valueEquals(LANGUAGE_COOKIE_NAME, "zh-CN");
+    }
+
+    @Test
+    void shouldRedirectToRefererIfRefererHeaderProvided() {
+        var formData = new LinkedMultiValueMap<String, String>();
+        formData.put("language", List.of("zh-CN"));
+        webClient.mutate().apply(csrf()).build()
+            .post().uri("/locale")
+            .header(HttpHeaders.REFERER, "/path?query#fragment")
+            .contentType(MediaType.APPLICATION_FORM_URLENCODED)
+            .bodyValue(formData)
+            .exchange()
+            .expectStatus().isFound()
+            .expectHeader().location("/path?query#fragment")
+            .expectCookie().valueEquals(LANGUAGE_COOKIE_NAME, "zh-CN");
+    }
+
+    @Test
+    void shouldRespondUndWhenLanguageIsInvalid() {
+        var formData = new LinkedMultiValueMap<String, String>();
+        formData.put("language", List.of("invalid_language"));
+        webClient.mutate().apply(csrf()).build()
+            .post().uri("/locale")
+            .header(HttpHeaders.REFERER, "/path?query#fragment")
+            .contentType(MediaType.APPLICATION_FORM_URLENCODED)
+            .bodyValue(formData)
+            .exchange()
+            .expectStatus().isFound()
+            .expectHeader().location("/path?query#fragment")
+            .expectCookie().valueEquals(LANGUAGE_COOKIE_NAME, "und");
+    }
+
+    @Test
+    void shouldRespondBadRequestWhenLanguageIsNotProvided() {
+        var formData = new LinkedMultiValueMap<String, String>();
+        webClient.mutate().apply(csrf()).build()
+            .post().uri("/locale")
+            .header(HttpHeaders.REFERER, "/path?query#fragment")
+            .contentType(MediaType.APPLICATION_FORM_URLENCODED)
+            .bodyValue(formData)
+            .exchange()
+            .expectStatus().isBadRequest();
+    }
+}


### PR DESCRIPTION
#### What type of PR is this?

/kind feature
/area core
/milestone 2.20.x

#### What this PR does / why we need it:

This PR adds support for changing locale by submitting a post request to `/locale` endpoint. A header `Set-Cookie` with name `language` will be returned, then subsequent requests will carry the Cookie on and server will response content with corresponding language.

Please see the result below:

```bash
http -f POST http://localhost:8090/locale language=zh-CN Cookie:XSRF-TOKEN=xyz x-xsrf-token:xyz Referer:/login\?error -p HBh
POST /locale HTTP/1.1
Accept: */*
Accept-Encoding: gzip, deflate
Connection: keep-alive
Content-Length: 14
Content-Type: application/x-www-form-urlencoded; charset=utf-8
Cookie: XSRF-TOKEN=xyz
Host: localhost:8090
Referer: /login?error
User-Agent: HTTPie/3.2.3
x-xsrf-token: xyz

language=zh-CN


HTTP/1.1 302 Found
Cache-Control: no-cache, no-store, max-age=0, must-revalidate
Expires: 0
Location: /login?error
Pragma: no-cache
Referrer-Policy: strict-origin-when-cross-origin
Vary: Origin
Vary: Access-Control-Request-Method
Vary: Access-Control-Request-Headers
X-Content-Type-Options: nosniff
X-Frame-Options: SAMEORIGIN
X-XSS-Protection: 0
content-length: 0
set-cookie: language=zh-CN; Max-Age=31536000; Expires=Sat, 13 Sep 2025 09:37:45 GMT; Path=/
```

#### Does this PR introduce a user-facing change?

```release-note
为主题端切换地区语言提供支持
```
