### PR TITLE
fix: vertical images are rotated to horizontal when generating thumbnails

### DIFF
--- a/api/build.gradle
+++ b/api/build.gradle
@@ -68,6 +68,7 @@ dependencies {
     api "org.thymeleaf.extras:thymeleaf-extras-springsecurity6"
     api 'org.apache.tika:tika-core'
     api "org.imgscalr:imgscalr-lib"
+    api 'com.drewnoakes:metadata-extractor'
 
     api "io.github.resilience4j:resilience4j-spring-boot3"
     api "io.github.resilience4j:resilience4j-reactor"

--- a/platform/application/build.gradle
+++ b/platform/application/build.gradle
@@ -24,6 +24,7 @@ ext {
     twoFactorAuth = "1.3"
     tika = "2.9.2"
     imgscalr = '4.2'
+    exifExtractor = '2.19.0'
 }
 
 javaPlatform {
@@ -58,6 +59,7 @@ dependencies {
         api "com.j256.two-factor-auth:two-factor-auth:$twoFactorAuth"
         api "org.apache.tika:tika-core:$tika"
         api "org.imgscalr:imgscalr-lib:$imgscalr"
+        api "com.drewnoakes:metadata-extractor:$exifExtractor"
     }
 
 }


### PR DESCRIPTION
#### What type of PR is this?
/kind improvement
/area core
/milestone 2.20.x

#### What this PR does / why we need it:
修复竖向图片生成缩略图后会丢失方向信息展示为横向图片的问题

#### Which issue(s) this PR fixes:
Fixes #6802

#### Does this PR introduce a user-facing change?
```release-note
修复竖向图片生成缩略图后会丢失方向信息展示为横向图片的问题
```
