### PR TITLE
Rearrange order of security configurers

### DIFF
--- a/application/src/main/java/run/halo/app/security/CorsConfigurer.java
+++ b/application/src/main/java/run/halo/app/security/CorsConfigurer.java
@@ -2,6 +2,7 @@ package run.halo.app.security;
 
 import com.google.common.net.HttpHeaders;
 import java.util.List;
+import org.springframework.core.annotation.Order;
 import org.springframework.security.config.web.server.ServerHttpSecurity;
 import org.springframework.stereotype.Component;
 import org.springframework.web.cors.CorsConfiguration;
@@ -10,6 +11,7 @@ import org.springframework.web.cors.reactive.UrlBasedCorsConfigurationSource;
 import run.halo.app.security.authentication.SecurityConfigurer;
 
 @Component
+@Order(0)
 public class CorsConfigurer implements SecurityConfigurer {
     @Override
     public void configure(ServerHttpSecurity http) {

--- a/application/src/main/java/run/halo/app/security/CsrfConfigurer.java
+++ b/application/src/main/java/run/halo/app/security/CsrfConfigurer.java
@@ -2,6 +2,7 @@ package run.halo.app.security;
 
 import static org.springframework.security.web.server.util.matcher.ServerWebExchangeMatchers.pathMatchers;
 
+import org.springframework.core.annotation.Order;
 import org.springframework.security.config.web.server.ServerHttpSecurity;
 import org.springframework.security.web.server.csrf.CookieServerCsrfTokenRepository;
 import org.springframework.security.web.server.csrf.CsrfWebFilter;
@@ -12,6 +13,7 @@ import org.springframework.stereotype.Component;
 import run.halo.app.security.authentication.SecurityConfigurer;
 
 @Component
+@Order(0)
 class CsrfConfigurer implements SecurityConfigurer {
 
     @Override

--- a/application/src/main/java/run/halo/app/security/ExceptionSecurityConfigurer.java
+++ b/application/src/main/java/run/halo/app/security/ExceptionSecurityConfigurer.java
@@ -5,6 +5,7 @@ import static org.springframework.security.web.server.util.matcher.ServerWebExch
 
 import java.util.ArrayList;
 import org.springframework.context.MessageSource;
+import org.springframework.core.annotation.Order;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.config.web.server.ServerHttpSecurity;
@@ -21,6 +22,7 @@ import run.halo.app.security.authentication.SecurityConfigurer;
 import run.halo.app.security.authentication.twofactor.TwoFactorAuthenticationEntryPoint;
 
 @Component
+@Order(0)
 public class ExceptionSecurityConfigurer implements SecurityConfigurer {
 
     private final MessageSource messageSource;

--- a/application/src/main/java/run/halo/app/security/LogoutSecurityConfigurer.java
+++ b/application/src/main/java/run/halo/app/security/LogoutSecurityConfigurer.java
@@ -7,6 +7,7 @@ import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.Bean;
+import org.springframework.core.annotation.Order;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.security.config.web.server.ServerHttpSecurity;
@@ -31,6 +32,7 @@ import run.halo.app.theme.router.ModelConst;
 
 @Component
 @RequiredArgsConstructor
+@Order(0)
 public class LogoutSecurityConfigurer implements SecurityConfigurer {
     private final RememberMeServices rememberMeServices;
     private final ApplicationContext applicationContext;

--- a/application/src/main/java/run/halo/app/security/SecurityWebFiltersConfigurer.java
+++ b/application/src/main/java/run/halo/app/security/SecurityWebFiltersConfigurer.java
@@ -24,7 +24,7 @@ import run.halo.app.security.authentication.SecurityConfigurer;
 
 @Component
 // Specific an order here to control the order or security configurer initialization
-@Order(-100)
+@Order(100)
 public class SecurityWebFiltersConfigurer implements SecurityConfigurer {
 
     private final ExtensionGetter extensionGetter;

--- a/application/src/main/java/run/halo/app/security/authentication/login/LoginSecurityConfigurer.java
+++ b/application/src/main/java/run/halo/app/security/authentication/login/LoginSecurityConfigurer.java
@@ -3,6 +3,7 @@ package run.halo.app.security.authentication.login;
 import io.github.resilience4j.ratelimiter.RateLimiterRegistry;
 import io.micrometer.observation.ObservationRegistry;
 import org.springframework.context.MessageSource;
+import org.springframework.core.annotation.Order;
 import org.springframework.http.HttpMethod;
 import org.springframework.security.authentication.ObservationReactiveAuthenticationManager;
 import org.springframework.security.authentication.ReactiveAuthenticationManager;
@@ -28,6 +29,7 @@ import run.halo.app.security.authentication.SecurityConfigurer;
 import run.halo.app.security.authentication.twofactor.TwoFactorAuthentication;
 
 @Component
+@Order(0)
 public class LoginSecurityConfigurer implements SecurityConfigurer {
 
     private final ObservationRegistry observationRegistry;

--- a/application/src/main/java/run/halo/app/security/authentication/oauth2/OAuth2SecurityConfigurer.java
+++ b/application/src/main/java/run/halo/app/security/authentication/oauth2/OAuth2SecurityConfigurer.java
@@ -1,5 +1,6 @@
 package run.halo.app.security.authentication.oauth2;
 
+import org.springframework.core.annotation.Order;
 import org.springframework.security.config.web.server.SecurityWebFiltersOrder;
 import org.springframework.security.config.web.server.ServerHttpSecurity;
 import org.springframework.security.core.userdetails.ReactiveUserDetailsService;
@@ -15,6 +16,7 @@ import run.halo.app.security.authentication.SecurityConfigurer;
  * @since 2.20.0
  */
 @Component
+@Order(0)
 class OAuth2SecurityConfigurer implements SecurityConfigurer {
 
     private final ServerSecurityContextRepository securityContextRepository;

--- a/application/src/main/java/run/halo/app/security/authentication/rememberme/RememberMeConfigurer.java
+++ b/application/src/main/java/run/halo/app/security/authentication/rememberme/RememberMeConfigurer.java
@@ -3,6 +3,7 @@ package run.halo.app.security.authentication.rememberme;
 import static org.springframework.security.web.server.util.matcher.ServerWebExchangeMatcher.MatchResult;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.core.annotation.Order;
 import org.springframework.security.config.web.server.SecurityWebFiltersOrder;
 import org.springframework.security.config.web.server.ServerHttpSecurity;
 import org.springframework.security.core.context.ReactiveSecurityContextHolder;
@@ -13,6 +14,7 @@ import run.halo.app.security.authentication.SecurityConfigurer;
 
 @Component
 @RequiredArgsConstructor
+@Order(0)
 public class RememberMeConfigurer implements SecurityConfigurer {
 
     private final RememberMeServices rememberMeServices;

--- a/application/src/main/java/run/halo/app/security/authentication/twofactor/TwoFactorAuthSecurityConfigurer.java
+++ b/application/src/main/java/run/halo/app/security/authentication/twofactor/TwoFactorAuthSecurityConfigurer.java
@@ -2,6 +2,7 @@ package run.halo.app.security.authentication.twofactor;
 
 import static org.springframework.security.web.server.util.matcher.ServerWebExchangeMatchers.pathMatchers;
 
+import org.springframework.core.annotation.Order;
 import org.springframework.http.HttpMethod;
 import org.springframework.security.config.web.server.SecurityWebFiltersOrder;
 import org.springframework.security.config.web.server.ServerHttpSecurity;
@@ -17,6 +18,7 @@ import run.halo.app.security.authentication.twofactor.totp.TotpAuthenticationMan
 import run.halo.app.security.authentication.twofactor.totp.TotpCodeAuthenticationConverter;
 
 @Component
+@Order(0)
 public class TwoFactorAuthSecurityConfigurer implements SecurityConfigurer {
 
     private final ServerSecurityContextRepository securityContextRepository;


### PR DESCRIPTION
#### What type of PR is this?

/kind improvement
/area core
/milestone 2.20.x

#### What this PR does / why we need it:

This PR rearranges order of security configurers. Especially, SecurityWebFiltersConfigurer has lower priority to configure than other security configurers.

So we can catch internal authentication in plugins.

#### Does this PR introduce a user-facing change?

```release-note
None
```
