### PR TITLE
fix: retain legacy enabled field for auth provider setting

### DIFF
--- a/api/src/main/java/run/halo/app/infra/SystemSetting.java
+++ b/api/src/main/java/run/halo/app/infra/SystemSetting.java
@@ -3,6 +3,8 @@ package run.halo.app.infra;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
 import lombok.Data;
 import lombok.experimental.Accessors;
 import org.springframework.boot.convert.ApplicationConversionService;
@@ -114,7 +116,34 @@ public class SystemSetting {
     @Data
     public static class AuthProvider {
         public static final String GROUP = "authProvider";
+        /**
+         * Currently keep it to be compatible with the reference of the plugin.
+         *
+         * @deprecated Use {@link #getStates()} instead.
+         */
+        @Deprecated(since = "2.20.0", forRemoval = true)
+        private Set<String> enabled;
+
         private List<AuthProviderState> states;
+
+        /**
+         * <p>To be compatible with the old version of the enabled field and retained,
+         * since 2.20.0 version, we uses the states field, so the data needs to be synchronized
+         * to the enabled field, and this method needs to be deleted when the enabled field is
+         * removed.</p>
+         *
+         * @deprecated Use {@link #getStates()} instead.
+         */
+        @Deprecated(since = "2.20.0", forRemoval = true)
+        public Set<String> getEnabled() {
+            if (states == null) {
+                return enabled;
+            }
+            return this.states.stream()
+                .filter(AuthProviderState::isEnabled)
+                .map(AuthProviderState::getName)
+                .collect(Collectors.toSet());
+        }
     }
 
     @Data

--- a/application/src/test/java/run/halo/app/security/AuthProviderServiceImplTest.java
+++ b/application/src/test/java/run/halo/app/security/AuthProviderServiceImplTest.java
@@ -66,6 +66,7 @@ class AuthProviderServiceImplTest {
         ConfigMap value = captor.getValue();
         JSONAssert.assertEquals("""
                 {
+                    "enabled":["github"],
                     "states": [
                         {
                             "name": "github",
@@ -102,6 +103,7 @@ class AuthProviderServiceImplTest {
         ConfigMap value = captor.getValue();
         JSONAssert.assertEquals("""
                 {
+                    "enabled":[],
                     "states": [
                         {
                             "name": "github",


### PR DESCRIPTION
#### What type of PR is this?
/kind bug
/area core
/milestone 2.20.x

#### What this PR does / why we need it:
恢复 https://github.com/halo-dev/halo/pull/6846 中删除的 SystemSetting.AuthProvider#enabled 字段避免插件应用到了它可能会发生错误，将其标记为过时

#### Does this PR introduce a user-facing change?
```release-note
None
```
