### PR TITLE
Disable CSRF protection for actuator endpoints

### DIFF
--- a/application/src/main/java/run/halo/app/security/CsrfConfigurer.java
+++ b/application/src/main/java/run/halo/app/security/CsrfConfigurer.java
@@ -18,8 +18,12 @@ class CsrfConfigurer implements SecurityConfigurer {
     public void configure(ServerHttpSecurity http) {
         var csrfMatcher = new AndServerWebExchangeMatcher(
             CsrfWebFilter.DEFAULT_CSRF_MATCHER,
-            new NegatedServerWebExchangeMatcher(
-                pathMatchers("/api/**", "/apis/**", "/system/setup"))
+            new NegatedServerWebExchangeMatcher(pathMatchers(
+                "/api/**",
+                "/apis/**",
+                "/actuator/**",
+                "/system/setup"
+            ))
         );
         http.csrf(csrfSpec -> csrfSpec
             .csrfTokenRepository(new CookieServerCsrfTokenRepository())


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/area core
/milestone 2.20.x

#### What this PR does / why we need it:

This PR disables CSRF protection for actuator endpoints because they are not state-changing operations.

#### Which issue(s) this PR fixes:

Fixes #6827 

#### Special notes for your reviewer:

Try to restore Halo.

#### Does this PR introduce a user-facing change?

```release-note
修复恢复备份后无法自动重启的问题
```
