### PR TITLE
fix: menu and post category dragging issue

### DIFF
--- a/ui/console-src/modules/contents/posts/categories/CategoryList.vue
+++ b/ui/console-src/modules/contents/posts/categories/CategoryList.vue
@@ -24,7 +24,6 @@ const { categories, categoriesTree, isLoading, handleFetchCategories } =
   usePostCategory();
 
 const batchUpdating = ref(false);
-const isDragging = ref(false);
 
 async function handleUpdateInBatch() {
   const categoriesTreeToUpdate = resetCategoriesTreePriority(
@@ -56,7 +55,6 @@ async function handleUpdateInBatch() {
   } finally {
     await handleFetchCategories();
     batchUpdating.value = false;
-    isDragging.value = false;
   }
 }
 </script>
@@ -130,16 +128,15 @@ async function handleUpdateInBatch() {
           :class="{
             'cursor-progress opacity-60': batchUpdating,
           }"
+          :disable-drag="batchUpdating"
           trigger-class="drag-element"
           :indent="40"
           @after-drop="handleUpdateInBatch"
-          @before-drag-start="isDragging = true"
         >
           <template #default="{ node, stat }">
             <CategoryListItem
               :category-tree-node="node"
               :is-child-level="stat.level > 1"
-              :is-dragging="isDragging"
             />
           </template>
         </Draggable>

--- a/ui/console-src/modules/contents/posts/categories/components/CategoryListItem.vue
+++ b/ui/console-src/modules/contents/posts/categories/components/CategoryListItem.vue
@@ -27,12 +27,10 @@ const queryClient = useQueryClient();
 const props = withDefaults(
   defineProps<{
     isChildLevel?: boolean;
-    isDragging?: boolean;
     categoryTreeNode: CategoryTreeNode;
   }>(),
   {
     isChildLevel: false,
-    isDragging: false,
   }
 );
 
@@ -92,9 +90,6 @@ const handleOpenCreateByParentModal = () => {
       <div
         v-permission="['system:posts:manage']"
         class="drag-element absolute inset-y-0 left-0 hidden w-3.5 cursor-move items-center bg-gray-100 transition-all hover:bg-gray-200 group-hover:flex"
-        :class="{
-          '!hidden': isDragging,
-        }"
       >
         <IconList class="h-3.5 w-3.5" />
       </div>

--- a/ui/console-src/modules/interface/menus/Menus.vue
+++ b/ui/console-src/modules/interface/menus/Menus.vue
@@ -45,7 +45,6 @@ const selectedMenu = ref<Menu>();
 const selectedMenuItem = ref<MenuItem>();
 const selectedParentMenuItem = ref<MenuItem>();
 const menuItemEditingModal = ref();
-const isDragging = ref(false);
 
 const {
   data: menuItems,
@@ -162,7 +161,6 @@ async function handleUpdateInBatch() {
     await queryClient.invalidateQueries({ queryKey: ["menus"] });
     await refetch();
     batchUpdating.value = false;
-    isDragging.value = false;
   }
 }
 
@@ -312,10 +310,10 @@ function getMenuItemRefDisplayName(menuItem: MenuTreeItem) {
               :class="{
                 'cursor-progress opacity-60': batchUpdating,
               }"
+              :disable-drag="batchUpdating"
               trigger-class="drag-element"
               :indent="40"
               @after-drop="handleUpdateInBatch"
-              @before-drag-start="isDragging = true"
             >
               <template #default="{ node }">
                 <div
@@ -325,9 +323,6 @@ function getMenuItemRefDisplayName(menuItem: MenuTreeItem) {
                     <div
                       v-permission="['system:menus:manage']"
                       class="drag-element absolute inset-y-0 left-0 hidden w-3.5 cursor-move items-center bg-gray-100 transition-all hover:bg-gray-200 group-hover:flex"
-                      :class="{
-                        '!hidden': isDragging,
-                      }"
                     >
                       <IconList class="h-3.5 w-3.5" />
                     </div>


### PR DESCRIPTION
#### What type of PR is this?

/area ui
/kind bug
/milestone 2.21.x

#### What this PR does / why we need it:

Fix issue where menu items and post categories could not be reordered via drag-and-drop

#### Which issue(s) this PR fixes:

Fixes #7607 

#### Does this PR introduce a user-facing change?

```release-note
修复菜单项和文章分类可能出现无法拖动排序的问题
```
