### PR TITLE
Refactor safeToUri method in HaloUtils to handle mixed special characters in URIs

### DIFF
--- a/application/src/main/java/run/halo/app/infra/utils/HaloUtils.java
+++ b/application/src/main/java/run/halo/app/infra/utils/HaloUtils.java
@@ -16,6 +16,7 @@ import org.springframework.util.Assert;
 import org.springframework.util.StreamUtils;
 import org.springframework.web.reactive.function.server.ServerRequest;
 import org.springframework.web.util.UriComponentsBuilder;
+import org.springframework.web.util.UriUtils;
 import run.halo.app.theme.router.ModelConst;
 
 /**
@@ -106,18 +107,12 @@ public class HaloUtils {
      * @return the uri
      */
     public static URI safeToUri(String uri) {
-        try {
-            return UriComponentsBuilder.fromUriString(uri)
-                .build(true)
-                .encode()
-                .toUri();
-        } catch (IllegalArgumentException ignored) {
-            // Try to build with encoding
-            return UriComponentsBuilder.fromUriString(uri)
-                .build()
-                .encode()
-                .toUri();
-        }
+        // try to decode first
+        var decodedUri = UriUtils.decode(uri, StandardCharsets.UTF_8);
+        return UriComponentsBuilder.fromUriString(decodedUri)
+            .build(false)
+            .encode()
+            .toUri();
     }
 
 }

--- a/application/src/test/java/run/halo/app/infra/utils/HaloUtilsTest.java
+++ b/application/src/test/java/run/halo/app/infra/utils/HaloUtilsTest.java
@@ -32,7 +32,8 @@ class HaloUtilsTest {
         "http://example.com/normal-path, http://example.com/normal-path",
         "http://example.com/路径, http://example.com/%E8%B7%AF%E5%BE%84",
         "http://example.com/space%20space, http://example.com/space%20space",
-        "http://example.com/100%100, http://example.com/100%100"
+        "http://example.com/100%100, http://example.com/100%100",
+        "http://example.com/mixed chars%20and 中文, http://example.com/mixed%20chars%20and%20%E4%B8%AD%E6%96%87"
     })
     void shouldConvertUriSafely(String uri, String expected) {
         assertEquals(expected, HaloUtils.safeToUri(uri).toString());


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/area core
/milestone 2.22.x

#### What this PR does / why we need it:

We may not handle mixed special chars in URIs correctly, which causes twice encoding.

This is a supplement of <https://github.com/halo-dev/halo/pull/7825>.

#### Does this PR introduce a user-facing change?

```release-note
None
```
