### PR TITLE
Enable Virtual Thread when running on JVM 21

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,4 +25,4 @@ RUN ln -sf /usr/share/zoneinfo/$TZ /etc/localtime \
 
 Expose 8090
 
-ENTRYPOINT ["sh", "-c", "java ${JVM_OPTS} org.springframework.boot.loader.launch.JarLauncher ${0} ${@}"]
+ENTRYPOINT ["sh", "-c", "java -Dreactor.schedulers.defaultBoundedElasticOnVirtualThreads=true ${JVM_OPTS} org.springframework.boot.loader.launch.JarLauncher ${0} ${@}"]

--- a/application/src/main/resources/application.yaml
+++ b/application/src/main/resources/application.yaml
@@ -34,6 +34,9 @@ spring:
     type: caffeine
     caffeine:
       spec: expireAfterAccess=1h, maximumSize=10000
+  threads:
+    virtual:
+      enabled: true
 
 halo:
   work-dir: ${user.home}/.halo2


### PR DESCRIPTION
#### What type of PR is this?

/kind improvement
/area core
/milestone 2.20.x

#### What this PR does / why we need it:

This PR enables Virtual Thread for instances running on JVM 21. This won't affect instances running on JVM 17.

References:
- https://spring.io/blog/2023/10/31/what-new-is-coming-in-reactor-core-3-6-0
- https://spring.io/blog/2022/10/11/embracing-virtual-threads
- https://docs.spring.io/spring-boot/3.4/reference/features/task-execution-and-scheduling.html

#### Does this PR introduce a user-facing change?

```release-note
None
```
