### PR TITLE
fix: resolve issue of duplicate image uploads in default editor

### DIFF
--- a/ui/src/components/editor/extensions/audio/AudioView.vue
+++ b/ui/src/components/editor/extensions/audio/AudioView.vue
@@ -39,13 +39,9 @@ const handleSetExternalLink = (attachment: AttachmentAttr) => {
 };
 
 const resetUpload = () => {
-  const canUpdateAttributes = props.editor.can().updateAttributes(Audio.name, {
-    width: undefined,
-    height: undefined,
-    file: undefined,
-  });
-  if (canUpdateAttributes && props.getPos()) {
-    props.editor.commands.updateAttributes(Audio.name, {
+  const { file } = props.node.attrs;
+  if (file) {
+    props.updateAttributes({
       width: undefined,
       height: undefined,
       file: undefined,

--- a/ui/src/components/editor/extensions/image/ImageView.vue
+++ b/ui/src/components/editor/extensions/image/ImageView.vue
@@ -80,13 +80,9 @@ const resetUpload = () => {
   fileBase64.value = undefined;
   uploadProgress.value = undefined;
 
-  const canUpdateAttributes = props.editor.can().updateAttributes(Image.name, {
-    width: undefined,
-    height: undefined,
-    file: undefined,
-  });
-  if (canUpdateAttributes && props.getPos()) {
-    props.editor.commands.updateAttributes(Image.name, {
+  const { file } = props.node.attrs;
+  if (file) {
+    props.updateAttributes({
       width: undefined,
       height: undefined,
       file: undefined,

--- a/ui/src/components/editor/extensions/video/VideoView.vue
+++ b/ui/src/components/editor/extensions/video/VideoView.vue
@@ -6,7 +6,6 @@ import RiVideoAddLine from "~icons/ri/video-add-line";
 import { EditorLinkObtain } from "../../components";
 import InlineBlockBox from "../../components/InlineBlockBox.vue";
 import type { AttachmentAttr } from "../../utils/attachment";
-import Video from "./index";
 
 const props = defineProps<NodeViewProps>();
 
@@ -44,13 +43,9 @@ const handleSetExternalLink = (attachment: AttachmentAttr) => {
 };
 
 const resetUpload = () => {
-  const canUpdateAttributes = props.editor.can().updateAttributes(Video.name, {
-    width: undefined,
-    height: undefined,
-    file: undefined,
-  });
-  if (canUpdateAttributes && props.getPos()) {
-    props.editor.commands.updateAttributes(Video.name, {
+  const { file } = props.node.attrs;
+  if (file) {
+    props.updateAttributes({
       width: undefined,
       height: undefined,
       file: undefined,


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/area editor
/milestone 2.20.x

#### What this PR does / why we need it:

解决默认编辑器中，粘贴后的图片，按下回车可能会导致重复触发上传的问题。

#### How to test it?

1. 在默认编辑器中粘贴一个图片。
2. 在图片前进行回车换行。
3. 查看图片是否被重复上传。

#### Which issue(s) this PR fixes:

Fixes #7206 

#### Does this PR introduce a user-facing change?
```release-note
解决默认编辑器中附件会重复上传的问题
```
