### PR TITLE
Set dynamic branch name for Docker image tags in build.gradle

### DIFF
--- a/application/build.gradle
+++ b/application/build.gradle
@@ -198,11 +198,12 @@ tasks.named('generateOpenApiDocs') {
 }
 
 def name = 'halo'
+def branchName = grgit.branch.current().name.replaceAll("/", "-")
 def tagName = "${project.version}-cnb"
 def isRelease = Objects.equals(project.findProperty('release'), 'true')
 if (!isRelease) {
     name = 'halo-dev'
-    tagName = "cnb-sha-${grgit.head().abbreviatedId}"
+    tagName = "sha-${grgit.head().abbreviatedId}-cnb"
 }
 
 tasks.register('publishToGhcr', BootBuildImage) {
@@ -211,7 +212,7 @@ tasks.register('publishToGhcr', BootBuildImage) {
     imageName = "ghcr.io/halo-dev/${name}:${tagName}"
     publish = StringUtils.hasText(System.getenv('GHCR_TOKEN'))
     if (!isRelease) {
-        tags = ["ghcr.io/halo-dev/${name}:cnb-main".toString()]
+        tags = ["ghcr.io/halo-dev/${name}:${branchName}-cnb".toString()]
     }
     docker {
         publishRegistry {
@@ -228,7 +229,7 @@ tasks.register('publishToDockerHub', BootBuildImage) {
     imageName = "halohub/${name}:${tagName}"
     publish = StringUtils.hasText(System.getenv('DOCKER_TOKEN'))
     if (!isRelease) {
-        tags = ["halohub/${name}:cnb-main".toString()]
+        tags = ["halohub/${name}:${branchName}-cnb".toString()]
     }
     docker {
         publishRegistry {


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup
/area core
/milestone 2.21.x

#### What this PR does / why we need it:

This PR sets dynamic branch name for Docker image tags in build.gradle, mainly for branchs like `release-2.x`.

#### Does this PR introduce a user-facing change?

```release-note
None
```

