### PR TITLE
Bump Spring Boot to 3.5.0

### DIFF
--- a/api/build.gradle
+++ b/api/build.gradle
@@ -14,15 +14,15 @@ tasks.withType(JavaCompile).configureEach {
     options.encoding = 'UTF-8'
 }
 
+tasks.withType(Javadoc).configureEach {
+    options.encoding = 'UTF-8'
+}
+
 java {
     toolchain {
         languageVersion = JavaLanguageVersion.of(21)
     }
 }
-
-compileJava.options.encoding = "UTF-8"
-compileTestJava.options.encoding = "UTF-8"
-javadoc.options.encoding = "UTF-8"
 
 repositories {
     mavenCentral()
@@ -95,6 +95,8 @@ dependencies {
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.security:spring-security-test'
     testImplementation 'io.projectreactor:reactor-test'
+
+    testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 
 java {

--- a/application/build.gradle
+++ b/application/build.gradle
@@ -91,6 +91,8 @@ dependencies {
     testImplementation 'org.springframework.security:spring-security-test'
     testImplementation 'io.projectreactor:reactor-test'
 
+    testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
     annotationProcessor 'com.github.therapi:therapi-runtime-javadoc-scribe'
 
     // webjars

--- a/application/src/main/resources/application.yaml
+++ b/application/src/main/resources/application.yaml
@@ -74,8 +74,13 @@ management:
         include: "*"
   endpoint:
     shutdown:
-      enabled: true
+      access: unrestricted
+    heapdump:
+      access: unrestricted
     health:
+      show-details: when-authorized
+      show-components: when-authorized
+      roles: super-role
       probes:
         enabled: true
   info:

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -39,7 +39,7 @@ apache = ['apache-commons-lang3', 'apache-tika-core']
 therapi = ['therapi-runtime-javadoc', 'therapi-runtime-javadoc-scribe']
 
 [plugins]
-spring-boot = 'org.springframework.boot:3.4.5'
+spring-boot = 'org.springframework.boot:3.5.0'
 spring-dependency-management = 'io.spring.dependency-management:1.1.7'
 git-properties = 'com.gorylenko.gradle-git-properties:2.5.0'
 undercouch-download = 'de.undercouch.download:5.6.0'


### PR DESCRIPTION
#### What type of PR is this?

/kind improvement
/area core
/milestone 2.21.x

#### What this PR does / why we need it:

This PR bumps Spring Boot to [3.5.0](https://github.com/spring-projects/spring-boot/releases/tag/v3.5.0).

#### Does this PR introduce a user-facing change?

```release-note
升级依赖 Spring Boot 至 3.5.0
```
