### PR TITLE
fix: post annotations form layout issues in Chrome browser

### DIFF
--- a/ui/src/components/form/AnnotationsForm.vue
+++ b/ui/src/components/form/AnnotationsForm.vue
@@ -230,7 +230,7 @@ function onCustomFormToggle(e: Event) {
     <!-- @vue-ignore -->
     <details
       :open="showCustomForm"
-      class="flex cursor-pointer space-y-4 py-4 transition-all first:pt-0"
+      class="flex flex-col cursor-pointer space-y-4 py-4 transition-all first:pt-0"
       @toggle="onCustomFormToggle"
     >
       <summary class="group flex items-center justify-between">


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/area ui
/milestone 2.20.x

#### What this PR does / why we need it:

修复文章元数据表单在 Chrome 下的异常样式。

原因：https://developer.chrome.com/blog/styling-details#demo

<img width="679" alt="image" src="https://github.com/user-attachments/assets/292b1a66-1e1b-4ddf-9999-d688066e8f10">

#### Does this PR introduce a user-facing change?

```release-note
修复文章元数据表单在 Chrome 下的异常样式。
```
