### PR TITLE
Turn off logging of TemplateEngine

### DIFF
--- a/application/src/main/resources/application-dev.yaml
+++ b/application/src/main/resources/application-dev.yaml
@@ -32,6 +32,7 @@ halo:
 logging:
   level:
     run.halo.app: DEBUG
+    web: DEBUG
     org.springframework.boot.autoconfigure.web.reactive.error.AbstractErrorWebExceptionHandler: DEBUG
 springdoc:
   cache:

--- a/application/src/main/resources/application.yaml
+++ b/application/src/main/resources/application.yaml
@@ -57,6 +57,8 @@ springdoc:
   writer-with-order-by-keys: true
 
 logging:
+  level:
+    org.thymeleaf.TemplateEngine: OFF
   file:
     name: ${halo.work-dir}/logs/halo.log
   logback:


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/area core
/milestone 2.20.x

#### What this PR does / why we need it:

This PR turns off the logging of TemplateEngine to prevent too many annoying and useless logs.

Please note that the TemplateExceptions won't be eat up because we have a global error handler to log them.

#### Which issue(s) this PR fixes:

Fixes https://github.com/halo-dev/halo/issues/4468

#### Special notes for your reviewer:

Steps to verify:
- Start Halo instance
- Execute command `ab -c 100 -n 10000 -H 'Accept: text/html' -H 'Cache-Control: no-cache' http://localhost:8090/` and then press `Ctrl + C` to stop the ab process.
- See the logs of Halo instance.

#### Does this PR introduce a user-facing change?

```release-note
解决日志中出现大量 InterruptedException 异常的问题
```
