### PR TITLE
WIP: Disable sync on start by default for various reconciler components

### DIFF
--- a/api/src/main/java/run/halo/app/extension/controller/ControllerBuilder.java
+++ b/api/src/main/java/run/halo/app/extension/controller/ControllerBuilder.java
@@ -35,7 +35,7 @@ public class ControllerBuilder {
 
     private final ExtensionClient client;
 
-    private boolean syncAllOnStart = true;
+    private boolean syncAllOnStart = false;
 
     private int workerCount = 1;
 

--- a/application/src/main/java/run/halo/app/core/attachment/reconciler/LocalThumbnailsReconciler.java
+++ b/application/src/main/java/run/halo/app/core/attachment/reconciler/LocalThumbnailsReconciler.java
@@ -54,6 +54,8 @@ class LocalThumbnailsReconciler implements Reconciler<Reconciler.Request> {
     public Controller setupWith(ControllerBuilder builder) {
         return builder
             .extension(new LocalThumbnail())
+            // Only for deletion
+            .syncAllOnStart(true)
             .build();
     }
 

--- a/application/src/main/java/run/halo/app/core/reconciler/AuthProviderReconciler.java
+++ b/application/src/main/java/run/halo/app/core/reconciler/AuthProviderReconciler.java
@@ -34,6 +34,7 @@ public class AuthProviderReconciler implements Reconciler<Reconciler.Request> {
     public Controller setupWith(ControllerBuilder builder) {
         return builder
             .extension(new AuthProvider())
+            .syncAllOnStart(true)
             .build();
     }
 

--- a/application/src/main/java/run/halo/app/core/reconciler/PluginReconciler.java
+++ b/application/src/main/java/run/halo/app/core/reconciler/PluginReconciler.java
@@ -737,6 +737,7 @@ public class PluginReconciler implements Reconciler<Request> {
     public Controller setupWith(ControllerBuilder builder) {
         return builder
             .extension(new Plugin())
+            .syncAllOnStart(true)
             .build();
     }
 

--- a/application/src/main/java/run/halo/app/core/reconciler/ThemeReconciler.java
+++ b/application/src/main/java/run/halo/app/core/reconciler/ThemeReconciler.java
@@ -76,6 +76,7 @@ public class ThemeReconciler implements Reconciler<Request> {
     public Controller setupWith(ControllerBuilder builder) {
         return builder
             .extension(new Theme())
+            .syncAllOnStart(true)
             .build();
     }
 

--- a/application/src/main/java/run/halo/app/migration/BackupReconciler.java
+++ b/application/src/main/java/run/halo/app/migration/BackupReconciler.java
@@ -128,6 +128,7 @@ public class BackupReconciler implements Reconciler<Request> {
     public Controller setupWith(ControllerBuilder builder) {
         return builder
             .extension(new Backup())
+            .syncAllOnStart(true)
             .build();
     }
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind improvement
/area core
/area plugin
/milestone 2.22.x

#### What this PR does / why we need it:

This PR makes syncAllOnStart be false as default to improve startup performance, especially with a lot of extensions.

Meanwhile, it might introduce some poetential data integrity issues. We have to fully test with plugins before merging.

There is another potential solution:
For potentially expand with a large amount of extensions, we set syncAllOnStart to false manually.

Eventually, we are suppose to provide a mechanism to ensure that only small data unreconciled should be synchronized on start.
#### Does this PR introduce a user-facing change?

```release-note
None
```

