### PR TITLE
fix: set default value for attachment storage policy in user center

### DIFF
--- a/application/src/main/resources/extensions/system-configurable-configmap.yaml
+++ b/application/src/main/resources/extensions/system-configurable-configmap.yaml
@@ -8,7 +8,8 @@ data:
       "allowRegistration": false,
       "mustVerifyEmailOnRegistration": false,
       "defaultRole": "guest",
-      "avatarPolicy": "default-policy"
+      "avatarPolicy": "default-policy",
+      "ucAttachmentPolicy": "default-policy"
     }
   theme: |
     {


### PR DESCRIPTION
#### What type of PR is this?

/area core
/kind bug
/milestone 2.20.x

#### What this PR does / why we need it:

修复首次初始化之后，个人中心使用的附件存储策略没有默认值的问题。

#### Which issue(s) this PR fixes:

Fixes #6834 

#### Does this PR introduce a user-facing change?

```release-note
None
```
