### PR TITLE
Add support for setting external URL at setup page

### DIFF
--- a/application/src/main/java/run/halo/app/infra/ExternalUrlChangedEvent.java
+++ b/application/src/main/java/run/halo/app/infra/ExternalUrlChangedEvent.java
@@ -1,0 +1,23 @@
+package run.halo.app.infra;
+
+import java.net.URL;
+import lombok.Getter;
+import org.springframework.context.ApplicationEvent;
+
+/**
+ * Event triggered when the external URL of the application changes.
+ *
+ * @author johnniang
+ * @since 2.21.0
+ */
+public class ExternalUrlChangedEvent extends ApplicationEvent {
+
+    @Getter
+    private final URL externalUrl;
+
+    public ExternalUrlChangedEvent(Object source, URL externalUrl) {
+        super(source);
+        this.externalUrl = externalUrl;
+    }
+
+}

--- a/application/src/main/resources/templates/setup.html
+++ b/application/src/main/resources/templates/setup.html
@@ -22,6 +22,7 @@
                     <span th:text="#{form.messages.h2.content}"> </span>
                 </div>
                 <form th:object="${form}" th:action="@{/system/setup}" class="halo-form" method="post">
+
                     <div class="form-item">
                         <label for="language" th:text="#{form.language.label}"></label>
                         <div class="form-input">
@@ -32,6 +33,20 @@
                                 <option value="zh-TW" th:selected="${#locale.toLanguageTag} == 'zh-TW'">繁体中文</option>
                             </select>
                         </div>
+                    </div>
+
+                    <div class="form-item">
+                        <label for="externalUrl" th:text="#{form.externalUrl.label}"></label>
+                        <div class="form-input">
+                            <input name="externalUrl"
+                                   type="url"
+                                   th:field="*{externalUrl}"
+                                   autocomplete="off"
+                                   spellcheck="false"
+                                   autocapitalize="off"
+                                   required/>
+                        </div>
+                        <p class="alert alert-error" th:if="${#fields.hasErrors('externalUrl')}" th:errors="*{externalUrl}"></p>
                     </div>
 
                     <div class="form-item">

--- a/application/src/main/resources/templates/setup.properties
+++ b/application/src/main/resources/templates/setup.properties
@@ -5,6 +5,7 @@ form.username.label=用户名
 form.email.label=电子邮箱
 form.password.label=密码
 form.confirmPassword.label=确认密码
+form.externalUrl.label=外部访问地址
 form.submit=初始化
 form.messages.h2.title=警告：正在使用 H2 数据库
 form.messages.h2.content=H2 数据库仅适用于开发环境和测试环境，不推荐在生产环境中使用，H2 非常容易因为操作不当导致数据文件损坏。如果必须要使用，请按时进行数据备份。

--- a/application/src/main/resources/templates/setup_en.properties
+++ b/application/src/main/resources/templates/setup_en.properties
@@ -5,6 +5,7 @@ form.username.label=Username
 form.email.label=Email
 form.password.label=Password
 form.confirmPassword.label=Confirm Password
+form.externalUrl.label=External URL
 form.submit=Setup
 form.messages.h2.title=Warning: Using H2 Database
 form.messages.h2.content=The H2 database is only suitable for development and testing environments. It is not recommended for production environments, as H2 is very prone to data file corruption due to improper operations. If you must use it, please back up your data regularly.

--- a/application/src/main/resources/templates/setup_es.properties
+++ b/application/src/main/resources/templates/setup_es.properties
@@ -5,6 +5,7 @@ form.username.label=Nombre de Usuario
 form.email.label=Correo Electrónico
 form.password.label=Contraseña
 form.confirmPassword.label=Confirmar Contraseña
+form.externalUrl.label=URL Externa
 form.submit=Configurar
 form.messages.h2.title=Advertencia: Usando la base de datos H2
 form.messages.h2.content=La base de datos H2 solo es adecuada para entornos de desarrollo y prueba. No se recomienda su uso en entornos de producción, ya que H2 es muy susceptible a la corrupción de archivos de datos debido a un manejo inadecuado. Si debe usarla, realice copias de seguridad de los datos regularmente.

--- a/application/src/main/resources/templates/setup_zh_TW.properties
+++ b/application/src/main/resources/templates/setup_zh_TW.properties
@@ -5,6 +5,7 @@ form.username.label=使用者名稱
 form.email.label=電子郵件
 form.password.label=密碼
 form.confirmPassword.label=確認密碼
+form.externalUrl.label=外部訪問地址
 form.submit=初始化
 form.messages.h2.title=警告：正在使用 H2 資料庫
 form.messages.h2.content=H2 資料庫僅適用於開發環境和測試環境，不建議在生產環境中使用，H2 非常容易因為操作不當導致資料檔案損壞。如果必須要使用，請按時進行資料備份。


### PR DESCRIPTION
#### What type of PR is this?

/kind improvement
/area core
/milestone 2.21.x

#### What this PR does / why we need it:

This PR allows users to set external URL at setup page without performing a restart.

#### Which issue(s) this PR fixes:

Fixes https://github.com/halo-dev/halo/issues/7479

#### Special notes for your reviewer:

1. Try to start Halo instance with a fresh environment.
2. Request index page and you will be redirected to setup page.
3. Check if the external URL is equal to the base URL in your browser.
4. Try to change external URL and finish the setup process.
5. Login to console and check the external URL in overview page.

#### Does this PR introduce a user-facing change?

```release-note
支持在初始化页面设置外部访问地址
```

