### PR TITLE
Add repository check to npm release workflow

### DIFF
--- a/.github/workflows/release-ui-packages.yaml
+++ b/.github/workflows/release-ui-packages.yaml
@@ -12,6 +12,7 @@ on:
 jobs:
   release:
     runs-on: ubuntu-latest
+    if: github.repository == 'halo-dev/halo'
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

The release-ui-packages workflow now only runs if the repository is 'halo-dev/halo', preventing unintended releases from forks or other repositories.

#### Does this PR introduce a user-facing change?

```release-note
None
```
