### PR TITLE
refactor: improve password hint text on reset password page

### DIFF
--- a/application/src/main/resources/templates/gateway_fragments/password_reset_email_reset.properties
+++ b/application/src/main/resources/templates/gateway_fragments/password_reset_email_reset.properties
@@ -1,4 +1,4 @@
 form.password.label=密码
 form.confirmPassword.label=确认密码
-form.password.tips=密码必须至少包含 8 个字符，并且至少包含一个大写字母、一个小写字母、一个数字和一个特殊字符。
+form.password.tips=密码只能使用大小写字母 (A-Z, a-z)、数字 (0-9)，以及以下特殊字符: !@#$%^&*。
 form.submit=修改密码

--- a/application/src/main/resources/templates/gateway_fragments/password_reset_email_reset_en.properties
+++ b/application/src/main/resources/templates/gateway_fragments/password_reset_email_reset_en.properties
@@ -1,4 +1,4 @@
 form.password.label=Password
 form.confirmPassword.label=Confirm Password
-form.password.tips=Password must be at least 8 characters long and contain at least one uppercase letter, one lowercase letter, one number, and one special character.
+form.password.tips=The password can only use uppercase and lowercase letters (A-Z, a-z), numbers (0-9), and the following special characters: !@#$%^&*
 form.submit=Change password

--- a/application/src/main/resources/templates/gateway_fragments/password_reset_email_reset_es.properties
+++ b/application/src/main/resources/templates/gateway_fragments/password_reset_email_reset_es.properties
@@ -1,4 +1,4 @@
 form.password.label=Contraseña
 form.confirmPassword.label=Confirmar Contraseña
-form.password.tips=La contraseña debe tener al menos 8 caracteres e incluir al menos una letra mayúscula, una letra minúscula, un número y un carácter especial.
+form.password.tips=La contraseña solo puede usar letras mayúsculas y minúsculas (A-Z, a-z), números (0-9) y los siguientes caracteres especiales: !@#$%^&*.
 form.submit=Cambiar Contraseña

--- a/application/src/main/resources/templates/gateway_fragments/password_reset_email_reset_zh_TW.properties
+++ b/application/src/main/resources/templates/gateway_fragments/password_reset_email_reset_zh_TW.properties
@@ -1,4 +1,4 @@
 form.password.label=密碼
 form.confirmPassword.label=確認密碼
-form.password.tips=密碼必須至少包含 8 個字元，並且至少包含一個大寫字母、一個小寫字母、一個數字和一個特殊字元。
+form.password.tips=密碼只能使用大小寫字母 (A-Z, a-z)、數字 (0-9)，以及以下特殊字符: !@#$%^&*。
 form.submit=修改密碼


### PR DESCRIPTION
#### What type of PR is this?

/area core
/kind improvement
/milestone 2.20.x

#### What this PR does / why we need it:

优化重置密码页面的密码提示文本，以 https://github.com/halo-dev/halo/blob/aab8806f0d64b4c4cd009ff0a7d9687c9207ab2a/application/src/main/resources/config/i18n/messages_zh.properties#L66 为准。

#### Does this PR introduce a user-facing change?

```release-note
None
```
