### PR TITLE
feat: disallow deletion of system-protected attachment policies

### DIFF
--- a/application/src/main/resources/extensions/attachment-local-policy.yaml
+++ b/application/src/main/resources/extensions/attachment-local-policy.yaml
@@ -10,6 +10,8 @@ apiVersion: storage.halo.run/v1alpha1
 kind: Policy
 metadata:
   name: default-policy
+  finalizers:
+    - system-protection
 spec:
   displayName: 本地存储
   templateName: local

--- a/ui/console-src/modules/contents/attachments/components/AttachmentPoliciesModal.vue
+++ b/ui/console-src/modules/contents/attachments/components/AttachmentPoliciesModal.vue
@@ -199,7 +199,12 @@ function getPolicyTemplateDisplayName(templateName: string) {
             </VEntityField>
           </template>
           <template #dropdownItems>
-            <VDropdownItem @click="handleOpenEditingModal(policy)">
+            <VDropdownItem
+              :disabled="
+                policy.metadata.finalizers?.includes(SYSTEM_PROTECTION)
+              "
+              @click="handleOpenEditingModal(policy)"
+            >
               {{ $t("core.common.buttons.edit") }}
             </VDropdownItem>
             <VDropdownItem

--- a/ui/console-src/modules/contents/attachments/components/AttachmentPoliciesModal.vue
+++ b/ui/console-src/modules/contents/attachments/components/AttachmentPoliciesModal.vue
@@ -1,4 +1,5 @@
 <script lang="ts" setup>
+import { SYSTEM_PROTECTION } from "@/constants/finalizers";
 import { formatDatetime } from "@/utils/date";
 import type { Policy, PolicyTemplate } from "@halo-dev/api-client";
 import { consoleApiClient, coreApiClient } from "@halo-dev/api-client";
@@ -15,6 +16,7 @@ import {
   VModal,
   VSpace,
   VStatusDot,
+  VTag,
 } from "@halo-dev/components";
 import { ref } from "vue";
 import { useI18n } from "vue-i18n";
@@ -171,6 +173,14 @@ function getPolicyTemplateDisplayName(templateName: string) {
             ></VEntityField>
           </template>
           <template #end>
+            <VEntityField>
+              <template
+                v-if="policy.metadata.finalizers?.includes(SYSTEM_PROTECTION)"
+                #description
+              >
+                <VTag>{{ $t("core.common.text.system_protection") }}</VTag>
+              </template>
+            </VEntityField>
             <VEntityField v-if="policy.metadata.deletionTimestamp">
               <template #description>
                 <VStatusDot
@@ -192,7 +202,13 @@ function getPolicyTemplateDisplayName(templateName: string) {
             <VDropdownItem @click="handleOpenEditingModal(policy)">
               {{ $t("core.common.buttons.edit") }}
             </VDropdownItem>
-            <VDropdownItem type="danger" @click="handleDelete(policy)">
+            <VDropdownItem
+              :disabled="
+                policy.metadata.finalizers?.includes(SYSTEM_PROTECTION)
+              "
+              type="danger"
+              @click="handleDelete(policy)"
+            >
               {{ $t("core.common.buttons.delete") }}
             </VDropdownItem>
           </template>

--- a/ui/src/constants/finalizers.ts
+++ b/ui/src/constants/finalizers.ts
@@ -1,0 +1,1 @@
+export const SYSTEM_PROTECTION = "system-protection";

--- a/ui/src/locales/en.yaml
+++ b/ui/src/locales/en.yaml
@@ -1777,6 +1777,7 @@ core:
       none: None
       tip: Tip
       warning: Warning
+      system_protection: System protection
     tooltips:
       unpublished_content_tip: There is content that has been saved but not yet published.
       publishing: Publishing

--- a/ui/src/locales/zh-CN.yaml
+++ b/ui/src/locales/zh-CN.yaml
@@ -1662,6 +1662,7 @@ core:
       none: 无
       tip: 提示
       warning: 警告
+      system_protection: 系统保留
     tooltips:
       unpublished_content_tip: 当前有内容已保存，但还未发布。
       publishing: 发布中

--- a/ui/src/locales/zh-TW.yaml
+++ b/ui/src/locales/zh-TW.yaml
@@ -1643,6 +1643,7 @@ core:
       none: 無
       tip: 提示
       warning: 警告
+      system_protection: 系統保留
     tooltips:
       unpublished_content_tip: 當前有內容已保存，但還未發布。
       publishing: 發布中


### PR DESCRIPTION
#### What type of PR is this?

/area core
/kind improvement
/milestone 2.20.x

#### What this PR does / why we need it:

为系统默认的存储策略添加保护措施，不允许删除。

<img width="893" alt="image" src="https://github.com/user-attachments/assets/990f834f-3d97-4ee8-9c24-01cc188b7be6">


#### Does this PR introduce a user-facing change?

```release-note
为系统默认的存储策略添加保护措施，不允许删除。
```
