### PR TITLE
fix: leading zeroes incorrect for index key comparator

### DIFF
--- a/api/src/main/java/run/halo/app/extension/index/KeyComparator.java
+++ b/api/src/main/java/run/halo/app/extension/index/KeyComparator.java
@@ -60,14 +60,6 @@ public class KeyComparator implements Comparator<String> {
         int i = startA;
         int j = startB;
 
-        // Skip leading zeros for both numbers
-        while (i < a.length() && a.charAt(i) == '0') {
-            i++;
-        }
-        while (j < b.length() && b.charAt(j) == '0') {
-            j++;
-        }
-
         // Compare lengths of remaining digits
         int lengthA = countDigits(a, i);
         int lengthB = countDigits(b, j);
@@ -114,13 +106,6 @@ public class KeyComparator implements Comparator<String> {
         int i = startA;
         int j = startB;
 
-        while (i < pointA && a.charAt(i) == '0') {
-            i++;
-        }
-        while (j < pointB && b.charAt(j) == '0') {
-            j++;
-        }
-
         int lengthA = pointA - i;
         int lengthB = pointB - j;
         if (lengthA != lengthB) {
@@ -150,6 +135,7 @@ public class KeyComparator implements Comparator<String> {
             j++;
         }
 
+        // If one number has more digits left, and they're not all zeroes, it is larger
         while (i < a.length() && Character.isDigit(a.charAt(i))) {
             if (a.charAt(i) != '0') {
                 return 1;

--- a/api/src/test/java/run/halo/app/extension/index/KeyComparatorTest.java
+++ b/api/src/test/java/run/halo/app/extension/index/KeyComparatorTest.java
@@ -388,6 +388,13 @@ class KeyComparatorTest {
             assertThat(comparator.compare("124", "123")).isGreaterThan(0);
             // Leading zeros
             assertThat(comparator.compare("00123", "123") > 0).isTrue();
+            assertThat(comparator.compare("0", "0")).isEqualTo(0);
+            assertThat(comparator.compare("0", "0000")).isLessThan(0);
+            assertThat(comparator.compare("0x", "0")).isGreaterThan(0);
+            assertThat(comparator.compare("0", "1")).isLessThan(0);
+            assertThat(comparator.compare("1", "0")).isGreaterThan(0);
+            assertThat(comparator.compare("001", "0")).isGreaterThan(0);
+            assertThat(comparator.compare("0x5e", "0000")).isLessThan(0);
         }
 
         @Test
@@ -430,6 +437,7 @@ class KeyComparatorTest {
             assertThat(comparator.compare("123.46", "123.45")).isGreaterThan(0);
             // Decimal equivalence
             assertThat(comparator.compare("123.5", "123.50")).isLessThan(0);
+            assertThat(comparator.compare("123.0005", "123.00050")).isLessThan(0);
         }
 
         @Test


### PR DESCRIPTION
#### What type of PR is this?
/kind bug
/area core
/milestone 2.20.x

#### What this PR does / why we need it:
修复索引比较会因为全是 0 的字符串与其他字符串可能相等的问题

原因是遇到了全是 0 的字符串会因为跳过前导 0 的逻辑导致全部忽略了

#### Does this PR introduce a user-facing change?
```release-note
None
```
