### PR TITLE
Add new plugins to presetPluginUrls list

### DIFF
--- a/application/build.gradle
+++ b/application/build.gradle
@@ -150,6 +150,8 @@ ext.presetPluginUrls = [
         'https://github.com/halo-dev/plugin-search-widget/releases/download/v1.7.0/plugin-search-widget-1.7.0.jar'             : 'plugin-search-widget.jar',
         'https://github.com/halo-dev/plugin-sitemap/releases/download/v1.1.2/plugin-sitemap-1.1.2.jar'                         : 'plugin-sitemap.jar',
         'https://github.com/halo-dev/plugin-feed/releases/download/v1.5.0/plugin-feed-1.5.0.jar'                               : 'plugin-feed.jar',
+        'https://github.com/halo-sigs/plugin-shiki/releases/download/v1.0.1/plugin-shiki-1.0.1.jar'                            : 'plugin-shiki.jar',
+        'https://github.com/halo-sigs/plugin-editor-hyperlink-card/releases/download/v1.5.2/plugin-editor-hyperlink-card-1.5.2.jar': 'plugin-editor-hyperlink-card.jar',
 
         // Currently, plugin-app-store is not open source, so we need to download it from the official website.
         // Please see https://github.com/halo-dev/plugin-app-store/issues/55


### PR DESCRIPTION
#### What type of PR is this?

/area core
/milestone 2.22.x

#### What this PR does / why we need it:

Added [plugin-shiki](https://github.com/halo-sigs/plugin-shiki) v1.0.1 and [plugin-editor-hyperlink-card](https://github.com/halo-sigs/plugin-editor-hyperlink-card) v1.5.2 to the presetPluginUrls in build.gradle to support their automatic download and inclusion.

#### Does this PR introduce a user-facing change?

```release-note
新增 Shiki 代码高亮和超链接卡片预设插件
```
