### PR TITLE
Fix the problem of not being able to create PAT for OAuth2 user

### DIFF
--- a/application/src/main/java/run/halo/app/security/authorization/AuthorityUtils.java
+++ b/application/src/main/java/run/halo/app/security/authorization/AuthorityUtils.java
@@ -4,9 +4,6 @@ import java.util.Collection;
 import java.util.Set;
 import java.util.stream.Collectors;
 import org.apache.commons.lang3.StringUtils;
-import org.springframework.security.authentication.RememberMeAuthenticationToken;
-import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
-import org.springframework.security.core.Authentication;
 import org.springframework.security.core.GrantedAuthority;
 
 /**
@@ -51,14 +48,4 @@ public enum AuthorityUtils {
         return roles.contains(SUPER_ROLE_NAME);
     }
 
-    /**
-     * Check if the authentication is a real user.
-     *
-     * @param authentication current authentication
-     * @return true if the authentication is a real user; false otherwise
-     */
-    public static boolean isRealUser(Authentication authentication) {
-        return authentication instanceof UsernamePasswordAuthenticationToken
-            || authentication instanceof RememberMeAuthenticationToken;
-    }
 }

--- a/application/src/test/java/run/halo/app/security/authorization/AuthorityUtilsTest.java
+++ b/application/src/test/java/run/halo/app/security/authorization/AuthorityUtilsTest.java
@@ -3,16 +3,12 @@ package run.halo.app.security.authorization;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.Mockito.mock;
 import static run.halo.app.security.authorization.AuthorityUtils.authoritiesToRoles;
 import static run.halo.app.security.authorization.AuthorityUtils.containsSuperRole;
-import static run.halo.app.security.authorization.AuthorityUtils.isRealUser;
 
 import java.util.List;
 import java.util.Set;
 import org.junit.jupiter.api.Test;
-import org.springframework.security.authentication.RememberMeAuthenticationToken;
-import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 
 class AuthorityUtilsTest {
@@ -39,9 +35,4 @@ class AuthorityUtilsTest {
         assertFalse(containsSuperRole(Set.of("admin")));
     }
 
-    @Test
-    void shouldReturnTrueWhenAuthenticationIsRealUser() {
-        assertTrue(isRealUser(mock(UsernamePasswordAuthenticationToken.class)));
-        assertTrue(isRealUser(mock(RememberMeAuthenticationToken.class)));
-    }
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/area core
/milestone 2.20.x

#### What this PR does / why we need it:

This PR refactors check of whether the current user is a real user to fix the problem of not being able to create PAT for OAuth2 user.

#### Does this PR introduce a user-facing change?

```release-note
修复通过 OAuth2 登录之后无法正常创建和恢复个人令牌的问题
```
