### PR TITLE
Add external asset transfer for editor attachments

### DIFF
--- a/ui/src/components/editor/composables/use-attachment.ts
+++ b/ui/src/components/editor/composables/use-attachment.ts
@@ -1,4 +1,10 @@
+import { useGlobalInfoStore } from "@/stores/global-info";
+import { ucApiClient } from "@halo-dev/api-client";
+import { Toast } from "@halo-dev/components";
 import type { AttachmentLike } from "@halo-dev/console-shared";
+import { computed, ref, type Ref } from "vue";
+import { useI18n } from "vue-i18n";
+import type { AttachmentAttr } from "../utils/attachment";
 
 interface useAttachmentSelectReturn {
   onAttachmentSelect: (attachments: AttachmentLike[]) => void;
@@ -22,5 +28,58 @@ export function useAttachmentSelect(): useAttachmentSelectReturn {
   return {
     onAttachmentSelect,
     attachmentResult,
+  };
+}
+
+export function useExternalAssetsTransfer(
+  src: Ref<string | undefined>,
+  callback: (attachment: AttachmentAttr) => void
+) {
+  const { globalInfo } = useGlobalInfoStore();
+  const { t } = useI18n();
+
+  const isExternalAsset = computed(() => {
+    if (src.value?.startsWith("/")) {
+      return false;
+    }
+
+    if (!globalInfo?.externalUrl) {
+      return false;
+    }
+
+    return !src.value?.startsWith(globalInfo?.externalUrl);
+  });
+
+  const transferring = ref(false);
+
+  async function handleTransfer() {
+    if (!src.value) {
+      return;
+    }
+
+    transferring.value = true;
+
+    const { data } =
+      await ucApiClient.storage.attachment.externalTransferAttachment1({
+        ucUploadFromUrlRequest: {
+          url: src.value,
+        },
+        waitForPermalink: true,
+      });
+
+    callback({
+      url: data.status?.permalink,
+      name: data.spec.displayName,
+    });
+
+    Toast.success(t("core.common.toast.save_success"));
+
+    transferring.value = false;
+  }
+
+  return {
+    isExternalAsset,
+    transferring,
+    handleTransfer,
   };
 }

--- a/ui/src/components/editor/extensions/audio/AudioView.vue
+++ b/ui/src/components/editor/extensions/audio/AudioView.vue
@@ -1,10 +1,12 @@
 <script lang="ts" setup>
+import HasPermission from "@/components/permission/HasPermission.vue";
 import { VButton } from "@halo-dev/components";
 import type { NodeViewProps } from "@halo-dev/richtext-editor";
 import { computed, ref } from "vue";
 import RiFileMusicLine from "~icons/ri/file-music-line";
 import { EditorLinkObtain } from "../../components";
 import InlineBlockBox from "../../components/InlineBlockBox.vue";
+import { useExternalAssetsTransfer } from "../../composables/use-attachment";
 import type { AttachmentAttr } from "../../utils/attachment";
 
 const props = defineProps<NodeViewProps>();
@@ -64,6 +66,9 @@ const handleResetInit = () => {
     file: undefined,
   });
 };
+
+const { isExternalAsset, transferring, handleTransfer } =
+  useExternalAssetsTransfer(src, handleSetExternalLink);
 </script>
 
 <template>
@@ -92,8 +97,28 @@ const handleResetInit = () => {
         ></audio>
         <div
           v-if="src"
-          class="absolute left-0 top-0 hidden h-1/4 w-full cursor-pointer justify-end bg-gradient-to-b from-gray-300 to-transparent p-2 ease-in-out group-hover:flex"
+          class="absolute left-0 top-0 hidden h-1/4 w-full cursor-pointer justify-end gap-2 bg-gradient-to-b from-gray-300 to-transparent p-2 ease-in-out group-hover:flex"
         >
+          <HasPermission :permissions="['uc:attachments:manage']">
+            <VButton
+              v-if="isExternalAsset"
+              v-tooltip="
+                $t(
+                  'core.components.default_editor.extensions.upload.operations.transfer.tooltip'
+                )
+              "
+              :loading="transferring"
+              size="sm"
+              ghost
+              @click="handleTransfer"
+            >
+              {{
+                $t(
+                  "core.components.default_editor.extensions.upload.operations.transfer.button"
+                )
+              }}
+            </VButton>
+          </HasPermission>
           <VButton size="xs" type="secondary" @click="handleResetInit">
             {{
               $t(

--- a/ui/src/components/editor/extensions/image/ImageView.vue
+++ b/ui/src/components/editor/extensions/image/ImageView.vue
@@ -1,9 +1,11 @@
 <script lang="ts" setup>
+import HasPermission from "@/components/permission/HasPermission.vue";
 import { IconImageAddLine, VButton } from "@halo-dev/components";
 import { type NodeViewProps } from "@halo-dev/richtext-editor";
 import { computed, onMounted, ref } from "vue";
 import { EditorLinkObtain } from "../../components";
 import InlineBlockBox from "../../components/InlineBlockBox.vue";
+import { useExternalAssetsTransfer } from "../../composables/use-attachment";
 import { type AttachmentAttr } from "../../utils/attachment";
 import { fileToBase64 } from "../../utils/upload";
 import Image from "./index";
@@ -143,6 +145,9 @@ onMounted(() => {
     document.documentElement.removeEventListener("mouseup", stopDrag, false);
   }
 });
+
+const { isExternalAsset, transferring, handleTransfer } =
+  useExternalAssetsTransfer(src, handleSetExternalLink);
 </script>
 
 <template>
@@ -171,8 +176,29 @@ onMounted(() => {
 
         <div
           v-if="src"
-          class="absolute left-0 top-0 hidden h-1/4 w-full cursor-pointer justify-end bg-gradient-to-b from-gray-300 to-transparent p-2 ease-in-out group-hover:flex"
+          class="absolute left-0 top-0 hidden h-1/4 w-full cursor-pointer justify-end gap-2 bg-gradient-to-b from-gray-300 to-transparent p-2 ease-in-out group-hover:flex"
         >
+          <HasPermission :permissions="['uc:attachments:manage']">
+            <VButton
+              v-if="isExternalAsset"
+              v-tooltip="
+                $t(
+                  'core.components.default_editor.extensions.upload.operations.transfer.tooltip'
+                )
+              "
+              :loading="transferring"
+              size="sm"
+              ghost
+              @click="handleTransfer"
+            >
+              {{
+                $t(
+                  "core.components.default_editor.extensions.upload.operations.transfer.button"
+                )
+              }}
+            </VButton>
+          </HasPermission>
+
           <VButton size="sm" type="secondary" @click="handleResetInit">
             {{
               $t(

--- a/ui/src/components/editor/extensions/upload/index.ts
+++ b/ui/src/components/editor/extensions/upload/index.ts
@@ -1,5 +1,5 @@
 import { i18n } from "@/locales";
-import { Dialog } from "@halo-dev/components";
+import { Dialog, Toast } from "@halo-dev/components";
 import {
   CoreEditor,
   Extension,
@@ -44,8 +44,12 @@ export const Upload = Extension.create({
                 ),
                 confirmText: i18n.global.t("core.common.buttons.confirm"),
                 cancelText: i18n.global.t("core.common.buttons.cancel"),
-                onConfirm() {
-                  batchUploadExternalLink(editor, externalNodes);
+                async onConfirm() {
+                  await batchUploadExternalLink(editor, externalNodes);
+
+                  Toast.success(
+                    i18n.global.t("core.common.toast.save_success")
+                  );
                 },
               });
             }

--- a/ui/src/components/editor/extensions/upload/index.ts
+++ b/ui/src/components/editor/extensions/upload/index.ts
@@ -1,3 +1,5 @@
+import { i18n } from "@/locales";
+import { Dialog } from "@halo-dev/components";
 import {
   CoreEditor,
   Extension,
@@ -35,9 +37,17 @@ export const Upload = Extension.create({
 
             const externalNodes = getAllExternalNodes(slice);
             if (externalNodes.length > 0) {
-              if (confirm("检测到具有外部链接，是否需要自动上传到附件库？")) {
-                batchUploadExternalLink(editor, externalNodes);
-              }
+              Dialog.info({
+                title: i18n.global.t("core.common.text.tip"),
+                description: i18n.global.t(
+                  "core.components.default_editor.extensions.upload.operations.transfer_in_batch.description"
+                ),
+                confirmText: i18n.global.t("core.common.buttons.confirm"),
+                cancelText: i18n.global.t("core.common.buttons.cancel"),
+                onConfirm() {
+                  batchUploadExternalLink(editor, externalNodes);
+                },
+              });
             }
 
             const types = event.clipboardData.types;
@@ -58,20 +68,13 @@ export const Upload = Extension.create({
 
             return false;
           },
-          handleDrop: (view, event, slice) => {
+          handleDrop: (view, event) => {
             if (view.props.editable && !view.props.editable(view.state)) {
               return false;
             }
 
             if (!event.dataTransfer) {
               return false;
-            }
-
-            const externalNodes = getAllExternalNodes(slice);
-            if (externalNodes.length > 0) {
-              if (confirm("检测到具有外部链接，是否需要自动上传到附件库？")) {
-                batchUploadExternalLink(editor, externalNodes);
-              }
             }
 
             const hasFiles = event.dataTransfer.files.length > 0;

--- a/ui/src/components/editor/extensions/video/VideoView.vue
+++ b/ui/src/components/editor/extensions/video/VideoView.vue
@@ -1,10 +1,12 @@
 <script lang="ts" setup>
+import HasPermission from "@/components/permission/HasPermission.vue";
 import { VButton } from "@halo-dev/components";
 import type { NodeViewProps } from "@halo-dev/richtext-editor";
 import { computed, ref } from "vue";
 import RiVideoAddLine from "~icons/ri/video-add-line";
 import { EditorLinkObtain } from "../../components";
 import InlineBlockBox from "../../components/InlineBlockBox.vue";
+import { useExternalAssetsTransfer } from "../../composables/use-attachment";
 import type { AttachmentAttr } from "../../utils/attachment";
 
 const props = defineProps<NodeViewProps>();
@@ -68,6 +70,9 @@ const handleResetInit = () => {
     file: undefined,
   });
 };
+
+const { isExternalAsset, transferring, handleTransfer } =
+  useExternalAssetsTransfer(src, handleSetExternalLink);
 </script>
 
 <template>
@@ -97,8 +102,28 @@ const handleResetInit = () => {
         ></video>
         <div
           v-if="src"
-          class="absolute left-0 top-0 hidden h-1/4 w-full cursor-pointer justify-end bg-gradient-to-b from-gray-300 to-transparent p-2 ease-in-out group-hover:flex"
+          class="absolute left-0 top-0 hidden h-1/4 w-full cursor-pointer justify-end gap-2 bg-gradient-to-b from-gray-300 to-transparent p-2 ease-in-out group-hover:flex"
         >
+          <HasPermission :permissions="['uc:attachments:manage']">
+            <VButton
+              v-if="isExternalAsset"
+              v-tooltip="
+                $t(
+                  'core.components.default_editor.extensions.upload.operations.transfer.tooltip'
+                )
+              "
+              :loading="transferring"
+              size="sm"
+              ghost
+              @click="handleTransfer"
+            >
+              {{
+                $t(
+                  "core.components.default_editor.extensions.upload.operations.transfer.button"
+                )
+              }}
+            </VButton>
+          </HasPermission>
           <VButton size="sm" type="secondary" @click="handleResetInit">
             {{
               $t(

--- a/ui/src/components/editor/utils/upload.ts
+++ b/ui/src/components/editor/utils/upload.ts
@@ -1,7 +1,7 @@
 // image drag and paste upload
 import { usePermission } from "@/utils/permission";
-import type { Attachment } from "@halo-dev/api-client";
-import { CoreEditor } from "@halo-dev/richtext-editor";
+import { ucApiClient, type Attachment } from "@halo-dev/api-client";
+import { CoreEditor, PMNode } from "@halo-dev/richtext-editor";
 import type { AxiosRequestConfig } from "axios";
 import ExtensionAudio from "../extensions/audio";
 import Image from "../extensions/image";
@@ -146,4 +146,56 @@ export function fileToBase64(file: File): Promise<string> {
 export function containsFileClipboardIdentifier(types: readonly string[]) {
   const fileTypes = ["files", "application/x-moz-file", "public.file-url"];
   return types.some((type) => fileTypes.includes(type.toLowerCase()));
+}
+
+export async function batchUploadExternalLink(
+  editor: CoreEditor,
+  nodes: { node: PMNode; pos: number; index: number; parent: PMNode | null }[]
+) {
+  const promises = nodes.map((node) => uploadExternalLink(editor, node));
+  await Promise.all(promises);
+}
+
+export async function uploadExternalLink(
+  editor: CoreEditor,
+  nodeWithPos: {
+    node: PMNode;
+    pos: number;
+    index: number;
+    parent: PMNode | null;
+  }
+) {
+  const { node, pos } = nodeWithPos;
+  const { src } = node.attrs;
+  if (!isExternalAsset(src)) {
+    return;
+  }
+
+  const { data } =
+    await ucApiClient.storage.attachment.externalTransferAttachment1({
+      ucUploadFromUrlRequest: {
+        url: src,
+      },
+      waitForPermalink: true,
+    });
+
+  const url = data.status?.permalink;
+  const name = data.spec.displayName;
+  const tr = editor.view.state.tr;
+  tr.setNodeMarkup(pos, node.type, {
+    ...node.attrs,
+    src: url,
+    name,
+  });
+  editor.view.dispatch(tr);
+}
+
+export function isExternalAsset(src: string) {
+  if (src?.startsWith("/")) {
+    return false;
+  }
+
+  const currentOrigin = window.location.origin;
+
+  return !src?.startsWith(currentOrigin);
 }

--- a/ui/src/locales/_missing_translations_es.yaml
+++ b/ui/src/locales/_missing_translations_es.yaml
@@ -117,7 +117,7 @@ core:
       fields:
         schedule_publish:
           tooltip: Schedule publish
-        comments-with-pending: ({count} pending comments)
+        comments-with-pending: " ({count} pending comments)"
     settings:
       fields:
         publish_time:
@@ -710,6 +710,9 @@ core:
           operations:
             replace:
               button: Replace
+            transfer:
+              button: Save locally
+              tooltip: This resource is detected as an external resource. Click this button to save it to the attachment library.
       toolbox:
         show_hide_sidebar: Show/Hide Sidebar
       title_placeholder: Please enter the title

--- a/ui/src/locales/_missing_translations_es.yaml
+++ b/ui/src/locales/_missing_translations_es.yaml
@@ -713,6 +713,8 @@ core:
             transfer:
               button: Save locally
               tooltip: This resource is detected as an external resource. Click this button to save it to the attachment library.
+            transfer_in_batch:
+              description: External link detected. Would you like to automatically upload it to the attachment library?
       toolbox:
         show_hide_sidebar: Show/Hide Sidebar
       title_placeholder: Please enter the title

--- a/ui/src/locales/en.yaml
+++ b/ui/src/locales/en.yaml
@@ -1805,6 +1805,10 @@ core:
               tooltip: >-
                 This resource is detected as an external resource. Click this
                 button to save it to the attachment library.
+            transfer_in_batch:
+              description: >-
+                External link detected. Would you like to automatically upload
+                it to the attachment library?
       toolbox:
         attachment: Attachment
         show_hide_sidebar: Show/Hide Sidebar

--- a/ui/src/locales/en.yaml
+++ b/ui/src/locales/en.yaml
@@ -1800,6 +1800,11 @@ core:
           operations:
             replace:
               button: Replace
+            transfer:
+              button: Save locally
+              tooltip: >-
+                This resource is detected as an external resource. Click this
+                button to save it to the attachment library.
       toolbox:
         attachment: Attachment
         show_hide_sidebar: Show/Hide Sidebar

--- a/ui/src/locales/zh-CN.yaml
+++ b/ui/src/locales/zh-CN.yaml
@@ -1665,6 +1665,9 @@ core:
           operations:
             replace:
               button: 替换
+            transfer:
+              button: 转存
+              tooltip: 检测到此资源为外部资源，点击此按钮以转存到附件库
       toolbox:
         attachment: 选择附件
         show_hide_sidebar: 显示 / 隐藏侧边栏

--- a/ui/src/locales/zh-CN.yaml
+++ b/ui/src/locales/zh-CN.yaml
@@ -1668,6 +1668,8 @@ core:
             transfer:
               button: 转存
               tooltip: 检测到此资源为外部资源，点击此按钮以转存到附件库
+            transfer_in_batch:
+              description: 检测到具有外部链接，是否需要自动上传到附件库？
       toolbox:
         attachment: 选择附件
         show_hide_sidebar: 显示 / 隐藏侧边栏

--- a/ui/src/locales/zh-TW.yaml
+++ b/ui/src/locales/zh-TW.yaml
@@ -1653,6 +1653,8 @@ core:
             transfer:
               button: 轉存
               tooltip: 偵測到此資源為外部資源，點擊此按鈕以轉存到附件庫
+            transfer_in_batch:
+              description: 檢測到具有外部連結，是否需要自動上傳到附件庫？
       toolbox:
         attachment: 選擇附件
         show_hide_sidebar: 顯示 / 隱藏側邊欄

--- a/ui/src/locales/zh-TW.yaml
+++ b/ui/src/locales/zh-TW.yaml
@@ -1650,6 +1650,9 @@ core:
           operations:
             replace:
               button: 替換
+            transfer:
+              button: 轉存
+              tooltip: 偵測到此資源為外部資源，點擊此按鈕以轉存到附件庫
       toolbox:
         attachment: 選擇附件
         show_hide_sidebar: 顯示 / 隱藏側邊欄


### PR DESCRIPTION
#### What type of PR is this?

/area ui
/area editor
/kind feature
/milestone 2.21.x

#### What this PR does / why we need it:

Support transfer external assets in the editor to the attachment library. Currently, it supports individual images, videos, and audio files.

<img width="845" height="167" alt="image" src="https://github.com/user-attachments/assets/930c6207-60f5-491a-afbd-c3f75b0d76a6" />

in progress:

- [ ] Batch transferring of all external assets.

#### Which issue(s) this PR fixes:

Fixes https://github.com/halo-dev/halo/issues/2335

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
支持转存编辑器中的外部资源到附件库
```
