### PR TITLE
Remove reviewers section from OWNERS file

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,10 +1,3 @@
-reviewers:
-- ruibaby
-- guqing
-- JohnNiang
-- wan92hen
-- LIlGG
-
 approvers:
 - ruibaby
 - guqing


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

This PR removes the reviewers configuration from the OWNERS file to disable the automatic assignment of reviewers for new PRs.

This feature isn’t working well and often assigns the wrong reviewers.

#### Does this PR introduce a user-facing change?

```release-note
None
```
