### PR TITLE
refactor: remove time field from plugin list

### DIFF
--- a/ui/console-src/modules/system/plugins/components/PluginListItem.vue
+++ b/ui/console-src/modules/system/plugins/components/PluginListItem.vue
@@ -1,5 +1,4 @@
 <script lang="ts" setup>
-import { formatDatetime } from "@/utils/date";
 import { usePermission } from "@/utils/permission";
 import {
   PluginStatusPhaseEnum,
@@ -227,15 +226,6 @@ const { startFields, endFields } = useEntityFieldItemExtensionPoint<Plugin>(
         props: {
           plugin: props.plugin,
         },
-      },
-      {
-        position: "end",
-        priority: 50,
-        component: markRaw(VEntityField),
-        props: {
-          description: formatDatetime(props.plugin.metadata.creationTimestamp),
-        },
-        hidden: !props.plugin.metadata.creationTimestamp,
       },
       {
         position: "end",

--- a/ui/console-src/modules/system/plugins/components/tabs/Detail.vue
+++ b/ui/console-src/modules/system/plugins/components/tabs/Detail.vue
@@ -275,6 +275,10 @@ const lastCondition = computed(() => {
             </span>
           </VDescriptionItem>
           <VDescriptionItem
+            :label="$t('core.plugin.detail.fields.creation_time')"
+            :content="formatDatetime(plugin?.metadata.creationTimestamp)"
+          />
+          <VDescriptionItem
             :label="$t('core.plugin.detail.fields.last_starttime')"
             :content="formatDatetime(plugin?.status?.lastStartTime)"
           />

--- a/ui/src/locales/_missing_translations_es.yaml
+++ b/ui/src/locales/_missing_translations_es.yaml
@@ -222,6 +222,7 @@ core:
         repo: Source Repository
         load_location: Storage Location
         issues: Issues feedback
+        creation_time: Installation Time
       operations:
         view_conditions:
           button: View recent conditions
@@ -505,6 +506,13 @@ core:
     fields:
       activated_theme: Activated theme
       enabled_plugins: Enabled plugins
+    external_url_form:
+      operations:
+        save:
+          title: Modify external url
+          description: Modifying the external access address requires restarting the Halo service. It will automatically restart after the modification is completed. Do you want to continue?
+      tips:
+        restarting: Modification completed, waiting for restart...
   backup:
     operations:
       remote_download:

--- a/ui/src/locales/en.yaml
+++ b/ui/src/locales/en.yaml
@@ -970,6 +970,7 @@ core:
         repo: Source Repository
         load_location: Storage Location
         issues: Issues feedback
+        creation_time: Installation Time
       operations:
         view_conditions:
           button: View recent conditions

--- a/ui/src/locales/zh-CN.yaml
+++ b/ui/src/locales/zh-CN.yaml
@@ -905,6 +905,7 @@ core:
         repo: 源码仓库
         load_location: 存储位置
         issues: 问题反馈
+        creation_time: 安装时间
       operations:
         view_conditions:
           button: 查看最近状态

--- a/ui/src/locales/zh-TW.yaml
+++ b/ui/src/locales/zh-TW.yaml
@@ -890,6 +890,7 @@ core:
         repo: 源碼倉庫
         load_location: 存儲位置
         issues: 問題回饋
+        creation_time: 安裝時間
       operations:
         view_conditions:
           button: 查看最近狀態


### PR DESCRIPTION
#### What type of PR is this?

/area ui
/kind improvement
/milestone 2.21.x

#### What this PR does / why we need it:

As per the title, the time shown in the plugin list is the installation time of the plugin. For usage purposes, this time seems to have no meaning or reference value.

#### Which issue(s) this PR fixes:

Fixes #7493 

#### Does this PR introduce a user-facing change?

```release-note
移除插件列表的时间字段，并在插件详情中显示安装时间。
```
