### PR TITLE
Set networkMode to 'always' in Vue Query config

### DIFF
--- a/ui/src/setup/setupVueQuery.ts
+++ b/ui/src/setup/setupVueQuery.ts
@@ -4,17 +4,15 @@ import {
 } from "@tanstack/vue-query";
 import type { App } from "vue";
 
-const networkMode = import.meta.env.PROD ? "online" : "always";
-
 const options: VueQueryPluginOptions = {
   queryClientConfig: {
     defaultOptions: {
       queries: {
         refetchOnWindowFocus: false,
-        networkMode,
+        networkMode: "always",
       },
       mutations: {
-        networkMode,
+        networkMode: "always",
       },
     },
   },


### PR DESCRIPTION
#### What type of PR is this?

/area ui
/kind improvement
/milestone 2.22.x

#### What this PR does / why we need it:

Replaces dynamic networkMode assignment with a static value of 'always' for both queries and mutations in the Vue Query plugin options. This ensures consistent network behavior regardless of environment.

#### Does this PR introduce a user-facing change?

```release-note
修复离线环境下，Console 无法请求接口的问题
```
