### PR TITLE
Exclude console and uc assets in security configuration

### DIFF
--- a/application/src/main/java/run/halo/app/infra/config/WebServerSecurityConfig.java
+++ b/application/src/main/java/run/halo/app/infra/config/WebServerSecurityConfig.java
@@ -59,6 +59,8 @@ public class WebServerSecurityConfig {
 
         var pathMatcher = pathMatchers("/**");
         var staticResourcesMatcher = pathMatchers(HttpMethod.GET,
+            "/console/assets/**",
+            "/uc/assets/**",
             "/themes/{themeName}/assets/{*resourcePaths}",
             "/plugins/{pluginName}/assets/**",
             "/upload/**",


### PR DESCRIPTION
#### What type of PR is this?

/kind improvement
/area core
/milestone 2.20.x

#### What this PR does / why we need it:

This PR excludes console and uc assets in security configuration to make them access by anonymous users.

#### Which issue(s) this PR fixes:

Fixes https://github.com/halo-dev/halo/issues/6908

#### Special notes for your reviewer:

```bash
http http://localhost:8090/uc/assets/index-E-uvwInx.css -ph

HTTP/1.1 200 OK
Accept-Ranges: bytes
Cache-Control: no-cache
Content-Encoding: gzip
Content-Length: 26213
Content-Type: text/css
Vary: Accept-Encoding
```

#### Does this PR introduce a user-facing change?

```release-note
None
```
