### PR TITLE
Refactor thumbnail generation to support configurable concurrent threads and disable option

### DIFF
--- a/application/src/main/java/run/halo/app/infra/properties/AttachmentProperties.java
+++ b/application/src/main/java/run/halo/app/infra/properties/AttachmentProperties.java
@@ -1,13 +1,36 @@
 package run.halo.app.infra.properties;
 
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.Min;
 import java.util.LinkedList;
 import java.util.List;
 import lombok.Data;
+import org.springframework.boot.context.properties.NestedConfigurationProperty;
 
 @Data
 public class AttachmentProperties {
 
     private List<ResourceMapping> resourceMappings = new LinkedList<>();
+
+    @Valid
+    @NestedConfigurationProperty
+    private final ThumbnailProperties thumbnail = new ThumbnailProperties();
+
+    @Data
+    public static class ThumbnailProperties {
+
+        /**
+         * Whether to disable thumbnail generation.
+         */
+        private boolean disabled;
+
+        /**
+         * The concurrent threads for thumbnail generation.
+         */
+        @Min(1)
+        private Integer concurrentThreads;
+
+    }
 
     @Data
     public static class ResourceMapping {

--- a/application/src/test/java/run/halo/app/core/attachment/thumbnail/DefaultLocalThumbnailServiceTest.java
+++ b/application/src/test/java/run/halo/app/core/attachment/thumbnail/DefaultLocalThumbnailServiceTest.java
@@ -3,6 +3,8 @@ package run.halo.app.core.attachment.thumbnail;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import com.google.common.util.concurrent.MoreExecutors;
@@ -14,13 +16,14 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.io.TempDir;
-import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.util.ResourceUtils;
 import reactor.test.StepVerifier;
 import run.halo.app.core.attachment.AttachmentRootGetter;
 import run.halo.app.core.attachment.ThumbnailSize;
+import run.halo.app.infra.properties.AttachmentProperties;
+import run.halo.app.infra.properties.HaloProperties;
 
 @ExtendWith(MockitoExtension.class)
 class DefaultLocalThumbnailServiceTest {
@@ -28,7 +31,12 @@ class DefaultLocalThumbnailServiceTest {
     @Mock
     AttachmentRootGetter attachmentRootGetter;
 
-    @InjectMocks
+    @Mock
+    HaloProperties haloProperties;
+
+    @Mock
+    AttachmentProperties.ThumbnailProperties thumbnailProperties;
+
     DefaultLocalThumbnailService generator;
 
     Path source;
@@ -38,14 +46,22 @@ class DefaultLocalThumbnailServiceTest {
 
     @BeforeEach
     void setUp() throws IOException {
-        var executorService = MoreExecutors.newDirectExecutorService();
-        this.generator.setExecutorService(executorService);
+        var attachmentProperties = mock(AttachmentProperties.class);
+        when(attachmentProperties.getThumbnail()).thenReturn(thumbnailProperties);
+        when(haloProperties.getAttachment()).thenReturn(attachmentProperties);
+        when(thumbnailProperties.isDisabled()).thenReturn(false);
+        when(thumbnailProperties.getConcurrentThreads()).thenReturn(1);
         var imagePath =
             ResourceUtils.getFile("classpath:static/images/halo-logo-401x401.png").toPath();
-        when(attachmentRootGetter.get()).thenReturn(attachmentRoot);
+        lenient().when(attachmentRootGetter.get()).thenReturn(attachmentRoot);
         this.source = attachmentRoot.resolve("static").resolve("hal-logo-401x401.png");
         Files.createDirectories(this.source.getParent());
         Files.copy(imagePath, this.source);
+
+        this.generator =
+            new DefaultLocalThumbnailService(this.attachmentRootGetter, this.haloProperties);
+        var executorService = MoreExecutors.newDirectExecutorService();
+        this.generator.setExecutorService(executorService);
     }
 
     @AfterEach
@@ -83,4 +99,18 @@ class DefaultLocalThumbnailServiceTest {
             .verifyComplete();
     }
 
+    @Test
+    void shouldDisableThumbnailGeneration() {
+        when(thumbnailProperties.isDisabled()).thenReturn(true);
+        this.generator.generate(source, ThumbnailSize.S)
+            .as(StepVerifier::create)
+            .assertNext(resource -> {
+                try {
+                    assertEquals(resource.getFile(), source.toFile());
+                } catch (IOException e) {
+                    throw new RuntimeException(e);
+                }
+            })
+            .verifyComplete();
+    }
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind improvement
/area core
/milestone 2.22.x

#### What this PR does / why we need it:

This PR refactors thumbnail generation to support configurable concurrent threads and disable option.

#### Does this PR introduce a user-facing change?

```release-note
支持配置缩略图生成启用、禁用和并发量
```

