### PR TITLE
Fix the problem of unit test failure under Java 21

### DIFF
--- a/api/src/main/java/run/halo/app/extension/controller/DefaultController.java
+++ b/api/src/main/java/run/halo/app/extension/controller/DefaultController.java
@@ -242,15 +242,17 @@ public class DefaultController<R> implements Controller {
         }
 
         try {
-            if (executor instanceof AutoCloseable closeable) {
+            // we have to check if the executor is an instance of ExecutorService at first.
+            // Because ExecutorService extends AutoCloseable interface in Java 21
+            if (executor instanceof ExecutorService executorService) {
+                closeExecutorService(executorService);
+            } else if (executor instanceof AutoCloseable closeable) {
                 closeable.close();
                 if (Thread.currentThread().isInterrupted()) {
                     log.warn("Wait timeout for controller {} shutdown", name);
                 } else {
                     log.info("Controller {} is disposed", name);
                 }
-            } else if (executor instanceof ExecutorService executorService) {
-                closeExecutorService(executorService);
             }
         } catch (Exception e) {
             log.warn("Interrupted while waiting for controller {} shutdown", name);


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/area core
/milestone 2.20.x

#### What this PR does / why we need it:

This PR adjusts the order of checking instance of ExecutorService and AutoCloseable interfaces. Because the ExecutorService extends AutoCloseable in Java 21. As a result, unit tests against the method won't be passed in Java 21.

#### Does this PR introduce a user-facing change?

```release-note
None
```
