### PR TITLE
Support redirecting to URI with fragment

### DIFF
--- a/application/src/test/java/run/halo/app/security/HaloServerRequestCacheTest.java
+++ b/application/src/test/java/run/halo/app/security/HaloServerRequestCacheTest.java
@@ -33,23 +33,28 @@ class HaloServerRequestCacheTest {
     @Test
     void shouldSaveIfPageCacheable() {
         var mockExchange = MockServerWebExchange.from(
-            MockServerHttpRequest.get("/archives").accept(MediaType.TEXT_HTML)
+            MockServerHttpRequest.get("/archives")
+                .queryParam("q", "v")
+                .accept(MediaType.TEXT_HTML)
         );
         requestCache.saveRequest(mockExchange)
             .then(requestCache.getRedirectUri(mockExchange))
             .as(StepVerifier::create)
-            .expectNext(URI.create("/archives"))
+            .expectNext(URI.create("/archives?q=v"))
             .verifyComplete();
     }
 
     @Test
-    void shouldSaveIfQueryPresent() {
-        var mockExchange =
-            MockServerWebExchange.from(MockServerHttpRequest.get("/login?redirect_uri=/halo?q=v"));
+    void shouldSaveIfRedirectUriPresent() {
+        var mockExchange = MockServerWebExchange.from(
+            MockServerHttpRequest.get("/login")
+                .queryParam("redirect_uri", "/halo?q=v#fragment")
+        );
         requestCache.saveRequest(mockExchange)
             .then(requestCache.getRedirectUri(mockExchange))
             .as(StepVerifier::create)
-            .expectNext(URI.create("/halo?q=v"));
+            .expectNext(URI.create("/halo?q=v#fragment"))
+            .verifyComplete();
     }
 
     @Test


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/area core
/milestone 2.20.x

#### What this PR does / why we need it:

This PR supports redirecting to URI with fragment. e.g.: <http://localhost:8090/login?redirect_uri=%2F%23afragment>(redirect_uri is `/#afragment`).

#### Which issue(s) this PR fixes:

Fixes #6767 

#### Special notes for your reviewer:

1. Request <http://localhost:8090/login?redirect_uri=%2F%23afragment>
2. Log in
3. See the redirection

#### Does this PR introduce a user-facing change?

```release-note
None
```
