### PR TITLE
Remove unused fields from User and UserVo classes

### DIFF
--- a/api/src/main/java/run/halo/app/core/extension/User.java
+++ b/api/src/main/java/run/halo/app/core/extension/User.java
@@ -7,7 +7,6 @@ import static run.halo.app.core.extension.User.VERSION;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.Instant;
-import java.util.List;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
@@ -87,30 +86,7 @@ public class User extends AbstractExtension {
     @Data
     public static class UserStatus {
 
-        private Instant lastLoginAt;
-
         private String permalink;
-
-        private List<LoginHistory> loginHistories;
-
-    }
-
-    @Data
-    public static class LoginHistory {
-
-        @Schema(requiredMode = REQUIRED)
-        private Instant loginAt;
-
-        @Schema(requiredMode = REQUIRED)
-        private String sourceIp;
-
-        @Schema(requiredMode = REQUIRED)
-        private String userAgent;
-
-        @Schema(requiredMode = REQUIRED)
-        private Boolean successful;
-
-        private String reason;
 
     }
 

--- a/application/src/main/java/run/halo/app/theme/finders/vo/UserVo.java
+++ b/application/src/main/java/run/halo/app/theme/finders/vo/UserVo.java
@@ -1,6 +1,5 @@
 package run.halo.app.theme.finders.vo;
 
-import java.util.List;
 import lombok.Builder;
 import lombok.Value;
 import org.apache.commons.lang3.ObjectUtils;
@@ -26,8 +25,6 @@ public class UserVo implements ExtensionVoOperator {
     public static UserVo from(User user) {
         User.UserStatus statusCopy =
             JsonUtils.deepCopy(ObjectUtils.defaultIfNull(user.getStatus(), new User.UserStatus()));
-        statusCopy.setLoginHistories(List.of());
-        statusCopy.setLastLoginAt(null);
 
         User.UserSpec userSpecCopy = JsonUtils.deepCopy(user.getSpec());
         userSpecCopy.setPassword("[PROTECTED]");

--- a/application/src/test/java/run/halo/app/theme/finders/vo/UserVoTest.java
+++ b/application/src/test/java/run/halo/app/theme/finders/vo/UserVoTest.java
@@ -3,7 +3,6 @@ package run.halo.app.theme.finders.vo;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.time.Instant;
-import java.util.List;
 import org.json.JSONException;
 import org.junit.jupiter.api.Test;
 import org.skyscreamer.jsonassert.JSONAssert;
@@ -37,12 +36,6 @@ class UserVoTest {
         user.getSpec().setTwoFactorAuthEnabled(false);
 
         user.setStatus(new User.UserStatus());
-        user.getStatus().setLastLoginAt(Instant.parse("2022-01-02T00:00:00.00Z"));
-        User.LoginHistory loginHistory = new User.LoginHistory();
-        loginHistory.setLoginAt(Instant.parse("2022-01-02T00:00:00.00Z"));
-        loginHistory.setReason("login reason");
-        loginHistory.setUserAgent("user agent");
-        user.getStatus().setLoginHistories(List.of(loginHistory));
 
         UserVo userVo = UserVo.from(user);
         JSONAssert.assertEquals("""
@@ -64,7 +57,6 @@ class UserVoTest {
                         "loginHistoryLimit": 5
                     },
                     "status": {
-                        "loginHistories": []
                     }
                 }
                 """,


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup
/area core
/milestone 2.22.x

#### What this PR does / why we need it:

This PR removes unused fields(`status.loginAt` and `status.loginHistory`) from User and UserVo classes.

#### Does this PR introduce a user-facing change?

```release-note
None
```

