### PR TITLE
fix: XSS vulnerability due to polyglot file type upload

### DIFF
--- a/api/src/main/java/run/halo/app/infra/utils/FileTypeDetectUtils.java
+++ b/api/src/main/java/run/halo/app/infra/utils/FileTypeDetectUtils.java
@@ -10,6 +10,7 @@ import org.apache.tika.metadata.Metadata;
 import org.apache.tika.metadata.TikaCoreProperties;
 import org.apache.tika.mime.MimeTypeException;
 import org.apache.tika.mime.MimeTypes;
+import org.springframework.lang.NonNull;
 import org.springframework.util.Assert;
 
 @UtilityClass
@@ -53,5 +54,42 @@ public class FileTypeDetectUtils {
     public static String detectFileExtension(String mimeType) throws MimeTypeException {
         MimeTypes mimeTypes = MimeTypes.getDefaultMimeTypes();
         return mimeTypes.forName(mimeType).getExtension();
+    }
+
+    /**
+     * <p>Get file extension from file name.</p>
+     * <p>The obtained file extension is in lowercase and includes the dot, such as ".jpg".</p>
+     */
+    @NonNull
+    public static String getFileExtension(String fileName) {
+        Assert.notNull(fileName, "The fileName must not be null");
+        int lastDot = fileName.lastIndexOf(".");
+        if (lastDot > 0) {
+            return fileName.substring(lastDot).toLowerCase();
+        }
+        return "";
+    }
+
+    /**
+     * <p>Recommend to use this method to verify whether the file extension matches the file type
+     * after matching the file type to avoid XSS attacks such as bypassing detection by polyglot
+     * file</p>
+     *
+     * @param mimeType file mime type,such as "image/png"
+     * @param fileName file name,such as "test.png"
+     * @see
+     * <a href="https://github.com/halo-dev/halo/security/advisories/GHSA-99mc-ch53-pqh9">CVE Stored XSS</a>
+     * @see <a href="https://github.com/halo-dev/halo/pull/7149">gh-7149</a>
+     */
+    public boolean isValidExtensionForMime(String mimeType, String fileName) {
+        Assert.notNull(mimeType, "The mimeType must not be null");
+        Assert.notNull(fileName, "The fileName must not be null");
+        String fileExtension = getFileExtension(fileName);
+        try {
+            String detectedExtByMime = detectFileExtension(mimeType);
+            return detectedExtByMime.equalsIgnoreCase(fileExtension);
+        } catch (MimeTypeException e) {
+            return false;
+        }
     }
 }

--- a/application/src/main/resources/config/i18n/messages.properties
+++ b/application/src/main/resources/config/i18n/messages.properties
@@ -82,6 +82,7 @@ problemDetail.conflict=Conflict detected, please check the data and retry.
 problemDetail.migration.backup.notFound=The backup file does not exist or has been deleted.
 problemDetail.attachment.upload.fileSizeExceeded=Make sure the file size is less than {0}.
 problemDetail.attachment.upload.fileTypeNotSupported=Unsupported upload of {0} type files.
+problemDetail.attachment.upload.fileTypeNotMatch=The file type {0} does not match the file extension, and the upload is rejected.
 problemDetail.comment.waitingForApproval=Comment is awaiting approval.
 
 title.visibility.identification.private=(Private)

--- a/application/src/main/resources/config/i18n/messages_zh.properties
+++ b/application/src/main/resources/config/i18n/messages_zh.properties
@@ -55,6 +55,7 @@ problemDetail.conflict=检测到冲突，请检查数据后重试。
 problemDetail.migration.backup.notFound=备份文件不存在或已删除。
 problemDetail.attachment.upload.fileSizeExceeded=最大支持上传 {0} 大小的文件。
 problemDetail.attachment.upload.fileTypeNotSupported=不支持上传 {0} 类型的文件。
+problemDetail.attachment.upload.fileTypeNotMatch=文件类型 {0} 与文件扩展名不匹配，上传被拒绝。
 problemDetail.comment.waitingForApproval=评论审核中。
 
 title.visibility.identification.private=（私有）

--- a/application/src/test/java/run/halo/app/infra/utils/FileTypeDetectUtilsTest.java
+++ b/application/src/test/java/run/halo/app/infra/utils/FileTypeDetectUtilsTest.java
@@ -96,5 +96,29 @@ class FileTypeDetectUtilsTest {
 
         ext = FileTypeDetectUtils.detectFileExtension("application/zip");
         assertThat(ext).isEqualTo(".zip");
+
+        ext = FileTypeDetectUtils.detectFileExtension("image/bmp");
+        assertThat(ext).isEqualTo(".bmp");
+    }
+
+    @Test
+    void getFileExtensionTest() {
+        var ext = FileTypeDetectUtils.getFileExtension("BMP+HTML+JAR.html");
+        assertThat(ext).isEqualTo(".html");
+
+        ext = FileTypeDetectUtils.getFileExtension("test.jpg");
+        assertThat(ext).isEqualTo(".jpg");
+
+        ext = FileTypeDetectUtils.getFileExtension("hello");
+        assertThat(ext).isEqualTo("");
+    }
+
+    @Test
+    void isValidExtensionForMimeTest() {
+        assertThat(FileTypeDetectUtils.isValidExtensionForMime("image/bmp", "hello.html"))
+            .isFalse();
+
+        assertThat(FileTypeDetectUtils.isValidExtensionForMime("image/bmp", "hello.bmp"))
+            .isTrue();
     }
 }


### PR DESCRIPTION
#### What type of PR is this?
/kind bug
/area core
/milestone 2.20.x

#### What this PR does / why we need it:
修复文件类型限制能通过混合文件类型绕过检测的问题

参考：https://github.com/halo-dev/halo/security/advisories/GHSA-99mc-ch53-pqh9

#### Does this PR introduce a user-facing change?

```release-note
修复文件类型限制能通过混合文件类型绕过检测的问题
```
