### PR TITLE
Make UI build optional by changing dependency to mustRunAfter in build.gradle

### DIFF
--- a/application/build.gradle
+++ b/application/build.gradle
@@ -121,7 +121,7 @@ tasks.register('createChecksums', Checksum) {
 tasks.register('copyUiDist', Copy) {
     from project(':ui').layout.buildDirectory.dir('dist')
     into layout.buildDirectory.dir('resources/main')
-    dependsOn ':ui:doBuild'
+    mustRunAfter ':ui:doBuild'
 }
 
 tasks.named('processResources', ProcessResources) {


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup
/area core
/milestone 2.22.x

#### What this PR does / why we need it:

This PR changes dependency `:ui:doBuild` to mustRunAfter for task `:application:copyUiDist` to speed up build process in IDEA. So that we can run our unit tests quicker and run task `bootRun` during UI development.

#### Special notes for your reviewer:

Make sure executing task `./gradlew build` will include UI resources.

#### Does this PR introduce a user-facing change?

```release-note
None
```

