### PR TITLE
fix: username length validation in user creation form is not working

### DIFF
--- a/ui/console-src/modules/system/users/components/UserCreationModal.vue
+++ b/ui/console-src/modules/system/users/components/UserCreationModal.vue
@@ -84,7 +84,7 @@ const handleCreateUser = async () => {
         name="name"
         :validation="[
           ['required'],
-          ['length:0,63'],
+          ['length', 0, 63],
           [
             'matches',
             /^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$/,


### PR DESCRIPTION
#### What type of PR is this?

/area ui
/kind bug
/milestone 2.20.x

#### What this PR does / why we need it:

修复创建用户表单的用户名长度校验不生效的问题。

#### Does this PR introduce a user-facing change?

```release-note
修复创建用户表单的用户名长度校验不生效的问题。
```
