### PR TITLE
fix: prioritize login page route to prevent single page override

### DIFF
--- a/application/src/main/java/run/halo/app/security/preauth/PreAuthEmailPasswordResetEndpoint.java
+++ b/application/src/main/java/run/halo/app/security/preauth/PreAuthEmailPasswordResetEndpoint.java
@@ -18,6 +18,8 @@ import java.util.Objects;
 import lombok.Data;
 import org.springframework.context.MessageSource;
 import org.springframework.context.annotation.Bean;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.server.reactive.ServerHttpRequest;
@@ -55,6 +57,7 @@ class PreAuthEmailPasswordResetEndpoint {
     }
 
     @Bean
+    @Order(Ordered.HIGHEST_PRECEDENCE + 100)
     RouterFunction<ServerResponse> preAuthPasswordResetEndpoints(
         GlobalInfoService globalInfoService,
         PasswordResetAvailabilityProviders availabilityProviders,

--- a/application/src/main/java/run/halo/app/security/preauth/PreAuthLoginEndpoint.java
+++ b/application/src/main/java/run/halo/app/security/preauth/PreAuthLoginEndpoint.java
@@ -8,6 +8,8 @@ import java.util.Objects;
 import java.util.Optional;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.context.annotation.Bean;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
 import org.springframework.security.web.server.savedrequest.ServerRequestCache;
 import org.springframework.stereotype.Component;
 import org.springframework.web.reactive.function.server.RouterFunction;
@@ -53,6 +55,7 @@ class PreAuthLoginEndpoint {
     }
 
     @Bean
+    @Order(Ordered.HIGHEST_PRECEDENCE + 100)
     RouterFunction<ServerResponse> preAuthLoginEndpoints() {
         return RouterFunctions.nest(path("/login"), RouterFunctions.route()
             .GET("", request -> {

--- a/application/src/main/java/run/halo/app/security/preauth/PreAuthSignUpEndpoint.java
+++ b/application/src/main/java/run/halo/app/security/preauth/PreAuthSignUpEndpoint.java
@@ -14,6 +14,8 @@ import jakarta.validation.constraints.NotBlank;
 import java.net.URI;
 import lombok.Data;
 import org.springframework.context.annotation.Bean;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.server.reactive.ServerHttpRequest;
 import org.springframework.stereotype.Component;
@@ -67,6 +69,7 @@ class PreAuthSignUpEndpoint {
     }
 
     @Bean
+    @Order(Ordered.HIGHEST_PRECEDENCE + 100)
     RouterFunction<ServerResponse> preAuthSignUpEndpoints() {
         return RouterFunctions.nest(path("/signup"), RouterFunctions.route()
             .GET("", request -> {

--- a/application/src/main/java/run/halo/app/security/preauth/PreAuthTwoFactorEndpoint.java
+++ b/application/src/main/java/run/halo/app/security/preauth/PreAuthTwoFactorEndpoint.java
@@ -2,6 +2,8 @@ package run.halo.app.security.preauth;
 
 import java.util.Map;
 import org.springframework.context.annotation.Bean;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
 import org.springframework.stereotype.Component;
 import org.springframework.web.reactive.function.server.RouterFunction;
 import org.springframework.web.reactive.function.server.RouterFunctions;
@@ -19,6 +21,7 @@ import run.halo.app.infra.utils.HaloUtils;
 class PreAuthTwoFactorEndpoint {
 
     @Bean
+    @Order(Ordered.HIGHEST_PRECEDENCE + 100)
     RouterFunction<ServerResponse> preAuthTwoFactorEndpoints(GlobalInfoService globalInfoService) {
         return RouterFunctions.route()
             .GET("/challenges/two-factor/totp",

--- a/application/src/main/java/run/halo/app/security/preauth/SystemSetupEndpoint.java
+++ b/application/src/main/java/run/halo/app/security/preauth/SystemSetupEndpoint.java
@@ -30,6 +30,8 @@ import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.beans.factory.config.PlaceholderConfigurerSupport;
 import org.springframework.boot.autoconfigure.r2dbc.R2dbcConnectionDetails;
 import org.springframework.context.annotation.Bean;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
 import org.springframework.core.io.ClassPathResource;
 import org.springframework.dao.OptimisticLockingFailureException;
 import org.springframework.http.HttpStatus;
@@ -86,6 +88,7 @@ public class SystemSetupEndpoint {
     private final ObjectProvider<R2dbcConnectionDetails> connectionDetails;
 
     @Bean
+    @Order(Ordered.HIGHEST_PRECEDENCE + 100)
     RouterFunction<ServerResponse> setupPageRouter() {
         final var tag = "SystemV1alpha1Public";
         return SpringdocRouteBuilder.route()


### PR DESCRIPTION
#### What type of PR is this?
/kind bug
/area core
/milestone 2.20.x

#### What this PR does / why we need it:
修复登录页面路由会被自定义页面覆盖导致无法登录的问题

#### Which issue(s) this PR fixes:
Fixes #6893

#### Does this PR introduce a user-facing change?
```release-note
修复登录页面路由会被自定义页面路由覆盖导致无法登录的问题
```
