### PR TITLE
feat: add supports for displaying jpeg icon in attachments list

### DIFF
--- a/ui/src/components/icon/AttachmentFileTypeIcon.vue
+++ b/ui/src/components/icon/AttachmentFileTypeIcon.vue
@@ -35,6 +35,7 @@ import VscodeIconsFileTypeYaml from "~icons/vscode-icons/file-type-yaml";
 const FileTypeIconsMap = {
   // image
   ".jpg": markRaw(VscodeIconsFileTypeImage),
+  ".jpeg": markRaw(VscodeIconsFileTypeImage),
   ".png": markRaw(VscodeIconsFileTypeImage),
   ".gif": markRaw(VscodeIconsFileTypeImage),
   ".webp": markRaw(VscodeIconsFileTypeImage),


### PR DESCRIPTION
#### What type of PR is this?

/kind improvement


#### What this PR does / why we need it:

在附件，列表模式中，为 jpeg 后缀文件添加图标。

#### Which issue(s) this PR fixes:

Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
为 jpeg 后缀文件添加图标
```
