### PR TITLE
Fix existence check of posts in some cases

### DIFF
--- a/api/src/main/java/run/halo/app/extension/router/selector/Operator.java
+++ b/api/src/main/java/run/halo/app/extension/router/selector/Operator.java
@@ -44,7 +44,7 @@ public enum Operator implements Converter<String, SelectorCriteria> {
         public SelectorCriteria convert(@Nullable String selector) {
             if (preFlightCheck(selector, 4)) {
                 var i = selector.indexOf(getOperator());
-                if (i > 0 && (i + getOperator().length()) < selector.length() - 1) {
+                if (i > 0 && (i + getOperator().length()) < selector.length()) {
                     String key = selector.substring(0, i);
                     String value = selector.substring(i + getOperator().length());
                     return new SelectorCriteria(key, this, Set.of(value));

--- a/api/src/test/java/run/halo/app/extension/router/selector/OperatorTest.java
+++ b/api/src/test/java/run/halo/app/extension/router/selector/OperatorTest.java
@@ -27,7 +27,7 @@ class OperatorTest {
             new TestCase("name=", Equals, null),
             new TestCase("name=value", Equals,
                 new SelectorCriteria("name", Equals, Set.of("value"))),
-            new TestCase("name=v", Equals, 
+            new TestCase("name=v", Equals,
                 new SelectorCriteria("name", Equals, Set.of("v"))),
 
             new TestCase("", NotEquals, null),
@@ -45,6 +45,10 @@ class OperatorTest {
             new TestCase("name", NotExist, null),
             new TestCase("na!me", NotExist, null),
             new TestCase("name!", NotExist, null),
+            new TestCase("name!=1", NotEquals,
+                new SelectorCriteria("name", NotEquals, Set.of("1"))),
+            new TestCase("name!=12", NotEquals,
+                new SelectorCriteria("name", NotEquals, Set.of("12"))),
 
             new TestCase("name", Exist, new SelectorCriteria("name", Exist, Set.of())),
             new TestCase("", Exist, null),
@@ -61,4 +65,5 @@ class OperatorTest {
             assertEquals(testCase.expected(), testCase.converter().convert(testCase.source()));
         });
     }
+
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/area core
/milestone 2.21.x

#### What this PR does / why we need it:

This PR fixes the internal check of selector converter `NotEquals`, which might lead to failing check of `metadata.name!=1`.

#### Which issue(s) this PR fixes:

Fixes https://github.com/halo-dev/halo/issues/7666

#### Does this PR introduce a user-facing change?

```release-note
修复极端场景下无法检查文章别名是否存在的问题
```

