### PR TITLE
Add help text for attachment display name form

### DIFF
--- a/ui/console-src/modules/contents/attachments/components/DisplayNameEditForm.vue
+++ b/ui/console-src/modules/contents/attachments/components/DisplayNameEditForm.vue
@@ -65,6 +65,7 @@ async function onSubmit({ displayName }: { displayName: string }) {
       name="displayName"
       validation="required:trim"
       :classes="{ outer: '!pb-0' }"
+      :help="$t('core.attachment.detail_modal.display_name_form.help')"
     ></FormKit>
   </FormKit>
   <VSpace class="mt-4">

--- a/ui/src/locales/_missing_translations_es.yaml
+++ b/ui/src/locales/_missing_translations_es.yaml
@@ -225,6 +225,8 @@ core:
     detail_modal:
       fields:
         thumbnails: Thumbnails
+      display_name_form:
+        help: Custom attachment name, only for display in the management interface, does not affect the file name and access link itself
       preview:
         not_support_thumbnail: This image does not support generating thumbnails.
     permalink_list:

--- a/ui/src/locales/en.yaml
+++ b/ui/src/locales/en.yaml
@@ -687,6 +687,8 @@ core:
         creation_time: Creation time
         permalink: Permalink
         thumbnails: Thumbnails
+      display_name_form:
+        help: Custom attachment name, only for display in the management interface, does not affect the file name and access link itself
       preview:
         video_not_support: The current browser does not support video playback.
         audio_not_support: The current browser does not support audio playback.

--- a/ui/src/locales/zh-CN.yaml
+++ b/ui/src/locales/zh-CN.yaml
@@ -647,13 +647,15 @@ core:
         preview: 预览
         storage_policy: 存储策略
         group: 所在分组
-        display_name: 文件名称
+        display_name: 附件名称
         media_type: 文件类型
         size: 文件大小
         owner: 上传者
         creation_time: 上传时间
         permalink: 链接
         thumbnails: 缩略图
+      display_name_form:
+        help: 自定义附件名称，仅用于管理界面显示，不会影响文件本身名称以及访问链接
       preview:
         video_not_support: 当前浏览器不支持该视频播放
         audio_not_support: 当前浏览器不支持该音频播放

--- a/ui/src/locales/zh-TW.yaml
+++ b/ui/src/locales/zh-TW.yaml
@@ -632,13 +632,15 @@ core:
         preview: 預覽
         storage_policy: 存儲策略
         group: 所在分組
-        display_name: 文件名稱
+        display_name: 附件名稱
         media_type: 文件類型
         size: 文件大小
         owner: 上傳者
         creation_time: 上傳時間
         permalink: 連結
         thumbnails: 縮略圖
+      display_name_form:
+        help: 自定義附件名稱，僅用於管理介面顯示，不會影響文件本身名稱以及訪問連結
       preview:
         video_not_support: 當前瀏覽器不支援該影片播放
         audio_not_support: 當前瀏覽器不支援該音頻播放


### PR DESCRIPTION
#### What type of PR is this?

/area ui
/kind improvement
/milestone 2.22.x

#### What this PR does / why we need it:

Added a help message to the display name field in the attachment edit form, clarifying that the custom name is only for management interface display and does not affect the file name or access link.

<img width="991" height="334" alt="image" src="https://github.com/user-attachments/assets/fd2ecec9-499b-405c-b2da-71c7bad4db7c" />

#### Does this PR introduce a user-facing change?

```release-note
None
```
