### PR TITLE
refactor: improve password input toggle button state display

### DIFF
--- a/ui/src/formkit/inputs/password/RevealButton.vue
+++ b/ui/src/formkit/inputs/password/RevealButton.vue
@@ -24,7 +24,7 @@ function handleChange() {
     @click="handleChange"
   >
     <IconEye
-      v-if="context.node.props.type === 'password'"
+      v-if="context.node.props.type !== 'password'"
       class="h-4 w-4 text-gray-500 group-hover:text-gray-700"
     />
     <IconEyeOff


### PR DESCRIPTION
#### What type of PR is this?

/area ui
/kind improvement
/milestone 2.20.x

#### What this PR does / why we need it:

优化密码输入框的明文显示图标的状态显示。

before:

<img width="508" alt="image" src="https://github.com/user-attachments/assets/5ae12beb-ce23-40a2-ad08-8e47c2eb6813">

after:

<img width="519" alt="image" src="https://github.com/user-attachments/assets/712e1735-a7ad-40f4-8900-a8c92eda7e54">


#### Does this PR introduce a user-facing change?

```release-note
None
```
