### PR TITLE
refactor: support locale-based validation messages based on users language

### DIFF
--- a/application/src/main/java/run/halo/app/core/endpoint/console/UserEndpoint.java
+++ b/application/src/main/java/run/halo/app/core/endpoint/console/UserEndpoint.java
@@ -59,7 +59,6 @@ import org.springframework.util.Assert;
 import org.springframework.util.CollectionUtils;
 import org.springframework.util.MultiValueMap;
 import org.springframework.util.unit.DataSize;
-import org.springframework.validation.BeanPropertyBindingResult;
 import org.springframework.validation.Validator;
 import org.springframework.web.reactive.function.BodyExtractors;
 import org.springframework.web.reactive.function.server.RouterFunction;
@@ -86,6 +85,7 @@ import run.halo.app.extension.ReactiveExtensionClient;
 import run.halo.app.extension.router.SortableRequest;
 import run.halo.app.infra.SystemConfigurableEnvironmentFetcher;
 import run.halo.app.infra.SystemSetting;
+import run.halo.app.infra.ValidationUtils;
 import run.halo.app.infra.exception.RateLimitExceededException;
 import run.halo.app.infra.exception.UnsatisfiedAttributeValueException;
 import run.halo.app.infra.utils.JsonUtils;
@@ -298,8 +298,8 @@ public class UserEndpoint implements CustomEndpoint {
                 () -> new ServerWebInputException("Request body is required."))
             )
             .doOnNext(emailReq -> {
-                var bindingResult = new BeanPropertyBindingResult(emailReq, "form");
-                validator.validate(emailReq, bindingResult);
+                var bindingResult =
+                    ValidationUtils.validate(emailReq, validator, request.exchange());
                 if (bindingResult.hasErrors()) {
                     // only email field is validated
                     throw new ServerWebInputException("validation.error.email.pattern");

--- a/application/src/main/java/run/halo/app/infra/ValidationUtils.java
+++ b/application/src/main/java/run/halo/app/infra/ValidationUtils.java
@@ -2,6 +2,11 @@ package run.halo.app.infra;
 
 import java.util.regex.Pattern;
 import lombok.experimental.UtilityClass;
+import org.springframework.context.i18n.LocaleContextHolder;
+import org.springframework.validation.BeanPropertyBindingResult;
+import org.springframework.validation.BindingResult;
+import org.springframework.validation.Validator;
+import org.springframework.web.server.ServerWebExchange;
 
 @UtilityClass
 public class ValidationUtils {
@@ -15,4 +20,24 @@ public class ValidationUtils {
     public static final String PASSWORD_REGEX = "^[A-Za-z0-9!@#$%^&*]+$";
 
     public static final Pattern PASSWORD_PATTERN = Pattern.compile(PASSWORD_REGEX);
+
+    /**
+     * Validate the target object with given locale context.
+     */
+    public static BindingResult validate(Object target, String objectName,
+        Validator validator, ServerWebExchange exchange) {
+        BindingResult bindingResult = new BeanPropertyBindingResult(target, objectName);
+        try {
+            LocaleContextHolder.setLocaleContext(exchange.getLocaleContext());
+            validator.validate(target, bindingResult);
+            return bindingResult;
+        } finally {
+            LocaleContextHolder.resetLocaleContext();
+        }
+    }
+
+    public static BindingResult validate(Object target, Validator validator,
+        ServerWebExchange exchange) {
+        return validate(target, "form", validator, exchange);
+    }
 }

--- a/application/src/main/java/run/halo/app/security/preauth/SystemSetupEndpoint.java
+++ b/application/src/main/java/run/halo/app/security/preauth/SystemSetupEndpoint.java
@@ -118,8 +118,7 @@ public class SystemSetupEndpoint {
                 .map(initialized -> !initialized)
             )
             .flatMap(body -> {
-                var bindingResult = body.toBindingResult();
-                validator.validate(body, bindingResult);
+                var bindingResult = ValidationUtils.validate(body, validator, request.exchange());
                 if (bindingResult.hasErrors()) {
                     return handleValidationErrors(bindingResult, request);
                 }
@@ -208,7 +207,7 @@ public class SystemSetupEndpoint {
                     return redirectToConsole();
                 }
                 var body = new SetupRequest(new LinkedMultiValueMap<>());
-                var bindingResult = body.toBindingResult();
+                var bindingResult = new BeanPropertyBindingResult(body, "form");
                 return ServerResponse.ok().render(SETUP_TEMPLATE, bindingResult.getModel());
             });
     }
@@ -242,10 +241,6 @@ public class SystemSetupEndpoint {
         @Size(max = 80)
         public String getSiteTitle() {
             return formData.getFirst("siteTitle");
-        }
-
-        public BindingResult toBindingResult() {
-            return new BeanPropertyBindingResult(this, "form");
         }
     }
 


### PR DESCRIPTION
#### What type of PR is this?
/kind improvement
/area core
/milestone 2.20.x

#### What this PR does / why we need it:
优化校验提示信息根据用户选择的语言代替 `Locale#getDefault()#getLanguage()`

#### Does this PR introduce a user-facing change?
```release-note
None
```
