### PR TITLE
fix: prevent data clearing on FormKit component unmount

### DIFF
--- a/ui/console-src/modules/interface/themes/ThemeSetting.vue
+++ b/ui/console-src/modules/interface/themes/ThemeSetting.vue
@@ -78,6 +78,7 @@ await suspense();
         :id="group"
         :value="currentConfigMapGroupData || {}"
         :name="group"
+        :preserve="true"
         type="form"
         @submit="handleSaveConfigMap"
       >

--- a/ui/console-src/modules/system/plugins/components/tabs/Setting.vue
+++ b/ui/console-src/modules/system/plugins/components/tabs/Setting.vue
@@ -76,6 +76,7 @@ const handleSaveConfigMap = async (data: object) => {
           :id="group"
           :value="currentConfigMapGroupData"
           :name="group"
+          :preserve="true"
           type="form"
           @submit="handleSaveConfigMap"
         >


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/area ui
/milestone 2.20.x

#### What this PR does / why we need it:

Prevent data clearing on FormKit component unmount

#### Which issue(s) this PR fixes:

Fixes #7121 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
修复 FormKit 组件卸载时，对应数据值也被清除的问题
```
