### PR TITLE
Remove wrong cache of pattern matchers

### DIFF
--- a/application/src/main/java/run/halo/app/theme/router/ThemeCompositeRouterFunction.java
+++ b/application/src/main/java/run/halo/app/theme/router/ThemeCompositeRouterFunction.java
@@ -4,7 +4,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
-import org.springframework.boot.context.event.ApplicationReadyEvent;
 import org.springframework.context.SmartLifecycle;
 import org.springframework.context.event.EventListener;
 import org.springframework.lang.NonNull;
@@ -96,11 +95,6 @@ public class ThemeCompositeRouterFunction
      */
     @EventListener
     public void onPermalinkRuleChanged(PermalinkRuleChangedEvent event) {
-        this.cachedRouters = routerFunctions();
-    }
-
-    @EventListener
-    public void onApplicationStarted(ApplicationReadyEvent event) {
         this.cachedRouters = routerFunctions();
     }
 

--- a/application/src/test/java/run/halo/app/theme/router/factories/PostRouteFactoryTest.java
+++ b/application/src/test/java/run/halo/app/theme/router/factories/PostRouteFactoryTest.java
@@ -7,6 +7,7 @@ import static org.mockito.Mockito.when;
 
 import java.util.Locale;
 import java.util.Map;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -65,6 +66,14 @@ class PostRouteFactoryTest extends RouteFactoryTestSuite {
 
     @InjectMocks
     private PostRouteFactory postRouteFactory;
+
+    @Test
+    void shouldBeSameResultWhenParsePattenMultiply() {
+        var parser = new PostRouteFactory.PatternParser("/?p={slug}");
+        Assertions.assertTrue(parser.isQueryParamPattern());
+        parser = new PostRouteFactory.PatternParser("/?p={slug}");
+        Assertions.assertTrue(parser.isQueryParamPattern());
+    }
 
     @Test
     void create() {


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/area core
/milestone 2.20.x

#### What this PR does / why we need it:

This PR removes wrong cache of pattern matchers. The method `matcher#find` should not be only invoked multiple times.

First invocation of `matcher#find` will return `true`, but `false` for second invocation.

#### Which issue(s) this PR fixes:

Fixes https://github.com/halo-dev/halo/issues/7426

#### Does this PR introduce a user-facing change?

```release-note
修复文章详情页访问规则为/?p={slug}时无法访问的问题
```
