### PR TITLE
Fix potential twice theme route handler invocations

### DIFF
--- a/application/src/main/java/run/halo/app/theme/router/ThemeCompositeRouterFunction.java
+++ b/application/src/main/java/run/halo/app/theme/router/ThemeCompositeRouterFunction.java
@@ -55,9 +55,7 @@ public class ThemeCompositeRouterFunction implements RouterFunction<ServerRespon
     @NonNull
     public Mono<HandlerFunction<ServerResponse>> route(@NonNull ServerRequest request) {
         return Flux.fromIterable(cachedRouters)
-            .concatMap(routerFunction -> routerFunction.route(request)
-                .filterWhen(handle -> handle.handle(request).hasElement())
-            )
+            .concatMap(routerFunction -> routerFunction.route(request))
             .next();
     }
 

--- a/application/src/main/java/run/halo/app/theme/router/factories/PostRouteFactory.java
+++ b/application/src/main/java/run/halo/app/theme/router/factories/PostRouteFactory.java
@@ -39,6 +39,7 @@ import run.halo.app.core.extension.content.Post;
 import run.halo.app.extension.MetadataUtil;
 import run.halo.app.extension.ReactiveExtensionClient;
 import run.halo.app.extension.index.query.QueryFactory;
+import run.halo.app.infra.exception.NotFoundException;
 import run.halo.app.infra.utils.JsonUtils;
 import run.halo.app.theme.DefaultTemplateEnum;
 import run.halo.app.theme.ViewNameResolver;
@@ -105,7 +106,8 @@ public class PostRouteFactory implements RouteFactory {
     HandlerFunction<ServerResponse> handlerFunction() {
         return request -> {
             PostPatternVariable patternVariable = PostPatternVariable.from(request);
-            return postResponse(request, patternVariable);
+            return postResponse(request, patternVariable)
+                .switchIfEmpty(Mono.error(() -> new NotFoundException("Post not found.")));
         };
     }
 


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/area core
/milestone 2.20.x

#### What this PR does / why we need it:

1. This PR removes duplicate invocations while resolving handler functions of theme.
2. Throw NotFoundException while post was not found.

#### Which issue(s) this PR fixes:

Fixes https://github.com/halo-dev/halo/issues/7409

#### Does this PR introduce a user-facing change?

```release-note
修复访问不存在的分类或者文章页面时始终抛出异常的问题
```
