### PR TITLE
fix: resolve issue with editor not detecting image paste in Firefox

### DIFF
--- a/ui/src/components/editor/extensions/upload/index.ts
+++ b/ui/src/components/editor/extensions/upload/index.ts
@@ -4,7 +4,10 @@ import {
   Plugin,
   PluginKey,
 } from "@halo-dev/richtext-editor";
-import { handleFileEvent } from "../../utils/upload";
+import {
+  containsFileClipboardIdentifier,
+  handleFileEvent,
+} from "../../utils/upload";
 
 export const Upload = Extension.create({
   name: "upload",
@@ -26,7 +29,8 @@ export const Upload = Extension.create({
             }
 
             const types = event.clipboardData.types;
-            if (!(types.length === 1 && types[0].toLowerCase() === "files")) {
+
+            if (!containsFileClipboardIdentifier(types)) {
               return false;
             }
 

--- a/ui/src/components/editor/utils/upload.ts
+++ b/ui/src/components/editor/utils/upload.ts
@@ -142,3 +142,8 @@ export function fileToBase64(file: File): Promise<string> {
     reader.readAsDataURL(file);
   });
 }
+
+export function containsFileClipboardIdentifier(types: readonly string[]) {
+  const fileTypes = ["files", "application/x-moz-file", "public.file-url"];
+  return types.some((type) => fileTypes.includes(type.toLowerCase()));
+}


### PR DESCRIPTION
#### What type of PR is this?

/area ui
/kind bug
/milestone 2.20.x

#### What this PR does / why we need it:

修复在 FireFox 浏览器下的编辑器中无法通过粘贴文件上传的问题。

#### Which issue(s) this PR fixes:

Fixes #6684 

#### Special notes for your reviewer:

在 FireFox 浏览器中，复制一张本地的图片，尝试在编辑器中粘贴，观察是否上传成功。

#### Does this PR introduce a user-facing change?

```release-note
修复在 FireFox 浏览器下的编辑器中无法通过粘贴文件上传的问题。
```
