### PR TITLE
Fix deprecation warnings from Gradle

### DIFF
--- a/api/build.gradle
+++ b/api/build.gradle
@@ -26,8 +26,8 @@ javadoc.options.encoding = "UTF-8"
 
 repositories {
     mavenCentral()
-    maven { url 'https://repo.spring.io/milestone' }
-    maven { url 'https://s01.oss.sonatype.org/content/repositories/snapshots' }
+    maven { url = 'https://repo.spring.io/milestone' }
+    maven { url = 'https://s01.oss.sonatype.org/content/repositories/snapshots' }
 }
 
 dependencies {

--- a/application/build.gradle
+++ b/application/build.gradle
@@ -44,8 +44,8 @@ checkstyle {
 repositories {
     mavenCentral()
 
-    maven { url 'https://repo.spring.io/milestone' }
-    maven { url 'https://s01.oss.sonatype.org/content/repositories/snapshots' }
+    maven { url = 'https://repo.spring.io/milestone' }
+    maven { url = 'https://s01.oss.sonatype.org/content/repositories/snapshots' }
 }
 
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,6 +1,6 @@
 pluginManagement {
     repositories {
-        maven { url 'https://repo.spring.io/milestone' }
+        maven { url = 'https://repo.spring.io/milestone' }
         gradlePluginPortal()
     }
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup
/area core
/milestone 2.21.x

#### What this PR does / why we need it:

This PR fixes fixes deprecation warnings complained from Gradle. Please see the Gradle logs below:

```bash

[Incubating] Problems report is available at: file:///home/runner/work/halo/halo/build/reports/problems/problems-report.html

Deprecated Gradle features were used in this build, making it incompatible with Gradle 9.0.

You can use '--warning-mode all' to show the individual deprecation warnings and determine if they come from your own scripts or plugins.

For more on this, please refer to https://docs.gradle.org/8.14/userguide/command_line_interface.html#sec:command_line_warnings in the Gradle documentation.

```

```bash
❯ ./gradlew --warning-mode all
Settings file '/home/johnniang/workspaces/halo-dev/halo/settings.gradle': line 3
Properties should be assigned using the 'propName = value' syntax. Setting a property via the Gradle-generated 'propName value' or 'propName(value)' syntax in Groovy DSL has been deprecated. This is scheduled to be removed in Gradle 10.0. Use assignment ('url = <value>') instead. Consult the upgrading guide for further information: https://docs.gradle.org/8.14/userguide/upgrading_version_8.html#groovy_space_assignment_syntax
        at settings_bmd73lhhmd3oozsi0bas361xt$_run_closure1$_closure2$_closure3.doCall$original(/home/johnniang/workspaces/halo-dev/halo/settings.gradle:3)
        (Run with --stacktrace to get the full stack trace of this deprecation warning.)
        at settings_bmd73lhhmd3oozsi0bas361xt$_run_closure1$_closure2.doCall$original(/home/johnniang/workspaces/halo-dev/halo/settings.gradle:3)
        (Run with --stacktrace to get the full stack trace of this deprecation warning.)

> Configure project :api
Build file '/home/johnniang/workspaces/halo-dev/halo/api/build.gradle': line 29
Properties should be assigned using the 'propName = value' syntax. Setting a property via the Gradle-generated 'propName value' or 'propName(value)' syntax in Groovy DSL has been deprecated. This is scheduled to be removed in Gradle 10.0. Use assignment ('url = <value>') instead. Consult the upgrading guide for further information: https://docs.gradle.org/8.14/userguide/upgrading_version_8.html#groovy_space_assignment_syntax
        at build_3nfrn4qa0l1h825smn7h7qxce$_run_closure3$_closure10.doCall$original(/home/johnniang/workspaces/halo-dev/halo/api/build.gradle:29)
        (Run with --stacktrace to get the full stack trace of this deprecation warning.)
        at build_3nfrn4qa0l1h825smn7h7qxce$_run_closure3.doCall$original(/home/johnniang/workspaces/halo-dev/halo/api/build.gradle:29)
        (Run with --stacktrace to get the full stack trace of this deprecation warning.)
Build file '/home/johnniang/workspaces/halo-dev/halo/api/build.gradle': line 30
Properties should be assigned using the 'propName = value' syntax. Setting a property via the Gradle-generated 'propName value' or 'propName(value)' syntax in Groovy DSL has been deprecated. This is scheduled to be removed in Gradle 10.0. Use assignment ('url = <value>') instead. Consult the upgrading guide for further information: https://docs.gradle.org/8.14/userguide/upgrading_version_8.html#groovy_space_assignment_syntax
        at build_3nfrn4qa0l1h825smn7h7qxce$_run_closure3$_closure11.doCall$original(/home/johnniang/workspaces/halo-dev/halo/api/build.gradle:30)
        (Run with --stacktrace to get the full stack trace of this deprecation warning.)
        at build_3nfrn4qa0l1h825smn7h7qxce$_run_closure3.doCall$original(/home/johnniang/workspaces/halo-dev/halo/api/build.gradle:30)
        (Run with --stacktrace to get the full stack trace of this deprecation warning.)

> Configure project :application
Build file '/home/johnniang/workspaces/halo-dev/halo/application/build.gradle': line 47
Properties should be assigned using the 'propName = value' syntax. Setting a property via the Gradle-generated 'propName value' or 'propName(value)' syntax in Groovy DSL has been deprecated. This is scheduled to be removed in Gradle 10.0. Use assignment ('url = <value>') instead. Consult the upgrading guide for further information: https://docs.gradle.org/8.14/userguide/upgrading_version_8.html#groovy_space_assignment_syntax
        at build_49fzsviti92gf6xdg4zzr6ufm$_run_closure5$_closure24.doCall$original(/home/johnniang/workspaces/halo-dev/halo/application/build.gradle:47)
        (Run with --stacktrace to get the full stack trace of this deprecation warning.)
        at build_49fzsviti92gf6xdg4zzr6ufm$_run_closure5.doCall$original(/home/johnniang/workspaces/halo-dev/halo/application/build.gradle:47)
        (Run with --stacktrace to get the full stack trace of this deprecation warning.)
Build file '/home/johnniang/workspaces/halo-dev/halo/application/build.gradle': line 48
Properties should be assigned using the 'propName = value' syntax. Setting a property via the Gradle-generated 'propName value' or 'propName(value)' syntax in Groovy DSL has been deprecated. This is scheduled to be removed in Gradle 10.0. Use assignment ('url = <value>') instead. Consult the upgrading guide for further information: https://docs.gradle.org/8.14/userguide/upgrading_version_8.html#groovy_space_assignment_syntax
        at build_49fzsviti92gf6xdg4zzr6ufm$_run_closure5$_closure25.doCall$original(/home/johnniang/workspaces/halo-dev/halo/application/build.gradle:48)
        (Run with --stacktrace to get the full stack trace of this deprecation warning.)
        at build_49fzsviti92gf6xdg4zzr6ufm$_run_closure5.doCall$original(/home/johnniang/workspaces/halo-dev/halo/application/build.gradle:48)
        (Run with --stacktrace to get the full stack trace of this deprecation warning.)

```

#### Does this PR introduce a user-facing change?

```release-note
None
```
