### PR TITLE
Fill operation ID while building setup route

### DIFF
--- a/application/src/main/java/run/halo/app/security/preauth/SystemSetupEndpoint.java
+++ b/application/src/main/java/run/halo/app/security/preauth/SystemSetupEndpoint.java
@@ -108,8 +108,7 @@ public class SystemSetupEndpoint {
                         .implementation(Void.class)
                     )
             )
-            .before(HaloUtils.noCache(), builder -> {
-            })
+            .before(HaloUtils.noCache(), builder -> builder.operationId("SetNoCacheForSetUpPage"))
             .build();
     }
 


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/area core
/milestone 2.20.x

#### What this PR does / why we need it:

This PR fills operation ID while building setup route to prevent errors when generating OpenAPI docs.

```java
2024-10-13T22:09:46.997+08:00 ERROR 68966 --- [     parallel-4] a.w.r.e.AbstractErrorWebExceptionHandler : [88654f05-3]  500 Server Error for HTTP GET "/v3/api-docs/apis_aggregated.api_v1alpha1"

java.lang.IllegalStateException: You should either fill, the Operation or at least the bean class and the bean method
	at org.springdoc.core.fn.builders.operation.Builder.build(Builder.java:467) ~[springdoc-openapi-starter-common-2.6.0.jar:2.6.0]
	Suppressed: reactor.core.publisher.FluxOnAssembly$OnAssemblyException: 
```

#### Does this PR introduce a user-facing change?

```release-note
None
```
