### PR TITLE
fix: preventing access to login page after Halo setup

### DIFF
--- a/application/src/main/resources/extensions/system-configurable-configmap.yaml
+++ b/application/src/main/resources/extensions/system-configurable-configmap.yaml
@@ -51,3 +51,11 @@ data:
     {
       "search-engine": ["search-engine-lucene"]
     }
+  authProvider: |
+    {
+      "states": [{
+          "name": "local",
+          "enabled": true,
+          "priority": 0
+      }]
+    }

--- a/application/src/test/java/run/halo/app/security/AuthProviderServiceImplTest.java
+++ b/application/src/test/java/run/halo/app/security/AuthProviderServiceImplTest.java
@@ -10,12 +10,14 @@ import static org.mockito.Mockito.when;
 
 import java.util.HashMap;
 import org.json.JSONException;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.skyscreamer.jsonassert.JSONAssert;
+import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.data.domain.Sort;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
@@ -28,6 +30,7 @@ import run.halo.app.extension.ConfigMap;
 import run.halo.app.extension.ListOptions;
 import run.halo.app.extension.Metadata;
 import run.halo.app.extension.ReactiveExtensionClient;
+import run.halo.app.infra.SystemConfigurableEnvironmentFetcher;
 import run.halo.app.infra.SystemSetting;
 import run.halo.app.infra.utils.JsonUtils;
 
@@ -43,8 +46,19 @@ class AuthProviderServiceImplTest {
     @Mock
     ReactiveExtensionClient client;
 
+    @Mock
+    ObjectProvider<SystemConfigurableEnvironmentFetcher> systemFetchProvider;
+
+    @Mock
+    SystemConfigurableEnvironmentFetcher systemConfigFetcher;
+
     @InjectMocks
     AuthProviderServiceImpl authProviderService;
+
+    @BeforeEach
+    void setUp() {
+        when(systemFetchProvider.getIfUnique()).thenReturn(systemConfigFetcher);
+    }
 
     @Test
     void testEnable() throws JSONException {
@@ -199,7 +213,7 @@ class AuthProviderServiceImplTest {
     void pileSystemConfigMap() {
         ConfigMap configMap = new ConfigMap();
         configMap.setData(new HashMap<>());
-        when(client.fetch(eq(ConfigMap.class), eq(SystemSetting.SYSTEM_CONFIG)))
+        when(systemConfigFetcher.getConfigMap())
             .thenReturn(Mono.just(configMap));
     }
 }


### PR DESCRIPTION
#### What type of PR is this?
/kind bug
/area core
/milestone 2.20.x

#### What this PR does / why we need it:
修复初始化 Halo 之后无法进入登录页面的问题

此问题原因是更改了 AuthProvider 的逻辑，当系统启动之后缺少默认的登录方式导致登录页面无法正确渲染
此 PR 将确保默认的登录方式始终存在来解决此问题

how to test it?
重新初始化 Halo 之后能正确渲染登录页面并登录即为符合预期

#### Does this PR introduce a user-facing change?
```release-note
修复初始化 Halo 之后无法进入登录页面的问题
```
