### PR TITLE
feat: support theme preview restriction with super admin access preserved

### DIFF
--- a/api/src/main/java/run/halo/app/infra/SystemSetting.java
+++ b/api/src/main/java/run/halo/app/infra/SystemSetting.java
@@ -32,6 +32,7 @@ public class SystemSetting {
     public static class ThemeRouteRules {
         public static final String GROUP = "routeRules";
 
+        private boolean disableThemePreview;
         private String categories;
         private String archives;
         private String post;

--- a/application/src/main/java/run/halo/app/theme/ThemeResolver.java
+++ b/application/src/main/java/run/halo/app/theme/ThemeResolver.java
@@ -1,14 +1,20 @@
 package run.halo.app.theme;
 
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import org.apache.commons.lang3.StringUtils;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.ReactiveSecurityContextHolder;
+import org.springframework.security.core.context.SecurityContext;
 import org.springframework.stereotype.Component;
 import org.springframework.util.Assert;
 import org.springframework.web.server.ServerWebExchange;
 import reactor.core.publisher.Mono;
 import run.halo.app.infra.SystemConfigurableEnvironmentFetcher;
 import run.halo.app.infra.SystemSetting.Theme;
+import run.halo.app.infra.SystemSetting.ThemeRouteRules;
 import run.halo.app.infra.ThemeRootGetter;
+import run.halo.app.security.authorization.AuthorityUtils;
 
 /**
  * @author johnniang
@@ -39,17 +45,17 @@ public class ThemeResolver {
 
     public Mono<ThemeContext> getTheme(ServerWebExchange exchange) {
         return fetchThemeFromExchange(exchange)
-            .switchIfEmpty(Mono.defer(() -> environmentFetcher.fetch(Theme.GROUP, Theme.class)
-                .map(Theme::getActive)
-                .switchIfEmpty(
-                    Mono.error(() -> new IllegalArgumentException("No theme activated")))
-                .map(activatedTheme -> {
+            .switchIfEmpty(Mono.defer(() -> fetchActivationState()
+                .map(themeState -> {
+                    var activatedTheme = themeState.activatedTheme();
                     var builder = ThemeContext.builder();
                     var themeName = exchange.getRequest().getQueryParams()
                         .getFirst(ThemeContext.THEME_PREVIEW_PARAM_NAME);
-                    if (StringUtils.isBlank(themeName)) {
+
+                    if (StringUtils.isBlank(themeName) || !themeState.supportsPreviewTheme()) {
                         themeName = activatedTheme;
                     }
+
                     boolean active = StringUtils.equals(activatedTheme, themeName);
                     var path = themeRoot.get().resolve(themeName);
                     return builder.name(themeName)
@@ -70,4 +76,45 @@ public class ThemeResolver {
             .cast(ThemeContext.class);
     }
 
+    private Mono<ThemeActivationState> fetchActivationState() {
+        var builder = ThemeActivationState.builder();
+
+        var activatedMono = environmentFetcher.fetch(Theme.GROUP, Theme.class)
+            .map(Theme::getActive)
+            .switchIfEmpty(Mono.error(() -> new IllegalArgumentException("No theme activated")))
+            .doOnNext(builder::activatedTheme);
+
+        var preivewDisabledMono = environmentFetcher.fetch(ThemeRouteRules.GROUP,
+                ThemeRouteRules.class)
+            .map(ThemeRouteRules::isDisableThemePreview)
+            .defaultIfEmpty(false)
+            .doOnNext(builder::previewDisabled);
+
+        var authenticatedUser = ReactiveSecurityContextHolder.getContext()
+            .map(SecurityContext::getAuthentication)
+            .doOnNext(builder::authenticatedUser);
+
+        return Mono.when(activatedMono, preivewDisabledMono, authenticatedUser)
+            .then(Mono.fromSupplier(builder::build));
+    }
+
+    @Builder
+    record ThemeActivationState(String activatedTheme, boolean previewDisabled,
+                                Authentication authenticatedUser) {
+
+        private boolean supportsPreviewTheme() {
+            if (!previewDisabled) {
+                return true;
+            }
+            return isSuperAdminUser();
+        }
+
+        private boolean isSuperAdminUser() {
+            if (authenticatedUser == null) {
+                return false;
+            }
+            var authorities = AuthorityUtils.authoritiesToRoles(authenticatedUser.getAuthorities());
+            return AuthorityUtils.containsSuperRole(authorities);
+        }
+    }
 }

--- a/application/src/main/resources/extensions/system-setting.yaml
+++ b/application/src/main/resources/extensions/system-setting.yaml
@@ -142,6 +142,11 @@ spec:
     - group: routeRules
       label: 主题路由设置
       formSchema:
+        - $formkit: checkbox
+          label: "关闭主题预览"
+          value: false
+          name: disableThemePreview
+          help: "关闭后，主题预览功能将始终预览的是已激活主题，但超级管理员仍然可以通过主题管理页面预览主题"
         - $formkit: text
           label: "分类页路由前缀"
           value: "categories"


### PR DESCRIPTION
#### What type of PR is this?
/kind feature
/area core
/milestone 2.20.x

#### What this PR does / why we need it:
支持禁用主题预览功能（此功能不对超级管理员有效）

#### Which issue(s) this PR fixes:

Fixes #7204

#### Does this PR introduce a user-facing change?

```release-note
支持禁用主题预览功能（此功能不对超级管理员有效）
```
