### PR TITLE
chore: bump @halo-dev/ui-plugin-bundler-kit version

### DIFF
--- a/ui/packages/ui-plugin-bundler-kit/package.json
+++ b/ui/packages/ui-plugin-bundler-kit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@halo-dev/ui-plugin-bundler-kit",
-  "version": "2.21.0",
+  "version": "2.21.1",
   "homepage": "https://github.com/halo-dev/halo/tree/main/ui/packages/ui-plugin-bundler-kit#readme",
   "bugs": {
     "url": "https://github.com/halo-dev/halo/issues"


### PR DESCRIPTION
#### What type of PR is this?

/area ui
/milestone 2.21.x

#### What this PR does / why we need it:

Bump @halo-dev/ui-plugin-bundler-kit version to 2.21.1

#### Does this PR introduce a user-facing change?

```release-note
None
```
