### PR TITLE
Add context propagation dependency to build.gradle

### DIFF
--- a/api/build.gradle
+++ b/api/build.gradle
@@ -60,6 +60,8 @@ dependencies {
     api 'org.springframework.security:spring-security-oauth2-client'
     api 'org.springframework.security:spring-security-oauth2-resource-server'
 
+    api 'io.micrometer:context-propagation'
+
     // Cache
     api "org.springframework.boot:spring-boot-starter-cache"
     api "com.github.ben-manes.caffeine:caffeine"


### PR DESCRIPTION
#### What type of PR is this?

/kind improvement
/area core
/area plugin
/milestone 2.21.x

#### What this PR does / why we need it:

This PR adds `io.micrometer:context-propagation` dependency to assist with context propagation across different types of context mechanisms, such as ThreadLocal, Reactor Context, and others.

#### Does this PR introduce a user-facing change?

```release-note
None
```

