### PR TITLE
refactor: optimize indentation behavior

### DIFF
--- a/ui/packages/editor/src/extensions/indent/index.ts
+++ b/ui/packages/editor/src/extensions/indent/index.ts
@@ -30,6 +30,7 @@ type IndentOptions = {
 };
 const Indent = Extension.create<IndentOptions, never>({
   name: "indent",
+  priority: 10000,
 
   addOptions() {
     return {
@@ -115,6 +116,28 @@ const Indent = Extension.create<IndentOptions, never>({
       "Shift-Tab": getOutdent(false),
       "Mod-]": getIndent(),
       "Mod-[": getOutdent(false),
+      Backspace: ({ editor }) => {
+        const { selection } = editor.state;
+        const { $from } = selection;
+
+        if ($from.parentOffset === 0) {
+          const node = $from.parent;
+
+          if (node.attrs.lineIndent) {
+            return editor
+              .chain()
+              .focus()
+              .updateAttributes(node.type.name, { lineIndent: false })
+              .run();
+          }
+
+          if (node.attrs.indent && node.attrs.indent > 0) {
+            return getOutdent(false)({ editor });
+          }
+        }
+
+        return false;
+      },
     };
   },
 

--- a/ui/packages/editor/src/extensions/paragraph/index.ts
+++ b/ui/packages/editor/src/extensions/paragraph/index.ts
@@ -176,6 +176,11 @@ export function handleDeletePreviousNode(
     return false;
   }
 
+  const allowGapCursor = nodeBefore.type.spec.allowGapCursor;
+  if (!allowGapCursor) {
+    return false;
+  }
+
   if (deleteNodeByPos($from.doc.resolve(beforePos - 1))(tr)) {
     dispatch(tr);
     return true;


### PR DESCRIPTION
#### What type of PR is this?

/area editor
/kind improvement
/milestone 2.21.x

#### What this PR does / why we need it:

Fixes #7492

优化默认编辑器中缩进的逻辑。现在使用 Tab 对文本进行缩进之后，再按 Backspace 会优先回退缩进。
并且原有的文本会直接删除其上一个节点，现在只有块级节点会被直接删除。

before:

![Kapture 2025-06-27 at 17 53 16](https://github.com/user-attachments/assets/9e4831ec-1e83-4d68-8d83-7dba7090b893)

after:

![Kapture 2025-06-27 at 17 57 01](https://github.com/user-attachments/assets/171d5136-5871-4394-ae94-12e159ed861d)


#### How to test it?

测试使用 Backspace 是否符合正常逻辑。

#### Does this PR introduce a user-facing change?
```release-note
优化默认编辑器缩进逻辑
```
