### PR TITLE
Remove Fit2Cloud registry publishing due to persistent 403 errors

### DIFF
--- a/application/build.gradle
+++ b/application/build.gradle
@@ -213,7 +213,7 @@ tasks.register('publishToGhcr', BootBuildImage) {
     imageName = "ghcr.io/halo/${name}:${tagName}"
     publish = StringUtils.hasText(System.getenv('GHCR_TOKEN'))
     if (!isRelease) {
-        tags = ["ghcr.io/halo/${name}:main".toString()]
+        tags = ["ghcr.io/halo/${name}:cnb-main".toString()]
     }
     docker {
         publishRegistry {
@@ -230,7 +230,7 @@ tasks.register('publishToDockerHub', BootBuildImage) {
     imageName = "halohub/${name}:${tagName}"
     publish = StringUtils.hasText(System.getenv('DOCKER_TOKEN'))
     if (!isRelease) {
-        tags = ["halohub/${name}:main".toString()]
+        tags = ["halohub/${name}:cnb-main".toString()]
     }
     docker {
         publishRegistry {
@@ -241,24 +241,8 @@ tasks.register('publishToDockerHub', BootBuildImage) {
     archiveFile = tasks.named('bootJar', BootJar).get().archiveFile
 }
 
-tasks.register('publishToFit2Cloud', BootBuildImage) {
-    imageName = "registry.fit2cloud.com/halo/${name}:${tagName}"
-    description = 'Build and publish the Docker image to Fit2Cloud Container Registry.'
-    publish = StringUtils.hasText(System.getenv('F2C_TOKEN'))
-    if (!isRelease) {
-        tags = ["registry.fit2cloud.com/halo/${name}:main".toString()]
-    }
-    docker {
-        publishRegistry {
-            username = System.getenv("F2C_USERNAME")
-            password = System.getenv("F2C_TOKEN")
-        }
-    }
-    archiveFile = tasks.named('bootJar', BootJar).get().archiveFile
-}
-
 tasks.register('publishToAllRegistries') {
     group = 'publishing'
     description = 'Build and publish the Docker image to all configured registries.'
-    dependsOn tasks.named('publishToGhcr'), tasks.named('publishToDockerHub'), tasks.named('publishToFit2Cloud')
+    dependsOn tasks.named('publishToGhcr'), tasks.named('publishToDockerHub')
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/area core
/milestone 2.21.x

#### What this PR does / why we need it:

This PR removes F2C Container Registry publishing due to persistent 403 errors.

#### Which issue(s) this PR fixes:

See https://github.com/halo-dev/halo/actions/runs/17771833184/job/50510643533 for more.

#### Does this PR introduce a user-facing change?

```release-note
None
```

