### PR TITLE
Handle ghost users in user retrieval logic

### DIFF
--- a/application/src/main/java/run/halo/app/core/user/service/impl/UserServiceImpl.java
+++ b/application/src/main/java/run/halo/app/core/user/service/impl/UserServiceImpl.java
@@ -105,7 +105,15 @@ public class UserServiceImpl implements UserService {
         var options = ListOptions.builder()
             .andQuery(QueryFactory.in("metadata.name", nameSet))
             .build();
-        return client.listAll(User.class, options, defaultSort());
+        return client.listAll(User.class, options, defaultSort())
+            .collectMap(u -> u.getMetadata().getName())
+            .map(map -> {
+                var ghost = map.get(GHOST_USER_NAME);
+                return names.stream()
+                    .map(name -> map.getOrDefault(name, ghost))
+                    .toList();
+            })
+            .flatMapMany(Flux::fromIterable);
     }
 
     @Override


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/area core
/milestone 2.21.x

#### What this PR does / why we need it:

This PR fixes the always show of ghost user in post contributors.

#### Which issue(s) this PR fixes:

Fixes https://github.com/halo-dev/halo/issues/7710

#### Does this PR introduce a user-facing change?

```release-note
修复文章贡献者中始终显示已删除用户的问题
```

