### PR TITLE
Bind sign up data instead of building by hand

### DIFF
--- a/api/src/main/java/run/halo/app/core/user/service/SignUpData.java
+++ b/api/src/main/java/run/halo/app/core/user/service/SignUpData.java
@@ -13,10 +13,7 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 import java.util.Objects;
-import java.util.Optional;
 import lombok.Data;
-import org.springframework.util.MultiValueMap;
-import org.springframework.util.StringUtils;
 import run.halo.app.infra.ValidationUtils;
 
 /**
@@ -51,35 +48,6 @@ public class SignUpData {
 
     @NotBlank
     private String confirmPassword;
-
-    public static SignUpData of(MultiValueMap<String, String> formData) {
-        var form = new SignUpData();
-        Optional.ofNullable(formData.getFirst("username"))
-            .filter(StringUtils::hasText)
-            .ifPresent(form::setUsername);
-
-        Optional.ofNullable(formData.getFirst("displayName"))
-            .filter(StringUtils::hasText)
-            .ifPresent(form::setDisplayName);
-
-        Optional.ofNullable(formData.getFirst("email"))
-            .filter(StringUtils::hasText)
-            .ifPresent(form::setEmail);
-
-        Optional.ofNullable(formData.getFirst("password"))
-            .filter(StringUtils::hasText)
-            .ifPresent(form::setPassword);
-
-        Optional.ofNullable(formData.getFirst("emailCode"))
-            .filter(StringUtils::hasText)
-            .ifPresent(form::setEmailCode);
-
-        Optional.ofNullable(formData.getFirst("confirmPassword"))
-            .filter(StringUtils::hasText)
-            .ifPresent(form::setConfirmPassword);
-
-        return form;
-    }
 
     @Target({ElementType.TYPE})
     @Retention(RetentionPolicy.RUNTIME)

--- a/application/src/main/java/run/halo/app/security/preauth/PreAuthSignUpEndpoint.java
+++ b/application/src/main/java/run/halo/app/security/preauth/PreAuthSignUpEndpoint.java
@@ -79,8 +79,7 @@ class PreAuthSignUpEndpoint {
             .POST(
                 "",
                 contentType(APPLICATION_FORM_URLENCODED),
-                request -> request.formData()
-                    .map(SignUpData::of)
+                request -> request.bind(SignUpData.class)
                     .flatMap(signUpData -> {
                         // sign up
                         var bindingResult = validate(signUpData, validator, request.exchange());


### PR DESCRIPTION
#### What type of PR is this?

/kind improvement
/area core
/milestone 2.20.x

#### What this PR does / why we need it:

This PR refactors sign up data binding using internal `bind` method in `ServerRequest` instead of binding my hand. It's more convenient and simpler.

#### Does this PR introduce a user-facing change?

```release-note
None
```
