### PR TITLE
Add timeout for blocking Extension client

### DIFF
--- a/application/src/main/java/run/halo/app/extension/DelegateExtensionClient.java
+++ b/application/src/main/java/run/halo/app/extension/DelegateExtensionClient.java
@@ -1,5 +1,6 @@
 package run.halo.app.extension;
 
+import java.time.Duration;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Optional;
@@ -16,6 +17,8 @@ import run.halo.app.extension.index.IndexedQueryEngine;
 @Component
 public class DelegateExtensionClient implements ExtensionClient {
 
+    private static final Duration TIMEOUT = Duration.ofSeconds(30);
+
     private final ReactiveExtensionClient client;
 
     public DelegateExtensionClient(ReactiveExtensionClient client) {
@@ -25,49 +28,49 @@ public class DelegateExtensionClient implements ExtensionClient {
     @Override
     public <E extends Extension> List<E> list(Class<E> type, Predicate<E> predicate,
         Comparator<E> comparator) {
-        return client.list(type, predicate, comparator).collectList().block();
+        return client.list(type, predicate, comparator).collectList().block(TIMEOUT);
     }
 
     @Override
     public <E extends Extension> ListResult<E> list(Class<E> type, Predicate<E> predicate,
         Comparator<E> comparator, int page, int size) {
-        return client.list(type, predicate, comparator, page, size).block();
+        return client.list(type, predicate, comparator, page, size).block(TIMEOUT);
     }
 
     @Override
     public <E extends Extension> List<E> listAll(Class<E> type, ListOptions options, Sort sort) {
-        return client.listAll(type, options, sort).collectList().block();
+        return client.listAll(type, options, sort).collectList().block(TIMEOUT);
     }
 
     @Override
     public <E extends Extension> ListResult<E> listBy(Class<E> type, ListOptions options,
         PageRequest page) {
-        return client.listBy(type, options, page).block();
+        return client.listBy(type, options, page).block(TIMEOUT);
     }
 
     @Override
     public <E extends Extension> Optional<E> fetch(Class<E> type, String name) {
-        return client.fetch(type, name).blockOptional();
+        return client.fetch(type, name).blockOptional(TIMEOUT);
     }
 
     @Override
     public Optional<Unstructured> fetch(GroupVersionKind gvk, String name) {
-        return client.fetch(gvk, name).blockOptional();
+        return client.fetch(gvk, name).blockOptional(TIMEOUT);
     }
 
     @Override
     public <E extends Extension> void create(E extension) {
-        client.create(extension).block();
+        client.create(extension).block(TIMEOUT);
     }
 
     @Override
     public <E extends Extension> void update(E extension) {
-        client.update(extension).block();
+        client.update(extension).block(TIMEOUT);
     }
 
     @Override
     public <E extends Extension> void delete(E extension) {
-        client.delete(extension).block();
+        client.delete(extension).block(TIMEOUT);
     }
 
     @Override


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/area core
/milestone 2.20.x

#### What this PR does / why we need it:

This PR adds timeout for blocking Extension client to prevent system from blocking without any error.

#### Which issue(s) this PR fixes:

Recently, we have received several issues about getting stuck in creating menu items. Please refer to the key threaddump detail:

![image](https://github.com/user-attachments/assets/84892449-5f15-4981-a805-df30eeafcdba)

#### Does this PR introduce a user-facing change?

```release-note
None
```
