### PR TITLE
Support nested configuration properties

### DIFF
--- a/application/src/main/java/run/halo/app/infra/properties/ConsoleProperties.java
+++ b/application/src/main/java/run/halo/app/infra/properties/ConsoleProperties.java
@@ -2,6 +2,7 @@ package run.halo.app.infra.properties;
 
 import jakarta.validation.Valid;
 import lombok.Data;
+import org.springframework.boot.context.properties.NestedConfigurationProperty;
 
 @Data
 public class ConsoleProperties {
@@ -9,6 +10,7 @@ public class ConsoleProperties {
     private String location = "classpath:/console/";
 
     @Valid
+    @NestedConfigurationProperty
     private ProxyProperties proxy = new ProxyProperties();
 
 }

--- a/application/src/main/java/run/halo/app/infra/properties/HaloProperties.java
+++ b/application/src/main/java/run/halo/app/infra/properties/HaloProperties.java
@@ -9,6 +9,7 @@ import java.util.HashSet;
 import java.util.Set;
 import lombok.Data;
 import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.context.properties.NestedConfigurationProperty;
 import org.springframework.validation.Errors;
 import org.springframework.validation.Validator;
 import org.springframework.validation.annotation.Validated;
@@ -45,21 +46,27 @@ public class HaloProperties implements Validator {
     private boolean requiredExtensionDisabled;
 
     @Valid
+    @NestedConfigurationProperty
     private final ExtensionProperties extension = new ExtensionProperties();
 
     @Valid
+    @NestedConfigurationProperty
     private final SecurityProperties security = new SecurityProperties();
 
     @Valid
+    @NestedConfigurationProperty
     private final ConsoleProperties console = new ConsoleProperties();
 
     @Valid
+    @NestedConfigurationProperty
     private final UcProperties uc = new UcProperties();
 
     @Valid
+    @NestedConfigurationProperty
     private final ThemeProperties theme = new ThemeProperties();
 
     @Valid
+    @NestedConfigurationProperty
     private final AttachmentProperties attachment = new AttachmentProperties();
 
     @Override


### PR DESCRIPTION
#### What type of PR is this?

/kind improvement
/area core
/milestone 2.20.x

#### What this PR does / why we need it:

This PR adds the annotations `@NestedConfigurationProperties` to let Spring Configuration Processor generate fully metadata.

We can execute command `./gradlew :application:compileJava` to generate `application/build/classes/java/main/META-INF/spring-configuration-metadata.json`. If you are using IDEA Ultimate, configuration hints related to Halo will be available.

#### Does this PR introduce a user-facing change?

```release-note
None
```
