### PR TITLE
Fix failing checks of staging repository when releasing to Maven

### DIFF
--- a/api/build.gradle
+++ b/api/build.gradle
@@ -91,6 +91,16 @@ java {
     withJavadocJar()
 }
 
+publishing {
+    publications.named('mavenJava', MavenPublication) {
+        from components.java
+        pom {
+            name = 'API library'
+            description = "$project.description"
+        }
+    }
+}
+
 tasks.named('test') {
     useJUnitPlatform()
     finalizedBy jacocoTestReport

--- a/buildSrc/src/main/groovy/halo.publish.gradle
+++ b/buildSrc/src/main/groovy/halo.publish.gradle
@@ -1,42 +1,29 @@
 plugins {
     id 'maven-publish'
+    id 'signing'
 }
 
 publishing {
-    publications {
-        def pubName = "${archivesBaseName}"
-        pluginManager.withPlugin('java-platform') {
-            pubName = pubName + 'Pom'
-        }
-        pluginManager.withPlugin('java') {
-            pubName = pubName + 'Library'
-        }
-        "${pubName}"(MavenPublication) {
-            pluginManager.withPlugin('java-platform') {
-                from components.javaPlatform
+    publications.register('mavenJava', MavenPublication) {
+        pom {
+            url = 'https://github.com/halo-dev/halo'
+            licenses {
+                license {
+                    name = 'The GNU General Public License v3.0'
+                    url = 'https://www.gnu.org/licenses/gpl-3.0.en.html'
+                }
             }
-            pluginManager.withPlugin('java') {
-                from components.java
+            developers {
+                developer {
+                    id = 'johnniang'
+                    name = 'JohnNiang'
+                    email = 'johnniang@foxmail.com'
+                }
             }
-            pom {
-                licenses {
-                    license {
-                        name = 'The GNU General Public License v3.0'
-                        url = 'https://www.gnu.org/licenses/gpl-3.0.en.html'
-                    }
-                }
-                developers {
-                    developer {
-                        id = 'johnniang'
-                        name = 'JohnNiang'
-                        email = 'johnniang@foxmil.com'
-                    }
-                }
-                scm {
-                    connection = 'scm:git:https://github.com/halo-dev/halo.git'
-                    developerConnection = 'scm:git:ssh://git@github.com:halo-dev/halo.git'
-                    url = 'https://github.com/halo-dev/halo'
-                }
+            scm {
+                connection = 'scm:git:https://github.com/halo-dev/halo.git'
+                developerConnection = 'scm:git:ssh://git@github.com:halo-dev/halo.git'
+                url = 'https://github.com/halo-dev/halo'
             }
         }
     }
@@ -53,4 +40,8 @@ publishing {
             }
         }
     }
+}
+
+signing {
+    sign publishing.publications.mavenJava
 }

--- a/platform/application/build.gradle
+++ b/platform/application/build.gradle
@@ -4,7 +4,6 @@ plugins {
     id 'org.springframework.boot' apply false
     id 'java-platform'
     id 'halo.publish'
-    id 'signing'
 }
 
 group = 'run.halo.tools.platform'
@@ -62,4 +61,14 @@ dependencies {
         api "com.drewnoakes:metadata-extractor:$exifExtractor"
     }
 
+}
+
+publishing {
+    publications.named('mavenJava', MavenPublication) {
+        from components.javaPlatform
+        pom {
+            name = 'Application platform.'
+            description = "$project.description"
+        }
+    }
 }

--- a/platform/plugin/build.gradle
+++ b/platform/plugin/build.gradle
@@ -19,3 +19,13 @@ dependencies {
         // e.g.: api 'halo.run.plugin:links-api:1.1.0'
     }
 }
+
+publishing {
+    publications.named('mavenJava', MavenPublication) {
+        from components.javaPlatform
+        pom {
+            name = 'Plugin platform'
+            description = "$project.description"
+        }
+    }
+}


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/area core

#### What this PR does / why we need it:

When I tried to publish Maven publications into OSSHR <https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/>, I couldn't close and release the opening staging repository because our Maven publications didn't meet the requirements of OSSHR, for example, `Sign Files with GPG/PGP` and `Project Name, Description and URL`.

This PR tries to fix those problem and all checks will pass. You can check it from <https://central.sonatype.com/artifact/run.halo.app/api/overview>.

> https://central.sonatype.org/publish/requirements/

#### Does this PR introduce a user-facing change?

```release-note
None
```
