### PR TITLE
Support resolving javadoc for SpringDoc

### DIFF
--- a/api/build.gradle
+++ b/api/build.gradle
@@ -26,6 +26,7 @@ repositories {
 
 dependencies {
     api platform(project(':platform:application'))
+    annotationProcessor platform(project(':platform:application'))
 
     api 'org.springframework.boot:spring-boot-starter-actuator'
     api 'org.springframework.boot:spring-boot-starter-data-jpa'
@@ -80,6 +81,9 @@ dependencies {
     runtimeOnly 'org.postgresql:r2dbc-postgresql'
     runtimeOnly 'org.mariadb:r2dbc-mariadb'
     runtimeOnly 'io.asyncer:r2dbc-mysql'
+    runtimeOnly 'com.github.therapi:therapi-runtime-javadoc'
+
+    annotationProcessor "com.github.therapi:therapi-runtime-javadoc-scribe"
 
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.security:spring-security-test'

--- a/application/build.gradle
+++ b/application/build.gradle
@@ -74,6 +74,7 @@ tasks.named('jar') {
 
 dependencies {
     implementation project(':api')
+    annotationProcessor platform(project(':platform:application'))
 
     annotationProcessor "org.springframework.boot:spring-boot-configuration-processor"
     annotationProcessor "org.springframework:spring-context-indexer"
@@ -81,6 +82,8 @@ dependencies {
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.security:spring-security-test'
     testImplementation 'io.projectreactor:reactor-test'
+
+    annotationProcessor 'com.github.therapi:therapi-runtime-javadoc-scribe'
 
     // webjars
     runtimeOnly 'org.webjars.npm:jsencrypt:3.3.2'

--- a/platform/application/build.gradle
+++ b/platform/application/build.gradle
@@ -24,6 +24,7 @@ ext {
     tika = "2.9.2"
     imgscalr = '4.2'
     exifExtractor = '2.19.0'
+    therapiVersion = '0.13.0'
 }
 
 javaPlatform {
@@ -59,6 +60,8 @@ dependencies {
         api "org.apache.tika:tika-core:$tika"
         api "org.imgscalr:imgscalr-lib:$imgscalr"
         api "com.drewnoakes:metadata-extractor:$exifExtractor"
+        api "com.github.therapi:therapi-runtime-javadoc:$therapiVersion"
+        api "com.github.therapi:therapi-runtime-javadoc-scribe:$therapiVersion"
     }
 
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind improvement
/area core
/milestone 2.20.x

#### What this PR does / why we need it:

This PR adds therapi-runtime-javadoc dependency and annotationProcessor for api and application projects. After doing that, SpringDoc will introspect Javadoc annotations and comments. See https://springdoc.org/#javadoc-support for more.

For support in plugin, just add an annotationProcessor like below:

```gradle
dependencies {
    implementation platform('run.halo.tools.platform:plugin:2.20.8-SNAPSHOT')
    compileOnly 'run.halo.app:api'

    annotationProcessor 'com.github.therapi:therapi-runtime-javadoc-scribe:0.13.0'
}
```

#### Does this PR introduce a user-facing change?

```release-note
None
```
