### PR TITLE
fix: prevent undefined key name when creating Secret

### DIFF
--- a/ui/src/formkit/inputs/secret/components/SecretCreationModal.vue
+++ b/ui/src/formkit/inputs/secret/components/SecretCreationModal.vue
@@ -14,9 +14,9 @@ const queryClient = useQueryClient();
 
 withDefaults(
   defineProps<{
-    formState: SecretFormState;
+    formState?: SecretFormState;
   }>(),
-  {}
+  { formState: undefined }
 );
 
 const emit = defineEmits<{

--- a/ui/src/formkit/inputs/secret/components/SecretCreationModal.vue
+++ b/ui/src/formkit/inputs/secret/components/SecretCreationModal.vue
@@ -12,6 +12,13 @@ import SecretForm from "./SecretForm.vue";
 const { t } = useI18n();
 const queryClient = useQueryClient();
 
+withDefaults(
+  defineProps<{
+    formState: SecretFormState;
+  }>(),
+  {}
+);
+
 const emit = defineEmits<{
   (event: "close"): void;
 }>();
@@ -61,7 +68,7 @@ function onSubmit(data: SecretFormState) {
     :width="600"
     @close="emit('close')"
   >
-    <SecretForm @submit="onSubmit" />
+    <SecretForm :form-state="formState" @submit="onSubmit" />
 
     <template #footer>
       <VSpace>


### PR DESCRIPTION
#### What type of PR is this?

/area ui
/kind bug
/milestone 2.20.x

#### What this PR does / why we need it:

修复使用 Secret 输入框创建 Secret 时，stringData 的 key 可能为 undefined 的问题。

#### Which issue(s) this PR fixes:

See https://github.com/halo-sigs/plugin-alist/issues/23#issuecomment-2443499980 for more

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
修复使用 Secret 输入框创建 Secret 时，stringData 的 key 可能为 undefined 的问题。
```
