### PR TITLE
Reduce application size by removing unused JPA dependency

### DIFF
--- a/api/build.gradle
+++ b/api/build.gradle
@@ -47,7 +47,6 @@ dependencies {
     annotationProcessor platform(project(':platform:application'))
 
     api 'org.springframework.boot:spring-boot-starter-actuator'
-    api 'org.springframework.boot:spring-boot-starter-data-jpa'
     api 'org.springframework.boot:spring-boot-starter-mail'
     api 'org.springframework.boot:spring-boot-starter-thymeleaf'
     api 'org.springframework.boot:spring-boot-starter-webflux'

--- a/application/src/main/java/run/halo/app/extension/store/ExtensionStore.java
+++ b/application/src/main/java/run/halo/app/extension/store/ExtensionStore.java
@@ -1,6 +1,5 @@
 package run.halo.app.extension.store;
 
-import jakarta.persistence.Lob;
 import lombok.Data;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.annotation.Version;
@@ -25,7 +24,6 @@ public class ExtensionStore {
     /**
      * Exactly Extension body, which might be base64 format.
      */
-    @Lob
     private byte[] data;
 
     /**


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup
/area core
/milestone 2.21.x

#### What this PR does / why we need it:

This PR removes unused JPA dependency to reduce application size about 14.6% off.

```bash
# Before
❯ ll application/build/libs
total 123M
-rw-r--r--. 1 johnniang johnniang 123M Jun 13 15:37 halo-2.21.0-SNAPSHOT.jar
-rw-r--r--. 1 johnniang johnniang   64 Jun 13 15:37 halo-2.21.0-SNAPSHOT.jar.sha256
```

```bash
# After
❯ ll application/build/libs
total 105M
-rw-r--r--. 1 johnniang johnniang 105M Jun 13 15:36 halo-2.21.0-SNAPSHOT.jar
-rw-r--r--. 1 johnniang johnniang   64 Jun 13 15:36 halo-2.21.0-SNAPSHOT.jar.sha256
```

#### Does this PR introduce a user-facing change?

```release-note
移除无用的依赖，软件包的体积减少近 15%
```

