### PR TITLE
Upgrade to Guava 33.3.1-jre

### DIFF
--- a/platform/application/build.gradle
+++ b/platform/application/build.gradle
@@ -15,7 +15,7 @@ ext {
     base62 = "0.1.3"
     pf4j = '3.12.0'
     javaDiffUtils = "4.12"
-    guava = "32.0.1-jre"
+    guava = "33.3.1-jre"
     jsoup = '1.15.3'
     jsonPatch = "1.13"
     springDocOpenAPI = "2.6.0"


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup
/area core
/milestone 2.20.x

#### What this PR does / why we need it:

This PR upgrades to Guava 33.3.1-jre. See https://github.com/google/guava/releases/tag/v33.3.1 for more.

#### Does this PR introduce a user-facing change?

```release-note
升级依赖 Guava 至 33.3.1-jre
```
