### PR TITLE
feat: add index build state as readiness check indicator

### DIFF
--- a/application/src/main/java/run/halo/app/extension/availability/IndexBuildState.java
+++ b/application/src/main/java/run/halo/app/extension/availability/IndexBuildState.java
@@ -1,0 +1,8 @@
+package run.halo.app.extension.availability;
+
+import org.springframework.boot.availability.AvailabilityState;
+
+public enum IndexBuildState implements AvailabilityState {
+    BUILDING,
+    BUILT;
+}

--- a/application/src/main/java/run/halo/app/extension/availability/IndexBuildStateHealthIndicator.java
+++ b/application/src/main/java/run/halo/app/extension/availability/IndexBuildStateHealthIndicator.java
@@ -1,0 +1,22 @@
+package run.halo.app.extension.availability;
+
+import org.springframework.boot.actuate.availability.AvailabilityStateHealthIndicator;
+import org.springframework.boot.actuate.health.Status;
+import org.springframework.boot.availability.ApplicationAvailability;
+import org.springframework.stereotype.Component;
+
+@Component
+public class IndexBuildStateHealthIndicator extends AvailabilityStateHealthIndicator {
+    /**
+     * Create a {@link IndexBuildStateHealthIndicator} instance by {@link ApplicationAvailability}.
+     * Mapping {@link IndexBuildState} to {@link Status}.
+     *
+     * @see IndexBuildState
+     */
+    public IndexBuildStateHealthIndicator(ApplicationAvailability availability) {
+        super(availability, IndexBuildState.class, (statusMappings) -> {
+            statusMappings.add(IndexBuildState.BUILT, Status.UP);
+            statusMappings.add(IndexBuildState.BUILDING, Status.OUT_OF_SERVICE);
+        });
+    }
+}


### PR DESCRIPTION
#### What type of PR is this?
/kind improvement
/area core
/milestone 2.20.x

#### What this PR does / why we need it:
将索引构建状态添加到就绪检测的指标中

#### Which issue(s) this PR fixes:
Fixes #6632

#### Does this PR introduce a user-facing change?
```release-note
将索引构建状态添加到就绪检测的指标中以优化就绪时访问出现索引不可用的问题
```
