### PR TITLE
Add support back for using relative permalink

### DIFF
--- a/application/src/main/java/run/halo/app/infra/SystemConfigFirstExternalUrlSupplier.java
+++ b/application/src/main/java/run/halo/app/infra/SystemConfigFirstExternalUrlSupplier.java
@@ -63,13 +63,12 @@ class SystemConfigFirstExternalUrlSupplier implements ExternalUrlSupplier {
     @Override
     public URI get() {
         try {
-            if (externalUrl != null) {
-                return externalUrl.toURI();
-            }
             if (!haloProperties.isUseAbsolutePermalink()) {
                 return URI.create(getBasePath());
             }
-
+            if (externalUrl != null) {
+                return externalUrl.toURI();
+            }
             return haloProperties.getExternalUrl().toURI();
         } catch (URISyntaxException e) {
             throw Exceptions.propagate(e);

--- a/application/src/test/java/run/halo/app/infra/SystemConfigFirstExternalUrlSupplierTest.java
+++ b/application/src/test/java/run/halo/app/infra/SystemConfigFirstExternalUrlSupplierTest.java
@@ -55,7 +55,7 @@ class SystemConfigFirstExternalUrlSupplierTest {
         }
 
         @Test
-        void getURIWhenBasePathSetAndNotUsingAbsolutePermalink() throws MalformedURLException {
+        void getURIWhenBasePathSetAndNotUsingAbsolutePermalink() {
             when(webFluxProperties.getBasePath()).thenReturn("/blog");
             when(haloProperties.isUseAbsolutePermalink()).thenReturn(false);
 
@@ -137,14 +137,31 @@ class SystemConfigFirstExternalUrlSupplierTest {
     class SystemConfigSupplier {
 
         @Test
-        void shouldGetUrlCorrectly() throws Exception {
+        void shouldGetUrlWhenUseAbsolutePermalink() throws Exception {
             var basic = new SystemSetting.Basic();
             basic.setExternalUrl("https://www.halo.run");
             when(systemConfigFetcher.getBasic()).thenReturn(Mono.just(basic));
+            when(haloProperties.isUseAbsolutePermalink()).thenReturn(true);
             externalUrl.onExtensionInitialized(null);
             assertEquals(URI.create("https://www.halo.run").toURL(), externalUrl.getRaw());
             assertEquals(URI.create("https://www.halo.run"), externalUrl.get());
 
+            var mockRequest = mock(HttpRequest.class);
+            assertEquals(URI.create("https://www.halo.run").toURL(),
+                externalUrl.getURL(mockRequest));
+        }
+
+        @Test
+        void shouldGetUrlWhenNotUsingAbsolutePermalink() throws MalformedURLException {
+            var basic = new SystemSetting.Basic();
+            basic.setExternalUrl("https://www.halo.run");
+            when(systemConfigFetcher.getBasic()).thenReturn(Mono.just(basic));
+            when(haloProperties.isUseAbsolutePermalink()).thenReturn(false);
+            when(webFluxProperties.getBasePath()).thenReturn("/fake");
+            externalUrl.onExtensionInitialized(null);
+
+            assertEquals(URI.create("https://www.halo.run").toURL(), externalUrl.getRaw());
+            assertEquals(URI.create("/fake"), externalUrl.get());
             var mockRequest = mock(HttpRequest.class);
             assertEquals(URI.create("https://www.halo.run").toURL(),
                 externalUrl.getURL(mockRequest));


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/area core
/milestone 2.21.x

#### What this PR does / why we need it:

This PR fixes the problem of not working for relative permalink caused by <https://github.com/halo-dev/halo/pull/7459>.

#### Special notes for your reviewer:

1. Try to start Halo instance with `halo.use-absolute-permalink=false` and check the permalinks of posts and attachments.
1. Try to start Halo instance with `halo.use-absolute-permalink=true` and check the permalinks of posts and attachments.

#### Does this PR introduce a user-facing change?

```release-note
None
```
