### PR TITLE
Set Java 21 as minimal version

### DIFF
--- a/.github/actions/setup-env/action.yaml
+++ b/.github/actions/setup-env/action.yaml
@@ -15,7 +15,7 @@ inputs:
   java-version:
     description: Java version.
     required: false
-    default: "17"
+    default: "21"
 
 runs:
   using: "composite"

--- a/api/build.gradle
+++ b/api/build.gradle
@@ -9,9 +9,15 @@ plugins {
 group = 'run.halo.app'
 description = 'API of halo project, connecting by other projects.'
 
+tasks.withType(JavaCompile).configureEach {
+    options.release = 21
+    options.encoding = 'UTF-8'
+}
+
 java {
-    sourceCompatibility = JavaVersion.VERSION_17
-    targetCompatibility = JavaVersion.VERSION_17
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(21)
+    }
 }
 
 compileJava.options.encoding = "UTF-8"

--- a/application/build.gradle
+++ b/application/build.gradle
@@ -17,12 +17,16 @@ plugins {
 }
 
 group = 'run.halo.app'
-compileJava.options.encoding = 'UTF-8'
-compileTestJava.options.encoding = 'UTF-8'
+
+tasks.withType(JavaCompile).configureEach {
+    options.release = 21
+    options.encoding = 'UTF-8'
+}
 
 java {
-    sourceCompatibility = JavaVersion.VERSION_17
-    targetCompatibility = JavaVersion.VERSION_17
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(21)
+    }
 }
 
 idea {


### PR DESCRIPTION
#### What type of PR is this?

/kind improvement
/area core
/milestone 2.21.x

#### What this PR does / why we need it:

This PR sets Java 21 as minimal version. After doing that, Halo can only run on Java 21 or newer version.

Fortunately, all plugins and themes won't be affected by the restriction.

> https://docs.gradle.org/current/userguide/toolchains.html#sec:release-flag-toolchain

#### Which issue(s) this PR fixes:

Fixes https://github.com/halo-dev/halo/issues/6867

#### Does this PR introduce a user-facing change?

```release-note
[Action Required] 更新最低运行环境为 Java 21
```
