### PR TITLE
chore: add exception information to log output when the plugin fails to start

### DIFF
--- a/application/src/main/java/run/halo/app/core/reconciler/PluginReconciler.java
+++ b/application/src/main/java/run/halo/app/core/reconciler/PluginReconciler.java
@@ -310,6 +310,7 @@ public class PluginReconciler implements Reconciler<Request> {
                     """.formatted(pluginName, pluginState));
             }
         } catch (Throwable e) {
+            log.debug("Error occurred when starting plugin {}", pluginName, e);
             conditions.addAndEvictFIFO(Condition.builder()
                 .type(ConditionType.READY)
                 .status(ConditionStatus.FALSE)

--- a/application/src/main/java/run/halo/app/plugin/SpringPlugin.java
+++ b/application/src/main/java/run/halo/app/plugin/SpringPlugin.java
@@ -52,6 +52,7 @@ public class SpringPlugin extends Plugin {
             log.error(
                 "Cleaning up plugin resources for plugin {} due to not being able to start plugin.",
                 pluginId);
+            log.debug("Error occurred when starting plugin {}", pluginId, t);
             this.stop();
             // propagate exception to invoker.
             throw t;

--- a/application/src/main/java/run/halo/app/plugin/SpringPlugin.java
+++ b/application/src/main/java/run/halo/app/plugin/SpringPlugin.java
@@ -52,7 +52,6 @@ public class SpringPlugin extends Plugin {
             log.error(
                 "Cleaning up plugin resources for plugin {} due to not being able to start plugin.",
                 pluginId);
-            log.debug("Error occurred when starting plugin {}", pluginId, t);
             this.stop();
             // propagate exception to invoker.
             throw t;


### PR DESCRIPTION
#### What type of PR is this?
/kind improvement

#### What this PR does / why we need it:
当插件启动失败时增加异常堆栈日志输出，否则在插件开发时难以知道具体插件为什么启动失败

#### Does this PR introduce a user-facing change?

```release-note
None
```
