### PR TITLE
Update GitHub Container Registry namespace for Docker image publishing

### DIFF
--- a/application/build.gradle
+++ b/application/build.gradle
@@ -208,10 +208,10 @@ if (!isRelease) {
 tasks.register('publishToGhcr', BootBuildImage) {
     group = 'publishing'
     description = 'Build and publish the Docker image to GitHub Container Registry.'
-    imageName = "ghcr.io/halo/${name}:${tagName}"
+    imageName = "ghcr.io/halo-dev/${name}:${tagName}"
     publish = StringUtils.hasText(System.getenv('GHCR_TOKEN'))
     if (!isRelease) {
-        tags = ["ghcr.io/halo/${name}:cnb-main".toString()]
+        tags = ["ghcr.io/halo-dev/${name}:cnb-main".toString()]
     }
     docker {
         publishRegistry {


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/area core
/milestone 2.21.x

#### What this PR does / why we need it:

This PR updates GHCR namespace for Docker image publishing.

#### Which issue(s) this PR fixes:

See https://github.com/halo-dev/halo/actions/runs/17824834579/job/50676290698 for more.

#### Does this PR introduce a user-facing change?

```release-note
None
```

