### PR TITLE
chore: bump app store plugin version

### DIFF
--- a/application/build.gradle
+++ b/application/build.gradle
@@ -128,7 +128,7 @@ ext.presetPluginUrls = [
         // Currently, plugin-app-store is not open source, so we need to download it from the official website.
         // Please see https://github.com/halo-dev/plugin-app-store/issues/55
         // https://www.halo.run/store/apps/app-VYJbF
-        'https://www.halo.run/store/apps/app-VYJbF/releases/download/app-release-CZSAd/assets/app-release-CZSAd-KZEqI': 'appstore.jar',
+        'https://www.halo.run/store/apps/app-VYJbF/releases/download/app-release-dEEUO/assets/app-release-dEEUO-ZRgkG': 'appstore.jar',
 ]
 
 tasks.register('downloadPluginPresets', Download) {


### PR DESCRIPTION
#### What type of PR is this?

/area core
/kind improvement
/milestone 2.20.x

#### What this PR does / why we need it:

Bump app store plugin to 1.6.0

#### Does this PR introduce a user-facing change?

```release-note
None
```
