### PR TITLE
Update locale labels for timezone and locale fields in overview page

### DIFF
--- a/ui/src/locales/en.yaml
+++ b/ui/src/locales/en.yaml
@@ -1565,8 +1565,8 @@ core:
     fields:
       external_url: External url
       start_time: Start time
-      timezone: System Timezone
-      locale: System Locale
+      timezone: Operating system Timezone
+      locale: Operating system Locale
       version: Version
       build_time: Build time
       database: Database

--- a/ui/src/locales/zh-CN.yaml
+++ b/ui/src/locales/zh-CN.yaml
@@ -1451,8 +1451,8 @@ core:
     fields:
       external_url: 外部访问地址
       start_time: 启动时间
-      timezone: 系统时区
-      locale: 系统语言
+      timezone: 操作系统时区
+      locale: 操作系统语言
       version: 版本
       build_time: 构建时间
       database: 数据库

--- a/ui/src/locales/zh-TW.yaml
+++ b/ui/src/locales/zh-TW.yaml
@@ -1435,8 +1435,8 @@ core:
     fields:
       external_url: 外部訪問地址
       start_time: 啟動時間
-      timezone: 系統時區
-      locale: 系統語言
+      timezone: 操作系統時區
+      locale: 操作系統語言
       version: 版本
       build_time: 構建時間
       database: 資料庫


### PR DESCRIPTION
#### What type of PR is this?

/area ui
/kind improvement
/milestone 2.22.x

#### What this PR does / why we need it:

Changed 'System Timezone' and 'System Locale' to 'Operating system Timezone' and 'Operating system Locale' in English, Simplified Chinese, and Traditional Chinese locale files for improved clarity.

#### Does this PR introduce a user-facing change?

```release-note
None
```
