### PR TITLE
fix: code block focus positioning error when switching languages

### DIFF
--- a/ui/packages/editor/src/extensions/code-block/CodeBlockViewRenderer.vue
+++ b/ui/packages/editor/src/extensions/code-block/CodeBlockViewRenderer.vue
@@ -121,7 +121,6 @@ const handleCopyCode = () => {
           class="w-48"
           :container="editor.options.element"
           :options="languageOptions"
-          @select="editor.commands.focus()"
         >
         </CodeBlockSelect>
         <CodeBlockSelect


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/area editor

#### What this PR does / why we need it:

当切换代码块语言时，可能会导致页面不正常跳动。

当前 PR 移除了切换代码块语言之后的设置焦点事件用于解决此问题

#### Which issue(s) this PR fixes:

Fixes #7795

#### Does this PR introduce a user-facing change?
```release-note
解决切换代码块语言时编辑器页面不正常跳动的问题
```
