### PR TITLE
fix: display settings button in Stack widgets

### DIFF
--- a/ui/console-src/modules/dashboard/widgets/presets/core/stack/components/WidgetEditableItem.vue
+++ b/ui/console-src/modules/dashboard/widgets/presets/core/stack/components/WidgetEditableItem.vue
@@ -59,7 +59,7 @@ function handleSaveConfig(config: Record<string, unknown>) {
     >
       <slot name="actions" />
       <ActionButton
-        v-if="widgetDefinition?.configFormKitSchema?.length"
+        v-if="widgetDefinition?.configFormKitSchema"
         class="bg-black"
         @click="configModalVisible = true"
       >


### PR DESCRIPTION
#### What type of PR is this?

/area ui
/kind bug
/milestone 2.21.x

#### What this PR does / why we need it:

Fix the issue where widgets in Stack Widgets cannot display the settings button

<img width="813" alt="image" src="https://github.com/user-attachments/assets/15a13703-99f2-49af-aa3e-831f8271c3a2" />

#### Which issue(s) this PR fixes:

Fixes #7562 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
修复堆叠部件中的部件可能无法显示设置按钮的问题。
```
