### PR TITLE
feat: add image thumbnail support for single pages

### DIFF
--- a/application/src/main/java/run/halo/app/content/PageContentThumbnailHandler.java
+++ b/application/src/main/java/run/halo/app/content/PageContentThumbnailHandler.java
@@ -1,0 +1,41 @@
+package run.halo.app.content;
+
+import static run.halo.app.content.HtmlThumbnailSrcsetInjector.generateSrcset;
+
+import java.net.URI;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.lang.NonNull;
+import org.springframework.stereotype.Component;
+import reactor.core.publisher.Mono;
+import run.halo.app.core.attachment.ThumbnailService;
+import run.halo.app.theme.ReactiveSinglePageContentHandler;
+
+/**
+ * A single page content handler to handle post html content and generate thumbnail by the img tag.
+ *
+ * @author guqing
+ * @since 2.21.0
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class PageContentThumbnailHandler implements ReactiveSinglePageContentHandler {
+    private final ThumbnailService thumbnailService;
+
+    @Override
+    public Mono<SinglePageContentContext> handle(
+        @NonNull SinglePageContentContext singlePageContent) {
+        var html = singlePageContent.getContent();
+        return HtmlThumbnailSrcsetInjector.injectSrcset(html,
+                src -> generateSrcset(URI.create(src), thumbnailService)
+            )
+            .onErrorResume(throwable -> {
+                log.debug("Failed to inject srcset to page content, fallback to original content",
+                    throwable);
+                return Mono.just(html);
+            })
+            .doOnNext(singlePageContent::setContent)
+            .thenReturn(singlePageContent);
+    }
+}

--- a/application/src/main/resources/extensions/extension-definitions.yaml
+++ b/application/src/main/resources/extensions/extension-definitions.yaml
@@ -57,3 +57,13 @@ spec:
   extensionPointName: reactive-post-content-handler
   displayName: "文章内容缩略图处理"
   description: "处理文章的 HTML 内容为 img 标签追加缩略图"
+---
+apiVersion: plugin.halo.run/v1alpha1
+kind: ExtensionDefinition
+metadata:
+  name: page-content-thumbnail-handler
+spec:
+  className: run.halo.app.content.PageContentThumbnailHandler
+  extensionPointName: reactive-page-content-handler
+  displayName: "自定义页面内容缩略图处理"
+  description: "处理页面的 HTML 内容为 img 标签追加缩略图"


### PR DESCRIPTION
#### What type of PR is this?
/kind improvment
/area core
/milestone 2.20.x

#### What this PR does / why we need it:
为自定义页面的图片增加缩略图支持

<img width="1594" alt="image" src="https://github.com/user-attachments/assets/f317d73b-e515-4c3c-83e7-06ef55873a37" />

#### Which issue(s) this PR fixes:

Fixes #7232

#### Does this PR introduce a user-facing change?

```release-note
为自定义页面的图片增加缩略图支持
```
