### PR TITLE
pref: change the toolbox from a floating pop-up to a single-click pop-up

### DIFF
--- a/ui/packages/editor/src/components/EditorHeader.vue
+++ b/ui/packages/editor/src/components/EditorHeader.vue
@@ -1,7 +1,7 @@
 <script lang="ts" setup>
 import { Editor, type AnyExtension } from "@/tiptap/vue-3";
 import type { ToolbarItemType, ToolboxItemType } from "@/types";
-import { Dropdown as VDropdown, Menu as VMenu } from "floating-vue";
+import { Dropdown as VDropdown } from "floating-vue";
 import MdiPlusCircle from "~icons/mdi/plus-circle";
 
 const props = defineProps({
@@ -62,7 +62,7 @@ function getToolboxItemsFromExtensions() {
     class="editor-header space-x-1 overflow-auto border-b bg-white px-1 py-1 text-center shadow-sm"
   >
     <div class="inline-flex h-full items-center">
-      <VMenu>
+      <VDropdown>
         <button class="rounded-md p-1.5 hover:bg-gray-100" tabindex="-1">
           <MdiPlusCircle class="text-[#4CCBA0]" />
         </button>
@@ -79,7 +79,7 @@ function getToolboxItemsFromExtensions() {
             />
           </div>
         </template>
-      </VMenu>
+      </VDropdown>
       <div class="!mx-1 h-5 w-[1px] bg-gray-100"></div>
       <div
         v-for="(item, index) in getToolbarItemsFromExtensions()"


### PR DESCRIPTION
#### What type of PR is this?

/kind improvement
/area editor
/milestone 2.21.x

#### What this PR does / why we need it:

将 toolbox 由悬浮弹出改为单击弹出。

#### Does this PR introduce a user-facing change?
```release-note
将 toolbox 由悬浮弹出改为单击弹出
```
