### PR TITLE
Fix recursive update issue in concurrent map for thumbnail generation

### DIFF
--- a/application/src/main/java/run/halo/app/core/attachment/endpoint/ThumbnailRouters.java
+++ b/application/src/main/java/run/halo/app/core/attachment/endpoint/ThumbnailRouters.java
@@ -149,8 +149,7 @@ class ThumbnailRouters {
     private Mono<Resource> generateThumbnail(
         String filename, Path attachmentPath, Path thumbnailPath, ThumbnailSize size
     ) {
-        return Mono.fromFuture(() -> inProgress.computeIfAbsent(filename,
-                    f ->
+        return Mono.fromFuture(() -> inProgress.computeIfAbsent(filename, f ->
                         CompletableFuture.supplyAsync(() -> generateThumbnail(
                                     attachmentPath, thumbnailPath, size
                                 ),
@@ -160,8 +159,10 @@ class ThumbnailRouters {
                                 DEFAULT_GENERATION_TIMEOUT_SECONDS,
                                 TimeUnit.SECONDS
                             )
-                            .whenComplete((p, t) -> inProgress.remove(filename))
-                ),
+                    )
+                    // Remove the entry from the map when the task is complete outside the
+                    // computeIfAbsent to prevent the recursive update
+                    .whenComplete((p, t) -> inProgress.remove(filename)),
                 // We don't want to cancel the thumbnail generation task
                 // when some requests are cancelled
                 true


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/area core
/milestone 2.22.x

#### What this PR does / why we need it:

This PR fixes recursive update issue in concurrent map for thumbnail generation.

```java
java.lang.IllegalStateException: Recursive update
	at java.base/java.util.concurrent.ConcurrentHashMap.replaceNode(Unknown Source) ~[na:na]
```

#### Does this PR introduce a user-facing change?

```release-note
None
```

