### PR TITLE
Allow target attribute on <a> tags in comment sanitizer

### DIFF
--- a/application/src/main/java/run/halo/app/content/comment/AbstractCommentService.java
+++ b/application/src/main/java/run/halo/app/content/comment/AbstractCommentService.java
@@ -28,7 +28,9 @@ public abstract class AbstractCommentService {
         // Allow <s> tag, which is used for strikethrough
         .addTags("s")
         // Allow <code> tag's class attribute, for syntax highlighting
-        .addAttributes("code", "class");
+        .addAttributes("code", "class")
+        // Allow <a> tag's target attribute
+        .addAttributes("a", "target");
 
     protected Mono<User> fetchCurrentUser() {
         return ReactiveSecurityContextHolder.getContext()


### PR DESCRIPTION
#### What type of PR is this?

/area core
/milestone 2.21.x
/kind improvement

#### What this PR does / why we need it:

Allow target attribute on <a> tags in comment sanitizer

#### Does this PR introduce a user-facing change?

```release-note
None
```
