### PR TITLE
Upgrade thumbnailator to version 0.4.21 and remove imgscalr and metadata-extractor dependencies

### DIFF
--- a/api/build.gradle
+++ b/api/build.gradle
@@ -88,9 +88,7 @@ dependencies {
     api "com.github.java-json-tools:json-patch"
     api "org.thymeleaf.extras:thymeleaf-extras-springsecurity6"
     api 'org.apache.tika:tika-core'
-    api "org.imgscalr:imgscalr-lib"
     api 'net.coobird:thumbnailator'
-    api 'com.drewnoakes:metadata-extractor'
 
     api "io.github.resilience4j:resilience4j-spring-boot3"
     api "io.github.resilience4j:resilience4j-reactor"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -29,9 +29,7 @@ springdoc-openapi = 'org.springdoc:springdoc-openapi-starter-webflux-ui:2.8.9'
 openapi-schema-validator = 'org.openapi4j:openapi-schema-validator:1.0.7'
 bouncycastle-bcpkix = 'org.bouncycastle:bcpkix-jdk18on:1.81'
 twofactor-auth = 'com.j256.two-factor-auth:two-factor-auth:1.3'
-imgscalr-lib = 'org.imgscalr:imgscalr-lib:4.2'
-thumbnailator = 'net.coobird:thumbnailator:0.4.20'
-metadata-extractor = 'com.drewnoakes:metadata-extractor:2.19.0'
+thumbnailator = 'net.coobird:thumbnailator:0.4.21'
 
 [bundles]
 lucene = ['lucene-core', 'lucene-queryparser', 'lucene-highlighter', 'lucene-backward-codecs', 'lucene-analyzers-common']

--- a/platform/application/build.gradle
+++ b/platform/application/build.gradle
@@ -31,9 +31,7 @@ dependencies {
         api libs.json.patch
         api libs.bundles.resilience4j
         api libs.twofactor.auth
-        api libs.imgscalr.lib
         api libs.thumbnailator
-        api libs.metadata.extractor
         api "org.springframework.integration:spring-integration-core"
         api "org.thymeleaf.extras:thymeleaf-extras-springsecurity6"
     }


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup
/area core
/milestone 2.22.x

#### What this PR does / why we need it:

This PR upgrades thumbnailator to version 0.4.21 and remove unused imgscalr and metadata-extractor dependencies.

#### Does this PR introduce a user-facing change?

```release-note
None
```

