### PR TITLE
refactor: add chunked execution mechanism for post batch operations

### DIFF
--- a/ui/console-src/modules/contents/posts/PostList.vue
+++ b/ui/console-src/modules/contents/posts/PostList.vue
@@ -23,6 +23,7 @@ import {
 } from "@halo-dev/components";
 import { useQuery } from "@tanstack/vue-query";
 import { useRouteQuery } from "@vueuse/router";
+import { chunk } from "lodash-es";
 import type { Ref } from "vue";
 import { computed, provide, ref, watch } from "vue";
 import { useI18n } from "vue-i18n";
@@ -266,13 +267,18 @@ const handleDeleteInBatch = async () => {
     confirmText: t("core.common.buttons.confirm"),
     cancelText: t("core.common.buttons.cancel"),
     onConfirm: async () => {
-      await Promise.all(
-        selectedPostNames.value.map((name) => {
-          return consoleApiClient.content.post.recyclePost({
-            name,
-          });
-        })
-      );
+      const chunks = chunk(selectedPostNames.value, 5);
+
+      for (const chunk of chunks) {
+        await Promise.all(
+          chunk.map((name) => {
+            return consoleApiClient.content.post.recyclePost({
+              name,
+            });
+          })
+        );
+      }
+
       await refetch();
       selectedPostNames.value = [];
 
@@ -288,9 +294,14 @@ const handlePublishInBatch = async () => {
     confirmText: t("core.common.buttons.confirm"),
     cancelText: t("core.common.buttons.cancel"),
     onConfirm: async () => {
-      for (const i in selectedPostNames.value) {
-        const name = selectedPostNames.value[i];
-        await consoleApiClient.content.post.publishPost({ name });
+      const chunks = chunk(selectedPostNames.value, 5);
+
+      for (const chunk of chunks) {
+        await Promise.all(
+          chunk.map((name) => {
+            return consoleApiClient.content.post.publishPost({ name });
+          })
+        );
       }
 
       await refetch();
@@ -308,9 +319,14 @@ const handleCancelPublishInBatch = async () => {
     confirmText: t("core.common.buttons.confirm"),
     cancelText: t("core.common.buttons.cancel"),
     onConfirm: async () => {
-      for (const i in selectedPostNames.value) {
-        const name = selectedPostNames.value[i];
-        await consoleApiClient.content.post.unpublishPost({ name });
+      const chunks = chunk(selectedPostNames.value, 5);
+
+      for (const chunk of chunks) {
+        await Promise.all(
+          chunk.map((name) => {
+            return consoleApiClient.content.post.unpublishPost({ name });
+          })
+        );
       }
 
       await refetch();


### PR DESCRIPTION
#### What type of PR is this?

/area ui
/kind improvement
/milestone 2.20.x

#### What this PR does / why we need it:

Use `Promise.all` to execute part of the batch operation logic of the post in chunks to optimize the execution performance.

#### Which issue(s) this PR fixes:

Fixes #

#### Does this PR introduce a user-facing change?

```release-note
优化文章部分批量操作的执行性能
```
