### PR TITLE
chore: remove vite build warnings about external libs

### DIFF
--- a/ui/src/vite/library-external.ts
+++ b/ui/src/vite/library-external.ts
@@ -102,8 +102,9 @@ export const setupLibraryExternal = (
         injectTo: "head",
         tag: "script",
         attrs: {
-          src: `${isProduction ? baseUrl : "/"}${target.dest}/${target.rename}`,
+          src: `${baseUrl}${target.dest}/${target.rename}`,
           type: "text/javascript",
+          "vite-ignore": true,
         },
       };
     })


### PR DESCRIPTION
#### What type of PR is this?

/area ui
/kind cleanup
/milestone 2.21.x

#### What this PR does / why we need it:

Remove vite build warnings about external libs.

<img width="1051" alt="image" src="https://github.com/user-attachments/assets/ae3e2471-37d5-481b-9a5f-281a6bfc3094" />

#### Does this PR introduce a user-facing change?

```release-note
None
```
