### PR TITLE
Upgrade to Spring Boot 3.4.5

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'org.springframework.boot' version '3.4.4' apply false
+    id 'org.springframework.boot' version '3.4.5' apply false
     id 'io.spring.dependency-management' version '1.1.7' apply false
     id "com.gorylenko.gradle-git-properties" version "2.4.1" apply false
     id "de.undercouch.download" version "5.6.0" apply false


### PR DESCRIPTION
#### What type of PR is this?

/kind improvement
/area core
/milestone 2.20.x

#### What this PR does / why we need it:

This PR bumps Spring Boot to [3.4.5](https://github.com/spring-projects/spring-boot/releases/tag/v3.4.5).

#### Which issue(s) this PR fixes:

Fixes #7374 

#### Does this PR introduce a user-facing change?

```release-note
升级依赖 Spring Boot 至 3.4.5，同时解决可能无法登录的问题
```
