### PR TITLE
fix: can not display error message for duplicate username during signup

### DIFF
--- a/application/src/main/resources/templates/gateway_modules/form_fragments.html
+++ b/application/src/main/resources/templates/gateway_modules/form_fragments.html
@@ -55,9 +55,9 @@
             <span th:text="#{form.signup.error.rateLimitExceeded}"></span>
         </strong>
     </div>
-    <div class="alert alert-error" role="alert" th:if="${error == 'duplicate-name'}">
+    <div class="alert alert-error" role="alert" th:if="${error == 'duplicate-username'}">
         <strong>
-            <span th:text="#{form.signup.error.duplicateName}"></span>
+            <span th:text="#{form.signup.error.duplicateUsername}"></span>
         </strong>
     </div>
     <div class="form-item-group">

--- a/application/src/main/resources/templates/gateway_modules/form_fragments.properties
+++ b/application/src/main/resources/templates/gateway_modules/form_fragments.properties
@@ -16,7 +16,7 @@ form.signup.password.label=密码
 form.signup.confirmPassword.label=确认密码
 form.signup.submit=注册
 form.signup.error.invalidEmailCode=无效的邮箱验证码
-form.signup.error.duplicateName=用户名已经被注册
+form.signup.error.duplicateUsername=用户名已经被注册
 form.signup.error.rateLimitExceeded=请求过于频繁，请稍后再试
 
 form.totp.messages.invalidError=错误的验证码

--- a/application/src/main/resources/templates/gateway_modules/form_fragments_en.properties
+++ b/application/src/main/resources/templates/gateway_modules/form_fragments_en.properties
@@ -16,7 +16,7 @@ form.signup.password.label=Password
 form.signup.confirmPassword.label=Confirm Password
 form.signup.submit=Sign Up
 form.signup.error.invalidEmailCode=Invalid Email Verification Code
-form.signup.error.duplicateName=Username is already taken
+form.signup.error.duplicateUsername=Username is already taken
 form.signup.error.rateLimitExceeded=Too many requests, please try again later
 
 form.totp.messages.invalidError=Invalid TOTP code

--- a/application/src/main/resources/templates/gateway_modules/form_fragments_es.properties
+++ b/application/src/main/resources/templates/gateway_modules/form_fragments_es.properties
@@ -16,7 +16,7 @@ form.signup.password.label=Contraseña
 form.signup.confirmPassword.label=Confirmar Contraseña
 form.signup.submit=Registrarse
 form.signup.error.invalidEmailCode=Código de verificación del correo inválido
-form.signup.error.duplicateName=El nombre de usuario ya está registrado
+form.signup.error.duplicateUsername=El nombre de usuario ya está registrado
 form.signup.error.rateLimitExceeded=Demasiadas solicitudes, por favor intente nuevamente más tarde
 
 form.totp.messages.invalidError=Código de verificación incorrecto

--- a/application/src/main/resources/templates/gateway_modules/form_fragments_zh_TW.properties
+++ b/application/src/main/resources/templates/gateway_modules/form_fragments_zh_TW.properties
@@ -16,7 +16,7 @@ form.signup.password.label=密碼
 form.signup.confirmPassword.label=確認密碼
 form.signup.submit=註冊
 form.signup.error.invalidEmailCode=無效的郵箱驗證碼
-form.signup.error.duplicateName=使用者名稱已經被註冊
+form.signup.error.duplicateUsername=使用者名稱已經被註冊
 form.signup.error.rateLimitExceeded=請求過於頻繁，請稍後再試
 
 form.totp.messages.invalidError=錯誤的驗證碼


### PR DESCRIPTION
#### What type of PR is this?

/area core
/kind bug
/milestone 2.20.x

#### What this PR does / why we need it:

修复注册时，不能正常显示用户名重复的错误的问题。

<img width="666" alt="image" src="https://github.com/user-attachments/assets/bef83af1-ab9d-4c84-8c3e-0d4f8a6892f3">

#### Does this PR introduce a user-facing change?

```release-note
None
```
