### PR TITLE
Use HTTP FOUND for redirection of thumbnail

### DIFF
--- a/application/src/main/java/run/halo/app/core/endpoint/theme/ThumbnailEndpoint.java
+++ b/application/src/main/java/run/halo/app/core/endpoint/theme/ThumbnailEndpoint.java
@@ -19,6 +19,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.core.io.Resource;
 import org.springframework.http.CacheControl;
 import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Component;
 import org.springframework.util.MultiValueMap;
 import org.springframework.web.reactive.function.BodyInserters;
@@ -69,7 +70,7 @@ public class ThumbnailEndpoint implements CustomEndpoint {
         return thumbnailService.get(query.getUri(), query.getSize())
             .filterWhen(uri -> isAccessible(request, uri))
             .defaultIfEmpty(query.getUri())
-            .flatMap(uri -> ServerResponse.temporaryRedirect(uri).build());
+            .flatMap(uri -> ServerResponse.status(HttpStatus.FOUND).location(uri).build());
     }
 
     Mono<Boolean> isAccessible(ServerRequest request, URI uri) {
@@ -177,7 +178,7 @@ public class ThumbnailEndpoint implements CustomEndpoint {
     }
 
     private Mono<ServerResponse> fallback(URI imageUri) {
-        return ServerResponse.temporaryRedirect(imageUri).build();
+        return ServerResponse.status(HttpStatus.FOUND).location(imageUri).build();
     }
 
     private static CacheControl getCacheControl(WebProperties.Resources resourceProperties) {

--- a/application/src/test/java/run/halo/app/core/endpoint/theme/ThumbnailEndpointTest.java
+++ b/application/src/test/java/run/halo/app/core/endpoint/theme/ThumbnailEndpointTest.java
@@ -44,8 +44,9 @@ class ThumbnailEndpointTest {
         webClient.get()
             .uri("/thumbnails/-/via-uri?size=l&uri=/myavatar.png")
             .exchange()
-            .expectAll(responseSpec -> responseSpec.expectHeader().location("/myavatar.png"))
             .expectStatus()
-            .is3xxRedirection();
+            .isFound()
+            .expectHeader()
+            .location("/myavatar.png");
     }
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind improvement
/area core
/milestone 2.21.x

#### What this PR does / why we need it:

This PR redirects thumbnail with HTTP status 302(Found) instead of 307(Temporary Redirect).

> 307 and 302 responses are identical when the request method is GET.

It's more common to use 301/302 to redirect in popular CDN services.

#### Does this PR introduce a user-facing change?

```release-note
None
```

