### PR TITLE
chore: bump ui packages version

### DIFF
--- a/ui/packages/api-client/package.json
+++ b/ui/packages/api-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@halo-dev/api-client",
-  "version": "2.20.0",
+  "version": "2.20.21",
   "description": "API Client for Halo 2",
   "homepage": "https://github.com/halo-dev/halo/tree/main/ui/packages/api-client#readme",
   "bugs": {

--- a/ui/packages/components/package.json
+++ b/ui/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@halo-dev/components",
-  "version": "2.20.0",
+  "version": "2.20.21",
   "description": "",
   "files": [
     "dist"

--- a/ui/packages/editor/package.json
+++ b/ui/packages/editor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@halo-dev/richtext-editor",
-  "version": "2.20.0",
+  "version": "2.20.21",
   "description": "Default editor for Halo",
   "homepage": "https://github.com/halo-dev/halo/tree/main/ui/packages/editor#readme",
   "bugs": {

--- a/ui/packages/shared/package.json
+++ b/ui/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@halo-dev/console-shared",
-  "version": "2.20.0",
+  "version": "2.20.21",
   "description": "",
   "files": [
     "dist"

--- a/ui/packages/ui-plugin-bundler-kit/package.json
+++ b/ui/packages/ui-plugin-bundler-kit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@halo-dev/ui-plugin-bundler-kit",
-  "version": "2.20.0",
+  "version": "2.20.21",
   "homepage": "https://github.com/halo-dev/halo/tree/main/ui/packages/ui-plugin-bundler-kit#readme",
   "bugs": {
     "url": "https://github.com/halo-dev/halo/issues"


### PR DESCRIPTION
#### What type of PR is this?

/area ui
/milestone 2.20.x

#### What this PR does / why we need it:

From 2.20.0 to 2.20.21, the UI packages have undergone some changes, it's time to release a new version.

#### Does this PR introduce a user-facing change?

```release-note
None
```
