### PR TITLE
Update toolbox priorities and add image command menu for editor

### DIFF
--- a/ui/packages/editor/src/extensions/audio/index.ts
+++ b/ui/packages/editor/src/extensions/audio/index.ts
@@ -155,7 +155,7 @@ const Audio = Node.create<ExtensionOptions>({
       },
       getToolboxItems({ editor }: { editor: Editor }) {
         return {
-          priority: 20,
+          priority: 30,
           component: markRaw(ToolboxItemVue),
           props: {
             editor,

--- a/ui/packages/editor/src/extensions/code-block/code-block.ts
+++ b/ui/packages/editor/src/extensions/code-block/code-block.ts
@@ -323,7 +323,7 @@ export default TiptapCodeBlock.extend<ExtensionCodeBlockOptions>({
       getToolboxItems({ editor }: { editor: Editor }) {
         return [
           {
-            priority: 50,
+            priority: 60,
             component: markRaw(ToolboxItem),
             props: {
               editor,

--- a/ui/packages/editor/src/extensions/columns/columns.ts
+++ b/ui/packages/editor/src/extensions/columns/columns.ts
@@ -188,7 +188,7 @@ const Columns = Node.create({
       getToolboxItems({ editor }: { editor: Editor }) {
         return [
           {
-            priority: 50,
+            priority: 70,
             component: markRaw(ToolboxItem),
             props: {
               editor,

--- a/ui/packages/editor/src/extensions/iframe/index.ts
+++ b/ui/packages/editor/src/extensions/iframe/index.ts
@@ -243,7 +243,7 @@ const Iframe = Node.create<ExtensionOptions>({
       getToolboxItems({ editor }: { editor: Editor }) {
         return [
           {
-            priority: 40,
+            priority: 50,
             component: markRaw(ToolboxItem),
             props: {
               editor,

--- a/ui/packages/editor/src/extensions/image/index.ts
+++ b/ui/packages/editor/src/extensions/image/index.ts
@@ -8,6 +8,7 @@ import {
   mergeAttributes,
   VueNodeViewRenderer,
   type Editor,
+  type Range,
 } from "@/tiptap/vue-3";
 import type { ExtensionOptions, NodeBubbleMenuType } from "@/types";
 import { deleteNode } from "@/utils";
@@ -126,6 +127,25 @@ const Image = TiptapImage.extend<ExtensionOptions & ImageOptions>({
             },
           },
         ];
+      },
+      getCommandMenuItems() {
+        return {
+          priority: 95,
+          icon: markRaw(MdiFileImageBox),
+          title: "editor.extensions.commands_menu.image",
+          keywords: ["image", "tupian"],
+          command: ({ editor, range }: { editor: Editor; range: Range }) => {
+            editor
+              .chain()
+              .focus()
+              .deleteRange(range)
+              .insertContent([
+                { type: "image", attrs: { src: "" } },
+                { type: "paragraph", content: "" },
+              ])
+              .run();
+          },
+        };
       },
       getBubbleMenu({ editor }: { editor: Editor }): NodeBubbleMenuType {
         return {

--- a/ui/packages/editor/src/extensions/table/index.ts
+++ b/ui/packages/editor/src/extensions/table/index.ts
@@ -225,7 +225,7 @@ const Table = TiptapTable.extend<ExtensionOptions & TableOptions>({
       allowTableNodeSelection: false,
       getToolboxItems({ editor }: { editor: Editor }) {
         return {
-          priority: 15,
+          priority: 40,
           component: markRaw(ToolboxItem),
           props: {
             editor,


### PR DESCRIPTION
#### What type of PR is this?

/area ui
/area editor
/kind improvement
/milestone 2.22.x

#### What this PR does / why we need it:

Adjusted the priority values for toolbox items in audio, code-block, columns, iframe, and table extensions to refine their ordering. Added a getCommandMenuItems method to the image extension, enabling image insertion via the command menu.

<img width="401" height="205" alt="image" src="https://github.com/user-attachments/assets/9a01f2f8-6281-4a56-8455-d35c44c37bdb" />

#### Does this PR introduce a user-facing change?

```release-note
为编辑器的命令面板添加插入图片的选项
```
