### PR TITLE
fix: prevent extension-point list from being obscured at bottom

### DIFF
--- a/ui/console-src/modules/system/plugins/PluginExtensionPointSettings.vue
+++ b/ui/console-src/modules/system/plugins/PluginExtensionPointSettings.vue
@@ -76,7 +76,7 @@ watch(
             </h2>
           </div>
           <ul
-            class="box-border h-full w-full divide-y divide-gray-100 overflow-auto"
+            class="box-border h-full w-full divide-y divide-gray-100 overflow-auto pb-12"
             role="list"
           >
             <li


### PR DESCRIPTION
#### What type of PR is this?

/area ui
/kind bug
/milestone 2.20.x

#### What this PR does / why we need it:

See https://github.com/halo-dev/halo/issues/7214

#### Which issue(s) this PR fixes:

Fixes https://github.com/halo-dev/halo/issues/7214

#### Does this PR introduce a user-facing change?

```release-note
修复插件扩展配置列表底部可能被遮挡的问题。
```
