### PR TITLE
Fix issue where Prettier ignore file configuration was not applied

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,3 +1,5 @@
+root=true
+
 [*]
 charset = utf-8
 end_of_line = lf
@@ -511,11 +513,3 @@ ij_yaml_keep_line_breaks = true
 
 [*.md]
 indent_size = 2
-
-[*.{js,jsx,mjs,cjs,ts,tsx,mts,cts,vue,css,scss,sass,less,styl}]
-indent_style = space
-indent_size = 2
-end_of_line = lf
-charset = utf-8
-trim_trailing_whitespace = false
-insert_final_newline = true

--- a/ui/.editorconfig
+++ b/ui/.editorconfig
@@ -1,0 +1,9 @@
+root=true
+
+[*.{js,jsx,mjs,cjs,ts,tsx,mts,cts,vue,css,scss,sass,less,styl}]
+indent_style = space
+indent_size = 2
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = false
+insert_final_newline = true

--- a/ui/package.json
+++ b/ui/package.json
@@ -19,7 +19,7 @@
     "test:unit:coverage": "vitest run --coverage",
     "typecheck": "vue-tsc --noEmit -p tsconfig.app.json --composite false && pnpm run typecheck:packages",
     "lint": "eslint . --max-warnings=0 -f html -o build/lint-result/index.html",
-    "prettier": "prettier . --write",
+    "prettier": "prettier . --write --ignore-path ../.gitignore --ignore-path ./.prettierignore",
     "typecheck:packages": "pnpm --parallel -r run typecheck",
     "test:unit:packages": "pnpm --parallel -r run test:unit",
     "publish:packages": "pnpm -r publish --access public --no-git-checks"


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

After the changes in #7831, the Prettier ignore file is no longer taking effect. This PR fixes this issue.

#### Does this PR introduce a user-facing change?

```release-note
None
```
