### PR TITLE
Fix the problem of accessing logout page without authentication

### DIFF
--- a/application/src/main/java/run/halo/app/security/authorization/AuthorizationExchangeConfigurers.java
+++ b/application/src/main/java/run/halo/app/security/authorization/AuthorizationExchangeConfigurers.java
@@ -59,8 +59,7 @@ class AuthorizationExchangeConfigurers {
             "/login/**",
             "/challenges/**",
             "/password-reset/**",
-            "/signup",
-            "/logout"
+            "/signup"
         ).permitAll());
     }
 
@@ -69,7 +68,11 @@ class AuthorizationExchangeConfigurers {
     SecurityConfigurer authenticatedAuthorizationConfigurer() {
         // Anonymous user is not allowed
         return http -> http.authorizeExchange(
-            spec -> spec.pathMatchers("/console/**", "/uc/**").authenticated()
+            spec -> spec.pathMatchers(
+                "/console/**",
+                "/uc/**",
+                "/logout"
+            ).authenticated()
         );
     }
 


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/area core
/milestone 2.20.x

#### What this PR does / why we need it:

Currently, logout page is always visible for anyone whether the user is authenticated. This PR restricts the visibility of logout page to authenticated users but anonymous users.

#### Special notes for your reviewer:

```bash
> http http://localhost:8090/logout

HTTP/1.1 302 Found
Cache-Control: no-cache, no-store, max-age=0, must-revalidate
Expires: 0
Location: /login?authentication_required
Pragma: no-cache
Referrer-Policy: strict-origin-when-cross-origin
Vary: Origin
Vary: Access-Control-Request-Method
Vary: Access-Control-Request-Headers
X-Content-Type-Options: nosniff
X-Frame-Options: SAMEORIGIN
X-XSS-Protection: 0
content-length: 0
```

#### Does this PR introduce a user-facing change?

```release-note
修复未登录情况下依然能够访问登出页面的问题
```
