### PR TITLE
Fix the problem of not being able to resolve headers correctly

### DIFF
--- a/application/src/main/resources/application.yaml
+++ b/application/src/main/resources/application.yaml
@@ -1,6 +1,6 @@
 server:
   port: 8090
-  forward-headers-strategy: framework
+  forward-headers-strategy: native
   compression:
     enabled: true
   error:

--- a/application/src/test/java/run/halo/app/XForwardHeaderTest.java
+++ b/application/src/test/java/run/halo/app/XForwardHeaderTest.java
@@ -17,7 +17,7 @@ import org.springframework.web.reactive.function.server.ServerResponse;
 import reactor.test.StepVerifier;
 
 @SpringBootTest(webEnvironment = RANDOM_PORT,
-    properties = "server.forward-headers-strategy=framework")
+    properties = "server.forward-headers-strategy=native")
 class XForwardHeaderTest {
 
     @LocalServerPort


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/area core
/milestone 2.20.x

#### What this PR does / why we need it:

This PR changes server.forward-header-strategy to native instead of framework due to a bug of Spring Framework 6.20.0-RC.1.

See https://github.com/spring-projects/spring-framework/pull/32097#discussion_r1791264218 for more.

If Halo server is proxied by OpenResty which is using HTTP 2, all header names proxied into Halo server will be lowercase. This behavior makes Halo get a null header(e.g.:: `content-type: application/json`) while invoking `request.getHeaders().getContentType()`.

And I found that `ServerHttpRequest` is mutated by `org.springframework.web.server.adapter.ForwardedHeaderTransformer`, so I try to use native forward-header-strategy to resolve the problem and it works very well. See [reactor.netty.http.server.DefaultHttpForwardedHeaderHandler](https://github.com/reactor/reactor-netty/blob/446683826b3020782fe3d647ef264ca7eace94f6/reactor-netty-http/src/main/java/reactor/netty/http/server/DefaultHttpForwardedHeaderHandler.java) for more.

#### Does this PR introduce a user-facing change?

```release-note
None
```
