### PR TITLE
fix: move cache after doFinally to ensure effective concurrency control

### DIFF
--- a/application/src/main/java/run/halo/app/core/attachment/impl/ThumbnailServiceImpl.java
+++ b/application/src/main/java/run/halo/app/core/attachment/impl/ThumbnailServiceImpl.java
@@ -50,8 +50,9 @@ public class ThumbnailServiceImpl implements ThumbnailService {
         // restriction
         return ongoingTasks.computeIfAbsent(cacheKey, k -> doGenerate(imageUri, size)
             // In the case of concurrency, doGenerate must return the same instance
+            .doFinally(signalType -> ongoingTasks.remove(cacheKey))
             .cache()
-            .doFinally(signalType -> ongoingTasks.remove(cacheKey)));
+        );
     }
 
     record CacheKey(URI imageUri, ThumbnailSize size) {

--- a/application/src/test/java/run/halo/app/core/attachment/impl/ThumbnailServiceImplTest.java
+++ b/application/src/test/java/run/halo/app/core/attachment/impl/ThumbnailServiceImplTest.java
@@ -192,7 +192,7 @@ class ThumbnailServiceImplTest {
             var createdUri = URI.create("/test-thumb.jpg");
             doReturn(Mono.just(createdUri)).when(spyThumbnailService).create(any(), any());
 
-            int threadCount = 10;
+            int threadCount = 100;
             ExecutorService executor = Executors.newFixedThreadPool(threadCount);
             var latch = new CountDownLatch(threadCount);
 


### PR DESCRIPTION
### What this PR does?
将 cache 移动到 doFinally 之后以确保并发控制有效，在这之前可能无法完全有效的控制并发


```release-note
None
```