### PR TITLE
Upgrade to Spring Boot 3.4.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'org.springframework.boot' version '3.4.0-RC1' apply false
+    id 'org.springframework.boot' version '3.4.0' apply false
     id 'io.spring.dependency-management' version '1.1.6' apply false
     id "com.gorylenko.gradle-git-properties" version "2.4.1" apply false
     id "de.undercouch.download" version "5.6.0" apply false


### PR DESCRIPTION
This PR upgrades to [Spring Boot 3.4.0](https://github.com/spring-projects/spring-boot/releases/tag/v3.4.0).

/kind cleanup
/area core

```release-note
升级依赖至 Spring Boot 3.4.0
```