### PR TITLE
refactor: add chunked execution mechanism for notification batch deletions

### DIFF
--- a/ui/uc-src/modules/notifications/Notifications.vue
+++ b/ui/uc-src/modules/notifications/Notifications.vue
@@ -16,6 +16,7 @@ import {
 } from "@halo-dev/components";
 import { useQuery, useQueryClient } from "@tanstack/vue-query";
 import { useRouteQuery } from "@vueuse/router";
+import { chunk } from "lodash-es";
 import { OverlayScrollbarsComponent } from "overlayscrollbars-vue";
 import { computed } from "vue";
 import { useI18n } from "vue-i18n";
@@ -78,12 +79,16 @@ function handleDeleteNotifications() {
         throw new Error("Current user is not found");
       }
 
-      for (const notification of notifications.value.items) {
-        await ucApiClient.notification.notification.deleteSpecifiedNotification(
-          {
-            username: currentUser.metadata.name,
-            name: notification.metadata.name,
-          }
+      const notificationChunks = chunk(notifications.value.items, 5);
+
+      for (const chunk of notificationChunks) {
+        await Promise.all(
+          chunk.map((notification) =>
+            ucApiClient.notification.notification.deleteSpecifiedNotification({
+              username: currentUser.metadata.name,
+              name: notification.metadata.name,
+            })
+          )
         );
       }
 


### PR DESCRIPTION
#### What type of PR is this?

/area ui
/kind improvement
/milestone 2.21.x

#### What this PR does / why we need it:

Use `Promise.all` to execute part of the batch deletion logic of the notification in chunks to optimize the execution performance.

#### Which issue(s) this PR fixes:

Fixes #

#### Does this PR introduce a user-facing change?

```release-note
优化通知批量删除的执行性能
```
