### PR TITLE
Add ClawCloud one-click deployment button to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,12 +30,14 @@
 如果你的设备有 Docker 环境，可以使用以下命令快速启动一个 Halo 的体验环境：
 
 ```bash
-docker run -d --name halo -p 8090:8090 -v ~/.halo2:/root/.halo2 halohub/halo:2.20
+docker run -d --name halo -p 8090:8090 -v ~/.halo2:/root/.halo2 halohub/halo:2.21
 ```
 
-或者点击下方按钮使用 [Gitpod](https://gitpod.io/) 启动一个体验环境：
+或者点击下方按钮使用 [Gitpod](https://gitpod.io/) 或 [ClawCloud Run](https://template.us-west-1.run.claw.cloud/deploy?templateName=halo) 启动一个体验环境：
 
 [![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/halo-sigs/gitpod-demo)
+
+[![Run on ClawCloud](https://raw.githubusercontent.com/ClawCloud/Run-Template/refs/heads/main/Run-on-ClawCloud.svg)](https://template.us-west-1.run.claw.cloud/deploy?templateName=halo)
 
 **以上方式仅作为体验使用，推荐使用开源 Linux 服务器运维管理面板 [1Panel](https://github.com/1Panel-dev/1Panel) 进行部署（[查看文档](https://docs.halo.run/getting-started/install/1panel)），轻松搞定反向代理、SSL 证书及升级备份任务。更多部署方式，请[查看文档](https://docs.halo.run/category/%E5%AE%89%E8%A3%85%E6%8C%87%E5%8D%97)。**
 


### PR DESCRIPTION
#### What type of PR is this?

/kind documentation

#### What this PR does / why we need it:

添加 ClawCloud Run 部署按钮，为 Halo 用户提供：

1. **零配置快速体验** - 无需服务器/域名，60秒内启动可用的 Halo 实例
2. **免费体验环境** - 每月免费提供 $5 的账户额度，用户可以持续稳定部署 Halo 博客在 ClawCloud Run 上
3. **原生集成体验** - 自动配置数据库和存储，开箱即用
4. **低门槛验证** - 降低新用户体验成本，促进项目采用率

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

按钮已添加在部署章节，位于 Gitpod 部署选项之后

#### Does this PR introduce a user-facing change?

```release-note
None
```