### PR TITLE
Upgrade JSONAssert to 2.0-rc1

### DIFF
--- a/application/src/test/java/run/halo/app/content/ContentRequestTest.java
+++ b/application/src/test/java/run/halo/app/content/ContentRequestTest.java
@@ -42,10 +42,10 @@ class ContentRequestTest {
     @Test
     void toSnapshot() throws JSONException {
         String expectedContentPath =
-            "<p>Four score and seven</p>\n<p>years ago our fathers</p>\n<br/>\n<p>brought forth "
-                + "on this continent</p>\n";
+            "<p>Four score and seven</p>\\n<p>years ago our fathers</p>\\n<br/>\\n<p>brought forth "
+                + "on this continent</p>\\n";
         String expectedRawPatch =
-            "Four score and seven\nyears ago our fathers\n\nbrought forth on this continent\n";
+            "Four score and seven\\nyears ago our fathers\\n\\nbrought forth on this continent\\n";
         Snapshot snapshot = contentRequest.toSnapshot();
         snapshot.getMetadata().setName("7b149646-ac60-4a5c-98ee-78b2dd0631b2");
         JSONAssert.assertEquals(JsonUtils.objectToJson(snapshot),

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,3 @@
 version=2.21.0-SNAPSHOT
 r2dbc-mysql.version=1.4.0
+jsonassert.version=2.0-rc1


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup
/area core
/milestone 2.21.x

#### What this PR does / why we need it:

If we introduce a dependency depending on `org.json:json`, some unit tests won't pass. Please see the error log below:

```java
org.json.JSONException: Unterminated string at 225 [character 0 line 10]
	at app//org.json.JSONTokener.syntaxError(JSONTokener.java:503)
	at app//org.json.JSONTokener.nextString(JSONTokener.java:302)
	at app//org.json.JSONTokener.nextSimpleValue(JSONTokener.java:430)
	at app//org.json.JSONTokener.nextValue(JSONTokener.java:421)
	at app//org.json.JSONObject.<init>(JSONObject.java:242)
	at app//org.json.JSONTokener.nextValue(JSONTokener.java:409)
	at app//org.json.JSONObject.<init>(JSONObject.java:242)
	at app//org.json.JSONObject.<init>(JSONObject.java:430)
	at app//org.skyscreamer.jsonassert.JSONParser.parseJSON(JSONParser.java:43)
	at app//org.skyscreamer.jsonassert.JSONCompare.compareJSON(JSONCompare.java:50)
	at app//org.skyscreamer.jsonassert.JSONCompare.compareJSON(JSONCompare.java:125)
	at app//org.skyscreamer.jsonassert.JSONAssert.assertEquals(JSONAssert.java:415)
	at app//org.skyscreamer.jsonassert.JSONAssert.assertEquals(JSONAssert.java:394)
	at app//org.skyscreamer.jsonassert.JSONAssert.assertEquals(JSONAssert.java:336)
	at app//run.halo.app.content.ContentRequestTest.toSnapshot(ContentRequestTest.java:51)
	at java.base@21.0.5/java.lang.reflect.Method.invoke(Method.java:580)
	at java.base@21.0.5/java.util.ArrayList.forEach(ArrayList.java:1596)
	at java.base@21.0.5/java.util.ArrayList.forEach(ArrayList.java:1596)
```

That is because the JSON string in ContentRequestTest file isn't a valid JSON but the old JSONAssert(1.5.3) depends on an old JSON library(`com.vaadin.external.google:android-json:0.0.20131108.vaadin1`). The JSONAssert [2.0-rc1](https://github.com/skyscreamer/JSONassert/releases/tag/jsonassert-2.0-rc1)
 has upgraded the JSON library to `org.json:json:20240303`.

At the same time, this PR corrects invalid JSON string in `ContentRequestTest#toSnapshot`.

#### Does this PR introduce a user-facing change?

```release-note
None
```
