### PR TITLE
feat: add password reset success message in login page

### DIFF
--- a/application/src/main/resources/templates/gateway_fragments/login.html
+++ b/application/src/main/resources/templates/gateway_fragments/login.html
@@ -1,10 +1,10 @@
 <form
-        th:fragment="form"
-        class="halo-form"
-        name="login-form"
-        id="login-form"
-        th:action="${authProvider.spec.authenticationUrl}"
-        th:method="${authProvider.spec.method}"
+    th:fragment="form"
+    class="halo-form"
+    name="login-form"
+    id="login-form"
+    th:action="${authProvider.spec.authenticationUrl}"
+    th:method="${authProvider.spec.method}"
 >
     <div class="alert alert-error" role="alert" th:if="${param.error.size() > 0}" th:with="error = ${param.error[0]}">
         <strong th:if="${error == 'invalid-credential'}">
@@ -22,6 +22,9 @@
     </div>
     <div class="alert" role="alert" th:if="${param.oauth2_bind.size() > 0}">
         <strong th:text="#{form.messages.oauth2Bind}"></strong>
+    </div>
+    <div class="alert" role="alert" th:if="${param.password_reset.size() > 0}">
+        <strong th:text="#{form.messages.passwordReset}"></strong>
     </div>
 
     <div th:replace="~{__${fragmentTemplateName}__::form}"></div>

--- a/application/src/main/resources/templates/gateway_fragments/login.properties
+++ b/application/src/main/resources/templates/gateway_fragments/login.properties
@@ -1,6 +1,7 @@
 form.messages.logoutSuccess=登出成功。
 form.messages.signupSuccess=恭喜！注册成功，请立即登录。
 form.messages.oauth2Bind=当前登录未绑定账号，请尝试通过其他方式登录，登录成功后会自动绑定账号。
+form.messages.passwordReset=密码重置成功，请立即登录。
 form.error.invalidCredential=无效的凭证。
 form.error.rateLimitExceeded=请求过于频繁，请稍后再试。
 form.rememberMe.label=保持登录会话

--- a/application/src/main/resources/templates/gateway_fragments/login_en.properties
+++ b/application/src/main/resources/templates/gateway_fragments/login_en.properties
@@ -1,6 +1,7 @@
 form.messages.logoutSuccess=Logout successfully.
 form.messages.signupSuccess=Congratulations! Sign up successfully, please login now.
 form.messages.oauth2Bind=The current login is not bound to an account. Please try to log in through other methods. After successful login, the account will be automatically bound.
+form.messages.passwordReset=Password reset successfully, please login now.
 form.error.invalidCredential=Invalid credentials.
 form.error.rateLimitExceeded=Too many requests, please try again later.
 form.rememberMe.label=Remember me

--- a/application/src/main/resources/templates/gateway_fragments/login_es.properties
+++ b/application/src/main/resources/templates/gateway_fragments/login_es.properties
@@ -1,6 +1,7 @@
 form.messages.logoutSuccess=Cierre de sesión exitoso.
 form.messages.signupSuccess=¡Felicidades! Registro exitoso, por favor inicie sesión de inmediato.
 form.messages.oauth2Bind=El inicio de sesión actual no está vinculado a una cuenta. Intente iniciar sesión a través de otros métodos. Después de un inicio de sesión exitoso, la cuenta se vinculará automáticamente.
+form.messages.passwordReset=¡Felicidades! La contraseña se ha restablecido con éxito.
 form.error.invalidCredential=Credenciales inválidas.
 form.error.rateLimitExceeded=Demasiadas solicitudes, por favor intente nuevamente más tarde.
 form.rememberMe.label=Mantener sesión iniciada

--- a/application/src/main/resources/templates/gateway_fragments/login_zh_TW.properties
+++ b/application/src/main/resources/templates/gateway_fragments/login_zh_TW.properties
@@ -1,6 +1,7 @@
 form.messages.logoutSuccess=登出成功。
 form.messages.signupSuccess=恭喜！註冊成功，請立即登入。
 form.messages.oauth2Bind=當前登入未綁定至帳戶。請嘗試通過其他方法登入。成功登入後，帳戶將自動綁定。
+form.messages.passwordReset=密碼重置成功。請立即登入。
 form.error.invalidCredential=無效的憑證。
 form.error.rateLimitExceeded=請求過於頻繁，請稍後再試。
 form.form.rememberMe.label=保持登入會話


### PR DESCRIPTION
#### What type of PR is this?

/area core
/kind improvement
/milestone 2.20.x

#### What this PR does / why we need it:

重置密码跳转到登录页面之后，在顶部添加重置成功的提示。

#### Does this PR introduce a user-facing change?

```release-note
None 
```
