### PR TITLE
refactor: add uniqueness check for local thumbnail original links and dimensions to avoid duplication

### DIFF
--- a/application/src/main/java/run/halo/app/core/attachment/extension/LocalThumbnail.java
+++ b/application/src/main/java/run/halo/app/core/attachment/extension/LocalThumbnail.java
@@ -19,6 +19,7 @@ import run.halo.app.extension.GVK;
 @GVK(group = "storage.halo.run", version = "v1alpha1", kind = "LocalThumbnail",
     plural = "localthumbnails", singular = "localthumbnail")
 public class LocalThumbnail extends AbstractExtension {
+    public static final String UNIQUE_IMAGE_AND_SIZE_INDEX = "uniqueImageAndSize";
     public static final String REQUEST_TO_GENERATE_ANNO = "storage.halo.run/request-to-generate";
 
     @Schema(requiredMode = REQUIRED)
@@ -79,5 +80,14 @@ public class LocalThumbnail extends AbstractExtension {
 
     public enum Phase {
         PENDING, SUCCEEDED, FAILED
+    }
+
+    public static String uniqueImageAndSize(LocalThumbnail localThumbnail) {
+        return uniqueImageAndSize(localThumbnail.getSpec().getImageSignature(),
+            localThumbnail.getSpec().getSize());
+    }
+
+    public static String uniqueImageAndSize(String imageSignature, ThumbnailSize size) {
+        return imageSignature + "-" + size.name();
     }
 }

--- a/application/src/main/java/run/halo/app/infra/SchemeInitializer.java
+++ b/application/src/main/java/run/halo/app/infra/SchemeInitializer.java
@@ -612,6 +612,14 @@ public class SchemeInitializer implements ApplicationListener<ApplicationContext
             );
         });
         schemeManager.register(LocalThumbnail.class, indexSpec -> {
+            // make sure image and size are unique
+            indexSpec.add(new IndexSpec()
+                .setUnique(true)
+                .setName(LocalThumbnail.UNIQUE_IMAGE_AND_SIZE_INDEX)
+                .setIndexFunc(simpleAttribute(LocalThumbnail.class,
+                    LocalThumbnail::uniqueImageAndSize)
+                )
+            );
             indexSpec.add(new IndexSpec()
                 .setName("spec.imageSignature")
                 .setIndexFunc(simpleAttribute(LocalThumbnail.class,

--- a/application/src/test/java/run/halo/app/core/attachment/impl/LocalThumbnailServiceImplTest.java
+++ b/application/src/test/java/run/halo/app/core/attachment/impl/LocalThumbnailServiceImplTest.java
@@ -12,6 +12,7 @@ import static run.halo.app.core.attachment.ThumbnailSigner.generateSignature;
 import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -20,6 +21,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.web.util.UriUtils;
 import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
 import run.halo.app.core.attachment.AttachmentRootGetter;
@@ -61,14 +63,14 @@ class LocalThumbnailServiceImplTest {
     @Test
     void geImageFileNameTest() throws MalformedURLException {
         var fileName =
-            LocalThumbnailServiceImpl.geImageFileName(new URL("https://halo.run/example.jpg"));
+            LocalThumbnailServiceImpl.geImageFileName(URI.create("https://halo.run/example.jpg"));
         assertThat(fileName).isEqualTo("example.jpg");
 
-        fileName = LocalThumbnailServiceImpl.geImageFileName(new URL("https://halo.run/"));
+        fileName = LocalThumbnailServiceImpl.geImageFileName(URI.create("https://halo.run/"));
         assertThat(fileName).isNotBlank();
 
-        fileName = LocalThumbnailServiceImpl.geImageFileName(
-            new URL("https://halo.run/.1fasfg(*&^%$.jpg"));
+        var encoded = UriUtils.encode("https://halo.run/.1fasfg(*&^%$.jpg", StandardCharsets.UTF_8);
+        fileName = LocalThumbnailServiceImpl.geImageFileName(URI.create(encoded));
         assertThat(fileName).isNotBlank();
     }
 


### PR DESCRIPTION
#### What type of PR is this?
/kind improvement
/area core
/milestone 2.20.x

#### What this PR does / why we need it:
对本地缩略图的原图链接和尺寸增加唯一性检查避免重复

#### Does this PR introduce a user-facing change?

```release-note
对本地缩略图的原图链接和尺寸增加唯一性检查避免重复
```
