### PR TITLE
Fix the problem of not being able to disconnect OAuth2 user

### DIFF
--- a/application/src/main/resources/extensions/role-template-authenticated.yaml
+++ b/application/src/main/resources/extensions/role-template-authenticated.yaml
@@ -29,7 +29,7 @@ rules:
     resources: [ "plugins/bundle.js", "plugins/bundle.css" ]
     resourceNames: [ "-" ]
     verbs: [ "get" ]
-  - apisGroups: [ "uc.api.auth.halo.run" ]
+  - apiGroups: [ "uc.api.auth.halo.run" ]
     resources: [ "user-connections/disconnect" ]
     verbs: [ "update" ]
 ---


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/area core
/milestone 2.20.x

#### What this PR does / why we need it:

This PR corrects typo of `apisGroups` to `apiGroups` to fix the problem of not being able to disconnect OAuth2 user.

#### Special notes for your reviewer:

0. Install OAuth2 plugin
1. Log in as a normal user
2. Bind a OAuth2 user
3. Try to unbind it

#### Does this PR introduce a user-facing change?

```release-note
修复无法正常解绑 OAuth2 用户
```
