### PR TITLE
fix: encode post cover image URLs to prevent loading issue

### DIFF
--- a/ui/src/utils/thumbnail.ts
+++ b/ui/src/utils/thumbnail.ts
@@ -1,5 +1,5 @@
 export function generateThumbnailUrl(url: string, size: string) {
-  return `/apis/api.storage.halo.run/v1alpha1/thumbnails/-/via-uri?uri=${encodeURI(
+  return `/apis/api.storage.halo.run/v1alpha1/thumbnails/-/via-uri?uri=${encodeURIComponent(
     url
   )}&size=${size}`;
 }


### PR DESCRIPTION
#### What type of PR is this?

/area ui
/kind bug
/milestone 2.21.x

#### What this PR does / why we need it:

Encode post cover image URLs to prevent loading issue

<img width="736" alt="image" src="https://github.com/user-attachments/assets/0f298c64-37b3-4692-bdfa-922fd0e37dd9" />

#### Does this PR introduce a user-facing change?

```release-note
None
```
