### PR TITLE
refactor: modify plugin class loading order to follow parent delegation mechanism

### DIFF
--- a/application/src/main/java/run/halo/app/plugin/SpringPlugin.java
+++ b/application/src/main/java/run/halo/app/plugin/SpringPlugin.java
@@ -51,7 +51,7 @@ public class SpringPlugin extends Plugin {
             // try to stop plugin for cleaning resources if something went wrong
             log.error(
                 "Cleaning up plugin resources for plugin {} due to not being able to start plugin.",
-                pluginId);
+                pluginId, t);
             this.stop();
             // propagate exception to invoker.
             throw t;

--- a/application/src/main/java/run/halo/app/plugin/loader/DevPluginLoader.java
+++ b/application/src/main/java/run/halo/app/plugin/loader/DevPluginLoader.java
@@ -1,10 +1,12 @@
-package run.halo.app.plugin;
+package run.halo.app.plugin.loader;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
 import org.pf4j.DevelopmentPluginLoader;
+import org.pf4j.PluginClassLoader;
 import org.pf4j.PluginDescriptor;
 import org.pf4j.PluginManager;
+import run.halo.app.plugin.PluginProperties;
 
 public class DevPluginLoader extends DevelopmentPluginLoader {
 
@@ -39,5 +41,12 @@ public class DevPluginLoader extends DevelopmentPluginLoader {
     public boolean isApplicable(Path pluginPath) {
         // Currently we only support a plugin loading from directory in dev mode.
         return Files.isDirectory(pluginPath);
+    }
+
+    @Override
+    protected PluginClassLoader createPluginClassLoader(Path pluginPath,
+        PluginDescriptor pluginDescriptor) {
+        return new HaloPluginClassLoader(this.pluginManager, pluginDescriptor,
+            this.getClass().getClassLoader());
     }
 }

--- a/application/src/main/java/run/halo/app/plugin/loader/HaloPluginClassLoader.java
+++ b/application/src/main/java/run/halo/app/plugin/loader/HaloPluginClassLoader.java
@@ -1,33 +1,34 @@
 package run.halo.app.plugin.loader;
 
-import lombok.extern.slf4j.Slf4j;
-import org.pf4j.ClassLoadingStrategy;
-import org.pf4j.PluginDescriptor;
-import org.pf4j.PluginManager;
-
 import java.io.IOException;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Enumeration;
 import java.util.List;
+import lombok.extern.slf4j.Slf4j;
+import org.pf4j.ClassLoadingStrategy;
+import org.pf4j.PluginClassLoader;
+import org.pf4j.PluginDescriptor;
+import org.pf4j.PluginManager;
 
 @Slf4j
-public class HaloPluginClassLoader extends org.pf4j.PluginClassLoader {
+public class HaloPluginClassLoader extends PluginClassLoader {
+
     /**
-     * see also <a href="https://github.com/halo-dev/halo/issues/4610">gh-4610</a>
+     * see also <a href="https://github.com/halo-dev/halo/issues/4610">gh-4610</a>.
      */
     private final ClassLoadingStrategy resourceLoadingStrategy = ClassLoadingStrategy.PDA;
 
     public HaloPluginClassLoader(PluginManager pluginManager, PluginDescriptor pluginDescriptor,
-                                 ClassLoader parent) {
+        ClassLoader parent) {
         super(pluginManager, pluginDescriptor, parent, ClassLoadingStrategy.APD);
     }
 
     @Override
     public URL getResource(String name) {
         for (ClassLoadingStrategy.Source classLoadingSource :
-                resourceLoadingStrategy.getSources()) {
+            resourceLoadingStrategy.getSources()) {
             URL url = switch (classLoadingSource) {
                 case APPLICATION -> super.getResource(name);
                 case PLUGIN -> this.findResource(name);
@@ -36,12 +37,12 @@ public class HaloPluginClassLoader extends org.pf4j.PluginClassLoader {
 
             if (url != null) {
                 log.trace("Found resource '{}' in {} classpath", name,
-                        classLoadingSource);
+                    classLoadingSource);
                 return url;
             }
 
             log.trace("Couldn't find resource '{}' in {}", name,
-                    classLoadingSource);
+                classLoadingSource);
         }
 
         return null;
@@ -53,12 +54,12 @@ public class HaloPluginClassLoader extends org.pf4j.PluginClassLoader {
         log.trace("Received request to load resources '{}'", name);
 
         for (ClassLoadingStrategy.Source classLoadingSource :
-                resourceLoadingStrategy.getSources()) {
+            resourceLoadingStrategy.getSources()) {
             switch (classLoadingSource) {
                 case APPLICATION:
                     if (this.getParent() != null) {
                         resources.addAll(
-                                Collections.list(this.getParent().getResources(name)));
+                            Collections.list(this.getParent().getResources(name)));
                     }
                     break;
                 case PLUGIN:
@@ -66,6 +67,9 @@ public class HaloPluginClassLoader extends org.pf4j.PluginClassLoader {
                     break;
                 case DEPENDENCIES:
                     resources.addAll(this.findResourcesFromDependencies(name));
+                    break;
+                default:
+                    // Do nothing
             }
         }
 

--- a/application/src/main/java/run/halo/app/plugin/loader/HaloPluginClassLoader.java
+++ b/application/src/main/java/run/halo/app/plugin/loader/HaloPluginClassLoader.java
@@ -1,0 +1,74 @@
+package run.halo.app.plugin.loader;
+
+import lombok.extern.slf4j.Slf4j;
+import org.pf4j.ClassLoadingStrategy;
+import org.pf4j.PluginDescriptor;
+import org.pf4j.PluginManager;
+
+import java.io.IOException;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Enumeration;
+import java.util.List;
+
+@Slf4j
+public class HaloPluginClassLoader extends org.pf4j.PluginClassLoader {
+    /**
+     * see also <a href="https://github.com/halo-dev/halo/issues/4610">gh-4610</a>
+     */
+    private final ClassLoadingStrategy resourceLoadingStrategy = ClassLoadingStrategy.PDA;
+
+    public HaloPluginClassLoader(PluginManager pluginManager, PluginDescriptor pluginDescriptor,
+                                 ClassLoader parent) {
+        super(pluginManager, pluginDescriptor, parent, ClassLoadingStrategy.APD);
+    }
+
+    @Override
+    public URL getResource(String name) {
+        for (ClassLoadingStrategy.Source classLoadingSource :
+                resourceLoadingStrategy.getSources()) {
+            URL url = switch (classLoadingSource) {
+                case APPLICATION -> super.getResource(name);
+                case PLUGIN -> this.findResource(name);
+                case DEPENDENCIES -> this.findResourceFromDependencies(name);
+            };
+
+            if (url != null) {
+                log.trace("Found resource '{}' in {} classpath", name,
+                        classLoadingSource);
+                return url;
+            }
+
+            log.trace("Couldn't find resource '{}' in {}", name,
+                    classLoadingSource);
+        }
+
+        return null;
+    }
+
+    @Override
+    public Enumeration<URL> getResources(String name) throws IOException {
+        List<URL> resources = new ArrayList<>();
+        log.trace("Received request to load resources '{}'", name);
+
+        for (ClassLoadingStrategy.Source classLoadingSource :
+                resourceLoadingStrategy.getSources()) {
+            switch (classLoadingSource) {
+                case APPLICATION:
+                    if (this.getParent() != null) {
+                        resources.addAll(
+                                Collections.list(this.getParent().getResources(name)));
+                    }
+                    break;
+                case PLUGIN:
+                    resources.addAll(Collections.list(this.findResources(name)));
+                    break;
+                case DEPENDENCIES:
+                    resources.addAll(this.findResourcesFromDependencies(name));
+            }
+        }
+
+        return Collections.enumeration(resources);
+    }
+}


### PR DESCRIPTION
#### What type of PR is this?
/kind improvement
/area core
/milestone 2.20.x

#### What this PR does / why we need it:
修改插件类加载顺序遵循双亲委派机制，以避免插件需要手动排除冲突类的问题

此 PR 的动力是：
1. 插件排除依赖复杂而麻烦
2. 尝试多次无法很好的通过工具实现这一点
3. 对于一些依赖如 kotlin 何 spring security oauth 等同一 JVM 只能加载一次（即不能再次从插件加载）且插件可能无法排除依赖或排除依赖后功能不正确如遇到链接错误等
4. 签名文件冲突等问题

resources 下的资源文件加载顺序还是插件优先，避免与 halo 同名文件不加载的问题

进过测试，插件依赖功能以及其他插件的功能不受影响，建议 Reviewer 再测试一遍

#### Does this PR introduce a user-facing change?

```release-note
调整插件类的加载顺序使其遵循双亲委派机制，替代原先的 Plugin -> Dependent Plugin -> Halo 加载顺序
```
