### PR TITLE
feat: improve built-in auth providers' i18n in detail page

### DIFF
--- a/ui/console-src/modules/system/auth-providers/AuthProviderDetail.vue
+++ b/ui/console-src/modules/system/auth-providers/AuthProviderDetail.vue
@@ -136,15 +136,36 @@ const handleSaveConfigMap = async () => {
   await handleFetchConfigMap();
   saving.value = false;
 };
+
+const displayName = computed(() => {
+  if (!authProvider.value) {
+    return t("core.common.status.loading");
+  }
+
+  return t(
+    `core.identity_authentication.fields.display_name.${authProvider.value?.metadata.name}`,
+    authProvider.value?.spec.displayName || ""
+  );
+});
+
+const description = computed(() => {
+  if (!authProvider.value) {
+    return t("core.common.status.loading");
+  }
+
+  return t(
+    `core.identity_authentication.fields.description.${authProvider.value?.metadata.name}`,
+    authProvider.value?.spec.description || ""
+  );
+});
 </script>
 
 <template>
-  <VPageHeader :title="authProvider?.spec.displayName">
+  <VPageHeader :title="displayName">
     <template #icon>
       <VAvatar
-        v-if="authProvider"
-        :src="authProvider.spec.logo"
-        :alt="authProvider.spec.displayName"
+        :src="authProvider?.spec.logo"
+        :alt="authProvider?.spec.displayName"
         class="mr-2"
         size="sm"
       />
@@ -168,13 +189,13 @@ const handleSaveConfigMap = async () => {
               :label="
                 $t('core.identity_authentication.detail.fields.display_name')
               "
-              :content="authProvider?.spec.displayName"
+              :content="displayName"
             />
             <VDescriptionItem
               :label="
                 $t('core.identity_authentication.detail.fields.description')
               "
-              :content="authProvider?.spec.description"
+              :content="description"
             />
             <VDescriptionItem
               :label="$t('core.identity_authentication.detail.fields.website')"

--- a/ui/console-src/modules/system/auth-providers/components/AuthProviderListItem.vue
+++ b/ui/console-src/modules/system/auth-providers/components/AuthProviderListItem.vue
@@ -76,13 +76,13 @@ const handleChangeStatus = async () => {
       <VEntityField
         :title="
           $t(
-            `core.identity_authentication.list.fields.display_name.${authProvider.name}`,
+            `core.identity_authentication.fields.display_name.${authProvider.name}`,
             authProvider.displayName
           )
         "
         :description="
           $t(
-            `core.identity_authentication.list.fields.description.${authProvider.name}`,
+            `core.identity_authentication.fields.description.${authProvider.name}`,
             authProvider.description || ''
           )
         "

--- a/ui/src/locales/en.yaml
+++ b/ui/src/locales/en.yaml
@@ -1135,12 +1135,11 @@ core:
         title: Disable identity authentication method
       disable_privileged:
         tooltip: The authentication method reserved by the system cannot be disabled
-    list:
-      fields:
-        display_name:
-          local: Login with credentials
-        description:
-          local: Default login method built into Halo
+    fields:
+      display_name:
+        local: Login with credentials
+      description:
+        local: Default login method built into Halo
     detail:
       title: Identity authentication detail
       fields:

--- a/ui/src/locales/zh-CN.yaml
+++ b/ui/src/locales/zh-CN.yaml
@@ -1063,12 +1063,11 @@ core:
         title: 停用认证方式
       disable_privileged:
         tooltip: 系统保留的认证方式，无法禁用
-    list:
-      fields:
-        display_name:
-          local: 账号密码登录
-        description:
-          local: Halo 内置的默认登录方式
+    fields:
+      display_name:
+        local: 账号密码登录
+      description:
+        local: Halo 内置的默认登录方式
     detail:
       title: 身份认证详情
       fields:

--- a/ui/src/locales/zh-TW.yaml
+++ b/ui/src/locales/zh-TW.yaml
@@ -1040,12 +1040,11 @@ core:
         title: 停用認證方式
       disable_privileged:
         tooltip: 系統保留的認證方式，無法禁用
-    list:
-      fields:
-        display_name:
-          local: 帳號密碼登入
-        description:
-          local: Halo 內建的默認登入方式
+    fields:
+      display_name:
+        local: 帳號密碼登入
+      description:
+        local: Halo 內建的默認登入方式
     detail:
       title: 身份認證詳情
       fields:


### PR DESCRIPTION
#### What type of PR is this?

/area ui
/kind improvement
/milestone 2.20.x

#### What this PR does / why we need it:

完善内置的认证提供商详情页面的 i18n，在 https://github.com/halo-dev/halo/pull/6814 中遗漏了详情页面。

<img width="653" alt="image" src="https://github.com/user-attachments/assets/7d4b4789-91d0-45e5-b5e7-98324ddc0899">

#### Does this PR introduce a user-facing change?

```release-note
None
```
