### PR TITLE
fix: resolve text wrapping issue in StatusDot component

### DIFF
--- a/ui/console-src/modules/contents/comments/components/CommentListItem.vue
+++ b/ui/console-src/modules/contents/comments/components/CommentListItem.vue
@@ -421,13 +421,11 @@ const { operationItems } = useOperationItemExtensionPoint<ListedComment>(
     <template #end>
       <VEntityField v-if="!comment?.comment.spec.approved">
         <template #description>
-          <VStatusDot state="success">
-            <template #text>
-              <span class="text-xs text-gray-500">
-                {{ $t("core.comment.list.fields.pending_review") }}
-              </span>
-            </template>
-          </VStatusDot>
+          <VStatusDot
+            state="warning"
+            animate
+            :text="$t('core.comment.list.fields.pending_review')"
+          />
         </template>
       </VEntityField>
       <VEntityField v-if="comment?.comment?.metadata.deletionTimestamp">

--- a/ui/console-src/modules/contents/comments/components/ReplyListItem.vue
+++ b/ui/console-src/modules/contents/comments/components/ReplyListItem.vue
@@ -216,13 +216,11 @@ const { operationItems } = useOperationItemExtensionPoint<ListedReply>(
     <template #end>
       <VEntityField v-if="!reply?.reply.spec.approved">
         <template #description>
-          <VStatusDot state="success">
-            <template #text>
-              <span class="text-xs text-gray-500">
-                {{ $t("core.comment.list.fields.pending_review") }}
-              </span>
-            </template>
-          </VStatusDot>
+          <VStatusDot
+            state="warning"
+            animate
+            :text="$t('core.comment.list.fields.pending_review')"
+          />
         </template>
       </VEntityField>
       <VEntityField v-if="reply?.reply.metadata.deletionTimestamp">

--- a/ui/packages/components/src/components/status/StatusDot.vue
+++ b/ui/packages/components/src/components/status/StatusDot.vue
@@ -40,7 +40,7 @@ const classes = computed(() => {
   }
 
   .status-dot-text {
-    @apply text-gray-500 text-xs;
+    @apply text-gray-500 text-xs whitespace-nowrap;
   }
 
   &.status-dot-animate {


### PR DESCRIPTION
#### What type of PR is this?

/area ui
/kind bug
/milestone 2.21.x


#### What this PR does / why we need it:

before:

<img width="273" alt="image" src="https://github.com/user-attachments/assets/e1e21e33-6ead-4d47-b3f6-1b19fb0a8a96" />

after:

<img width="323" alt="image" src="https://github.com/user-attachments/assets/950023f8-6e71-4db4-97c4-9a3b2be6dffb" />


#### Does this PR introduce a user-facing change?

```release-note
None
```
