### PR TITLE
Preserve remember-me option after authentication failure

### DIFF
--- a/application/src/main/java/run/halo/app/security/authentication/rememberme/TokenBasedRememberMeServices.java
+++ b/application/src/main/java/run/halo/app/security/authentication/rememberme/TokenBasedRememberMeServices.java
@@ -203,7 +203,7 @@ public class TokenBasedRememberMeServices implements ServerLogoutHandler, Rememb
     public Mono<Void> loginFail(ServerWebExchange exchange) {
         log.debug("Interactive login attempt was unsuccessful.");
         cancelCookie(exchange);
-        return Mono.empty();
+        return rememberMeRequestCache.saveRememberMe(exchange);
     }
 
     @Override

--- a/application/src/main/java/run/halo/app/security/preauth/PreAuthLoginEndpoint.java
+++ b/application/src/main/java/run/halo/app/security/preauth/PreAuthLoginEndpoint.java
@@ -22,6 +22,8 @@ import run.halo.app.plugin.PluginConst;
 import run.halo.app.security.AuthProviderService;
 import run.halo.app.security.HaloServerRequestCache;
 import run.halo.app.security.authentication.CryptoService;
+import run.halo.app.security.authentication.rememberme.RememberMeRequestCache;
+import run.halo.app.security.authentication.rememberme.WebSessionRememberMeRequestCache;
 
 /**
  * Pre-auth login endpoints.
@@ -39,6 +41,9 @@ class PreAuthLoginEndpoint {
     private final AuthProviderService authProviderService;
 
     private final ServerRequestCache serverRequestCache = new HaloServerRequestCache();
+
+    private final RememberMeRequestCache rememberMeRequestCache =
+        new WebSessionRememberMeRequestCache();
 
     PreAuthLoginEndpoint(CryptoService cryptoService, GlobalInfoService globalInfoService,
         AuthProviderService authProviderService) {
@@ -91,7 +96,8 @@ class PreAuthLoginEndpoint {
                         "authProvider", authProvider,
                         "fragmentTemplateName", fragmentTemplateName,
                         "socialAuthProviders", socialAuthProviders,
-                        "formAuthProviders", formAuthProviders
+                        "formAuthProviders", formAuthProviders,
+                        "rememberMe", rememberMeRequestCache.isRememberMe(exchange)
                         // TODO Add more models here
                     ))
                 ));

--- a/application/src/main/resources/templates/gateway_fragments/login.html
+++ b/application/src/main/resources/templates/gateway_fragments/login.html
@@ -30,7 +30,7 @@
     <div th:replace="~{__${fragmentTemplateName}__::form}"></div>
 
     <div th:if="${authProvider.spec.rememberMeSupport}" class="form-item-compact">
-        <input type="checkbox" id="remember-me" name="remember-me" value="true" />
+        <input type="checkbox" id="remember-me" name="remember-me" value="true" th:checked="${rememberMe}"/>
         <label for="remember-me" th:text="#{form.rememberMe.label}"></label>
     </div>
 


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/area core
/milestone 2.20.x

#### What this PR does / why we need it:

This PR preserves `remember-me` option after authentication failure.

#### Which issue(s) this PR fixes:

Fixes https://github.com/halo-dev/halo/issues/6835

#### Special notes for your reviewer:

1. Go to login page
2. Input invalid username or password and select `remember-me` option
3. Click `Login` button
4. See the result

#### Does this PR introduce a user-facing change?

```release-note
修复登录失败后记住我选项被重置的问题
```
