### PR TITLE
Ingore build directory while linting ui project

### DIFF
--- a/ui/eslint.config.ts
+++ b/ui/eslint.config.ts
@@ -9,7 +9,12 @@ import pluginVue from "eslint-plugin-vue";
 export default defineConfigWithVueTs(
   {
     name: "app/global-ignores",
-    ignores: ["**/dist/**", "**/node_modules/**", "packages/api-client/src/"],
+    ignores: [
+      "**/dist/**",
+      "**/node_modules/**",
+      "packages/api-client/src/",
+      "**/build/**",
+    ],
   },
 
   pluginVue.configs["flat/recommended"],


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/area ui

#### What this PR does / why we need it:

This PR ignores build directory while linting ui project to prevent eslint from linting js files in build/test-results directory.

#### Does this PR introduce a user-facing change?

```release-note
None
```

