### PR TITLE
fix: equals and hash code for unstructured metadata

### DIFF
--- a/api/src/main/java/run/halo/app/extension/Unstructured.java
+++ b/api/src/main/java/run/halo/app/extension/Unstructured.java
@@ -72,7 +72,7 @@ public class Unstructured implements Extension {
         return new UnstructuredMetadata();
     }
 
-    @EqualsAndHashCode(exclude = "tatersion")
+    @EqualsAndHashCode(exclude = "version")
     class UnstructuredMetadata implements MetadataOperator {
 
         @Override


### PR DESCRIPTION
#### What type of PR is this?
/kind bug
/area core
/milestone 2.20.x

#### What this PR does / why we need it:
修复 Unstructured Metadata 的 equals hashcode  排除 version，这可能是之前误操作提交的

https://github.com/halo-dev/halo/blob/ed50a0224d726b420df70a198111f75e8b0d97a3/api/src/main/java/run/halo/app/extension/Unstructured.java#L75

#### Does this PR introduce a user-facing change?

```release-note
None
```
