### PR TITLE
Add hidden flag for attachment policies in upload UI

### DIFF
--- a/ui/src/constants/labels.ts
+++ b/ui/src/constants/labels.ts
@@ -28,3 +28,10 @@ export enum singlePageLabels {
   VISIBLE = "content.halo.run/visible",
   PHASE = "content.halo.run/phase",
 }
+
+// attachment
+export enum attachmentPolicyLabels {
+  // Used for ui display only
+  HIDDEN = "storage.halo.run/policy-hidden-in-upload-ui",
+  HIDDEN_WITH_JSON_PATCH = "storage.halo.run~1policy-hidden-in-upload-ui",
+}

--- a/ui/src/locales/en.yaml
+++ b/ui/src/locales/en.yaml
@@ -752,6 +752,11 @@ core:
           label: Display name
         config:
           label: Policy configuration
+        hidden:
+          label: Hide on upload screen
+          help: >-
+            If enabled, this storage policy will not be visible on the upload
+            screen
       toast:
         policy_name_exists: Storage policy name already exists
     upload_modal:

--- a/ui/src/locales/es.yaml
+++ b/ui/src/locales/es.yaml
@@ -504,6 +504,9 @@ core:
       fields:
         display_name:
           label: Nombre para Mostrar
+        hidden:
+          label: Hide in upload interface
+          help: When enabled, this storage policy will be hidden in the upload interface
     upload_modal:
       title: Cargar adjunto
       filters:

--- a/ui/src/locales/zh-CN.yaml
+++ b/ui/src/locales/zh-CN.yaml
@@ -706,6 +706,9 @@ core:
           label: 名称
         config:
           label: 策略配置
+        hidden:
+          label: 在上传界面隐藏
+          help: 开启后，会在上传界面隐藏该存储策略
       toast:
         policy_name_exists: 存储策略名称已存在
     upload_modal:

--- a/ui/src/locales/zh-TW.yaml
+++ b/ui/src/locales/zh-TW.yaml
@@ -691,6 +691,9 @@ core:
           label: 名稱
         config:
           label: 策略配置
+        hidden:
+          label: 在上傳介面隱藏
+          help: 開啟後，會在上傳介面隱藏該儲存策略
       toast:
         policy_name_exists: 儲存策略名稱已存在
     upload_modal:


### PR DESCRIPTION
#### What type of PR is this?

/area ui
/milestone 2.22.x
/kind feature

#### What this PR does / why we need it:

This PR adds an option in the storage policy settings to hide a policy from the upload interface.

This is useful because some storage policies are not intended for direct user uploads. Hiding them can help declutter the UI and prevent users from selecting them by mistake.

#### Which issue(s) this PR fixes:

Fixes #7787 

#### Does this PR introduce a user-facing change?

```release-note
支持在附件上传界面隐藏部分存储策略
```
