### PR TITLE
Enhance thumbnail retrieval to support relative permalinks and local site checks

### DIFF
--- a/application/src/test/java/run/halo/app/core/attachment/thumbnail/DefaultThumbnailServiceTest.java
+++ b/application/src/test/java/run/halo/app/core/attachment/thumbnail/DefaultThumbnailServiceTest.java
@@ -3,7 +3,9 @@ package run.halo.app.core.attachment.thumbnail;
 import static org.mockito.ArgumentMatchers.isA;
 import static org.mockito.ArgumentMatchers.same;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
+import java.net.MalformedURLException;
 import java.net.URI;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
@@ -20,6 +22,7 @@ import run.halo.app.core.extension.attachment.Attachment;
 import run.halo.app.extension.ListOptions;
 import run.halo.app.extension.Metadata;
 import run.halo.app.extension.ReactiveExtensionClient;
+import run.halo.app.infra.ExternalUrlSupplier;
 
 @ExtendWith(MockitoExtension.class)
 class DefaultThumbnailServiceTest {
@@ -27,21 +30,37 @@ class DefaultThumbnailServiceTest {
     @Mock
     ReactiveExtensionClient client;
 
+    @Mock
+    ExternalUrlSupplier externalUrlSupplier;
+
     @InjectMocks
     DefaultThumbnailService thumbnailService;
 
     @Test
-    void shouldGetEmptyThumbnailIfNoAttachmentsFound() {
+    void shouldGetThumbnailDirectlyIfPermalinkIsRelative() {
+        thumbnailService.get(URI.create("/images/fake.png"), ThumbnailSize.M)
+            .as(StepVerifier::create)
+            .expectNext(URI.create("/images/fake.png?width=800"))
+            .verifyComplete();
+    }
+
+    @Test
+    void shouldGetThumbnailDirectlyIfPermalinkIsInSite() throws MalformedURLException {
+        when(externalUrlSupplier.getRaw()).thenReturn(URI.create("https://www.halo.run").toURL());
+        thumbnailService.get(URI.create("https://www.halo.run/images/fake.png"), ThumbnailSize.M)
+            .as(StepVerifier::create)
+            .expectNext(URI.create("https://www.halo.run/images/fake.png?width=800"))
+            .verifyComplete();
+    }
+
+    @Test
+    void shouldGetEmptyThumbnailIfNoAttachmentsFound() throws MalformedURLException {
+        when(externalUrlSupplier.getRaw()).thenReturn(URI.create("https://www.halo.run").toURL());
         Mockito.when(
                 client.listAll(same(Attachment.class), isA(ListOptions.class), isA(Sort.class))
             )
             .thenReturn(Flux.empty());
-        thumbnailService.get(URI.create("/fake.png"))
-            .as(StepVerifier::create)
-            .expectNext(Map.of())
-            .verifyComplete();
-
-        thumbnailService.get(URI.create("/fake.png"))
+        thumbnailService.get(URI.create("https://fake.halo.run/fake.png"))
             .as(StepVerifier::create)
             .expectNext(Map.of())
             .verifyComplete();
@@ -51,20 +70,19 @@ class DefaultThumbnailServiceTest {
     }
 
     @Test
-    void shouldGetThumbnailsIfAttachmentsFound() {
+    void shouldGetThumbnailsIfAttachmentsFound() throws MalformedURLException {
+        when(externalUrlSupplier.getRaw()).thenReturn(URI.create("https://www.halo.run").toURL());
         Mockito.when(
                 client.listAll(same(Attachment.class), isA(ListOptions.class), isA(Sort.class))
             )
             .thenReturn(Flux.just(
-                createAttachment("fake-png", "/fake.png", Map.of("s", "/fake.png?width=400")),
-                createAttachment("fake-png", "/fake.png", Map.of("m", "/fake.png?width=800"))
+                createAttachment("fake-png", "https://fake.halo.run/fake.png",
+                    Map.of("s", "/fake.png?width=400")),
+                createAttachment("fake-png", "https://fake.halo.run/fake.png",
+                    Map.of("m", "/fake.png?width=800"))
             ));
-        thumbnailService.get(URI.create("/fake.png"))
-            .as(StepVerifier::create)
-            .expectNext(Map.of(ThumbnailSize.S, URI.create("/fake.png?width=400")))
-            .verifyComplete();
 
-        thumbnailService.get(URI.create("/fake.png"))
+        thumbnailService.get(URI.create("https://fake.halo.run/fake.png"))
             .as(StepVerifier::create)
             .expectNext(Map.of(ThumbnailSize.S, URI.create("/fake.png?width=400")))
             .verifyComplete();


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/area core
/milestone 2.22.x

#### What this PR does / why we need it:

This PR enhances thumbnail retrieval to support relative permalinks and in-site checks.

#### Does this PR introduce a user-facing change?

```release-note
None
```

