### PR TITLE
refactor: hide essential notifications to prevent accidental disabling

### DIFF
--- a/api/src/main/java/run/halo/app/extension/MetadataUtil.java
+++ b/api/src/main/java/run/halo/app/extension/MetadataUtil.java
@@ -8,6 +8,7 @@ public enum MetadataUtil {
     ;
 
     public static final String SYSTEM_FINALIZER = "system-protection";
+    public static final String HIDDEN_LABEL = "halo.run/hidden";
 
     /**
      * Gets extension metadata labels null safe.

--- a/application/src/main/java/run/halo/app/notification/endpoint/UserNotificationPreferencesEndpoint.java
+++ b/application/src/main/java/run/halo/app/notification/endpoint/UserNotificationPreferencesEndpoint.java
@@ -33,7 +33,9 @@ import run.halo.app.core.extension.endpoint.CustomEndpoint;
 import run.halo.app.core.extension.notification.NotifierDescriptor;
 import run.halo.app.core.extension.notification.ReasonType;
 import run.halo.app.extension.Comparators;
+import run.halo.app.extension.ExtensionUtil;
 import run.halo.app.extension.GroupVersion;
+import run.halo.app.extension.ListOptions;
 import run.halo.app.extension.MetadataUtil;
 import run.halo.app.extension.ReactiveExtensionClient;
 import run.halo.app.infra.utils.JsonUtils;
@@ -140,7 +142,12 @@ public class UserNotificationPreferencesEndpoint implements CustomEndpoint {
     }
 
     Mono<ReasonTypeNotifierMatrix> listReasonTypeNotifierMatrix(String username) {
-        return client.list(ReasonType.class, null, Comparators.defaultComparator())
+        var listOptions = ListOptions.builder()
+            .labelSelector()
+            .notExists(MetadataUtil.HIDDEN_LABEL)
+            .end()
+            .build();
+        return client.listAll(ReasonType.class, listOptions, ExtensionUtil.defaultSort())
             .map(ReasonTypeInfo::from)
             .collectList()
             .flatMap(reasonTypes -> client.list(NotifierDescriptor.class, null,

--- a/application/src/main/resources/extensions/notification.yaml
+++ b/application/src/main/resources/extensions/notification.yaml
@@ -171,7 +171,7 @@ kind: ReasonType
 metadata:
   name: email-verification
   labels:
-    halo.run/hide: "true"
+    halo.run/hidden: "true"
 spec:
   displayName: "邮箱验证"
   description: "当你的邮箱被用于注册账户时，会收到一条带有验证码的邮件，你需要点击邮件中的链接来验证邮箱是否属于你。"
@@ -191,7 +191,7 @@ kind: ReasonType
 metadata:
   name: reset-password-by-email
   labels:
-    halo.run/hide: "true"
+    halo.run/hidden: "true"
 spec:
   displayName: "根据邮件地址重置密码"
   description: "当你通过邮件地址找回密码时，会收到一条带密码重置链接的邮件，你需要点击邮件中的链接来重置密码。"

--- a/application/src/test/java/run/halo/app/notification/endpoint/UserNotificationPreferencesEndpointTest.java
+++ b/application/src/test/java/run/halo/app/notification/endpoint/UserNotificationPreferencesEndpointTest.java
@@ -1,6 +1,8 @@
 package run.halo.app.notification.endpoint;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.assertArg;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
 
@@ -15,6 +17,7 @@ import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import run.halo.app.core.extension.notification.NotifierDescriptor;
 import run.halo.app.core.extension.notification.ReasonType;
+import run.halo.app.extension.ExtensionUtil;
 import run.halo.app.extension.ReactiveExtensionClient;
 import run.halo.app.notification.UserNotificationPreferenceService;
 
@@ -43,11 +46,16 @@ class UserNotificationPreferencesEndpointTest {
         webTestClient = WebTestClient
             .bindToRouterFunction(userNotificationPreferencesEndpoint.endpoint())
             .build();
+
+        when(client.listAll(eq(ReasonType.class), assertArg(option ->
+                assertThat(option.toString())
+                    .isEqualTo("labelSelector: (halo.run/hidden NOT_EXISTS)")),
+            eq(ExtensionUtil.defaultSort()))
+        ).thenReturn(Flux.empty());
     }
 
     @Test
     void listNotificationPreferences() {
-        when(client.list(eq(ReasonType.class), eq(null), any())).thenReturn(Flux.empty());
         when(client.list(eq(NotifierDescriptor.class), eq(null), any())).thenReturn(Flux.empty());
         when(userNotificationPreferenceService.getByUser(any())).thenReturn(Mono.empty());
         webTestClient.post()
@@ -59,7 +67,6 @@ class UserNotificationPreferencesEndpointTest {
 
     @Test
     void saveNotificationPreferences() {
-        when(client.list(eq(ReasonType.class), eq(null), any())).thenReturn(Flux.empty());
         when(client.list(eq(NotifierDescriptor.class), eq(null), any())).thenReturn(Flux.empty());
         when(userNotificationPreferenceService.getByUser(any())).thenReturn(Mono.empty());
         webTestClient.post()


### PR DESCRIPTION
#### What type of PR is this?
/kind improvement
/area core
/milestone 2.20.x

#### What this PR does / why we need it:
隐藏关键通知项设置以避免用户意外禁用而无法收到通知

#### Which issue(s) this PR fixes:
Fixes #6967

#### Does this PR introduce a user-facing change?
```release-note
隐藏关键通知项设置以避免用户意外禁用而无法收到通知

```
