### PR TITLE
fix: e2e pipeline permission denied

### DIFF
--- a/.github/workflows/halo.yaml
+++ b/.github/workflows/halo.yaml
@@ -125,4 +125,4 @@ jobs:
         run: |
           sudo curl -L https://github.com/docker/compose/releases/download/v2.23.0/docker-compose-linux-x86_64 -o /usr/local/bin/docker-compose
           sudo chmod u+x /usr/local/bin/docker-compose
-          cd e2e && make all
+          cd e2e && sudo make all


### PR DESCRIPTION
#### What type of PR is this?
/kind failing-test

#### What this PR does / why we need it:
Currently E2E test pipeline is skipped due to permission denied. 
See: https://github.com/halo-dev/halo/actions/runs/13527241835/job/37829023983?pr=7239

#### Does this PR introduce a user-facing change?

```release-note
None
```
