### PR TITLE
Use Argon2 password encoder as default to remove password limit

### DIFF
--- a/api/build.gradle
+++ b/api/build.gradle
@@ -50,6 +50,7 @@ dependencies {
     api "org.springdoc:springdoc-openapi-starter-webflux-ui"
     api 'org.openapi4j:openapi-schema-validator'
     api "net.bytebuddy:byte-buddy"
+    api "org.bouncycastle:bcpkix-jdk18on"
 
     // Apache Lucene
     api "org.apache.lucene:lucene-core"

--- a/application/src/test/java/run/halo/app/config/SecurityConfigTest.java
+++ b/application/src/test/java/run/halo/app/config/SecurityConfigTest.java
@@ -1,13 +1,16 @@
 package run.halo.app.config;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.springframework.security.web.server.header.StrictTransportSecurityServerHttpHeadersWriter.STRICT_TRANSPORT_SECURITY;
 
+import org.apache.commons.lang3.RandomStringUtils;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.reactive.AutoConfigureWebTestClient;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.test.web.reactive.server.WebTestClient;
 
 @SpringBootTest
@@ -34,6 +37,12 @@ class SecurityConfigTest {
             .expectHeader()
             .value(STRICT_TRANSPORT_SECURITY,
                 hsts -> assertFalse(hsts.contains("includeSubDomains")));
+    }
+
+    @Test
+    void shouldAllowPasswordLengthMoreThan72(@Autowired PasswordEncoder passwordEncoder) {
+        var encoded = passwordEncoder.encode(RandomStringUtils.secure().nextAlphanumeric(73));
+        assertNotNull(encoded);
     }
 
 }

--- a/platform/application/build.gradle
+++ b/platform/application/build.gradle
@@ -25,6 +25,7 @@ ext {
     imgscalr = '4.2'
     exifExtractor = '2.19.0'
     therapiVersion = '0.13.0'
+    bouncycastleVersion = '1.80'
 }
 
 javaPlatform {
@@ -37,6 +38,7 @@ dependencies {
     constraints {
         api "org.springdoc:springdoc-openapi-starter-webflux-ui:$springDocOpenAPI"
         api 'org.openapi4j:openapi-schema-validator:1.0.7'
+        api "org.bouncycastle:bcpkix-jdk18on:$bouncycastleVersion"
 
         // Apache Lucene
         api "org.apache.lucene:lucene-core:$lucene"


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/area core
/milestone 2.20.x

#### What this PR does / why we need it:

This PR makes Argon2 password encoder as default to remove password limit of 72.

Please note that there is no compatibility issue for old passwords.

#### Which issue(s) this PR fixes:

Fixes #7405 

#### Special notes for your reviewer:

1. Try to login as admin
2. Create a password having the length of 73 or more for a new user
3. See the result

#### Does this PR introduce a user-facing change?

```release-note
修复无法设置长度超过72个字符的密码的问题
```
