### PR TITLE
fix: pasting excel text will turn it into an image

### DIFF
--- a/ui/src/components/editor/extensions/upload/index.ts
+++ b/ui/src/components/editor/extensions/upload/index.ts
@@ -29,6 +29,10 @@ export const Upload = Extension.create({
             }
 
             const types = event.clipboardData.types;
+            // Only process when a single file is pasted.
+            if (types.length > 1) {
+              return false;
+            }
 
             if (!containsFileClipboardIdentifier(types)) {
               return false;


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/area editor

#### What this PR does / why we need it:

将粘贴图片上传的选项，改为仅支持单个文件，此举可以解决会将 excel 转为图片的问题。

#### How to test it?

在文章中粘贴 excel 表格中的内容，查看是否转为表格。

#### Does this PR introduce a user-facing change?
```release-note
解决将粘贴 Excel 内容会变为图片的问题。
```
