### PR TITLE
Add safeToUri method to HaloUtils for robust URI conversion

### DIFF
--- a/application/src/main/java/run/halo/app/core/attachment/endpoint/LocalAttachmentUploadHandler.java
+++ b/application/src/main/java/run/halo/app/core/attachment/endpoint/LocalAttachmentUploadHandler.java
@@ -59,6 +59,7 @@ import run.halo.app.infra.exception.FileSizeExceededException;
 import run.halo.app.infra.exception.FileTypeNotAllowedException;
 import run.halo.app.infra.utils.FileNameUtils;
 import run.halo.app.infra.utils.FileTypeDetectUtils;
+import run.halo.app.infra.utils.HaloUtils;
 import run.halo.app.infra.utils.JsonUtils;
 
 @Slf4j
@@ -293,21 +294,7 @@ class LocalAttachmentUploadHandler implements AttachmentHandler {
             return Optional.empty();
         }
         var uriStr = annotations.get(Constant.URI_ANNO_KEY);
-        URI uri;
-        try {
-            uri = UriComponentsBuilder.fromUri(externalUrl.get())
-                // The URI has been encoded before, so there is no need to encode it again.
-                .path(uriStr)
-                .build(true)
-                .toUri();
-        } catch (IllegalArgumentException e) {
-            // The URI may not be encoded, so we need to build with encoding.
-            uri = UriComponentsBuilder.fromUri(externalUrl.get())
-                .path(uriStr)
-                .build()
-                .toUri();
-        }
-        return Optional.of(uri);
+        return Optional.of(HaloUtils.safeToUri(uriStr));
     }
 
     private Map<ThumbnailSize, URI> doGetThumbnailLinks(Attachment attachment) {

--- a/application/src/main/java/run/halo/app/core/attachment/thumbnail/ThumbnailImgTagPostProcessor.java
+++ b/application/src/main/java/run/halo/app/core/attachment/thumbnail/ThumbnailImgTagPostProcessor.java
@@ -9,13 +9,13 @@ import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 import org.springframework.util.StringUtils;
-import org.springframework.web.util.UriComponentsBuilder;
 import org.thymeleaf.context.ITemplateContext;
 import org.thymeleaf.engine.ElementNames;
 import org.thymeleaf.model.IAttribute;
 import org.thymeleaf.model.IProcessableElementTag;
 import org.thymeleaf.processor.element.MatchingElementName;
 import reactor.core.publisher.Mono;
+import run.halo.app.infra.utils.HaloUtils;
 import run.halo.app.theme.dialect.ElementTagPostProcessor;
 
 @Slf4j
@@ -53,11 +53,7 @@ class ThumbnailImgTagPostProcessor implements ElementTagPostProcessor {
             .map(IAttribute::getValue)
             .filter(StringUtils::hasText)
             .map(String::trim)
-            .map(str -> UriComponentsBuilder.fromUriString(str)
-                .build()
-                .encode()
-                .toUri()
-            );
+            .map(HaloUtils::safeToUri);
         if (srcValue.isEmpty()) {
             log.debug("Skip processing img tag without src attribute");
             return Mono.empty();

--- a/application/src/main/java/run/halo/app/core/endpoint/theme/ThumbnailEndpoint.java
+++ b/application/src/main/java/run/halo/app/core/endpoint/theme/ThumbnailEndpoint.java
@@ -16,12 +16,12 @@ import org.springframework.web.reactive.function.server.RouterFunction;
 import org.springframework.web.reactive.function.server.ServerRequest;
 import org.springframework.web.reactive.function.server.ServerResponse;
 import org.springframework.web.server.ServerWebInputException;
-import org.springframework.web.util.UriComponentsBuilder;
 import reactor.core.publisher.Mono;
 import run.halo.app.core.attachment.ThumbnailSize;
 import run.halo.app.core.attachment.thumbnail.ThumbnailService;
 import run.halo.app.core.extension.endpoint.CustomEndpoint;
 import run.halo.app.extension.GroupVersion;
+import run.halo.app.infra.utils.HaloUtils;
 
 /**
  * Thumbnail endpoint for thumbnail resource access.
@@ -82,11 +82,7 @@ public class ThumbnailEndpoint implements CustomEndpoint {
     private Mono<ServerResponse> getThumbnailByUri(ServerRequest request) {
         var uri = request.queryParam("uri")
             .filter(StringUtils::isNotBlank)
-            .map(uriString -> UriComponentsBuilder.fromUriString(uriString)
-                .build()
-                .encode()
-                .toUri()
-            );
+            .map(HaloUtils::safeToUri);
         if (uri.isEmpty()) {
             return Mono.error(
                 new ServerWebInputException("Required parameter 'uri' is missing or invalid")

--- a/application/src/main/java/run/halo/app/infra/utils/HaloUtils.java
+++ b/application/src/main/java/run/halo/app/infra/utils/HaloUtils.java
@@ -2,6 +2,7 @@ package run.halo.app.infra.utils;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.time.Instant;
 import java.time.ZoneId;
@@ -14,6 +15,7 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.util.Assert;
 import org.springframework.util.StreamUtils;
 import org.springframework.web.reactive.function.server.ServerRequest;
+import org.springframework.web.util.UriComponentsBuilder;
 import run.halo.app.theme.router.ModelConst;
 
 /**
@@ -95,4 +97,27 @@ public class HaloUtils {
             return request;
         };
     }
+
+    /**
+     * Safely convert string to URI. This method will assume the input string is already encoded.
+     * If failed, it will try to encode the string.
+     *
+     * @param uri the uri string
+     * @return the uri
+     */
+    public static URI safeToUri(String uri) {
+        try {
+            return UriComponentsBuilder.fromUriString(uri)
+                .build(true)
+                .encode()
+                .toUri();
+        } catch (IllegalArgumentException ignored) {
+            // Try to build with encoding
+            return UriComponentsBuilder.fromUriString(uri)
+                .build()
+                .encode()
+                .toUri();
+        }
+    }
+
 }

--- a/application/src/test/java/run/halo/app/infra/utils/HaloUtilsTest.java
+++ b/application/src/test/java/run/halo/app/infra/utils/HaloUtilsTest.java
@@ -4,6 +4,8 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 import org.springframework.mock.http.server.reactive.MockServerHttpRequest;
 import org.springframework.mock.web.reactive.function.server.MockServerRequest;
 import org.springframework.mock.web.server.MockServerWebExchange;
@@ -22,4 +24,17 @@ class HaloUtilsTest {
         assertTrue(() -> exchange.getRequiredAttribute(ModelConst.NO_CACHE));
     }
 
+    @ParameterizedTest
+    @CsvSource({
+        "http://example.com/path with spaces, http://example.com/path%20with%20spaces",
+        "https://example.com/üñîçødé, https://example.com/%C3%BC%C3%B1%C3%AE%C3%A7%C3%B8d%C3%A9",
+        "ftp://example.com/special?param=äöü, ftp://example.com/special?param=%C3%A4%C3%B6%C3%BC",
+        "http://example.com/normal-path, http://example.com/normal-path",
+        "http://example.com/路径, http://example.com/%E8%B7%AF%E5%BE%84",
+        "http://example.com/space%20space, http://example.com/space%20space",
+        "http://example.com/100%100, http://example.com/100%100"
+    })
+    void shouldConvertUriSafely(String uri, String expected) {
+        assertEquals(expected, HaloUtils.safeToUri(uri).toString());
+    }
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/area core
/milestone 2.22.x

#### What this PR does / why we need it:

This PR allow user to pass an encoded/non-encoded URI to process thummbnails.

Related to <https://github.com/halo-dev/halo/pull/7821>.

#### Does this PR introduce a user-facing change?

```release-note
None
```
