### PR TITLE
Add a system config changed event

### DIFF
--- a/application/src/main/java/run/halo/app/infra/SystemConfigChangedEvent.java
+++ b/application/src/main/java/run/halo/app/infra/SystemConfigChangedEvent.java
@@ -1,0 +1,17 @@
+package run.halo.app.infra;
+
+import org.springframework.context.ApplicationEvent;
+
+/**
+ * Event that is published when the system configuration changes.
+ *
+ * @author johnniang
+ * @since 2.21.0
+ */
+public class SystemConfigChangedEvent extends ApplicationEvent {
+
+    public SystemConfigChangedEvent(Object source) {
+        super(source);
+    }
+
+}


### PR DESCRIPTION
#### What type of PR is this?

/kind feature
/area core
/milestone 2.21.x

#### What this PR does / why we need it:

This PR adds a SystemConfigChangedEvent event to let other components listen the change of system config.

#### Does this PR introduce a user-facing change?

```release-note
None
```

