### PR TITLE
feat: remove the button for viewing passwords in the Edge browser

### DIFF
--- a/application/src/main/resources/static/styles/main.css
+++ b/application/src/main/resources/static/styles/main.css
@@ -408,3 +408,7 @@
         flex-direction: column;
     }
 }
+
+::-ms-reveal {
+    display: none;
+}


### PR DESCRIPTION
#### What type of PR is this?

/area core
/kind improvement
/milestone 2.20.x

#### What this PR does / why we need it:

移除在 Edge 浏览器中，为密码输入框添加显示密码明文按钮。

<img width="406" alt="image" src="https://github.com/user-attachments/assets/49801c25-d8dc-46db-9cba-302653af1951">

#### Does this PR introduce a user-facing change?

```release-note
None
```
