### PR TITLE
Add support for rewriting URL with trailing slash

### DIFF
--- a/application/src/main/java/run/halo/app/infra/config/WebFluxConfig.java
+++ b/application/src/main/java/run/halo/app/infra/config/WebFluxConfig.java
@@ -25,6 +25,7 @@ import org.springframework.http.codec.json.Jackson2JsonDecoder;
 import org.springframework.http.codec.json.Jackson2JsonEncoder;
 import org.springframework.lang.NonNull;
 import org.springframework.web.filter.reactive.ServerWebExchangeContextFilter;
+import org.springframework.web.filter.reactive.UrlHandlerFilter;
 import org.springframework.web.reactive.config.ResourceHandlerRegistration;
 import org.springframework.web.reactive.config.ResourceHandlerRegistry;
 import org.springframework.web.reactive.config.WebFluxConfigurer;
@@ -267,4 +268,11 @@ public class WebFluxConfig implements WebFluxConfigurer {
         return new ServerWebExchangeContextFilter();
     }
 
+    @Bean
+    @Order(Ordered.HIGHEST_PRECEDENCE)
+    UrlHandlerFilter urlHandlerFilter() {
+        return UrlHandlerFilter
+            .trailingSlashHandler("/**").mutateRequest()
+            .build();
+    }
 }

--- a/application/src/test/java/run/halo/app/config/WebFluxConfigTest.java
+++ b/application/src/test/java/run/halo/app/config/WebFluxConfigTest.java
@@ -42,7 +42,8 @@ import run.halo.app.extension.Metadata;
     SpringBootTest.WebEnvironment.RANDOM_PORT)
 @Import({
     WebFluxConfigTest.WebSocketSupportTest.TestWebSocketConfiguration.class,
-    WebFluxConfigTest.ServerWebExchangeContextFilterTest.TestConfig.class
+    WebFluxConfigTest.ServerWebExchangeContextFilterTest.TestConfig.class,
+    WebFluxConfigTest.UrlHandlerFilterTest.TestConfig.class
 })
 @AutoConfigureWebTestClient
 class WebFluxConfigTest {
@@ -203,6 +204,31 @@ class WebFluxConfigTest {
             webClient.get().uri("/assert-server-web-exchange")
                 .exchange()
                 .expectStatus().isOk();
+        }
+
+    }
+
+    @Nested
+    class UrlHandlerFilterTest {
+
+        @TestConfiguration
+        static class TestConfig {
+
+            @Bean
+            RouterFunction<ServerResponse> urlHandlerFilterTestRoute() {
+                return RouterFunctions.route()
+                    .GET("/fake", request -> ServerResponse.ok().bodyValue("ok"))
+                    .build();
+            }
+
+        }
+
+        @Test
+        void shouldHandleUrlWithTrailingSlash() {
+            webClient.get().uri("/fake/")
+                .exchange()
+                .expectStatus().isOk()
+                .expectBody(String.class).isEqualTo("ok");
         }
 
     }


### PR DESCRIPTION
#### What type of PR is this?

/kind improvement
/area core
/milstone 2.21.x

#### What this PR does / why we need it:

This PR uses UrlHandlerFilter to rewrite URL with trailing slash.

#### Which issue(s) this PR fixes:

Fixes https://github.com/halo-dev/halo/issues/5420

#### Special notes for your reviewer:

1. Start Halo instance
2. Request to `/archives` and `/archives/` and see the result

#### Does this PR introduce a user-facing change?

```release-note
支持自动重写尾部包含斜杠的 URL
```

