### PR TITLE
refactor: remove underline in h2 warning alert

### DIFF
--- a/ui/src/components/alerts/H2WarningAlert.vue
+++ b/ui/src/components/alerts/H2WarningAlert.vue
@@ -26,8 +26,5 @@ const { data: info } = useQuery<Info>({
     <template #description>
       {{ $t("core.components.h2_warning_alert.description") }}
     </template>
-    <template #actions>
-      <slot name="actions" />
-    </template>
   </VAlert>
 </template>


### PR DESCRIPTION
#### What type of PR is this?

/area ui
/kind improvement
/milestone 2.20.x

#### What this PR does / why we need it:

before:

<img width="804" alt="image" src="https://github.com/user-attachments/assets/3d55d7d2-1dfa-4988-afbd-dd502e54fdb2">

after:

<img width="806" alt="image" src="https://github.com/user-attachments/assets/6194d995-b6f1-404a-820d-b667ccfab9f1">

#### Does this PR introduce a user-facing change?

```release-note
None
```
