### PR TITLE
fix: avoid NPE by skipping nonexistent notifiers in user preferences

### DIFF
--- a/application/src/main/java/run/halo/app/notification/endpoint/UserNotificationPreferencesEndpoint.java
+++ b/application/src/main/java/run/halo/app/notification/endpoint/UserNotificationPreferencesEndpoint.java
@@ -174,6 +174,11 @@ public class UserNotificationPreferencesEndpoint implements CustomEndpoint {
                             var notifierNames =
                                 reasonTypeNotifierMap.getNotifiers(reasonType.name());
                             for (String notifierName : notifierNames) {
+                                // Skip if the notifier enabled in the user preference does not
+                                // exist to avoid null index
+                                if (!notifierIndexMap.containsKey(notifierName)) {
+                                    continue;
+                                }
                                 var notifierIndex = notifierIndexMap.get(notifierName);
                                 stateMatrix[reasonTypeIndex][notifierIndex] = true;
                             }


### PR DESCRIPTION
#### What type of PR is this?
/kind improvement
/area core
/milestone 2.20.x

#### What this PR does / why we need it:
修复当用户通知偏好设置中出现不存在的通知器名称时会导致 NPE 的问题

此问题可能发生在，通知器由插件或者专业版提供并且修改了偏好设置后禁用了插件或切换到开源版导致找不到该通知器的记录

#### Does this PR introduce a user-facing change?
```release-note
None
```
