### PR TITLE
Refactor to use shallowRef for tab and provider arrays

### DIFF
--- a/ui/console-src/modules/contents/comments/composables/use-subject-ref.ts
+++ b/ui/console-src/modules/contents/comments/composables/use-subject-ref.ts
@@ -9,13 +9,13 @@ import type {
   CommentSubjectRefProvider,
   CommentSubjectRefResult,
 } from "@halo-dev/console-shared";
-import { computed, onMounted, ref } from "vue";
+import { computed, onMounted, shallowRef } from "vue";
 import { useI18n } from "vue-i18n";
 
 export function useSubjectRef(comment: ListedComment) {
   const { t } = useI18n();
 
-  const SubjectRefProviders = ref<CommentSubjectRefProvider[]>([
+  const SubjectRefProviders = shallowRef<CommentSubjectRefProvider[]>([
     {
       kind: "Post",
       group: "content.halo.run",
@@ -67,7 +67,7 @@ export function useSubjectRef(comment: ListedComment) {
 
       const providers = callbackFunction();
 
-      SubjectRefProviders.value.push(...providers);
+      SubjectRefProviders.value = [...SubjectRefProviders.value, ...providers];
     }
   });
 

--- a/ui/console-src/modules/contents/pages/SinglePageEditor.vue
+++ b/ui/console-src/modules/contents/pages/SinglePageEditor.vue
@@ -39,6 +39,7 @@ import {
   onMounted,
   provide,
   ref,
+  shallowRef,
   toRef,
   watch,
   type ComputedRef,
@@ -55,7 +56,7 @@ const { currentUserHasPermission } = usePermission();
 
 // Editor providers
 const { editorProviders, fetchEditorProviders } = useEditorExtensionPoints();
-const currentEditorProvider = ref<EditorProvider>();
+const currentEditorProvider = shallowRef<EditorProvider>();
 const storedEditorProviderName = useLocalStorage("editor-provider-name", "");
 
 const handleChangeEditorProvider = async (provider: EditorProvider) => {

--- a/ui/console-src/modules/contents/posts/PostEditor.vue
+++ b/ui/console-src/modules/contents/posts/PostEditor.vue
@@ -42,6 +42,7 @@ import {
   onMounted,
   provide,
   ref,
+  shallowRef,
   toRef,
   watch,
   type ComputedRef,
@@ -60,7 +61,7 @@ const { currentUserHasPermission } = usePermission();
 
 // Editor providers
 const { editorProviders, fetchEditorProviders } = useEditorExtensionPoints();
-const currentEditorProvider = ref<EditorProvider>();
+const currentEditorProvider = shallowRef<EditorProvider>();
 const storedEditorProviderName = useLocalStorage("editor-provider-name", "");
 
 const handleChangeEditorProvider = async (provider: EditorProvider) => {

--- a/ui/console-src/modules/dashboard/composables/use-dashboard-extension-point.ts
+++ b/ui/console-src/modules/dashboard/composables/use-dashboard-extension-point.ts
@@ -1,13 +1,13 @@
 import { usePluginModuleStore } from "@/stores/plugin";
 import type { DashboardWidgetDefinition } from "@halo-dev/console-shared";
-import { onMounted, ref } from "vue";
+import { onMounted, shallowRef } from "vue";
 
 const EXTENSION_POINT_NAME = "console:dashboard:widgets:create";
 
 export function useDashboardExtensionPoint() {
   const { pluginModuleMap } = usePluginModuleStore();
 
-  const widgetDefinitions = ref<DashboardWidgetDefinition[]>([]);
+  const widgetDefinitions = shallowRef<DashboardWidgetDefinition[]>([]);
 
   onMounted(async () => {
     const finalDefinitions: DashboardWidgetDefinition[] = [];

--- a/ui/console-src/modules/dashboard/widgets/presets/core/quick-action/composables/use-dashboard-extension-point.ts
+++ b/ui/console-src/modules/dashboard/widgets/presets/core/quick-action/composables/use-dashboard-extension-point.ts
@@ -1,6 +1,6 @@
 import { usePluginModuleStore } from "@/stores/plugin";
 import type { DashboardWidgetQuickActionItem } from "@halo-dev/console-shared";
-import { onMounted, ref } from "vue";
+import { onMounted, shallowRef } from "vue";
 
 const EXTENSION_POINT_NAME =
   "console:dashboard:widgets:internal:quick-action:item:create";
@@ -8,7 +8,7 @@ const EXTENSION_POINT_NAME =
 export function useDashboardQuickActionExtensionPoint() {
   const { pluginModuleMap } = usePluginModuleStore();
 
-  const quickActionItems = ref<DashboardWidgetQuickActionItem[]>([]);
+  const quickActionItems = shallowRef<DashboardWidgetQuickActionItem[]>([]);
 
   onMounted(async () => {
     const result: DashboardWidgetQuickActionItem[] = [];

--- a/ui/console-src/modules/interface/themes/components/ThemeListModal.vue
+++ b/ui/console-src/modules/interface/themes/components/ThemeListModal.vue
@@ -13,6 +13,7 @@ import {
   onMounted,
   provide,
   ref,
+  shallowRef,
   watch,
   type Ref,
 } from "vue";
@@ -34,7 +35,7 @@ const emit = defineEmits<{
 
 const modal = ref<InstanceType<typeof VModal> | null>(null);
 
-const tabs = ref<ThemeListTab[]>([
+const tabs = shallowRef<ThemeListTab[]>([
   {
     id: "installed",
     label: t("core.theme.list_modal.tabs.installed"),

--- a/ui/console-src/modules/interface/themes/layouts/ThemeLayout.vue
+++ b/ui/console-src/modules/interface/themes/layouts/ThemeLayout.vue
@@ -6,6 +6,7 @@ import {
   onMounted,
   provide,
   ref,
+  shallowRef,
   watch,
   type Ref,
 } from "vue";
@@ -69,7 +70,7 @@ const initialTabs: ThemeTab[] = [
   },
 ];
 
-const tabs = ref<ThemeTab[]>(cloneDeep(initialTabs));
+const tabs = shallowRef<ThemeTab[]>(initialTabs);
 const selectedTheme = ref<Theme>();
 const themesModal = ref(false);
 const previewModal = ref(false);

--- a/ui/console-src/modules/system/auth-providers/AuthProviderDetail.vue
+++ b/ui/console-src/modules/system/auth-providers/AuthProviderDetail.vue
@@ -13,14 +13,14 @@ import {
   VTabbar,
 } from "@halo-dev/components";
 import { useQuery } from "@tanstack/vue-query";
-import { computed, ref, toRaw } from "vue";
+import { computed, ref, shallowRef, toRaw } from "vue";
 import { useI18n } from "vue-i18n";
 import { useRoute } from "vue-router";
 
 const route = useRoute();
 const { t } = useI18n();
 
-const tabs = ref<{ id: string; label: string }[]>([
+const tabs = shallowRef<{ id: string; label: string }[]>([
   {
     id: "detail",
     label: t("core.identity_authentication.tabs.detail"),
@@ -39,10 +39,13 @@ const { data: authProvider } = useQuery<AuthProvider>({
   },
   onSuccess(data) {
     if (data.spec.settingRef?.name) {
-      tabs.value.push({
-        id: "setting",
-        label: t("core.identity_authentication.tabs.setting"),
-      });
+      tabs.value = [
+        ...tabs.value,
+        {
+          id: "setting",
+          label: t("core.identity_authentication.tabs.setting"),
+        },
+      ];
     }
   },
   enabled: computed(() => !!route.params.name),

--- a/ui/console-src/modules/system/plugins/components/PluginInstallationModal.vue
+++ b/ui/console-src/modules/system/plugins/components/PluginInstallationModal.vue
@@ -12,6 +12,7 @@ import {
   onMounted,
   provide,
   ref,
+  shallowRef,
   toRefs,
   type Ref,
 } from "vue";
@@ -40,7 +41,7 @@ provide<Ref<Plugin | undefined>>("pluginToUpgrade", pluginToUpgrade);
 
 const modal = ref<InstanceType<typeof VModal> | null>(null);
 
-const tabs = ref<PluginInstallationTab[]>([
+const tabs = shallowRef<PluginInstallationTab[]>([
   {
     id: "local",
     label: t("core.plugin.upload_modal.tabs.local"),

--- a/ui/console-src/modules/system/plugins/composables/use-plugin.ts
+++ b/ui/console-src/modules/system/plugins/composables/use-plugin.ts
@@ -12,7 +12,7 @@ import type { PluginTab } from "@halo-dev/console-shared";
 import { useMutation, useQuery } from "@tanstack/vue-query";
 import { useRouteQuery } from "@vueuse/router";
 import type { ComputedRef, Ref } from "vue";
-import { computed, markRaw, ref } from "vue";
+import { computed, markRaw, ref, shallowRef } from "vue";
 import { useI18n } from "vue-i18n";
 import DetailTab from "../components/tabs/Detail.vue";
 import SettingTab from "../components/tabs/Setting.vue";
@@ -292,7 +292,7 @@ export function usePluginDetailTabs(
     },
   ];
 
-  const tabs = ref<PluginTab[]>(initialTabs);
+  const tabs = shallowRef<PluginTab[]>(initialTabs);
   const activeTab = recordsActiveTab
     ? useRouteQuery<string>("tab", tabs.value[0].id)
     : ref(tabs.value[0].id);

--- a/ui/console-src/modules/system/settings/SystemSettings.vue
+++ b/ui/console-src/modules/system/settings/SystemSettings.vue
@@ -1,6 +1,6 @@
 <script lang="ts" setup>
 // core libs
-import { provide, ref, type Ref } from "vue";
+import { provide, shallowRef, type Ref } from "vue";
 
 // components
 import { usePermission } from "@/utils/permission";
@@ -29,7 +29,7 @@ interface Tab {
   component: Raw<Component>;
 }
 
-const tabs = ref<Tab[]>([
+const tabs = shallowRef<Tab[]>([
   {
     id: "loading",
     label: t("core.common.status.loading"),
@@ -65,11 +65,14 @@ const { data: setting } = useQuery({
 
       // TODO: use integrations center to refactor this
       if (currentUserHasPermission(["system:notifier:configuration"])) {
-        tabs.value.push({
-          id: "notification",
-          label: "通知设置",
-          component: markRaw(NotificationsTab),
-        });
+        tabs.value = [
+          ...tabs.value,
+          {
+            id: "notification",
+            label: "通知设置",
+            component: markRaw(NotificationsTab),
+          },
+        ];
       }
     }
   },

--- a/ui/console-src/modules/system/settings/tabs/Notifications.vue
+++ b/ui/console-src/modules/system/settings/tabs/Notifications.vue
@@ -4,7 +4,7 @@ import { coreApiClient } from "@halo-dev/api-client";
 import { VTabbar } from "@halo-dev/components";
 import { useQuery } from "@tanstack/vue-query";
 import type { Component, ComputedRef, Raw } from "vue";
-import { computed, markRaw, provide, ref } from "vue";
+import { computed, markRaw, provide, ref, shallowRef } from "vue";
 import NotificationSetting from "./NotificationSetting.vue";
 
 interface Tab {
@@ -13,7 +13,7 @@ interface Tab {
   component: Raw<Component>;
 }
 
-const tabs = ref<Tab[]>();
+const tabs = shallowRef<Tab[]>();
 
 const activeTab = ref();
 

--- a/ui/console-src/modules/system/users/UserDetail.vue
+++ b/ui/console-src/modules/system/users/UserDetail.vue
@@ -24,7 +24,7 @@ import {
   onMounted,
   provide,
   ref,
-  toRaw,
+  shallowRef,
   type Ref,
 } from "vue";
 import { useI18n } from "vue-i18n";
@@ -60,7 +60,7 @@ const {
   enabled: computed(() => !!params.name),
 });
 
-const tabs = ref<UserTab[]>([
+const tabs = shallowRef<UserTab[]>([
   {
     id: "detail",
     label: t("core.user.detail.tabs.detail"),
@@ -83,7 +83,9 @@ onMounted(async () => {
 
       const providers = await callbackFunction();
 
-      tabs.value.push(...providers);
+      tabs.value = [...tabs.value, ...providers].sort(
+        (a, b) => a.priority - b.priority
+      );
     } catch (error) {
       console.error(`Error processing plugin module:`, pluginModule, error);
     }
@@ -97,12 +99,10 @@ const activeTab = useRouteQuery<string>("tab", tabs.value[0].id, {
 provide<Ref<string>>("activeTab", activeTab);
 
 const tabbarItems = computed(() => {
-  return toRaw(tabs)
-    .value.sort((a, b) => a.priority - b.priority)
-    .map((tab) => ({
-      id: tab.id,
-      label: tab.label,
-    }));
+  return tabs.value.map((tab) => ({
+    id: tab.id,
+    label: tab.label,
+  }));
 });
 
 const handleDelete = async (user: User) => {

--- a/ui/uc-src/modules/contents/posts/PostEditor.vue
+++ b/ui/uc-src/modules/contents/posts/PostEditor.vue
@@ -32,7 +32,16 @@ import { AxiosError, type AxiosRequestConfig } from "axios";
 import { isEqual } from "lodash-es";
 import ShortUniqueId from "short-unique-id";
 import type { ComputedRef } from "vue";
-import { computed, nextTick, onMounted, provide, ref, toRef, watch } from "vue";
+import {
+  computed,
+  nextTick,
+  onMounted,
+  provide,
+  ref,
+  shallowRef,
+  toRef,
+  watch,
+} from "vue";
 import { useI18n } from "vue-i18n";
 import { useRouter } from "vue-router";
 import PostCreationModal from "./components/PostCreationModal.vue";
@@ -112,7 +121,7 @@ provide<ComputedRef<string | undefined>>(
 
 // Editor providers
 const { editorProviders, fetchEditorProviders } = useEditorExtensionPoints();
-const currentEditorProvider = ref<EditorProvider>();
+const currentEditorProvider = shallowRef<EditorProvider>();
 const storedEditorProviderName = useLocalStorage("editor-provider-name", "");
 
 const handleChangeEditorProvider = async (provider: EditorProvider) => {

--- a/ui/uc-src/modules/profile/Profile.vue
+++ b/ui/uc-src/modules/profile/Profile.vue
@@ -18,7 +18,7 @@ import {
   onMounted,
   provide,
   ref,
-  toRaw,
+  shallowRef,
   type Ref,
 } from "vue";
 import { useI18n } from "vue-i18n";
@@ -49,7 +49,7 @@ const {
 
 provide<Ref<DetailedUser | undefined>>("user", user);
 
-const tabs = ref<UserProfileTab[]>([
+const tabs = shallowRef<UserProfileTab[]>([
   {
     id: "detail",
     label: t("core.uc_profile.tabs.detail"),
@@ -96,7 +96,9 @@ onMounted(async () => {
 
       const providers = await callbackFunction();
 
-      tabs.value.push(...providers);
+      tabs.value = [...tabs.value, ...providers].sort(
+        (a, b) => a.priority - b.priority
+      );
     } catch (error) {
       console.error(`Error processing plugin module:`, pluginModule, error);
     }
@@ -104,12 +106,10 @@ onMounted(async () => {
 });
 
 const tabbarItems = computed(() => {
-  return toRaw(tabs)
-    .value.sort((a, b) => a.priority - b.priority)
-    .map((tab) => ({
-      id: tab.id,
-      label: tab.label,
-    }));
+  return tabs.value.map((tab) => ({
+    id: tab.id,
+    label: tab.label,
+  }));
 });
 
 const activeTab = useRouteQuery<string>("tab", tabs.value[0].id, {


### PR DESCRIPTION
#### What type of PR is this?

/area ui
/kind improvement
/milestone 2.22.x

#### What this PR does / why we need it:

This PR refactors the code to use shallowRef instead of ref in scenarios where deep reactivity for the properties of an object or array is unnecessary.

Using shallowRef is more performant in these cases as it avoids the overhead of making the entire data structure deeply reactive.

#### Does this PR introduce a user-facing change?

```release-note
None
```
