### PR TITLE
fix: prevent hidden English characters in post title input

### DIFF
--- a/ui/src/components/editor/DefaultEditor.vue
+++ b/ui/src/components/editor/DefaultEditor.vue
@@ -484,7 +484,7 @@ function handleFocusEditor(event) {
           :value="title"
           type="text"
           :placeholder="$t('core.components.default_editor.title_placeholder')"
-          class="w-full border-x-0 !border-b border-t-0 !border-solid !border-gray-100 p-0 !py-2 text-4xl font-semibold placeholder:text-gray-300"
+          class="w-full border-x-0 !border-b border-t-0 !border-solid !border-gray-100 p-0 !py-2 text-4xl font-semibold placeholder:text-gray-300 leading-none"
           @input="onTitleInput"
           @keydown.enter="handleFocusEditor"
         />


### PR DESCRIPTION
#### What type of PR is this?

/area ui
/kind improvement

#### What this PR does / why we need it:


#### Which issue(s) this PR fixes:

#6748 

Fixes #6748 
#### Special notes for your reviewer:

使英文标题中字母不被截断 

![image](https://github.com/user-attachments/assets/10b677c1-a30a-4261-85fc-d2cf328b003e)

#### Does this PR introduce a user-facing change?

```release-note
修复文章编辑页面标题输入框中，英文字符可能会被隐藏的问题
```

