### PR TITLE
Update external link visibility to use opacity transition

### DIFF
--- a/ui/console-src/modules/contents/pages/components/entity-fields/TitleField.vue
+++ b/ui/console-src/modules/contents/pages/components/entity-fields/TitleField.vue
@@ -74,7 +74,7 @@ const commentText = computed(() => {
         <a
           target="_blank"
           :href="externalUrl"
-          class="hidden text-gray-600 transition-all hover:text-gray-900 group-hover:inline-block"
+          class="text-gray-600 opacity-0 transition-all hover:text-gray-900 group-hover:opacity-100"
         >
           <IconExternalLinkLine class="h-3.5 w-3.5" />
         </a>

--- a/ui/console-src/modules/contents/posts/components/entity-fields/TitleField.vue
+++ b/ui/console-src/modules/contents/posts/components/entity-fields/TitleField.vue
@@ -75,7 +75,7 @@ const commentText = computed(() => {
         <a
           target="_blank"
           :href="externalUrl"
-          class="hidden text-gray-600 transition-all hover:text-gray-900 group-hover:inline-block"
+          class="text-gray-600 opacity-0 transition-all hover:text-gray-900 group-hover:opacity-100"
         >
           <IconExternalLinkLine class="h-3.5 w-3.5" />
         </a>

--- a/ui/console-src/modules/contents/posts/tags/components/TagListItem.vue
+++ b/ui/console-src/modules/contents/posts/tags/components/TagListItem.vue
@@ -51,7 +51,7 @@ const emit = defineEmits<{
             <a
               target="_blank"
               :href="tag.status?.permalink"
-              class="hidden text-gray-600 transition-all hover:text-gray-900 group-hover:inline-block"
+              class="text-gray-600 opacity-0 transition-all hover:text-gray-900 group-hover:opacity-100"
             >
               <IconExternalLinkLine class="h-3.5 w-3.5" />
             </a>

--- a/ui/console-src/modules/dashboard/widgets/presets/posts/components/PostListItem.vue
+++ b/ui/console-src/modules/dashboard/widgets/presets/posts/components/PostListItem.vue
@@ -104,7 +104,7 @@ const commentText = computed(() => {
               target="_blank"
               :href="previewUrl"
               :title="previewUrl"
-              class="hidden text-gray-600 transition-all hover:text-gray-900 group-hover:inline-block"
+              class="text-gray-600 opacity-0 transition-all hover:text-gray-900 group-hover:opacity-100"
             >
               <IconExternalLinkLine class="h-3.5 w-3.5" />
             </a>

--- a/ui/uc-src/modules/contents/posts/components/PostListItem.vue
+++ b/ui/uc-src/modules/contents/posts/components/PostListItem.vue
@@ -156,7 +156,7 @@ function handleDelete() {
             <a
               target="_blank"
               :href="externalUrl"
-              class="hidden text-gray-600 transition-all hover:text-gray-900 group-hover:inline-block"
+              class="text-gray-600 opacity-0 transition-all hover:text-gray-900 group-hover:opacity-100"
             >
               <IconExternalLinkLine class="h-3.5 w-3.5" />
             </a>


### PR DESCRIPTION
#### What type of PR is this?

/area ui
/milestone 2.22.x

#### What this PR does / why we need it:

Replaces 'hidden' and 'inline-block' classes with 'opacity-0' and 'group-hover:opacity-100' for external link icons in multiple components. This change enables smoother transitions and better control over the visibility of external link icons on hover.

#### Does this PR introduce a user-facing change?

```release-note
None
```
