### PR TITLE
Upgrade to R2DBC MySQL 1.4.0

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,2 @@
 version=2.20.11-SNAPSHOT
+r2dbc-mysql.version=1.4.0


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/area core
/milestone 2.20.x

#### What this PR does / why we need it:

This PR upgrades to R2dbc MySQL [1.4.0](https://github.com/asyncer-io/r2dbc-mysql/releases/tag/r2dbc-mysql-1.4.0) and tries to fix <https://github.com/halo-dev/halo/issues/6854>.

#### Which issue(s) this PR fixes:

Fixes https://github.com/halo-dev/halo/issues/6854

#### Does this PR introduce a user-facing change?

```release-note
升级依赖 R2DBC MySQL 至 1.4.0
```
