### PR TITLE
refactor: pass NODE_ENV for vite config in ui plugin bunlder kit

### DIFF
--- a/ui/packages/ui-plugin-bundler-kit/src/vite.ts
+++ b/ui/packages/ui-plugin-bundler-kit/src/vite.ts
@@ -33,9 +33,7 @@ function createVitePresetsConfig(manifestPath: string) {
     return {
       mode: mode || "production",
       plugins: [Vue()],
-      define: {
-        "process.env": process.env,
-      },
+      define: { "process.env.NODE_ENV": "'production'" },
       build: {
         outDir: isProduction ? DEFAULT_OUT_DIR_PROD : DEFAULT_OUT_DIR_DEV,
         emptyOutDir: true,


### PR DESCRIPTION
#### What type of PR is this?

/area ui
/area plugin
/kind improvement
/milestone 2.21.x

#### What this PR does / why we need it:

Modify the vite configuration in ui-plugin-bunlder-kit to avoid passing the entire process.env to the build process.

#### Does this PR introduce a user-facing change?

```release-note
None
```
