### PR TITLE
Fix the repeat registration with the email already verified

### DIFF
--- a/api/src/main/java/run/halo/app/core/user/service/UserService.java
+++ b/api/src/main/java/run/halo/app/core/user/service/UserService.java
@@ -25,6 +25,8 @@ public interface UserService {
 
     Flux<User> listByEmail(String email);
 
+    Mono<Boolean> checkEmailAlreadyVerified(String email);
+
     String encryptPassword(String rawPassword);
 
     Mono<User> disable(String username);

--- a/application/src/main/java/run/halo/app/infra/exception/EmailAlreadyTakenException.java
+++ b/application/src/main/java/run/halo/app/infra/exception/EmailAlreadyTakenException.java
@@ -1,0 +1,20 @@
+package run.halo.app.infra.exception;
+
+import java.net.URI;
+import org.springframework.web.server.ServerWebInputException;
+
+/**
+ * Exception thrown when email is already verified and taken.
+ *
+ * @author johnniang
+ */
+public class EmailAlreadyTakenException extends ServerWebInputException {
+
+    public static final URI TYPE = URI.create("https://halo.run/errors/email-already-taken");
+
+    public EmailAlreadyTakenException(String reason) {
+        super(reason);
+        setType(TYPE);
+    }
+
+}

--- a/application/src/main/java/run/halo/app/security/preauth/PreAuthSignUpEndpoint.java
+++ b/application/src/main/java/run/halo/app/security/preauth/PreAuthSignUpEndpoint.java
@@ -31,6 +31,7 @@ import run.halo.app.core.user.service.SignUpData;
 import run.halo.app.core.user.service.UserService;
 import run.halo.app.infra.actuator.GlobalInfoService;
 import run.halo.app.infra.exception.DuplicateNameException;
+import run.halo.app.infra.exception.EmailAlreadyTakenException;
 import run.halo.app.infra.exception.EmailVerificationFailed;
 import run.halo.app.infra.exception.RateLimitExceededException;
 import run.halo.app.infra.exception.RequestBodyValidationException;
@@ -111,6 +112,15 @@ class PreAuthSignUpEndpoint {
                                         "Invalid Email Code"));
                                 }
                             )
+                            .doOnError(EmailAlreadyTakenException.class, e -> {
+                                bindingResult.addError(new FieldError("form",
+                                    "email",
+                                    signUpData.getEmail(),
+                                    true,
+                                    new String[] {"signup.error.email.already-taken"},
+                                    null,
+                                    "Email Already Taken"));
+                            })
                             .doOnError(RateLimitExceededException.class,
                                 e -> model.put("error", "rate-limit-exceeded")
                             )

--- a/application/src/main/resources/config/i18n/messages.properties
+++ b/application/src/main/resources/config/i18n/messages.properties
@@ -88,6 +88,7 @@ problemDetail.comment.waitingForApproval=Comment is awaiting approval.
 title.visibility.identification.private=(Private)
 signup.error.confirm-password-not-match=The confirmation password does not match the password.
 signup.error.email-code.invalid=Invalid email code.
+signup.error.email.already-taken=Email address is already taken.
 
 validation.error.email.pattern=The email format is incorrect
 validation.error.username.pattern=The username can only be lowercase and can only contain letters, numbers, hyphens, and dots, starting and ending with characters.

--- a/application/src/main/resources/config/i18n/messages_zh.properties
+++ b/application/src/main/resources/config/i18n/messages_zh.properties
@@ -61,6 +61,7 @@ problemDetail.comment.waitingForApproval=评论审核中。
 title.visibility.identification.private=（私有）
 signup.error.confirm-password-not-match=确认密码与密码不匹配。
 signup.error.email-code.invalid=邮箱验证码无效。
+signup.error.email.already-taken=邮箱地址已被注册。
 
 validation.error.email.pattern=邮箱格式不正确
 validation.error.username.pattern=用户名只能小写且只能包含字母、数字、中划线和点，以字符开头和结尾


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/area core
/milestone 2.20.x

#### What this PR does / why we need it:

This PR fixes the repeat registration with the email already verified.

![Screenshot From 2025-04-02 16-33-22](https://github.com/user-attachments/assets/1caf0550-f80f-42e4-8db6-747ff1035f63)

#### Which issue(s) this PR fixes:

Fixes https://github.com/halo-dev/halo/issues/7308

#### Does this PR introduce a user-facing change?

```release-note
修复注册时未验证邮箱是否已被占用的问题
```
