### PR TITLE
Add Gradle plugin to discover dependency updates

### DIFF
--- a/api/build.gradle
+++ b/api/build.gradle
@@ -3,6 +3,7 @@ plugins {
     id 'halo.publish'
     id 'jacoco'
     id "io.freefair.lombok"
+    id "com.github.ben-manes.versions"
 }
 
 group = 'run.halo.app'

--- a/application/build.gradle
+++ b/application/build.gradle
@@ -13,6 +13,7 @@ plugins {
     id "io.freefair.lombok"
     id 'org.gradle.crypto.checksum'
     id 'org.springdoc.openapi-gradle-plugin'
+    id "com.github.ben-manes.versions"
 }
 
 group = 'run.halo.app'

--- a/build.gradle
+++ b/build.gradle
@@ -7,4 +7,5 @@ plugins {
     id 'org.gradle.crypto.checksum' version '1.4.0' apply false
     id "com.github.node-gradle.node" version "7.0.2" apply false
     id "org.springdoc.openapi-gradle-plugin" version "1.9.0" apply false
+    id "com.github.ben-manes.versions" version "0.51.0" apply false
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind improvement
/area core
/milestone 2.20.x

#### What this PR does / why we need it:

This PR adds [a Gradle plugin ](https://github.com/ben-manes/gradle-versions-plugin)to discover dependency updates.

```bash
❯ ./gradlew dependencyUpdates -Drevision=release

> Task :api:dependencyUpdates

------------------------------------------------------------
:api Project Dependency Updates (report to plain text file)
------------------------------------------------------------

The following dependencies are using the latest release version:
 - com.github.ben-manes.caffeine:caffeine:3.1.8
 - com.github.java-json-tools:json-patch:1.13
 - com.j256.two-factor-auth:two-factor-auth:1.3
 - io.asyncer:r2dbc-mysql:1.3.0
 - io.github.java-diff-utils:java-diff-utils:4.12
 - io.github.resilience4j:resilience4j-reactor:2.2.0
 - io.github.resilience4j:resilience4j-spring-boot3:2.2.0
 - io.projectreactor:reactor-test:3.7.0-M6
 - io.r2dbc:r2dbc-h2:1.0.0.RELEASE
 - io.seruco.encoding:base62:0.1.3
 - org.apache.commons:commons-lang3:3.17.0
 - org.imgscalr:imgscalr-lib:4.2
 - org.jacoco:org.jacoco.agent:0.8.12
 - org.jacoco:org.jacoco.ant:0.8.12
 - org.mariadb:r2dbc-mariadb:1.2.2
 - org.openapi4j:openapi-schema-validator:1.0.7
 - org.pf4j:pf4j:3.12.0
 - org.postgresql:postgresql:42.7.4
 - org.postgresql:r2dbc-postgresql:1.0.5.RELEASE
 - org.projectlombok:lombok:1.18.30
 - org.springdoc:springdoc-openapi-starter-webflux-ui:2.6.0
 - org.springframework.boot:spring-boot-starter-actuator:3.4.0-M3
 - org.springframework.boot:spring-boot-starter-cache:3.4.0-M3
 - org.springframework.boot:spring-boot-starter-data-jpa:3.4.0-M3
 - org.springframework.boot:spring-boot-starter-data-r2dbc:3.4.0-M3
 - org.springframework.boot:spring-boot-starter-mail:3.4.0-M3
 - org.springframework.boot:spring-boot-starter-security:3.4.0-M3
 - org.springframework.boot:spring-boot-starter-test:3.4.0-M3
 - org.springframework.boot:spring-boot-starter-thymeleaf:3.4.0-M3
 - org.springframework.boot:spring-boot-starter-validation:3.4.0-M3
 - org.springframework.boot:spring-boot-starter-webflux:3.4.0-M3
 - org.springframework.integration:spring-integration-core:6.4.0-M3
 - org.springframework.security:spring-security-oauth2-client:6.4.0-M4
 - org.springframework.security:spring-security-oauth2-jose:6.4.0-M4
 - org.springframework.security:spring-security-oauth2-resource-server:6.4.0-M4
 - org.springframework.security:spring-security-test:6.4.0-M4
 - org.springframework.session:spring-session-core:3.4.0-M2
 - org.thymeleaf.extras:thymeleaf-extras-springsecurity6:3.1.2.RELEASE

The following dependencies have later release versions:
 - com.google.guava:guava [32.0.1-jre -> 33.3.1-jre]
     https://github.com/google/guava
 - net.bytebuddy:byte-buddy [1.15.1 -> 1.15.3]
     https://bytebuddy.net
 - org.apache.lucene:lucene-analysis-common [9.11.1 -> 9.12.0]
     https://lucene.apache.org/
 - org.apache.lucene:lucene-backward-codecs [9.11.1 -> 9.12.0]
     https://lucene.apache.org/
 - org.apache.lucene:lucene-core [9.11.1 -> 9.12.0]
     https://lucene.apache.org/
 - org.apache.lucene:lucene-highlighter [9.11.1 -> 9.12.0]
     https://lucene.apache.org/
 - org.apache.lucene:lucene-queryparser [9.11.1 -> 9.12.0]
     https://lucene.apache.org/
 - org.apache.tika:tika-core [2.9.2 -> 3.0.0-BETA2]
     https://tika.apache.org/
 - org.jsoup:jsoup [1.15.3 -> 1.18.1]
     https://jsoup.org/

Gradle release-candidate updates:
 - Gradle: [8.10.2: UP-TO-DATE]

Generated report file build/dependencyUpdates/report.txt

> Task :application:dependencyUpdates

------------------------------------------------------------
:application Project Dependency Updates (report to plain text file)
------------------------------------------------------------

The following dependencies are using the latest release version:
 - com.puppycrawl.tools:checkstyle:9.3
 - io.projectreactor:reactor-test:3.7.0-M6
 - org.jacoco:org.jacoco.agent:0.8.12
 - org.jacoco:org.jacoco.ant:0.8.12
 - org.springframework:spring-context-indexer:6.2.0-RC1
 - org.springframework.boot:spring-boot-configuration-processor:3.4.0-M3
 - org.springframework.boot:spring-boot-starter-test:3.4.0-M3
 - org.springframework.security:spring-security-test:6.4.0-M4
 - org.webjars.npm:jsencrypt:3.3.2
 - org.webjars.npm:normalize.css:8.0.1

The following dependencies have later release versions:
 - org.projectlombok:lombok [1.18.30 -> 1.18.34]
     https://projectlombok.org

Gradle release-candidate updates:
 - Gradle: [8.10.2: UP-TO-DATE]

Generated report file build/dependencyUpdates/report.txt

Deprecated Gradle features were used in this build, making it incompatible with Gradle 9.0.

You can use '--warning-mode all' to show the individual deprecation warnings and determine if they come from your own scripts or plugins.

For more on this, please refer to https://docs.gradle.org/8.10.2/userguide/command_line_interface.html#sec:command_line_warnings in the Gradle documentation.

BUILD SUCCESSFUL in 1s
9 actionable tasks: 2 executed, 7 up-to-date
```

#### Does this PR introduce a user-facing change?

<!--
如果当前 Pull Request 的修改不会造成用户侧的任何变更，在 `release-note` 代码块儿中填写 `NONE`。
否则请填写用户侧能够理解的 Release Note。如果当前 Pull Request 包含破坏性更新（Break Change），
Release Note 需要以 `action required` 开头。
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->

```release-note
None
```
