### PR TITLE
WIP: Add social login endpoint for remember-me support

### DIFF
--- a/application/src/main/java/run/halo/app/security/HaloServerRequestCache.java
+++ b/application/src/main/java/run/halo/app/security/HaloServerRequestCache.java
@@ -106,7 +106,8 @@ public class HaloServerRequestCache extends WebSessionServerRequestCache {
         var get = pathMatchers(HttpMethod.GET, "/**");
         var notFavicon = new NegatedServerWebExchangeMatcher(
             pathMatchers(
-                "/favicon.*", "/login/**", "/signup/**", "/password-reset/**", "/challenges/**"
+                "/favicon.*", "/login/**", "/signup/**", "/password-reset/**", "/challenges/**",
+                "/oauth2/**", "/social/**"
             ));
         var html = new MediaTypeServerWebExchangeMatcher(MediaType.TEXT_HTML);
         html.setIgnoredMediaTypes(Collections.singleton(MediaType.ALL));


### PR DESCRIPTION
#### What type of PR is this?

/kind feature
/kind api-change
/area core
/milestone 2.21.x

#### What this PR does / why we need it:

This PR adds a new endpoint `POST /login/social/{auth_provider_name}?remember-me=true` to make the social login support remember-me mechanism. 

#### Does this PR introduce a user-facing change?

```release-note
支持社交登录时选择是否保持登录
```

