### PR TITLE
chore: restrict packages-preview-release job to current repo only

### DIFF
--- a/.github/workflows/packages-preview-release.yaml
+++ b/.github/workflows/packages-preview-release.yaml
@@ -13,6 +13,7 @@ on:
 jobs:
   packages-preview-release:
     runs-on: ubuntu-latest
+    if: github.repository == 'halo-dev/halo'
     steps:
       - uses: actions/checkout@v4
       - name: Setup Environment


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Restrict packages-preview-release job to current repo only

#### Does this PR introduce a user-facing change?

```release-note
None
```
