### PR TITLE
feat: add slug existence check when creating categories and tags

### DIFF
--- a/ui/src/locales/_missing_translations_es.yaml
+++ b/ui/src/locales/_missing_translations_es.yaml
@@ -771,6 +771,9 @@ core:
       system_protection: System protection
       all: All
       detail: Detail
+    form:
+      validation:
+        slug_unique: The current slug already exists
   uc_post:
     creation_modal:
       title: Create post

--- a/ui/src/locales/en.yaml
+++ b/ui/src/locales/en.yaml
@@ -1998,6 +1998,9 @@ core:
       recovering: Recovering
     fields:
       post_count: "{count} Posts"
+    form:
+      validation:
+        slug_unique: The current slug already exists
   uc_post:
     creation_modal:
       title: Create post

--- a/ui/src/locales/zh-CN.yaml
+++ b/ui/src/locales/zh-CN.yaml
@@ -1858,6 +1858,9 @@ core:
       recovering: 恢复中
     fields:
       post_count: "{count} 篇文章"
+    form:
+      validation:
+        slug_unique: 当前别名已存在
   tool:
     title: 工具
     empty:

--- a/ui/src/locales/zh-TW.yaml
+++ b/ui/src/locales/zh-TW.yaml
@@ -1843,6 +1843,9 @@ core:
       recovering: 還原中
     fields:
       post_count: "{count} 篇文章"
+    form:
+      validation:
+        slug_unique: 當前別名已存在
   uc_post:
     creation_modal:
       title: 創建文章


### PR DESCRIPTION
#### What type of PR is this?

/area ui
/kind improvement
/milestone 2.21.x

#### What this PR does / why we need it:

This PR adds frontend support for checking if an slug already exists when creating post categories and tags.

<img width="701" alt="image" src="https://github.com/user-attachments/assets/050c2fc3-b82c-42f1-b58e-cf12c6852959" />

#### Which issue(s) this PR fixes:

Fixes https://github.com/halo-dev/halo/issues/3172

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
创建文章分类和标签时支持检查别名是否已存在
```
