### PR TITLE
Use secure random to generate metadat name instead of strong secure random

### DIFF
--- a/application/src/main/java/run/halo/app/extension/ReactiveExtensionClientImpl.java
+++ b/application/src/main/java/run/halo/app/extension/ReactiveExtensionClientImpl.java
@@ -1,6 +1,6 @@
 package run.halo.app.extension;
 
-import static org.apache.commons.lang3.RandomStringUtils.secureStrong;
+import static org.apache.commons.lang3.RandomStringUtils.secure;
 import static org.springframework.util.StringUtils.hasText;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -238,8 +238,7 @@ public class ReactiveExtensionClientImpl implements ReactiveExtensionClient {
                         }
 
                         // generate name with random text
-                        // use secureStrong() to make sure the generated name is unpredictable.
-                        metadata.setName(metadata.getGenerateName() + secureStrong()
+                        metadata.setName(metadata.getGenerateName() + secure()
                             .nextAlphanumeric(GENERATE_NAME_RANDOM_LENGTH)
                             // Prevent data conflicts caused by database case sensitivity
                             .toLowerCase()


### PR DESCRIPTION
### What type of PR is this?

/kind bug
/area core
/milestone 2.20.x

#### What this PR does / why we need it:

In PR <https://github.com/halo-dev/halo/pull/7371>, I used strong secure random to generate metadata name, but the random may cause system block in some specific environments. See https://github.com/orgs/lxware-dev/discussions/13#discussioncomment-12907298 for more.

So this PR revert the use of strong secure random.

#### Does this PR introduce a user-facing change?

```release-note
None
```
