### PR TITLE
pref: remove anonymous and ghost users from the userSelect

### DIFF
--- a/ui/src/formkit/inputs/user-select.ts
+++ b/ui/src/formkit/inputs/user-select.ts
@@ -1,15 +1,16 @@
-// TODO: This is a temporary approach.
-// We will provide searchable user selection components in the future.
-
 import type { FormKitNode, FormKitTypeDefinition } from "@formkit/core";
 import { consoleApiClient } from "@halo-dev/api-client";
 import { select } from "./select";
+
+const ANONYMOUSUSER_NAME = "anonymousUser";
+const DELETEDUSER_NAME = "ghost";
 
 const search = async ({ page, size, keyword }) => {
   const { data } = await consoleApiClient.user.listUsers({
     page,
     size,
     keyword,
+    fieldSelector: [`name!=${ANONYMOUSUSER_NAME}`, `name!=${DELETEDUSER_NAME}`],
   });
   return {
     options: data.items?.map((user) => {


### PR DESCRIPTION
#### What type of PR is this?

/kind improvement
/area ui
/milsetone 2.20.x

#### What this PR does / why we need it:

在 userSelect 查询用户列表时，移除匿名与已删除用户这两个保留用户。

#### How to test it?

在文章设置，用户列表中不存在匿名与已删除用户即可。

#### Which issue(s) this PR fixes:

Fixes #6665 

#### Does this PR introduce a user-facing change?
```release-note
在 user select 中不再显示匿名与已删除用户。
```
