### PR TITLE
fix: resolve issue with categoryName parameter not working in postFinder.list()

### DIFF
--- a/application/src/main/java/run/halo/app/theme/finders/impl/PostFinderImpl.java
+++ b/application/src/main/java/run/halo/app/theme/finders/impl/PostFinderImpl.java
@@ -325,10 +325,6 @@ public class PostFinderImpl implements PostFinder {
                 builder.andQuery(equal("spec.tags", tagName));
                 hasQuery = true;
             }
-            if (StringUtils.isNotBlank(categoryName)) {
-                builder.andQuery(in("spec.categories", categoryName));
-                hasQuery = true;
-            }
             // Exclude hidden posts when no query
             if (!hasQuery) {
                 builder.fieldQuery(notHiddenPostQuery());


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:

修复 postFinder.list() 传参 categoryName 查询不到子类文章

#### Which issue(s) this PR fixes:

Fixes #7296 

#### Does this PR introduce a user-facing change?

```release-note
修复 postFinder.list() 的 categoryName 参数无效的问题
```
