### PR TITLE
Bump Lucene to 10.2.1

### DIFF
--- a/application/src/main/java/run/halo/app/search/lucene/LuceneSearchEngine.java
+++ b/application/src/main/java/run/halo/app/search/lucene/LuceneSearchEngine.java
@@ -273,7 +273,7 @@ public class LuceneSearchEngine implements SearchEngine, InitializingBean, Dispo
             }
             var result = new SearchResult();
             result.setHits(haloDocs);
-            result.setTotal(hits.totalHits.value);
+            result.setTotal(hits.totalHits.value());
             result.setKeyword(keyword);
             result.setLimit(limit);
             result.setProcessingTimeMillis(stopWatch.getTotalTimeMillis());

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-lucene = '9.12.0'
+lucene = '10.2.1'
 resilience4j = '2.3.0'
 therapi = '0.15.0'
 


### PR DESCRIPTION
#### What type of PR is this?

/kind improvement
/area core
/milestone 2.21.x

#### What this PR does / why we need it:

This PR bumps Lucene to [10.2.1](https://github.com/apache/lucene/releases/tag/releases%2Flucene%2F10.2.1). Please note that this version requires Java 21 as minimal version.

#### Does this PR introduce a user-facing change?

```release-note
升级依赖 Lucene 至 10.2.1
```

