### PR TITLE
fix: remove httpOnly from language cookie to allow JS to access current language

### DIFF
--- a/application/src/main/java/run/halo/app/infra/webfilter/LocaleChangeWebFilter.java
+++ b/application/src/main/java/run/halo/app/infra/webfilter/LocaleChangeWebFilter.java
@@ -54,7 +54,6 @@ public class LocaleChangeWebFilter implements WebFilter {
     void setLanguageCookie(ServerWebExchange exchange, Locale locale) {
         var cookie = ResponseCookie.from(LANGUAGE_COOKIE_NAME, locale.toLanguageTag())
             .path("/")
-            .httpOnly(true)
             .secure("https".equalsIgnoreCase(exchange.getRequest().getURI().getScheme()))
             .sameSite("Lax")
             .build();


### PR DESCRIPTION
#### What type of PR is this?
/kind bug
/area core
/milestone 2.20.x

#### What this PR does / why we need it:
修复登录时切换了其他语言但是登录成功后始终显示中文的问题

此问题为 https://github.com/halo-dev/halo/pull/6891 导致

#### Does this PR introduce a user-facing change?
```release-note
修复登录时切换了其他语言但是登录成功后始终显示中文的问题
```
