### PR TITLE
Allow <s> tag and class attribute on <code> in comments

### DIFF
--- a/application/src/main/java/run/halo/app/content/comment/AbstractCommentService.java
+++ b/application/src/main/java/run/halo/app/content/comment/AbstractCommentService.java
@@ -25,8 +25,10 @@ public abstract class AbstractCommentService {
     protected final UserService userService;
     protected final CounterService counterService;
     private final Safelist safelist = Safelist.relaxed()
-        .addTags("s") // Allow <s> tag, which is used for strikethrough
-        .addAttributes("code", "class"); // Allow <code> tag's class attribute, for syntax highlighting
+        // Allow <s> tag, which is used for strikethrough
+        .addTags("s")
+        // Allow <code> tag's class attribute, for syntax highlighting
+        .addAttributes("code", "class");
 
     protected Mono<User> fetchCurrentUser() {
         return ReactiveSecurityContextHolder.getContext()

--- a/application/src/main/java/run/halo/app/content/comment/AbstractCommentService.java
+++ b/application/src/main/java/run/halo/app/content/comment/AbstractCommentService.java
@@ -24,7 +24,9 @@ public abstract class AbstractCommentService {
     protected final ReactiveExtensionClient client;
     protected final UserService userService;
     protected final CounterService counterService;
-    private final Safelist safelist = Safelist.relaxed();
+    private final Safelist safelist = Safelist.relaxed()
+        .addTags("s") // Allow <s> tag, which is used for strikethrough
+        .addAttributes("code", "class"); // Allow <code> tag's class attribute, for syntax highlighting
 
     protected Mono<User> fetchCurrentUser() {
         return ReactiveSecurityContextHolder.getContext()


### PR DESCRIPTION
#### What type of PR is this?

/area code
/milestone 2.21.x
/kind improvement

#### What this PR does / why we need it:

Comments are allowed to contain `s` tags and `code` tags with class attributes for the following reasons:

1. `s`: The comment component uses tiptap editor's [strikethrough extension](https://tiptap.dev/docs/editor/extensions/marks/strike#:~:text=while%20you%20type.-,Restrictions,-The%20extension%20will) which enforces the use of `s` tags for strikethrough text and cannot be changed.
2. `code[class]`: Used for code highlighting (class="language-*")

#### Does this PR introduce a user-facing change?

```release-note
None
```
