### PR TITLE
Remove template engine after upgrading theme

### DIFF
--- a/application/src/main/java/run/halo/app/theme/TemplateEngineManager.java
+++ b/application/src/main/java/run/halo/app/theme/TemplateEngineManager.java
@@ -5,7 +5,6 @@ import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.boot.autoconfigure.thymeleaf.ThymeleafProperties;
 import org.springframework.stereotype.Component;
 import org.springframework.util.ConcurrentLruCache;
-import org.thymeleaf.TemplateEngine;
 import org.thymeleaf.dialect.IDialect;
 import org.thymeleaf.spring6.ISpringWebFluxTemplateEngine;
 import org.thymeleaf.spring6.dialect.SpringStandardDialect;
@@ -72,12 +71,7 @@ public class TemplateEngineManager {
 
     public Mono<Void> clearCache(String themeName) {
         return themeResolver.getThemeContext(themeName)
-            .doOnNext(themeContext -> {
-                CacheKey cacheKey = buildCacheKey(themeContext);
-                TemplateEngine templateEngine =
-                    (TemplateEngine) engineCache.get(cacheKey);
-                templateEngine.clearTemplateCache();
-            })
+            .doOnNext(themeContext -> engineCache.remove(buildCacheKey(themeContext)))
             .then();
     }
 


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/area core
/milestone 2.20.x

#### What this PR does / why we need it:

This PR removes template engine instead of clearing cache of template engine after upgrading theme to resolve incomplete cache clear.

#### Which issue(s) this PR fixes:

Fixes https://github.com/halo-dev/halo/issues/7056

#### Special notes for your reviewer:

1. Try to install the theme `theme-earth 1.12.0`
2. Request index page and you will see the `上一页` which should be `下一页`
3. Try to upgrade to the theme `theme-earth 1.12.1`
4. Request index page and you should see the `下一页` directly. 

#### Does this PR introduce a user-facing change?

```release-note
修复升级主题后语言包未更新的问题
```
