### PR TITLE
fix: user avatar shadow display issue in Safari browser

### DIFF
--- a/ui/src/components/user-avatar/UserAvatar.vue
+++ b/ui/src/components/user-avatar/UserAvatar.vue
@@ -161,7 +161,7 @@ const hasAvatar = computed(() => {
       circle
       width="100%"
       height="100%"
-      class="ring-4 ring-white drop-shadow-md"
+      class="ring-4 ring-white shadow-xl"
     />
     <VDropdown
       v-if="currentUserHasPermission(['system:users:manage']) || isCurrentUser"


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/area ui
/milestone 2.21.x

#### What this PR does / why we need it:

Fix user avatar shadow display issue in Safari browser

before:

<img width="281" alt="image" src="https://github.com/user-attachments/assets/72165f9d-b3c4-4d98-902d-b7558fea8c76" />

after:

<img width="388" alt="image" src="https://github.com/user-attachments/assets/12b4b160-53aa-4f19-a335-1f0a53ae9111" />


#### Does this PR introduce a user-facing change?

```release-note
修复用户资料页面头像在 Safari 浏览器下的阴影问题。
```

<!-- Fuck Safari -->
