### PR TITLE
chore: ignore preset plugin installation errors to avoid initialization failure

### DIFF
--- a/application/src/main/java/run/halo/app/plugin/PluginServiceImpl.java
+++ b/application/src/main/java/run/halo/app/plugin/PluginServiceImpl.java
@@ -516,7 +516,8 @@ public class PluginServiceImpl implements PluginService, InitializingBean, Dispo
                     return path;
                 });
         } catch (IOException e) {
-            return Flux.error(e);
+            log.debug("Failed to load preset plugins: {}", e.getMessage());
+            return Flux.empty();
         }
     }
 


### PR DESCRIPTION
#### What type of PR is this?
/milestone 2.20.x
/area core
/milestone 2.20.x

#### What this PR does / why we need it:
忽略预设插件安装时的错误避免无法初始化

可能因为没有预先 download 预设插件到项目目录而发生 IO 异常影响初始化流程

#### Does this PR introduce a user-facing change?

```release-note
None
```
