### PR TITLE
feat: add custom file paths options for ui-plugin-bundler-kit

### DIFF
--- a/ui/packages/ui-plugin-bundler-kit/src/index.ts
+++ b/ui/packages/ui-plugin-bundler-kit/src/index.ts
@@ -3,20 +3,42 @@ import fs from "fs";
 import yaml from "js-yaml";
 import { Plugin } from "vite";
 
-export function HaloUIPluginBundlerKit(): Plugin {
+const DEFAULT_OUT_DIR_DEV = "../src/main/resources/console";
+const DEFAULT_OUT_DIR_PROD = "../build/resources/main/console";
+const DEFAULT_MANIFEST_PATH = "../src/main/resources/plugin.yaml";
+
+interface HaloUIPluginBundlerKitOptions {
+  outDir?:
+    | string
+    | {
+        dev: string;
+        prod: string;
+      };
+  manifestPath?: string;
+}
+
+export function HaloUIPluginBundlerKit(
+  options: HaloUIPluginBundlerKitOptions = {}
+): Plugin {
   return {
     name: "halo-ui-plugin-bundler-kit",
     config(config, env) {
       const isProduction = env.mode === "production";
 
-      // fixme: allow user to config outDir
-      const outDir = isProduction
-        ? "../src/main/resources/console"
-        : "../build/resources/main/console";
+      let outDir = isProduction ? DEFAULT_OUT_DIR_PROD : DEFAULT_OUT_DIR_DEV;
 
-      // fixme: allow user to config manifest path
+      if (options.outDir) {
+        if (typeof options.outDir === "string") {
+          outDir = options.outDir;
+        } else {
+          outDir = isProduction ? options.outDir.prod : options.outDir.dev;
+        }
+      }
+
+      const manifestPath = options.manifestPath || DEFAULT_MANIFEST_PATH;
+
       const manifest = yaml.load(
-        fs.readFileSync("../src/main/resources/plugin.yaml", "utf8")
+        fs.readFileSync(manifestPath, "utf8")
       ) as HaloPlugin;
 
       return {


### PR DESCRIPTION
#### What type of PR is this?

/area ui
/kind improvement
/area plugin
/milestone 2.21.x

#### What this PR does / why we need it:

Added support for customization options to the HaloUIPluginBundlerKit.

example:

```ts
import { HaloUIPluginBundlerKit } from '@halo-dev/ui-plugin-bundler-kit';

export default {
  plugins: [
    HaloUIPluginBundlerKit({
      outDir: {
        dev: "../custom/dev/path",
        prod: "../custom/prod/path"
      },
      manifestPath: "../custom/plugin.yaml"
    })
  ]
}
```

#### Does this PR introduce a user-facing change?

```release-note
`@halo-dev/ui-plugin-bundler-kit` 支持自定义 `outDir` 和 `manifestPath`。
```
