### PR TITLE
fix: resolve button height overflow in signup form on older Safari

### DIFF
--- a/application/src/main/resources/static/styles/main.css
+++ b/application/src/main/resources/static/styles/main.css
@@ -234,6 +234,7 @@
     grid-template-columns: repeat(3, minmax(0, 1fr));
     align-items: center;
     display: grid;
+    height: 2.5em;
 }
 
 .halo-form .form-input {


### PR DESCRIPTION
#### What type of PR is this?

/area core
/kind bug
/milestone 2.20.x

#### What this PR does / why we need it:

修复在低版本 Safari 浏览器中，注册表单中的按钮高度溢出的问题。

#### Which issue(s) this PR fixes:

Fixes #6910 

#### Does this PR introduce a user-facing change?

```release-note
修复在低版本 Safari 浏览器中，注册表单中的按钮高度溢出的问题。
```

<!-- Fuck Safari -->