### PR TITLE
Refactor AttachmentSelectorModal visibility handling

### DIFF
--- a/ui/console-src/modules/contents/attachments/components/AttachmentSelectorModal.vue
+++ b/ui/console-src/modules/contents/attachments/components/AttachmentSelectorModal.vue
@@ -5,7 +5,14 @@ import type {
   AttachmentLike,
   AttachmentSelectProvider,
 } from "@halo-dev/console-shared";
-import { computed, markRaw, onMounted, ref } from "vue";
+import {
+  computed,
+  markRaw,
+  onMounted,
+  ref,
+  shallowRef,
+  useTemplateRef,
+} from "vue";
 import { useI18n } from "vue-i18n";
 import CoreSelectorProvider from "./selector-providers/CoreSelectorProvider.vue";
 
@@ -13,13 +20,11 @@ const { t } = useI18n();
 
 const props = withDefaults(
   defineProps<{
-    visible: boolean;
     accepts?: string[];
     min?: number;
     max?: number;
   }>(),
   {
-    visible: false,
     accepts: () => ["*/*"],
     min: undefined,
     max: undefined,
@@ -27,14 +32,14 @@ const props = withDefaults(
 );
 
 const emit = defineEmits<{
-  (event: "update:visible", visible: boolean): void;
   (event: "close"): void;
   (event: "select", attachments: AttachmentLike[]): void;
 }>();
 
 const selected = ref<AttachmentLike[]>([] as AttachmentLike[]);
+const modal = useTemplateRef<InstanceType<typeof VModal> | null>("modal");
 
-const attachmentSelectProviders = ref<AttachmentSelectProvider[]>([
+const attachmentSelectProviders = shallowRef<AttachmentSelectProvider[]>([
   {
     id: "core",
     label: t("core.attachment.select_modal.providers.default.label"),
@@ -56,7 +61,10 @@ onMounted(async () => {
       }
 
       const providers = await callbackFunction();
-      attachmentSelectProviders.value.push(...providers);
+      attachmentSelectProviders.value = [
+        ...attachmentSelectProviders.value,
+        ...providers,
+      ].flat();
     } catch (error) {
       console.error(`Error processing plugin module:`, pluginModule, error);
     }
@@ -64,13 +72,6 @@ onMounted(async () => {
 });
 
 const activeId = ref(attachmentSelectProviders.value[0].id);
-
-const onVisibleChange = (visible: boolean) => {
-  emit("update:visible", visible);
-  if (!visible) {
-    emit("close");
-  }
-};
 
 const onChangeProvider = (providerId: string) => {
   const provider = attachmentSelectProviders.value.find(
@@ -86,7 +87,7 @@ const onChangeProvider = (providerId: string) => {
 
 const handleConfirm = () => {
   emit("select", Array.from(selected.value));
-  onVisibleChange(false);
+  modal.value?.close();
 };
 
 const confirmDisabled = computed(() => {
@@ -105,13 +106,13 @@ const confirmCountMessage = computed(() => {
 </script>
 <template>
   <VModal
-    :visible="visible"
+    ref="modal"
     :width="1240"
     :mount-to-body="true"
     :layer-closable="true"
     :title="$t('core.attachment.select_modal.title')"
     height="calc(100vh - 20px)"
-    @update:visible="onVisibleChange"
+    @close="emit('close')"
   >
     <VTabbar
       v-model:active-id="activeId"
@@ -125,10 +126,10 @@ const confirmCountMessage = computed(() => {
       type="outline"
     ></VTabbar>
 
-    <div v-if="visible" class="mt-2">
+    <div class="mt-2">
       <template
-        v-for="(provider, index) in attachmentSelectProviders"
-        :key="index"
+        v-for="provider in attachmentSelectProviders"
+        :key="provider.id"
       >
         <Suspense>
           <component
@@ -162,7 +163,7 @@ const confirmCountMessage = computed(() => {
             }}
           </span>
         </VButton>
-        <VButton @click="onVisibleChange(false)">
+        <VButton @click="modal?.close()">
           {{ $t("core.common.buttons.cancel") }}
         </VButton>
       </VSpace>

--- a/ui/src/components/editor/DefaultEditor.vue
+++ b/ui/src/components/editor/DefaultEditor.vue
@@ -203,7 +203,7 @@ const AttachmentSelectorModal = defineAsyncComponent({
   },
 });
 
-const attachmentSelectorModal = ref(false);
+const attachmentSelectorModalVisible = ref(false);
 const { onAttachmentSelect, attachmentResult } = useAttachmentSelect();
 
 const initAttachmentOptions = {
@@ -218,8 +218,9 @@ const attachmentOptions = ref<{
   max?: number;
 }>(initAttachmentOptions);
 
-const handleCloseAttachmentSelectorModal = () => {
+const onAttachmentSelectorModalClose = () => {
   attachmentOptions.value = initAttachmentOptions;
+  attachmentSelectorModalVisible.value = false;
 };
 
 const { filterDuplicateExtensions } = useExtension();
@@ -347,7 +348,7 @@ const presetExtensions = [
           if (options) {
             attachmentOptions.value = options;
           }
-          attachmentSelectorModal.value = true;
+          attachmentSelectorModalVisible.value = true;
           attachmentResult.updateAttachment = (
             attachments: AttachmentLike[]
           ) => {
@@ -578,18 +579,19 @@ onCoverInputChange((files) => {
   <VLoading v-if="!isInitialized" />
   <div v-else>
     <AttachmentSelectorModal
+      v-if="attachmentSelectorModalVisible"
       v-bind="attachmentOptions"
-      v-model:visible="attachmentSelectorModal"
       @select="onAttachmentSelect"
-      @close="handleCloseAttachmentSelectorModal"
+      @close="onAttachmentSelectorModalClose"
     />
     <!-- For cover image -->
     <AttachmentSelectorModal
-      v-model:visible="coverSelectorModalVisible"
+      v-if="coverSelectorModalVisible"
       :min="1"
       :max="1"
       :accepts="['image/*']"
       @select="onCoverSelect"
+      @close="coverSelectorModalVisible = false"
     />
     <RichTextEditor v-if="editor" :editor="editor" :locale="currentLocale">
       <template #content>
@@ -702,6 +704,7 @@ onCoverInputChange((files) => {
             @input="onTitleInput"
             @keydown.enter="handleFocusEditor"
           />
+          <slot name="content" />
         </div>
       </template>
       <template v-if="showSidebar" #extra>

--- a/ui/src/formkit/inputs/attachment/AttachmentInput.vue
+++ b/ui/src/formkit/inputs/attachment/AttachmentInput.vue
@@ -14,7 +14,7 @@ const props = defineProps({
   },
 });
 
-const attachmentSelectorModal = ref(false);
+const attachmentSelectorModalVisible = ref(false);
 
 const AttachmentSelectorModal = defineAsyncComponent({
   loader: () => {
@@ -69,17 +69,18 @@ const onAttachmentSelect = (attachments: AttachmentLike[]) => {
   >
     <div
       class="group flex h-full cursor-pointer items-center border-l px-3 transition-all hover:bg-gray-100"
-      @click="attachmentSelectorModal = true"
+      @click="attachmentSelectorModalVisible = true"
     >
       <IconFolder class="h-4 w-4 text-gray-500 group-hover:text-gray-700" />
     </div>
   </HasPermission>
 
   <AttachmentSelectorModal
-    v-model:visible="attachmentSelectorModal"
+    v-if="attachmentSelectorModalVisible"
     :accepts="context.accepts as string[]"
     :min="1"
     :max="1"
     @select="onAttachmentSelect"
+    @close="attachmentSelectorModalVisible = false"
   />
 </template>


### PR DESCRIPTION
#### What type of PR is this?

/area ui
/kind improvement
/milestone 2.22.x

#### What this PR does / why we need it:

Replaces the 'visible' prop and v-model usage with internal modal ref and event-based close handling in AttachmentSelectorModal components. Updates all usages to use explicit visibility state and @close event, improving modal control and code consistency.

#### Does this PR introduce a user-facing change?

```release-note
None
```
