### PR TITLE
fix: modify name column charset to make it case-sensitive for MySQL

### DIFF
--- a/application/src/main/resources/schema-mariadb.sql
+++ b/application/src/main/resources/schema-mariadb.sql
@@ -1,6 +1,6 @@
 create table if not exists extensions
 (
-    name    varchar(255) not null,
+    name    varchar(255) not null COLLATE utf8mb4_bin,
     data    longblob,
     version bigint,
     primary key (name)

--- a/application/src/main/resources/schema-mysql.sql
+++ b/application/src/main/resources/schema-mysql.sql
@@ -1,6 +1,6 @@
 create table if not exists extensions
 (
-    name    varchar(255) not null,
+    name    varchar(255) not null COLLATE utf8mb4_bin,
     data    longblob,
     version bigint,
     primary key (name)


### PR DESCRIPTION
#### What type of PR is this?
/kind improvement
/area core
/milestone 2.20.x

#### What this PR does / why we need it:
将 MySQL 的表创建脚本 name 列字符集改为 utf8mb4_bin 以使其对大小写敏感

Fixes https://github.com/halo-dev/halo/issues/4372

**how to test it?**
使用 docker 运行 MySQL
```shell
# mariadb 同样将镜像改为 mariadb 后执行相同步骤
docker run --name mysql-test -e MYSQL_ROOT_PASSWORD=root -e MYSQL_DATABASE=halo -p 3306:3306 --rm -d mysql:latest
```
然后执行表创建脚本并手动执行以下两条 SQL 能成功插入
```sql
insert into extensions(name,data,version) values('a', 'a', 0)
insert into extensions(name,data,version) values('A', 'A', 0)
```

#### Does this PR introduce a user-facing change?
```release-note
修改 MySQL 表创建脚本 name 列的字符集使其大小写敏感以解决可能会遇到切换数据库时因为数据冲突而无法导入备份的问题（这只对此版本及之后的新用户有效）
```
