### PR TITLE
fix: new tags showing null post count on theme

### DIFF
--- a/application/src/main/java/run/halo/app/core/reconciler/TagReconciler.java
+++ b/application/src/main/java/run/halo/app/core/reconciler/TagReconciler.java
@@ -52,9 +52,16 @@ public class TagReconciler implements Reconciler<Reconciler.Request> {
                 String newPattern = tagPermalinkPolicy.pattern();
                 annotations.put(Constant.PERMALINK_PATTERN_ANNO, newPattern);
 
-                String permalink = tagPermalinkPolicy.permalink(tag);
                 var status = tag.getStatusOrDefault();
+                String permalink = tagPermalinkPolicy.permalink(tag);
                 status.setPermalink(permalink);
+
+                if (status.getPostCount() == null) {
+                    status.setPostCount(0);
+                }
+                if (status.getVisiblePostCount() == null) {
+                    status.setVisiblePostCount(0);
+                }
 
                 // Update the observed version.
                 status.setObservedVersion(tag.getMetadata().getVersion() + 1);

--- a/application/src/main/java/run/halo/app/theme/finders/vo/TagVo.java
+++ b/application/src/main/java/run/halo/app/theme/finders/vo/TagVo.java
@@ -1,5 +1,7 @@
 package run.halo.app.theme.finders.vo;
 
+import static org.apache.commons.lang3.ObjectUtils.defaultIfNull;
+
 import lombok.Builder;
 import lombok.Value;
 import run.halo.app.core.extension.content.Tag;
@@ -33,7 +35,7 @@ public class TagVo implements ExtensionVoOperator {
             .metadata(tag.getMetadata())
             .spec(spec)
             .status(status)
-            .postCount(tag.getStatusOrDefault().getVisiblePostCount())
+            .postCount(defaultIfNull(status.getVisiblePostCount(), 0))
             .build();
     }
 }


### PR DESCRIPTION
#### What type of PR is this?
/kind improvement
/area core
/milestone 2.20.x

#### What this PR does / why we need it:
修复新创建的标签在主题端展示关联文章数量为 null 的问题

#### Which issue(s) this PR fixes:

Fixes #7042

#### Does this PR introduce a user-facing change?

```release-note
修复新创建的标签在主题端展示关联文章数量为 null 的问题
```
