### PR TITLE
fix: optional plugin dependencies not working correctly

### DIFF
--- a/application/src/main/java/run/halo/app/plugin/DefaultPluginApplicationContextFactory.java
+++ b/application/src/main/java/run/halo/app/plugin/DefaultPluginApplicationContextFactory.java
@@ -70,7 +70,21 @@ public class DefaultPluginApplicationContextFactory implements PluginApplication
         var pluginWrapper = pluginManager.getPlugin(pluginId);
         var classLoader = pluginWrapper.getPluginClassLoader();
 
-        // create a custom bean factory to set the class loader
+        /*
+         * Manually creating a BeanFactory and setting the plugin's ClassLoader is necessary
+         * to ensure that conditional annotations (e.g., @ConditionalOnClass) within the plugin
+         * context can correctly load classes.
+         * When PluginApplicationContext is created, its constructor initializes an
+         * AnnotatedBeanDefinitionReader, which in turn creates a ConditionEvaluator.
+         * ConditionEvaluator is responsible for evaluating conditional annotations such as
+         * @ConditionalOnClass.
+         * It relies on the BeanDefinitionRegistry's ClassLoader to load the classes specified in
+         * the annotations.
+         * Without explicitly setting the plugin's ClassLoader, the default application
+         * ClassLoader is used, which fails to load classes from the plugin.
+         * Therefore, a custom DefaultListableBeanFactory with the plugin ClassLoader is required
+         * to resolve this issue.
+         */
         var beanFactory = new DefaultListableBeanFactory();
         beanFactory.setBeanClassLoader(classLoader);
 

--- a/application/src/main/java/run/halo/app/plugin/OptionalDependentResolver.java
+++ b/application/src/main/java/run/halo/app/plugin/OptionalDependentResolver.java
@@ -1,0 +1,56 @@
+package run.halo.app.plugin;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.pf4j.PluginDependency;
+import org.pf4j.PluginDescriptor;
+import org.pf4j.util.DirectedGraph;
+
+/**
+ * <p>Pass in a list of started plugin names to resolve dependency relationships, and return a
+ * list of plugin names that depend on the specified plugin.</p>
+ * <p>Do not consider the problem of circular dependency, because all the plugins that have been
+ * started must not have this problem.</p>
+ */
+public class OptionalDependentResolver {
+    private final DirectedGraph<String> dependentsGraph;
+    private final List<PluginDescriptor> plugins;
+
+    public OptionalDependentResolver(List<PluginDescriptor> startedPlugins) {
+        this.plugins = startedPlugins;
+        this.dependentsGraph = new DirectedGraph<>();
+        resolve();
+    }
+
+    private void resolve() {
+        // populate graphs
+        for (PluginDescriptor plugin : plugins) {
+            addPlugin(plugin);
+        }
+    }
+
+    public List<String> getOptionalDependents(String pluginId) {
+        return new ArrayList<>(dependentsGraph.getNeighbors(pluginId));
+    }
+
+    private void addPlugin(PluginDescriptor descriptor) {
+        String pluginId = descriptor.getPluginId();
+        List<PluginDependency> dependencies = descriptor.getDependencies();
+        if (dependencies.isEmpty()) {
+            dependentsGraph.addVertex(pluginId);
+        } else {
+            boolean edgeAdded = false;
+            for (PluginDependency dependency : dependencies) {
+                if (dependency.isOptional()) {
+                    edgeAdded = true;
+                    dependentsGraph.addEdge(dependency.getPluginId(), pluginId);
+                }
+            }
+
+            // Register the plugin without dependencies, if all of its dependencies are optional.
+            if (!edgeAdded) {
+                dependentsGraph.addVertex(pluginId);
+            }
+        }
+    }
+}

--- a/application/src/main/java/run/halo/app/plugin/PluginApplicationContext.java
+++ b/application/src/main/java/run/halo/app/plugin/PluginApplicationContext.java
@@ -2,6 +2,7 @@ package run.halo.app.plugin;
 
 import java.util.List;
 import java.util.concurrent.locks.StampedLock;
+import org.springframework.beans.factory.support.DefaultListableBeanFactory;
 import org.springframework.context.ApplicationEvent;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 import org.springframework.core.ResolvableType;
@@ -27,7 +28,9 @@ public class PluginApplicationContext extends AnnotationConfigApplicationContext
 
     private final SpringPluginManager pluginManager;
 
-    public PluginApplicationContext(String pluginId, SpringPluginManager pluginManager) {
+    public PluginApplicationContext(String pluginId, SpringPluginManager pluginManager,
+        DefaultListableBeanFactory beanFactory) {
+        super(beanFactory);
         this.pluginId = pluginId;
         this.pluginManager = pluginManager;
     }

--- a/application/src/main/java/run/halo/app/plugin/PluginService.java
+++ b/application/src/main/java/run/halo/app/plugin/PluginService.java
@@ -1,6 +1,9 @@
 package run.halo.app.plugin;
 
 import java.nio.file.Path;
+import java.util.List;
+import java.util.function.Predicate;
+import org.pf4j.PluginWrapper;
 import org.springframework.core.io.Resource;
 import org.springframework.core.io.buffer.DataBuffer;
 import org.springframework.web.server.ServerWebInputException;
@@ -102,4 +105,14 @@ public interface PluginService {
      */
     Mono<Plugin> changeState(String pluginName, boolean requestToEnable, boolean wait);
 
+    /**
+     * Gets required dependencies of the given plugin.
+     *
+     * @param plugin the plugin to get dependencies from
+     * {@link Plugin.PluginSpec#getPluginDependencies()}
+     * @param predicate the predicate to filter by {@link PluginWrapper},such as enabled or disabled
+     * @return plugin names of required dependencies
+     */
+    List<String> getRequiredDependencies(Plugin plugin,
+        Predicate<PluginWrapper> predicate);
 }

--- a/application/src/main/java/run/halo/app/plugin/PluginServiceImpl.java
+++ b/application/src/main/java/run/halo/app/plugin/PluginServiceImpl.java
@@ -21,10 +21,12 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
 import org.pf4j.DependencyResolver;
+import org.pf4j.PluginDependency;
 import org.pf4j.PluginDescriptor;
 import org.pf4j.PluginWrapper;
 import org.reactivestreams.Publisher;
@@ -269,11 +271,11 @@ public class PluginServiceImpl implements PluginService, InitializingBean, Dispo
             .sort(Comparator.comparing(PluginWrapper::getPluginId))
             .flatMapSequential(pluginWrapper -> {
                 var pluginId = pluginWrapper.getPluginId();
-                return Mono.<Resource>fromSupplier(
-                        () -> BundleResourceUtils.getJsBundleResource(
+                return Mono.fromSupplier(() -> BundleResourceUtils.getJsBundleResource(
                             pluginManager, pluginId, BundleResourceUtils.JS_BUNDLE
                         )
                     )
+                    .cast(Resource.class)
                     .filter(Resource::isReadable)
                     .flatMapMany(resource -> {
                         var head = Mono.<DataBuffer>fromSupplier(
@@ -297,9 +299,10 @@ public class PluginServiceImpl implements PluginService, InitializingBean, Dispo
             .flatMapSequential(pluginWrapper -> {
                 var pluginId = pluginWrapper.getPluginId();
                 var dataBufferFactory = DefaultDataBufferFactory.sharedInstance;
-                return Mono.<Resource>fromSupplier(() -> BundleResourceUtils.getJsBundleResource(
+                return Mono.fromSupplier(() -> BundleResourceUtils.getJsBundleResource(
                         pluginManager, pluginId, BundleResourceUtils.CSS_BUNDLE
                     ))
+                    .cast(Resource.class)
                     .filter(Resource::isReadable)
                     .flatMapMany(resource -> {
                         var head = Mono.<DataBuffer>fromSupplier(() -> dataBufferFactory.wrap(
@@ -344,14 +347,9 @@ public class PluginServiceImpl implements PluginService, InitializingBean, Dispo
                     // preflight check
                     if (requestToEnable) {
                         // make sure the dependencies are enabled
-                        var dependencies = plugin.getSpec().getPluginDependencies().keySet();
-                        var notStartedDependencies = dependencies.stream()
-                            .filter(dependency -> {
-                                var pluginWrapper = pluginManager.getPlugin(dependency);
-                                return pluginWrapper == null
-                                    || !Objects.equals(STARTED, pluginWrapper.getPluginState());
-                            })
-                            .toList();
+                        var notStartedDependencies = getRequiredDependencies(plugin,
+                            pw -> pw == null || !Objects.equals(STARTED, pw.getPluginState())
+                        );
                         if (!CollectionUtils.isEmpty(notStartedDependencies)) {
                             return Mono.error(
                                 new PluginDependenciesNotEnabledException(notStartedDependencies)
@@ -414,6 +412,28 @@ public class PluginServiceImpl implements PluginService, InitializingBean, Dispo
         }
 
         return updatedPlugin;
+    }
+
+    @Override
+    public List<String> getRequiredDependencies(Plugin plugin,
+        Predicate<PluginWrapper> predicate) {
+        return getPluginDependency(plugin)
+            .stream()
+            .filter(dependency -> !dependency.isOptional())
+            .map(PluginDependency::getPluginId)
+            .filter(dependencyPlugin -> {
+                var pluginWrapper = pluginManager.getPlugin(dependencyPlugin);
+                return predicate.test(pluginWrapper);
+            })
+            .sorted()
+            .toList();
+    }
+
+    private static List<PluginDependency> getPluginDependency(Plugin plugin) {
+        return plugin.getSpec().getPluginDependencies().keySet()
+            .stream()
+            .map(PluginDependency::new)
+            .toList();
     }
 
     Mono<Plugin> findPluginManifest(Path path) {

--- a/application/src/main/java/run/halo/app/plugin/PluginServiceImpl.java
+++ b/application/src/main/java/run/halo/app/plugin/PluginServiceImpl.java
@@ -271,12 +271,7 @@ public class PluginServiceImpl implements PluginService, InitializingBean, Dispo
             .sort(Comparator.comparing(PluginWrapper::getPluginId))
             .flatMapSequential(pluginWrapper -> {
                 var pluginId = pluginWrapper.getPluginId();
-                return Mono.fromSupplier(() -> BundleResourceUtils.getJsBundleResource(
-                            pluginManager, pluginId, BundleResourceUtils.JS_BUNDLE
-                        )
-                    )
-                    .cast(Resource.class)
-                    .filter(Resource::isReadable)
+                return getBundleResource(pluginId, BundleResourceUtils.JS_BUNDLE)
                     .flatMapMany(resource -> {
                         var head = Mono.<DataBuffer>fromSupplier(
                             () -> dataBufferFactory.wrap(
@@ -299,11 +294,7 @@ public class PluginServiceImpl implements PluginService, InitializingBean, Dispo
             .flatMapSequential(pluginWrapper -> {
                 var pluginId = pluginWrapper.getPluginId();
                 var dataBufferFactory = DefaultDataBufferFactory.sharedInstance;
-                return Mono.fromSupplier(() -> BundleResourceUtils.getJsBundleResource(
-                        pluginManager, pluginId, BundleResourceUtils.CSS_BUNDLE
-                    ))
-                    .cast(Resource.class)
-                    .filter(Resource::isReadable)
+                return getBundleResource(pluginId, BundleResourceUtils.CSS_BUNDLE)
                     .flatMapMany(resource -> {
                         var head = Mono.<DataBuffer>fromSupplier(() -> dataBufferFactory.wrap(
                             ("/* Generated from plugin " + pluginId + " */\n").getBytes()
@@ -314,6 +305,13 @@ public class PluginServiceImpl implements PluginService, InitializingBean, Dispo
                         return Flux.concat(head, content, tail);
                     });
             });
+    }
+
+    private Mono<Resource> getBundleResource(String pluginName, String bundleName) {
+        return Mono.fromSupplier(
+                () -> BundleResourceUtils.getJsBundleResource(pluginManager, pluginName, bundleName)
+            )
+            .filter(Resource::isReadable);
     }
 
     @Override

--- a/application/src/test/java/run/halo/app/plugin/OptionalDependentResolverTest.java
+++ b/application/src/test/java/run/halo/app/plugin/OptionalDependentResolverTest.java
@@ -1,0 +1,126 @@
+package run.halo.app.plugin;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
+
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.pf4j.PluginDependency;
+import org.pf4j.PluginDescriptor;
+
+/**
+ * Tests for {@link OptionalDependentResolver}.
+ *
+ * @author guqing
+ * @since 2.20.11
+ */
+class OptionalDependentResolverTest {
+
+    @Test
+    void testNoPlugins() {
+        OptionalDependentResolver resolver = new OptionalDependentResolver(List.of());
+        assertTrue(resolver.getOptionalDependents("nonexistent").isEmpty(),
+            "No dependents expected for non-existent plugin");
+    }
+
+    @Test
+    void testSinglePluginNoDependencies() {
+        var pluginA = createpluginDescriptor("A", List.of());
+        OptionalDependentResolver resolver = new OptionalDependentResolver(List.of(pluginA));
+
+        assertTrue(resolver.getOptionalDependents("A").isEmpty(), "A has no dependents");
+    }
+
+    @Test
+    void testSingleOptionalDependency() {
+        var pluginA = createpluginDescriptor("A", List.of(new PluginDependency("B?")));
+        var pluginB = createpluginDescriptor("B", List.of());
+        OptionalDependentResolver resolver =
+            new OptionalDependentResolver(List.of(pluginA, pluginB));
+
+        assertEquals(List.of("A"), resolver.getOptionalDependents("B"),
+            "B should have A as dependent");
+        assertTrue(resolver.getOptionalDependents("A").isEmpty(), "A has no dependents");
+    }
+
+    @Test
+    void testMultipleOptionalDependencies() {
+        var pluginA = createpluginDescriptor("A", List.of(
+            new PluginDependency("B?"),
+            new PluginDependency("C?"))
+        );
+
+        var pluginB = createpluginDescriptor("B", List.of());
+
+        var pluginC = createpluginDescriptor("C", List.of());
+
+        OptionalDependentResolver resolver =
+            new OptionalDependentResolver(List.of(pluginA, pluginB, pluginC));
+
+        assertEquals(List.of("A"), resolver.getOptionalDependents("B"),
+            "B should have A as dependent");
+        assertEquals(List.of("A"), resolver.getOptionalDependents("C"),
+            "C should have A as dependent");
+        assertTrue(resolver.getOptionalDependents("A").isEmpty(), "A has no dependents");
+    }
+
+    @Test
+    void testNestedDependencies() {
+        var pluginA = createpluginDescriptor("A", List.of(
+            new PluginDependency("B?")
+        ));
+        var pluginB = createpluginDescriptor("B", List.of(
+            new PluginDependency("C?")
+        ));
+        var pluginC = createpluginDescriptor("C", List.of());
+
+        OptionalDependentResolver resolver =
+            new OptionalDependentResolver(List.of(pluginA, pluginB, pluginC));
+
+        assertEquals(List.of("B"), resolver.getOptionalDependents("C"),
+            "C should have B as dependent");
+        assertEquals(List.of("A"), resolver.getOptionalDependents("B"),
+            "B should have A as dependent");
+        assertTrue(resolver.getOptionalDependents("A").isEmpty(), "A has no dependents");
+    }
+
+    @Test
+    void testCircularDependencies() {
+        var pluginA = createpluginDescriptor("A", List.of(
+            new PluginDependency("B?")
+        ));
+        var pluginB = createpluginDescriptor("B", List.of(
+            new PluginDependency("A?")
+        ));
+        OptionalDependentResolver resolver =
+            new OptionalDependentResolver(List.of(pluginA, pluginB));
+
+        assertEquals(List.of("B"), resolver.getOptionalDependents("A"),
+            "A should have B as dependent");
+        assertEquals(List.of("A"), resolver.getOptionalDependents("B"),
+            "B should have A as dependent");
+    }
+
+    @Test
+    void testNonOptionalDependencies() {
+        var pluginA = createpluginDescriptor("A", List.of(
+            new PluginDependency("B")
+        ));
+        var pluginB = createpluginDescriptor("B", List.of());
+        OptionalDependentResolver resolver =
+            new OptionalDependentResolver(List.of(pluginA, pluginB));
+
+        assertTrue(resolver.getOptionalDependents("B").isEmpty(), "B should have no dependents");
+        assertTrue(resolver.getOptionalDependents("A").isEmpty(), "A should have no dependents");
+    }
+
+    PluginDescriptor createpluginDescriptor(String pluginName,
+        List<PluginDependency> dependencies) {
+        var descriptor = mock(PluginDescriptor.class);
+        lenient().when(descriptor.getPluginId()).thenReturn(pluginName);
+        lenient().when(descriptor.getDependencies()).thenReturn(dependencies);
+        return descriptor;
+    }
+}

--- a/application/src/test/java/run/halo/app/plugin/extensionpoint/DefaultExtensionGetterTest.java
+++ b/application/src/test/java/run/halo/app/plugin/extensionpoint/DefaultExtensionGetterTest.java
@@ -2,8 +2,11 @@ package run.halo.app.plugin.extensionpoint;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.same;
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
 import static run.halo.app.infra.SystemSetting.ExtensionPointEnabled.GROUP;
 
@@ -83,10 +86,12 @@ class DefaultExtensionGetterTest {
         when(beanFactory.getBeanProvider(FakeExtensionPoint.class)).thenReturn(objectProvider);
 
         var extensionImpl = new FakeExtensionPointImpl();
-        when(pluginManager.getExtensions(FakeExtensionPoint.class))
-            .thenReturn(List.of(extensionImpl));
 
-        getter.getEnabledExtensions(FakeExtensionPoint.class)
+        var spyGetter = spy(getter);
+        doReturn(List.of(extensionImpl)).when(spyGetter)
+            .lookExtensions(eq(FakeExtensionPoint.class));
+
+        spyGetter.getEnabledExtensions(FakeExtensionPoint.class)
             .as(StepVerifier::create)
             .expectNext(extensionImpl)
             .verifyComplete();
@@ -112,10 +117,11 @@ class DefaultExtensionGetterTest {
             .thenReturn(Stream.of(extensionDefaultImpl));
         when(beanFactory.getBeanProvider(FakeExtensionPoint.class)).thenReturn(objectProvider);
 
-        when(pluginManager.getExtensions(FakeExtensionPoint.class))
-            .thenReturn(List.of());
+        var spyGetter = spy(getter);
+        doReturn(List.of()).when(spyGetter)
+            .lookExtensions(eq(FakeExtensionPoint.class));
 
-        getter.getEnabledExtensions(FakeExtensionPoint.class)
+        spyGetter.getEnabledExtensions(FakeExtensionPoint.class)
             .as(StepVerifier::create)
             .expectNext(extensionDefaultImpl)
             .verifyComplete();
@@ -162,10 +168,12 @@ class DefaultExtensionGetterTest {
         var extensionImpl = new FakeExtensionPointImpl();
         var anotherExtensionImpl = new FakeExtensionPoint() {
         };
-        when(pluginManager.getExtensions(FakeExtensionPoint.class))
-            .thenReturn(List.of(extensionImpl, anotherExtensionImpl));
 
-        getter.getEnabledExtensions(FakeExtensionPoint.class)
+        var spyGetter = spy(getter);
+        doReturn(List.of(extensionImpl, anotherExtensionImpl)).when(spyGetter)
+            .lookExtensions(eq(FakeExtensionPoint.class));
+
+        spyGetter.getEnabledExtensions(FakeExtensionPoint.class)
             .as(StepVerifier::create)
             // should keep the order of enabled extensions
             .expectNext(extensionDefaultImpl)
@@ -198,10 +206,12 @@ class DefaultExtensionGetterTest {
         var extensionImpl = new FakeExtensionPointImpl();
         var anotherExtensionImpl = new FakeExtensionPoint() {
         };
-        when(pluginManager.getExtensions(FakeExtensionPoint.class))
-            .thenReturn(List.of(extensionImpl, anotherExtensionImpl));
 
-        getter.getEnabledExtensions(FakeExtensionPoint.class)
+        var spyGetter = spy(getter);
+        doReturn(List.of(extensionImpl, anotherExtensionImpl)).when(spyGetter)
+            .lookExtensions(eq(FakeExtensionPoint.class));
+
+        spyGetter.getEnabledExtensions(FakeExtensionPoint.class)
             .as(StepVerifier::create)
             // should keep the order according to @Order annotation
             // order is 1
@@ -217,13 +227,16 @@ class DefaultExtensionGetterTest {
     void shouldGetExtensionsFromPluginManagerAndApplicationContext() {
         var extensionFromPlugin = new FakeExtensionPointDefaultImpl();
         var extensionFromAppContext = new FakeExtensionPointImpl();
-        when(pluginManager.getExtensions(FakeExtensionPoint.class))
-            .thenReturn(List.of(extensionFromPlugin));
+
+        var spyGetter = spy(getter);
+        doReturn(List.of(extensionFromPlugin)).when(spyGetter)
+            .lookExtensions(eq(FakeExtensionPoint.class));
+
         when(beanFactory.getBeanProvider(FakeExtensionPoint.class))
             .thenReturn(extensionPointObjectProvider);
         when(extensionPointObjectProvider.orderedStream())
             .thenReturn(Stream.of(extensionFromAppContext));
-        var extensions = getter.getExtensionList(FakeExtensionPoint.class);
+        var extensions = spyGetter.getExtensionList(FakeExtensionPoint.class);
         assertEquals(List.of(extensionFromAppContext, extensionFromPlugin), extensions);
     }
 


### PR DESCRIPTION
#### What type of PR is this?
/kind bug
/area core
/milestone 2.20.x

#### What this PR does / why we need it:
修复可选插件依赖功能无法正常工作的问题

#### Special notes for your reviewer:

使用以下两个插件测试可选依赖：

[测试插件集合.zip](https://github.com/user-attachments/files/17989250/default.zip)

使用以下测试用例进行测试：

测试用例1：plugin-feed 插件提供 RSS 扩展功能

- **前置条件：**  
    安装并启用 `plugin-feed` 插件。
- **操作步骤：**  
    访问 `http://localhost:8090/feed/rss.xml`。
- **期望结果：**  
    返回 `plugin-feed` 提供的 RSS 内容。

---

测试用例 2: plugin-moments 扩展了 plugin-feed 的 RSS 功能（依赖于 plugin-feed）

- **前置条件：**  
    安装并启用 `plugin-feed` 和 `plugin-moments` 插件。
- **操作步骤：**  
    访问 `http://localhost:8090/feed/moments/rss.xml`。
- **期望结果：**  
    返回 `plugin-moments` 提供的 RSS 内容。

---

测试用例 3: plugin-feed 启用时安装 plugin-moments

- **前置条件：**  
    启用 `plugin-feed` 插件。
- **操作步骤：**
    1. 安装 `plugin-moments` 插件。
    2. 访问 `http://localhost:8090/feed/moments/rss.xml`。
- **期望结果：**  
    `plugin-moments` 提供的 RSS 路由可访问，并返回正确内容。

---

测试用例 4: plugin-feed 未启用时安装 plugin-moments

- **前置条件：**  
    未安装或未启用 `plugin-feed` 插件。
- **操作步骤：**
    1. 安装并启用 `plugin-moments` 插件。
    2. 访问 `http://localhost:8090/feed/moments/rss.xml`。
- **期望结果：**
    - `plugin-moments` 的 RSS 路由不可访问，返回 404。
    - `plugin-moments` 的其他功能正常运行。

---

测试用例 5: plugin-moments 启用后安装 plugin-feed

- **前置条件：**  
    已安装并启用 `plugin-moments` 插件。
- **操作步骤：**
    1. 安装并启用 `plugin-feed` 插件。
    2. 访问 `http://localhost:8090/feed/moments/rss.xml`。
- **期望结果：**  
    `plugin-moments` 提供的 RSS 路由可访问，并返回正确内容。

---

测试用例 6: 停止 plugin-feed 后验证 RSS 路由

- **前置条件：**  
    已启用 `plugin-feed` 和 `plugin-moments` 插件。
- **操作步骤：**
    1. 停止 `plugin-feed` 插件。
    2. 访问 `http://localhost:8090/feed/moments/rss.xml`。
- **期望结果：**
    - `plugin-feed` 停止成功。
    - `plugin-moments` 提供的 RSS 路由不可访问，返回 404。

---

测试用例 7: 重启 Halo 后验证可选依赖插件的启动顺序

- **前置条件：**  
    已启用 `plugin-feed` 和 `plugin-moments` 插件。
- **操作步骤：**
    1. 重启 Halo 服务。
    2. 访问 `http://localhost:8090/feed/moments/rss.xml`。
- **期望结果：**
    - `plugin-moments` 提供的 RSS 路由**始终可访问**。

---

测试用例 8: 必选依赖插件验证

- **场景 1: 安装 seo 插件时未安装应用市场**
    
    - **前置条件：**  
        未安装 `app-store-integration` 插件。
    - **操作步骤：**  
        安装 `plugin-seo` 插件。
    - **期望结果：**  
        提示需要先安装 `app-store-integration` 插件。
- **场景 2: 停止应用市场插件时 seo 插件仍启用**
    
    - **前置条件：**  
        已启用 `app-store-integration` 和 `plugin-seo` 插件。
    - **操作步骤：**  
        停止 `app-store-integration` 插件。
    - **期望结果：**  
        提示需要先停止 `plugin-seo` 插件。

#### Does this PR introduce a user-facing change?

```release-note
修复可选插件依赖功能无法正常工作的问题
```
