### PR TITLE
feat: add name existence check before creating attachment group and storage policy

### DIFF
--- a/ui/console-src/modules/contents/attachments/components/AttachmentGroupEditingModal.vue
+++ b/ui/console-src/modules/contents/attachments/components/AttachmentGroupEditingModal.vue
@@ -44,15 +44,12 @@ const modalTitle = props.group
 const handleSave = async () => {
   try {
     isSubmitting.value = true;
-    const existingGroupsResponse =
-      await coreApiClient.storage.group.listGroup();
-    const existingGroups = existingGroupsResponse.data.items || [];
-    const nameExists = existingGroups.some(
+    const { data: groups } = await coreApiClient.storage.group.listGroup();
+    const hasDisplayNameDuplicate = groups.items.some(
       (group) => group.spec.displayName === formState.value.spec.displayName
     );
-
-    if (nameExists) {
-      alert("该分组名称已存在，请重新创建!");
+    if (hasDisplayNameDuplicate) {
+      Toast.error(t("core.common.toast.group_name_exists"));
       return;
     }
 

--- a/ui/console-src/modules/contents/attachments/components/AttachmentGroupEditingModal.vue
+++ b/ui/console-src/modules/contents/attachments/components/AttachmentGroupEditingModal.vue
@@ -11,11 +11,9 @@ import { useI18n } from "vue-i18n";
 const props = withDefaults(
   defineProps<{
     group?: Group;
-    isNew?: boolean;
   }>(),
   {
     group: undefined,
-    isNew: false,
   }
 );
 
@@ -46,7 +44,12 @@ const modalTitle = props.group
 const handleSave = async () => {
   try {
     isSubmitting.value = true;
-    if (props.isNew) {
+    if (props.group) {
+      await coreApiClient.storage.group.updateGroup({
+        name: formState.value.metadata.name,
+        group: formState.value,
+      });
+    } else {
       const { data: groups } = await coreApiClient.storage.group.listGroup();
       const hasDisplayNameDuplicate = groups.items.some(
         (group) => group.spec.displayName === formState.value.spec.displayName
@@ -57,14 +60,6 @@ const handleSave = async () => {
         );
         return;
       }
-    }
-
-    if (props.group) {
-      await coreApiClient.storage.group.updateGroup({
-        name: formState.value.metadata.name,
-        group: formState.value,
-      });
-    } else {
       await coreApiClient.storage.group.createGroup({
         group: formState.value,
       });

--- a/ui/console-src/modules/contents/attachments/components/AttachmentGroupEditingModal.vue
+++ b/ui/console-src/modules/contents/attachments/components/AttachmentGroupEditingModal.vue
@@ -11,9 +11,11 @@ import { useI18n } from "vue-i18n";
 const props = withDefaults(
   defineProps<{
     group?: Group;
+    isNew?: boolean;
   }>(),
   {
     group: undefined,
+    isNew: false,
   }
 );
 
@@ -44,15 +46,17 @@ const modalTitle = props.group
 const handleSave = async () => {
   try {
     isSubmitting.value = true;
-    const { data: groups } = await coreApiClient.storage.group.listGroup();
-    const hasDisplayNameDuplicate = groups.items.some(
-      (group) => group.spec.displayName === formState.value.spec.displayName
-    );
-    if (hasDisplayNameDuplicate) {
-      Toast.error(
-        t("core.attachment.group_editing_modal.toast.group_name_exists")
+    if (props.isNew) {
+      const { data: groups } = await coreApiClient.storage.group.listGroup();
+      const hasDisplayNameDuplicate = groups.items.some(
+        (group) => group.spec.displayName === formState.value.spec.displayName
       );
-      return;
+      if (hasDisplayNameDuplicate) {
+        Toast.error(
+          t("core.attachment.group_editing_modal.toast.group_name_exists")
+        );
+        return;
+      }
     }
 
     if (props.group) {

--- a/ui/console-src/modules/contents/attachments/components/AttachmentGroupEditingModal.vue
+++ b/ui/console-src/modules/contents/attachments/components/AttachmentGroupEditingModal.vue
@@ -49,7 +49,9 @@ const handleSave = async () => {
       (group) => group.spec.displayName === formState.value.spec.displayName
     );
     if (hasDisplayNameDuplicate) {
-      Toast.error(t("core.common.toast.group_name_exists"));
+      Toast.error(
+        t("core.attachment.group_editing_modal.toast.group_name_exists")
+      );
       return;
     }
 

--- a/ui/console-src/modules/contents/attachments/components/AttachmentGroupEditingModal.vue
+++ b/ui/console-src/modules/contents/attachments/components/AttachmentGroupEditingModal.vue
@@ -44,6 +44,18 @@ const modalTitle = props.group
 const handleSave = async () => {
   try {
     isSubmitting.value = true;
+    const existingGroupsResponse =
+      await coreApiClient.storage.group.listGroup();
+    const existingGroups = existingGroupsResponse.data.items || [];
+    const nameExists = existingGroups.some(
+      (group) => group.spec.displayName === formState.value.spec.displayName
+    );
+
+    if (nameExists) {
+      alert("该分组名称已存在，请重新创建!");
+      return;
+    }
+
     if (props.group) {
       await coreApiClient.storage.group.updateGroup({
         name: formState.value.metadata.name,

--- a/ui/console-src/modules/contents/attachments/components/AttachmentGroupList.vue
+++ b/ui/console-src/modules/contents/attachments/components/AttachmentGroupList.vue
@@ -1,4 +1,5 @@
 <script lang="ts" setup>
+import HasPermission from "@/components/permission/HasPermission.vue";
 import type { Group } from "@halo-dev/api-client";
 import { IconAddCircle } from "@halo-dev/components";
 import { useQueryClient } from "@tanstack/vue-query";
@@ -25,7 +26,7 @@ const emit = defineEmits<{
 }>();
 
 const queryClient = useQueryClient();
-
+const isNewGroup = ref(false);
 const defaultGroups: Group[] = [
   {
     spec: {
@@ -67,10 +68,16 @@ const onCreationModalClose = () => {
   queryClient.invalidateQueries({ queryKey: ["attachment-groups"] });
   creationModalVisible.value = false;
 };
+
+const handleBadgeClick = () => {
+  creationModalVisible.value = true;
+  isNewGroup.value = true;
+};
 </script>
 <template>
   <AttachmentGroupEditingModal
     v-if="!readonly && creationModalVisible"
+    :is-new="isNewGroup"
     @close="onCreationModalClose"
   />
   <div
@@ -100,7 +107,7 @@ const onCreationModalClose = () => {
     >
       <AttachmentGroupBadge
         :features="{ actions: false }"
-        @click="creationModalVisible = true"
+        @click="handleBadgeClick"
       >
         <template #text>
           <span>{{ $t("core.common.buttons.new") }}</span>

--- a/ui/console-src/modules/contents/attachments/components/AttachmentGroupList.vue
+++ b/ui/console-src/modules/contents/attachments/components/AttachmentGroupList.vue
@@ -26,7 +26,6 @@ const emit = defineEmits<{
 }>();
 
 const queryClient = useQueryClient();
-const isNewGroup = ref(false);
 const defaultGroups: Group[] = [
   {
     spec: {
@@ -68,16 +67,10 @@ const onCreationModalClose = () => {
   queryClient.invalidateQueries({ queryKey: ["attachment-groups"] });
   creationModalVisible.value = false;
 };
-
-const handleBadgeClick = () => {
-  creationModalVisible.value = true;
-  isNewGroup.value = true;
-};
 </script>
 <template>
   <AttachmentGroupEditingModal
     v-if="!readonly && creationModalVisible"
-    :is-new="isNewGroup"
     @close="onCreationModalClose"
   />
   <div
@@ -107,7 +100,7 @@ const handleBadgeClick = () => {
     >
       <AttachmentGroupBadge
         :features="{ actions: false }"
-        @click="handleBadgeClick"
+        @click="creationModalVisible = true"
       >
         <template #text>
           <span>{{ $t("core.common.buttons.new") }}</span>

--- a/ui/console-src/modules/contents/attachments/components/AttachmentPoliciesModal.vue
+++ b/ui/console-src/modules/contents/attachments/components/AttachmentPoliciesModal.vue
@@ -40,17 +40,14 @@ const selectedPolicy = ref<Policy>();
 const selectedTemplateName = ref();
 
 const policyEditingModal = ref(false);
-const isNewPolicy = ref(false);
 
 const handleOpenEditingModal = (policy: Policy) => {
   selectedPolicy.value = policy;
-  isNewPolicy.value = false;
   policyEditingModal.value = true;
 };
 
 const handleOpenCreateNewPolicyModal = (policyTemplate: PolicyTemplate) => {
   selectedTemplateName.value = policyTemplate.metadata.name;
-  isNewPolicy.value = true;
   policyEditingModal.value = true;
 };
 
@@ -234,7 +231,6 @@ function getPolicyTemplateDisplayName(templateName: string) {
     v-if="policyEditingModal"
     :policy="selectedPolicy"
     :template-name="selectedTemplateName"
-    :is-new="isNewPolicy"
     @close="onEditingModalClose"
   />
 </template>

--- a/ui/console-src/modules/contents/attachments/components/AttachmentPoliciesModal.vue
+++ b/ui/console-src/modules/contents/attachments/components/AttachmentPoliciesModal.vue
@@ -40,14 +40,17 @@ const selectedPolicy = ref<Policy>();
 const selectedTemplateName = ref();
 
 const policyEditingModal = ref(false);
+const isNewPolicy = ref(false);
 
 const handleOpenEditingModal = (policy: Policy) => {
   selectedPolicy.value = policy;
+  isNewPolicy.value = false;
   policyEditingModal.value = true;
 };
 
 const handleOpenCreateNewPolicyModal = (policyTemplate: PolicyTemplate) => {
   selectedTemplateName.value = policyTemplate.metadata.name;
+  isNewPolicy.value = true;
   policyEditingModal.value = true;
 };
 
@@ -231,6 +234,7 @@ function getPolicyTemplateDisplayName(templateName: string) {
     v-if="policyEditingModal"
     :policy="selectedPolicy"
     :template-name="selectedTemplateName"
+    :is-new="isNewPolicy"
     @close="onEditingModalClose"
   />
 </template>

--- a/ui/console-src/modules/contents/attachments/components/AttachmentPolicyEditingModal.vue
+++ b/ui/console-src/modules/contents/attachments/components/AttachmentPolicyEditingModal.vue
@@ -47,14 +47,6 @@ const formState = ref<Policy>({
 
 const isUpdateMode = !!props.policy;
 
-const { data: policies } = useQuery({
-  queryKey: ["core:attachment:policies"],
-  queryFn: async () => {
-    const { data } = await coreApiClient.storage.policy.listPolicy(); // 修改为 listPolicy
-    return data;
-  },
-});
-
 onMounted(async () => {
   if (props.policy) {
     formState.value = cloneDeep(props.policy);
@@ -143,12 +135,13 @@ const submitting = ref(false);
 const handleSave = async () => {
   try {
     submitting.value = true;
-    const nameExists = policies.value?.items.some(
+    const { data: policies } = await coreApiClient.storage.policy.listPolicy();
+    const hasDisplayNameDuplicate = policies.items.some(
       (policy) => policy.spec.displayName === formState.value.spec.displayName
     );
 
-    if (nameExists) {
-      alert("该存储策略名称已存在，请重新创建!");
+    if (hasDisplayNameDuplicate) {
+      Toast.error(t("core.common.toast.policy_name_exists"));
       return;
     }
 

--- a/ui/console-src/modules/contents/attachments/components/AttachmentPolicyEditingModal.vue
+++ b/ui/console-src/modules/contents/attachments/components/AttachmentPolicyEditingModal.vue
@@ -141,7 +141,9 @@ const handleSave = async () => {
     );
 
     if (hasDisplayNameDuplicate) {
-      Toast.error(t("core.common.toast.policy_name_exists"));
+      Toast.error(
+        t("core.attachment.policy_editing_modal.toast.policy_name_exists")
+      );
       return;
     }
 

--- a/ui/console-src/modules/contents/attachments/components/AttachmentPolicyEditingModal.vue
+++ b/ui/console-src/modules/contents/attachments/components/AttachmentPolicyEditingModal.vue
@@ -47,6 +47,14 @@ const formState = ref<Policy>({
 
 const isUpdateMode = !!props.policy;
 
+const { data: policies } = useQuery({
+  queryKey: ["core:attachment:policies"],
+  queryFn: async () => {
+    const { data } = await coreApiClient.storage.policy.listPolicy(); // 修改为 listPolicy
+    return data;
+  },
+});
+
 onMounted(async () => {
   if (props.policy) {
     formState.value = cloneDeep(props.policy);
@@ -135,6 +143,14 @@ const submitting = ref(false);
 const handleSave = async () => {
   try {
     submitting.value = true;
+    const nameExists = policies.value?.items.some(
+      (policy) => policy.spec.displayName === formState.value.spec.displayName
+    );
+
+    if (nameExists) {
+      alert("该存储策略名称已存在，请重新创建!");
+      return;
+    }
 
     const configMapToUpdate = convertToSave();
 

--- a/ui/console-src/modules/contents/attachments/components/AttachmentPolicyEditingModal.vue
+++ b/ui/console-src/modules/contents/attachments/components/AttachmentPolicyEditingModal.vue
@@ -14,10 +14,12 @@ const props = withDefaults(
   defineProps<{
     policy?: Policy;
     templateName?: string;
+    isNew?: boolean;
   }>(),
   {
     policy: undefined,
     templateName: undefined,
+    isNew: false,
   }
 );
 
@@ -135,18 +137,20 @@ const submitting = ref(false);
 const handleSave = async () => {
   try {
     submitting.value = true;
-    const { data: policies } = await coreApiClient.storage.policy.listPolicy();
-    const hasDisplayNameDuplicate = policies.items.some(
-      (policy) => policy.spec.displayName === formState.value.spec.displayName
-    );
-
-    if (hasDisplayNameDuplicate) {
-      Toast.error(
-        t("core.attachment.policy_editing_modal.toast.policy_name_exists")
+    if (props.isNew) {
+      const { data: policies } =
+        await coreApiClient.storage.policy.listPolicy();
+      const hasDisplayNameDuplicate = policies.items.some(
+        (policy) => policy.spec.displayName === formState.value.spec.displayName
       );
-      return;
-    }
 
+      if (hasDisplayNameDuplicate) {
+        Toast.error(
+          t("core.attachment.policy_editing_modal.toast.policy_name_exists")
+        );
+        return;
+      }
+    }
     const configMapToUpdate = convertToSave();
 
     if (isUpdateMode) {

--- a/ui/console-src/modules/contents/attachments/components/AttachmentUploadModal.vue
+++ b/ui/console-src/modules/contents/attachments/components/AttachmentUploadModal.vue
@@ -143,14 +143,17 @@ const onGroupEditingModalClose = async () => {
           @click="selectedGroupName = group.metadata.name"
         />
 
-        <AttachmentPolicyBadge @click="handleOpenCreateNewGroupModal">
+        <AttachmentGroupBadge
+          :features="{ actions: false }"
+          @click="handleOpenCreateNewGroupModal"
+        >
           <template #text>
             <span>{{ $t("core.common.buttons.new") }}</span>
           </template>
           <template #actions>
             <IconAddCircle />
           </template>
-        </AttachmentPolicyBadge>
+        </AttachmentGroupBadge>
       </div>
       <UppyUpload
         endpoint="/apis/api.console.halo.run/v1alpha1/attachments/upload"

--- a/ui/console-src/modules/contents/attachments/components/AttachmentUploadModal.vue
+++ b/ui/console-src/modules/contents/attachments/components/AttachmentUploadModal.vue
@@ -33,6 +33,8 @@ const selectedGroupName = useLocalStorage("attachment-upload-group", "");
 const selectedPolicyName = useLocalStorage("attachment-upload-policy", "");
 const policyEditingModal = ref(false);
 const groupEditingModal = ref(false);
+const isNewPolicy = ref(false);
+const isNewGroup = ref(false);
 const policyTemplateNameToCreate = ref();
 
 onMounted(() => {
@@ -41,12 +43,16 @@ onMounted(() => {
   }
 });
 
-const handleOpenCreateNewPolicyModal = (policyTemplate: PolicyTemplate) => {
+const handleOpenCreateNewPolicyModal = async (
+  policyTemplate: PolicyTemplate
+) => {
   policyTemplateNameToCreate.value = policyTemplate.metadata.name;
+  isNewPolicy.value = true;
   policyEditingModal.value = true;
 };
 
 const handleOpenCreateNewGroupModal = () => {
+  isNewGroup.value = true;
   groupEditingModal.value = true;
 };
 
@@ -177,11 +183,13 @@ const onGroupEditingModalClose = async () => {
   <AttachmentPolicyEditingModal
     v-if="policyEditingModal"
     :template-name="policyTemplateNameToCreate"
+    :is-new="isNewPolicy"
     @close="onEditingModalClose"
   />
 
   <AttachmentGroupEditingModal
     v-if="groupEditingModal"
+    :is-new="isNewGroup"
     @close="onGroupEditingModalClose"
   />
 </template>

--- a/ui/console-src/modules/contents/attachments/components/AttachmentUploadModal.vue
+++ b/ui/console-src/modules/contents/attachments/components/AttachmentUploadModal.vue
@@ -19,6 +19,8 @@ import AttachmentGroupBadge from "./AttachmentGroupBadge.vue";
 import AttachmentGroupEditingModal from "./AttachmentGroupEditingModal.vue";
 import AttachmentPolicyBadge from "./AttachmentPolicyBadge.vue";
 import AttachmentPolicyEditingModal from "./AttachmentPolicyEditingModal.vue";
+import AttachmentGroupEditingModal from "./AttachmentGroupEditingModal.vue";
+import UppyUpload from "@/components/upload/UppyUpload.vue";
 
 const emit = defineEmits<{
   (event: "close"): void;

--- a/ui/console-src/modules/contents/attachments/components/AttachmentUploadModal.vue
+++ b/ui/console-src/modules/contents/attachments/components/AttachmentUploadModal.vue
@@ -19,8 +19,6 @@ import AttachmentGroupBadge from "./AttachmentGroupBadge.vue";
 import AttachmentGroupEditingModal from "./AttachmentGroupEditingModal.vue";
 import AttachmentPolicyBadge from "./AttachmentPolicyBadge.vue";
 import AttachmentPolicyEditingModal from "./AttachmentPolicyEditingModal.vue";
-import AttachmentGroupEditingModal from "./AttachmentGroupEditingModal.vue";
-import UppyUpload from "@/components/upload/UppyUpload.vue";
 
 const emit = defineEmits<{
   (event: "close"): void;
@@ -145,14 +143,14 @@ const onGroupEditingModalClose = async () => {
           @click="selectedGroupName = group.metadata.name"
         />
 
-        <AttachmentGroupBadge @click="handleOpenCreateNewGroupModal">
+        <AttachmentPolicyBadge @click="handleOpenCreateNewGroupModal">
           <template #text>
             <span>{{ $t("core.common.buttons.new") }}</span>
           </template>
           <template #actions>
             <IconAddCircle />
           </template>
-        </AttachmentGroupBadge>
+        </AttachmentPolicyBadge>
       </div>
       <UppyUpload
         endpoint="/apis/api.console.halo.run/v1alpha1/attachments/upload"

--- a/ui/console-src/modules/contents/attachments/components/AttachmentUploadModal.vue
+++ b/ui/console-src/modules/contents/attachments/components/AttachmentUploadModal.vue
@@ -33,8 +33,6 @@ const selectedGroupName = useLocalStorage("attachment-upload-group", "");
 const selectedPolicyName = useLocalStorage("attachment-upload-policy", "");
 const policyEditingModal = ref(false);
 const groupEditingModal = ref(false);
-const isNewPolicy = ref(false);
-const isNewGroup = ref(false);
 const policyTemplateNameToCreate = ref();
 
 onMounted(() => {
@@ -47,12 +45,10 @@ const handleOpenCreateNewPolicyModal = async (
   policyTemplate: PolicyTemplate
 ) => {
   policyTemplateNameToCreate.value = policyTemplate.metadata.name;
-  isNewPolicy.value = true;
   policyEditingModal.value = true;
 };
 
 const handleOpenCreateNewGroupModal = () => {
-  isNewGroup.value = true;
   groupEditingModal.value = true;
 };
 
@@ -183,13 +179,11 @@ const onGroupEditingModalClose = async () => {
   <AttachmentPolicyEditingModal
     v-if="policyEditingModal"
     :template-name="policyTemplateNameToCreate"
-    :is-new="isNewPolicy"
     @close="onEditingModalClose"
   />
 
   <AttachmentGroupEditingModal
     v-if="groupEditingModal"
-    :is-new="isNewGroup"
     @close="onGroupEditingModalClose"
   />
 </template>

--- a/ui/src/locales/en.yaml
+++ b/ui/src/locales/en.yaml
@@ -26,7 +26,9 @@ core:
       logout:
         tooltip: Logout
         title: Logout
-        description: Clicking Confirm will redirect to the logout page. Please ensure that the content you are editing is saved.
+        description: >-
+          Clicking Confirm will redirect to the logout page. Please ensure that
+          the content you are editing is saved.
       profile:
         tooltip: Profile
       visit_homepage:
@@ -598,6 +600,8 @@ core:
       fields:
         display_name:
           label: Display name
+      toast:
+        group_name_exists: Group name already exists
     group_list:
       internal_groups:
         all: All
@@ -643,6 +647,8 @@ core:
       fields:
         display_name:
           label: Display name
+      toast:
+        policy_name_exists: Storage policy name already exists
     upload_modal:
       title: Upload attachment
       filters:
@@ -666,8 +672,8 @@ core:
     empty:
       title: There are no attachments.
       message: >-
-        There are no attachments, you can try refreshing or
-        uploading attachments.
+        There are no attachments, you can try refreshing or uploading
+        attachments.
       actions:
         upload: Upload Attachment
     filters:
@@ -1457,7 +1463,9 @@ core:
         first: >-
           1. The restore process may last for a long time, please do not refresh
           the page during this period.
-        second: 2. Before performing the restore, all existing data will be cleared. Please ensure that there is no data that needs to be retained.
+        second: >-
+          2. Before performing the restore, all existing data will be cleared.
+          Please ensure that there is no data that needs to be retained.
         third: >-
           3. After the restore is completed, you need to restart Halo to load
           the system resources normally.
@@ -1673,7 +1681,9 @@ core:
       creation_label: Create {text} tag
     validation:
       trim: Please remove the leading and trailing spaces
-      password: "The password can only use uppercase and lowercase letters (A-Z, a-z), numbers (0-9), and the following special characters: !{'@'}#$%^&*"
+      password: >-
+        The password can only use uppercase and lowercase letters (A-Z, a-z),
+        numbers (0-9), and the following special characters: !{'@'}#$%^&*
     verification_form:
       no_action_defined: "{label} interface not defined"
       verify_success: "{label} successful"
@@ -1791,7 +1801,10 @@ core:
         editor_not_found: >-
           No editor found that matches the {raw_type} format. Please check if
           the editor plugin has been installed.
-        login_expired: The current session has expired. Click Confirm to go to the login page. Please ensure that the current content is saved. You can click Cancel to manually copy any unsaved content.
+        login_expired: >-
+          The current session has expired. Click Confirm to go to the login
+          page. Please ensure that the current content is saved. You can click
+          Cancel to manually copy any unsaved content.
     filters:
       results:
         keyword: "Keyword: {keyword}"
@@ -1832,7 +1845,9 @@ core:
         title: Cancel publish
       delete:
         title: Delete post
-        description: This action will move the post to the recycle bin, where it will be managed by the site administrator.
+        description: >-
+          This action will move the post to the recycle bin, where it will be
+          managed by the site administrator.
     publish_modal:
       title: Publish post
     setting_modal:

--- a/ui/src/locales/zh-CN.yaml
+++ b/ui/src/locales/zh-CN.yaml
@@ -1671,6 +1671,8 @@ core:
       unknown_error: 未知错误
       disable_success: 禁用成功
       enable_success: 啟用成功
+      group_name_exists: 该分组名称已存在，请重新创建
+      policy_name_exists: 该存储策略已存在，请重新创建
     dialog:
       titles:
         tip: 提示

--- a/ui/src/locales/zh-CN.yaml
+++ b/ui/src/locales/zh-CN.yaml
@@ -572,6 +572,8 @@ core:
       fields:
         display_name:
           label: 名称
+      toast:
+        group_name_exists: 分组名称已存在
     group_list:
       internal_groups:
         all: 全部
@@ -607,6 +609,8 @@ core:
       fields:
         display_name:
           label: 名称
+      toast:
+        policy_name_exists: 存储策略名称已存在
     upload_modal:
       title: 上传附件
       filters:
@@ -1671,8 +1675,6 @@ core:
       unknown_error: 未知错误
       disable_success: 禁用成功
       enable_success: 啟用成功
-      group_name_exists: 该分组名称已存在，请重新创建
-      policy_name_exists: 该存储策略已存在，请重新创建
     dialog:
       titles:
         tip: 提示

--- a/ui/src/locales/zh-TW.yaml
+++ b/ui/src/locales/zh-TW.yaml
@@ -549,6 +549,8 @@ core:
       fields:
         display_name:
           label: 名稱
+      toast:
+        group_name_exists: 分組名稱已存在
     group_list:
       internal_groups:
         all: 全部
@@ -584,6 +586,8 @@ core:
       fields:
         display_name:
           label: 名稱
+      toast:
+        policy_name_exists: 儲存策略名稱已存在
     upload_modal:
       title: 上傳附件
       filters:


### PR DESCRIPTION
#### What type of PR is this?

/area ui
/kind improvement
/milestone 2.20.x

#### What this PR does / why we need it:

在创建附件分组或者存储策略时，支持检查是否有已存在的名称。

#### Which issue(s) this PR fixes:

Fixes #6946

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
在创建附件分组或者存储策略时，支持检查是否有已存在的名称。
```
