### PR TITLE
fix: prevent initialization failure when theme directory already exists

### DIFF
--- a/application/src/main/java/run/halo/app/theme/service/ThemeServiceImpl.java
+++ b/application/src/main/java/run/halo/app/theme/service/ThemeServiceImpl.java
@@ -47,6 +47,7 @@ import run.halo.app.extension.ReactiveExtensionClient;
 import run.halo.app.extension.Unstructured;
 import run.halo.app.infra.SystemVersionSupplier;
 import run.halo.app.infra.ThemeRootGetter;
+import run.halo.app.infra.exception.ThemeAlreadyExistsException;
 import run.halo.app.infra.exception.ThemeUpgradeException;
 import run.halo.app.infra.exception.UnsatisfiedAttributeValueException;
 import run.halo.app.infra.properties.HaloProperties;
@@ -84,6 +85,10 @@ public class ThemeServiceImpl implements ThemeService {
             ))
             .onErrorResume(IOException.class, e -> {
                 log.warn("Failed to initialize theme from {}", location, e);
+                return Mono.empty();
+            })
+            .onErrorResume(ThemeAlreadyExistsException.class, e -> {
+                log.warn("Failed to initialize theme from {}, because it already exists", location);
                 return Mono.empty();
             })
             .then();


### PR DESCRIPTION
#### What type of PR is this?
/kind bug
/area core
/milestone 2.20.x

#### What this PR does / why we need it:
修复从旧版本升级到 2.20 会因为默认主题目录已经存在而无法初始化的问题

#### Which issue(s) this PR fixes:
Fixes #6887

#### Does this PR introduce a user-facing change?
```release-note
修复从旧版本升级到 2.20 会因为默认主题目录已经存在而无法初始化的问题
```
