### PR TITLE
feat: add retry mechanism for publishing posts on the UC end

### DIFF
--- a/ui/uc-src/modules/contents/posts/components/PostCreationModal.vue
+++ b/ui/uc-src/modules/contents/posts/components/PostCreationModal.vue
@@ -7,6 +7,7 @@ import { Toast, VButton, VModal, VSpace } from "@halo-dev/components";
 import { useMutation } from "@tanstack/vue-query";
 import { ref } from "vue";
 import { useI18n } from "vue-i18n";
+import { usePostPublishMutate } from "../composables/use-post-publish-mutate";
 import type { PostFormState } from "../types";
 import PostSettingForm from "./PostSettingForm.vue";
 
@@ -30,6 +31,8 @@ const emit = defineEmits<{
 }>();
 
 const modal = ref<InstanceType<typeof VModal> | null>(null);
+
+const { mutateAsync: postPublishMutate } = usePostPublishMutate();
 
 const { mutate, isLoading } = useMutation({
   mutationKey: ["uc:create-post"],
@@ -55,7 +58,7 @@ const { mutate, isLoading } = useMutation({
         htmlMetas: [],
         pinned: data.pinned,
         priority: 0,
-        publish: false,
+        publish: props.publish,
         publishTime: data.publishTime,
         slug: data.slug,
         tags: data.tags,
@@ -69,9 +72,7 @@ const { mutate, isLoading } = useMutation({
     });
 
     if (props.publish) {
-      await ucApiClient.content.post.publishMyPost({
-        name: post.metadata.name,
-      });
+      await postPublishMutate({ name: post.metadata.name });
     }
 
     return createdPost;

--- a/ui/uc-src/modules/contents/posts/components/PostListItem.vue
+++ b/ui/uc-src/modules/contents/posts/components/PostListItem.vue
@@ -24,6 +24,7 @@ import {
 import { useQueryClient } from "@tanstack/vue-query";
 import { computed } from "vue";
 import { useI18n } from "vue-i18n";
+import { usePostPublishMutate } from "../composables/use-post-publish-mutate";
 
 const { t } = useI18n();
 const queryClient = useQueryClient();
@@ -67,13 +68,17 @@ const isPublishing = computed(() => {
   );
 });
 
-async function handlePublish() {
-  await ucApiClient.content.post.publishMyPost({
-    name: props.post.post.metadata.name,
-  });
+const { mutateAsync: postPublishMutate } = usePostPublishMutate();
 
-  Toast.success(t("core.common.toast.publish_success"));
-  queryClient.invalidateQueries({ queryKey: ["my-posts"] });
+async function handlePublish() {
+  try {
+    await postPublishMutate({ name: props.post.post.metadata.name });
+
+    Toast.success(t("core.common.toast.publish_success"));
+    queryClient.invalidateQueries({ queryKey: ["my-posts"] });
+  } catch (_) {
+    Toast.error(t("core.common.toast.publish_failed_and_retry"));
+  }
 }
 
 function handleUnpublish() {

--- a/ui/uc-src/modules/contents/posts/composables/use-post-publish-mutate.ts
+++ b/ui/uc-src/modules/contents/posts/composables/use-post-publish-mutate.ts
@@ -1,0 +1,19 @@
+import { ucApiClient } from "@halo-dev/api-client";
+import { useMutation } from "@tanstack/vue-query";
+
+export function usePostPublishMutate() {
+  return useMutation({
+    mutationKey: ["uc:publish-post"],
+    mutationFn: async ({ name }: { name: string }) => {
+      return await ucApiClient.content.post.publishMyPost(
+        {
+          name: name,
+        },
+        {
+          mute: true,
+        }
+      );
+    },
+    retry: 3,
+  });
+}


### PR DESCRIPTION
#### What type of PR is this?

/area ui
/kind improvement
/milestone 2.20.x

#### What this PR does / why we need it:

为 UC 端发布文章的操作添加重试机制，防止出现因为锁导致的保存失败问题。

#### Which issue(s) this PR fixes:

Fixes #7139

#### Does this PR introduce a user-facing change?

```release-note
为 UC 端发布文章的操作添加重试机制，防止出现因为锁导致的保存失败问题。
```
