### PR TITLE
Add loading indicator to DefaultEditor initialization

### DIFF
--- a/ui/src/components/editor/DefaultEditor.vue
+++ b/ui/src/components/editor/DefaultEditor.vue
@@ -63,6 +63,7 @@ import {
   IconFolder,
   IconLink,
   IconUserFollow,
+  VLoading,
   VTabItem,
   VTabs,
 } from "@halo-dev/components";
@@ -75,6 +76,7 @@ import {
   defineAsyncComponent,
   inject,
   markRaw,
+  nextTick,
   onBeforeUnmount,
   onMounted,
   ref,
@@ -412,6 +414,8 @@ const presetExtensions = [
   }),
 ];
 
+const isInitialized = ref(false);
+
 onMounted(async () => {
   const extensionsFromPlugins: Extensions = [];
 
@@ -451,11 +455,14 @@ onMounted(async () => {
       debounceOnUpdate();
     },
     onCreate() {
-      if (editor.value?.isEmpty && !props.title) {
-        editorTitleRef.value.focus();
-      } else {
-        editor.value?.commands.focus();
-      }
+      isInitialized.value = true;
+      nextTick(() => {
+        if (editor.value?.isEmpty && !props.title) {
+          editorTitleRef.value.focus();
+        } else {
+          editor.value?.commands.focus();
+        }
+      });
     },
   });
 });
@@ -501,7 +508,8 @@ function handleFocusEditor(event) {
 </script>
 
 <template>
-  <div>
+  <VLoading v-if="!isInitialized" />
+  <div v-else>
     <AttachmentSelectorModal
       v-bind="attachmentOptions"
       v-model:visible="attachmentSelectorModal"


### PR DESCRIPTION
#### What type of PR is this?

/area ui
/kind improvement
/milestone 2.21.x

#### What this PR does / why we need it:

When there are multiple async extensions to load in the editor, the page might stay blank for a while, which could be confusing for users. This PR adds a loading state to address that.

#### Does this PR introduce a user-facing change?

```release-note
为文章编辑器添加加载状态。
```
