### PR TITLE
Enable configuration properties by scanning

### DIFF
--- a/application/src/main/java/run/halo/app/Application.java
+++ b/application/src/main/java/run/halo/app/Application.java
@@ -4,9 +4,8 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.autoconfigure.integration.IntegrationAutoConfiguration;
 import org.springframework.boot.builder.SpringApplicationBuilder;
 import org.springframework.boot.context.metrics.buffering.BufferingApplicationStartup;
-import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
 import org.springframework.scheduling.annotation.EnableScheduling;
-import run.halo.app.infra.properties.HaloProperties;
 
 /**
  * Halo main class.
@@ -19,7 +18,7 @@ import run.halo.app.infra.properties.HaloProperties;
 @EnableScheduling
 @SpringBootApplication(scanBasePackages = "run.halo.app", exclude =
     IntegrationAutoConfiguration.class)
-@EnableConfigurationProperties({HaloProperties.class})
+@ConfigurationPropertiesScan(basePackages = "run.halo.app.infra.properties")
 public class Application {
 
     public static void main(String[] args) {


### PR DESCRIPTION
#### What type of PR is this?

/kind improvement
/area core
/milestone 2.20.x

#### What this PR does / why we need it:

This PR change the enable method of configuration properties from `EnableConfigurationProperties` to `ConfigurationPropertiesScan`. This way can decouple the add of configuration properties.

See https://docs.spring.io/spring-boot/reference/features/external-config.html#features.external-config.typesafe-configuration-properties.enabling-annotated-types for more.

#### Does this PR introduce a user-facing change?

```release-note
None
```
