### PR TITLE
refactor: remove async loading logic for editor

### DIFF
--- a/ui/src/components/editor/utils/upload.ts
+++ b/ui/src/components/editor/utils/upload.ts
@@ -12,8 +12,6 @@ export interface FileProps {
   editor: CoreEditor;
 }
 
-const { currentUserHasPermission } = usePermission();
-
 /**
  * Handles file events, determining if the file is an image and triggering the appropriate upload process.
  *
@@ -21,6 +19,8 @@ const { currentUserHasPermission } = usePermission();
  * @returns {boolean} - True if a file is handled, otherwise false
  */
 export const handleFileEvent = ({ file, editor }: FileProps) => {
+  const { currentUserHasPermission } = usePermission();
+
   if (!file) {
     return false;
   }

--- a/ui/src/composables/use-editor-extension-points.ts
+++ b/ui/src/composables/use-editor-extension-points.ts
@@ -1,8 +1,8 @@
 import Logo from "@/assets/logo.png";
+import DefaultEditor from "@/components/editor/DefaultEditor.vue";
 import { usePluginModuleStore } from "@/stores/plugin";
-import { VLoading } from "@halo-dev/components";
 import type { EditorProvider } from "@halo-dev/console-shared";
-import { defineAsyncComponent, markRaw, ref, type Ref } from "vue";
+import { markRaw, ref, type Ref } from "vue";
 import { useI18n } from "vue-i18n";
 
 interface useEditorExtensionPointsReturn {
@@ -19,13 +19,7 @@ export function useEditorExtensionPoints(): useEditorExtensionPointsReturn {
     {
       name: "default",
       displayName: t("core.plugin.extension_points.editor.providers.default"),
-      component: markRaw(
-        defineAsyncComponent({
-          loader: () => import("@/components/editor/DefaultEditor.vue"),
-          loadingComponent: VLoading,
-          delay: 200,
-        })
-      ),
+      component: markRaw(DefaultEditor),
       rawType: "HTML",
       logo: Logo,
     },


### PR DESCRIPTION
#### What type of PR is this?

/area ui
/kind improvement
/milestone 2.20.x

#### What this PR does / why we need it:

取消异步加载默认编辑器，在之前的版本中，由于编辑器体积较大，所以做了异步加载的处理，但近期的版本中，为了让插件可以使用编辑器或者扩展编辑器，已经将编辑器依赖作为全局加载，如果这个时候还是异步加载编辑器组件的话，进入编辑页面的时候出现短暂的灰屏闪烁。

#### Does this PR introduce a user-facing change?

```release-note
优化默认编辑器的加载方式，防止出现灰屏闪烁的问题。
```
