### PR TITLE
Show username in user-select labels

### DIFF
--- a/ui/src/formkit/inputs/user-select.ts
+++ b/ui/src/formkit/inputs/user-select.ts
@@ -16,7 +16,7 @@ const search = async ({ page, size, keyword }) => {
     options: data.items?.map((user) => {
       return {
         value: user.user.metadata.name,
-        label: user.user.spec.displayName,
+        label: `${user.user.spec.displayName}(${user.user.metadata.name})`,
       };
     }),
     total: data.total,


### PR DESCRIPTION
#### What type of PR is this?

/area ui
/milestone 2.22.x
/kind improvement

#### What this PR does / why we need it:

Updated the user-select input to display both the display name and username in the label, improving clarity when selecting users.

#### Does this PR introduce a user-facing change?

```release-note
文章设置中选择作者时支持显示用户名
```
