### PR TITLE
Support pushing Docker image into Fit2Cloud Docker Registry

### DIFF
--- a/.github/actions/docker-buildx-push/action.yaml
+++ b/.github/actions/docker-buildx-push/action.yaml
@@ -14,6 +14,14 @@ inputs:
     description: Token for the DockerHub account
     required: false
     default: ""
+  f2c-registry-user:
+    description: "User name of Fit2Cloud Docker Registry."
+    required: false
+    default: ""
+  f2c-registry-token:
+    description: "Token of Fit2Cloud Docker Registry."
+    required: false
+    default: ""
   push:
     description: Should push the docker image or not.
     required: false
@@ -37,6 +45,7 @@ runs:
         images: |
           ghcr.io/${{ github.repository_owner }}/${{ inputs.image-name }}
           halohub/${{ inputs.image-name }}
+          registry.fit2cloud.com/halo/${{ inputs.image-name }}
         tags: |
           type=schedule,pattern=nightly-{{date 'YYYYMMDD'}},enabled=${{ github.event_name == 'schedule' }}
           type=ref,event=branch,enabled=${{ github.event_name == 'push' }}
@@ -64,6 +73,12 @@ runs:
       with:
         username: ${{ inputs.dockerhub-user }}
         password: ${{ inputs.dockerhub-token }}
+    - name: Login to Fit2Cloud Docker Registry
+      if: inputs.f2c-registry-token != '' && github.event_name != 'pull_request'
+      uses: docker/login-action@v3
+      with:
+        username: ${{ inputs.f2c-registry-username }}
+        password: ${{ inputs.f2c-registry-token }}
     - name: Build and push
       uses: docker/build-push-action@v5
       with:

--- a/.github/workflows/halo.yaml
+++ b/.github/workflows/halo.yaml
@@ -98,6 +98,8 @@ jobs:
           ghcr-token: ${{ secrets.GITHUB_TOKEN }}
           dockerhub-user: ${{ secrets.DOCKER_USERNAME }}
           dockerhub-token: ${{ secrets.DOCKER_TOKEN }}
+          f2c-registry-user: ${{ secrets.F2C_REGISTRY_USER }}
+          f2c-registry-token: ${{ secrets.F2C_REGISTRY_TOKEN }}
           push: true
           platforms: linux/amd64,linux/arm64/v8,linux/ppc64le,linux/s390x
 


### PR DESCRIPTION
#### What type of PR is this?

/kind improvement
/area core
/milestone 2.20.x

#### What this PR does / why we need it:

This PR adds Fit2Cloud Docker Registry into build stage in Halo workflow.

Before it works, we need to configure Action secrets `F2C_REGISTRY_USER` and `F2C_REGISTRY_TOKEN` in current repository.

#### Does this PR introduce a user-facing change?

```release-note
None
```
