### PR TITLE
Improve navigation logic after publishing content

### DIFF
--- a/ui/console-src/modules/contents/pages/SinglePageEditor.vue
+++ b/ui/console-src/modules/contents/pages/SinglePageEditor.vue
@@ -220,9 +220,15 @@ const handlePublish = async () => {
       });
 
       if (returnToView.value && permalink) {
+        handleClearCache(routeQueryName.value);
         window.location.href = permalink;
-      } else {
+        return;
+      }
+
+      if (router.options.history.state.back === null) {
         router.push({ name: "SinglePages" });
+      } else {
+        router.back();
       }
     } else {
       formState.value.page.spec.publish = true;
@@ -237,7 +243,7 @@ const handlePublish = async () => {
     }
 
     Toast.success(t("core.common.toast.publish_success"));
-    handleClearCache(routeQueryName.value as string);
+    handleClearCache(routeQueryName.value);
   } catch (error) {
     console.error("Failed to publish single page", error);
     Toast.error(t("core.common.toast.publish_failed_and_retry"));

--- a/ui/console-src/modules/contents/posts/PostEditor.vue
+++ b/ui/console-src/modules/contents/posts/PostEditor.vue
@@ -262,9 +262,15 @@ const handlePublish = async () => {
       });
 
       if (returnToView.value === "true" && permalink) {
+        handleClearCache(name.value);
         window.location.href = permalink;
-      } else {
+        return;
+      }
+
+      if (router.options.history.state.back === null) {
         router.push({ name: "Posts" });
+      } else {
+        router.back();
       }
     } else {
       const { data } = await consoleApiClient.content.post.draftPost({


### PR DESCRIPTION
#### What type of PR is this?

/area ui
/kind improvement
/milestone 2.21.x

#### What this PR does / why we need it:

Optimize the navigation logic after publishing an post.

If there’s a previous page, use router.back() so that the query parameters from the previous page are preserved.

#### Which issue(s) this PR fixes:

Fixes https://github.com/halo-dev/halo/issues/7609

#### Does this PR introduce a user-facing change?

```release-note
发布文章后支持回到上一页并保留查询状态。
```
