### PR TITLE
Fix the problem of not redirecting to corresponding login page after authentication failure

### DIFF
--- a/application/src/main/java/run/halo/app/security/authentication/login/UsernamePasswordHandler.java
+++ b/application/src/main/java/run/halo/app/security/authentication/login/UsernamePasswordHandler.java
@@ -65,12 +65,12 @@ public class UsernamePasswordHandler implements ServerAuthenticationSuccessHandl
                 .filter(ServerWebExchangeMatcher.MatchResult::isMatch)
                 .switchIfEmpty(Mono.defer(
                     () -> {
-                        URI location = URI.create("/login?error");
+                        URI location = URI.create("/login?error&method=local");
                         if (exception instanceof BadCredentialsException) {
-                            location = URI.create("/login?error=invalid-credential");
+                            location = URI.create("/login?error=invalid-credential&method=local");
                         }
                         if (exception instanceof TooManyRequestsException) {
-                            location = URI.create("/login?error=rate-limit-exceeded");
+                            location = URI.create("/login?error=rate-limit-exceeded&method=local");
                         }
                         return redirectStrategy.sendRedirect(exchange, location);
                     }).then(Mono.empty())


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/area core
/milestone 2.20.x

#### What this PR does / why we need it:

This PR appends query `method=local` after redirection location in authentication failure handler to redirect to login page with local method.

#### Which issue(s) this PR fixes:

Fixes https://github.com/halo-dev/halo/issues/6894

#### Does this PR introduce a user-facing change?

```release-note
修复非默认登录方式登录失败之后跳转至默认登录方式的问题
```
