### PR TITLE
fix: can not return to post list after publishing when re-logged in

### DIFF
--- a/ui/console-src/modules/contents/pages/SinglePageEditor.vue
+++ b/ui/console-src/modules/contents/pages/SinglePageEditor.vue
@@ -223,7 +223,7 @@ const handlePublish = async () => {
       if (returnToView.value && permalink) {
         window.location.href = permalink;
       } else {
-        router.back();
+        router.push({ name: "SinglePages" });
       }
     } else {
       formState.value.page.spec.publish = true;

--- a/ui/console-src/modules/contents/posts/PostEditor.vue
+++ b/ui/console-src/modules/contents/posts/PostEditor.vue
@@ -236,7 +236,7 @@ const handlePublish = async () => {
       if (returnToView.value === "true" && permalink) {
         window.location.href = permalink;
       } else {
-        router.back();
+        router.push({ name: "Posts" });
       }
     } else {
       const { data } = await consoleApiClient.content.post.draftPost({


### PR DESCRIPTION
#### What type of PR is this?

/area ui
/kind bug
/milestone 2.20.x

#### What this PR does / why we need it:

修复通过登录跳转到文章编辑页面时，发布文章会跳转到个人中心的问题。

#### Which issue(s) this PR fixes:

Fixes #6901 

#### Special notes for your reviewer:

测试步骤：

1. 新建文章，编写内容，但是不发布
2. 在新的浏览器选项卡中退出登录
3. 回到文章编辑页面，跳转到登录页面重新登录之后，发布文章
4. 观察是否会返回到 Console 的文章管理页面。

#### Does this PR introduce a user-facing change?

```release-note
修复通过登录跳转到文章编辑页面时，发布文章会跳转到个人中心的问题。
```
