### PR TITLE
Upgrade Checkstyle to version 12.1.0 and standardize plugin declaration

### DIFF
--- a/api/build.gradle
+++ b/api/build.gradle
@@ -1,4 +1,5 @@
 plugins {
+    id 'checkstyle'
     id 'java-library'
     id 'halo.publish'
     id 'jacoco'
@@ -24,6 +25,12 @@ java {
     }
     withJavadocJar()
     withSourcesJar()
+}
+
+checkstyle {
+    toolVersion = libs.versions.checkstyle.get()
+    showViolations = false
+    ignoreFailures = false
 }
 
 jar {

--- a/application/build.gradle
+++ b/application/build.gradle
@@ -5,7 +5,7 @@ import org.springframework.boot.gradle.tasks.bundling.BootJar
 import org.springframework.util.StringUtils
 
 plugins {
-    id "checkstyle"
+    id 'checkstyle'
     id 'java'
     id 'idea'
     id 'jacoco'
@@ -40,7 +40,7 @@ idea {
 }
 
 checkstyle {
-    toolVersion = "9.3"
+    toolVersion = libs.versions.checkstyle.get()
     showViolations = false
     ignoreFailures = false
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,6 +2,7 @@
 lucene = '10.3.0'
 resilience4j = '2.3.0'
 therapi = '0.15.0'
+checkstyle = "12.1.0"
 
 [libraries]
 lucene-core = { module = 'org.apache.lucene:lucene-core', version.ref = 'lucene' }


### PR DESCRIPTION
#### What type of PR is this?

/kind improvement
/area core
/milstone 2.22.x

#### What this PR does / why we need it:

This PR upgrades Checkstyle to version [12.1.0](https://github.com/checkstyle/checkstyle/releases/tag/checkstyle-12.1.0) for Java 21 support.

#### Which issue(s) this PR fixes:

Old checkstyle may not support record introduced or switch introduced in Java 14.

#### Does this PR introduce a user-facing change?

```release-note
None
```

