### PR TITLE
Support hooking user creation

### DIFF
--- a/api/src/main/java/run/halo/app/core/user/service/UserPostCreatingHandler.java
+++ b/api/src/main/java/run/halo/app/core/user/service/UserPostCreatingHandler.java
@@ -1,0 +1,23 @@
+package run.halo.app.core.user.service;
+
+import org.pf4j.ExtensionPoint;
+import reactor.core.publisher.Mono;
+import run.halo.app.core.extension.User;
+
+/**
+ * User post-creating handler.
+ *
+ * @author johnniang
+ * @since 2.20.8
+ */
+public interface UserPostCreatingHandler extends ExtensionPoint {
+
+    /**
+     * Do something after creating user.
+     *
+     * @param user create user.
+     * @return {@code Mono.empty()} if handling successfully.
+     */
+    Mono<Void> postCreating(User user);
+
+}

--- a/api/src/main/java/run/halo/app/core/user/service/UserPreCreatingHandler.java
+++ b/api/src/main/java/run/halo/app/core/user/service/UserPreCreatingHandler.java
@@ -1,0 +1,23 @@
+package run.halo.app.core.user.service;
+
+import org.pf4j.ExtensionPoint;
+import reactor.core.publisher.Mono;
+import run.halo.app.core.extension.User;
+
+/**
+ * User pre-creating handler.
+ *
+ * @author johnniang
+ * @since 2.20.8
+ */
+public interface UserPreCreatingHandler extends ExtensionPoint {
+
+    /**
+     * Do something before user creating.
+     *
+     * @param user modifiable user detail
+     * @return {@code Mono.empty()} if handling successfully.
+     */
+    Mono<Void> preCreating(User user);
+
+}


### PR DESCRIPTION
#### What type of PR is this?

/kind feature
/area core
/milestone 2.20.x

#### What this PR does / why we need it:

This PR adds support for hooking user creating. Plugin developers can define extension points of `UserPreCreatingHandler` and `UserPostCreatingHandler` to do something else.

#### Does this PR introduce a user-facing change?

```release-note
支持在插件中定义用户创建的前置和后置处理器
```
