### PR TITLE
fix: language preference is not remembered under non-HTTPS connections

### DIFF
--- a/application/src/main/java/run/halo/app/infra/webfilter/LocaleChangeWebFilter.java
+++ b/application/src/main/java/run/halo/app/infra/webfilter/LocaleChangeWebFilter.java
@@ -45,15 +45,19 @@ public class LocaleChangeWebFilter implements WebFilter {
                     .getFirst(LANGUAGE_PARAMETER_NAME);
                 if (StringUtils.hasText(language)) {
                     var locale = Locale.forLanguageTag(language);
-                    exchange.getResponse()
-                        .addCookie(ResponseCookie.from(LANGUAGE_COOKIE_NAME, locale.toLanguageTag())
-                            .path("/")
-                            .secure(true)
-                            .build()
-                        );
+                    setLanguageCookie(exchange, locale);
                 }
             })
             .then(Mono.defer(() -> chain.filter(exchange)));
     }
 
+    void setLanguageCookie(ServerWebExchange exchange, Locale locale) {
+        var cookie = ResponseCookie.from(LANGUAGE_COOKIE_NAME, locale.toLanguageTag())
+            .path("/")
+            .httpOnly(true)
+            .secure("https".equalsIgnoreCase(exchange.getRequest().getURI().getScheme()))
+            .sameSite("Lax")
+            .build();
+        exchange.getResponse().getCookies().set(LANGUAGE_COOKIE_NAME, cookie);
+    }
 }


### PR DESCRIPTION
#### What type of PR is this?
/kind bug
/area core
/milestone 2.20.x

#### What this PR does / why we need it:
修复非 HTTPS 连接下无法记住用户语言偏好的问题

#### Which issue(s) this PR fixes:
Fixes #6888

#### Does this PR introduce a user-facing change?
```release-note
修复非 HTTPS 连接下无法记住用户语言偏好的问题
```
