### PR TITLE
refactor: generate summaries only for content changes

### DIFF
--- a/api/src/main/java/run/halo/app/core/extension/content/Constant.java
+++ b/api/src/main/java/run/halo/app/core/extension/content/Constant.java
@@ -10,4 +10,6 @@ public enum Constant {
     public static final String PERMALINK_PATTERN_ANNO = "content.halo.run/permalink-pattern";
 
     public static final String CHECKSUM_CONFIG_ANNO = "checksum/config";
+
+    public static final String CONTENT_CHECKSUM_ANNO = "checksum/content";
 }


### PR DESCRIPTION
#### What type of PR is this?
/kind improvement
/area core
/milestone 2.20.x

#### What this PR does / why we need it:
自动生成摘要仅对内容变更时生效

see https://github.com/halo-dev/halo/issues/7193#issuecomment-2581699190 for more details

避免对资源造成浪费如 AI 摘要生成

#### Which issue(s) this PR fixes:

Fixes #7193

#### Does this PR introduce a user-facing change?

```release-note
自动生成摘要仅对内容发生变更时生效
```
