### PR TITLE
Expose dayjs in utils.date to allow users to call dayjs methods directly

### DIFF
--- a/ui/console-src/modules/system/backup/composables/use-backup.ts
+++ b/ui/console-src/modules/system/backup/composables/use-backup.ts
@@ -1,7 +1,7 @@
 import { BackupStatusPhaseEnum, coreApiClient } from "@halo-dev/api-client";
 import { Dialog, Toast } from "@halo-dev/components";
+import { utils } from "@halo-dev/console-shared";
 import { useQuery, useQueryClient } from "@tanstack/vue-query";
-import dayjs from "dayjs";
 import { useI18n } from "vue-i18n";
 
 export function useBackupFetch() {
@@ -58,7 +58,7 @@ export function useBackup() {
               name: "",
             },
             spec: {
-              expiresAt: dayjs().add(7, "day").toISOString(),
+              expiresAt: utils.date.dayjs().add(7, "day").toISOString(),
             },
           },
         });

--- a/ui/package.json
+++ b/ui/package.json
@@ -92,7 +92,6 @@
     "core-js": "^3.43.0",
     "cropperjs": "^1.5.13",
     "crypto-js": "^4.2.0",
-    "dayjs": "^1.11.7",
     "emoji-mart": "^5.6.0",
     "es-toolkit": "^1.41.0",
     "floating-vue": "^5.2.2",

--- a/ui/packages/shared/env.d.ts
+++ b/ui/packages/shared/env.d.ts
@@ -5,13 +5,6 @@ export {};
 import type { Component } from "vue";
 import type { CoreMenuGroupId } from "./src/types/menus";
 
-declare module "*.vue" {
-  import type { DefineComponent } from "vue";
-  // eslint-disable-next-line
-  const component: DefineComponent<{}, {}, any>;
-  export default component;
-}
-
 declare module "vue-router" {
   interface RouteMeta {
     title?: string;

--- a/ui/packages/shared/package.json
+++ b/ui/packages/shared/package.json
@@ -43,6 +43,7 @@
     "vue-router": "^4.5.1"
   },
   "devDependencies": {
+    "dayjs": "^1.11.19",
     "uuid": "^13.0.0"
   }
 }

--- a/ui/packages/shared/src/utils/date.ts
+++ b/ui/packages/shared/src/utils/date.ts
@@ -1,4 +1,4 @@
-import dayjs from "dayjs";
+import _dayjs from "dayjs";
 import "dayjs/locale/en";
 import "dayjs/locale/zh-cn";
 import "dayjs/locale/zh-tw";
@@ -6,13 +6,13 @@ import relativeTime from "dayjs/plugin/relativeTime";
 import timezone from "dayjs/plugin/timezone";
 import utc from "dayjs/plugin/utc";
 
-dayjs.extend(timezone);
-dayjs.extend(utc);
-dayjs.extend(relativeTime);
+_dayjs.extend(timezone);
+_dayjs.extend(utc);
+_dayjs.extend(relativeTime);
 
 const DEFAULT_FORMAT = "YYYY-MM-DD HH:mm";
 
-const dayjsLocales: Record<string, string> = {
+const locales: Record<string, string> = {
   en: "en",
   zh: "zh-cn",
   "en-US": "en",
@@ -21,6 +21,12 @@ const dayjsLocales: Record<string, string> = {
 };
 
 export class DateUtils {
+  readonly dayjs: typeof _dayjs;
+
+  constructor() {
+    this.dayjs = _dayjs;
+  }
+
   /**
    * Formats a date to a string according to the specified format
    *
@@ -39,7 +45,7 @@ export class DateUtils {
     if (!date) {
       return "";
     }
-    return dayjs(date).format(format || DEFAULT_FORMAT);
+    return this.dayjs(date).format(format || DEFAULT_FORMAT);
   }
 
   /**
@@ -58,7 +64,7 @@ export class DateUtils {
     if (!date) {
       return "";
     }
-    return dayjs(date).utc(false).toISOString();
+    return this.dayjs(date).utc(false).toISOString();
   }
 
   /**
@@ -80,7 +86,7 @@ export class DateUtils {
       return "";
     }
     // see https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/datetime-local#the_y10k_problem_often_client-side
-    return dayjs(date).format("YYYY-MM-DDTHH:mm");
+    return this.dayjs(date).format("YYYY-MM-DDTHH:mm");
   }
 
   /**
@@ -103,7 +109,7 @@ export class DateUtils {
       return;
     }
 
-    return dayjs().to(dayjs(date));
+    return this.dayjs().to(this.dayjs(date));
   }
 
   /**
@@ -129,6 +135,48 @@ export class DateUtils {
    * ```
    */
   setLocale(locale: string): void {
-    dayjs.locale(dayjsLocales[locale] || dayjsLocales["en"]);
+    this.dayjs.locale(locales[locale] || locales["en"]);
   }
+}
+
+// See https://github.com/iamkun/dayjs/issues/364
+declare module "dayjs" {
+  interface Dayjs {
+    fromNow(withoutSuffix?: boolean): string;
+    from(compared: _dayjs.ConfigType, withoutSuffix?: boolean): string;
+    toNow(withoutSuffix?: boolean): string;
+    to(compared: _dayjs.ConfigType, withoutSuffix?: boolean): string;
+  }
+}
+
+declare module "dayjs" {
+  interface Dayjs {
+    tz(timezone?: string, keepLocalTime?: boolean): _dayjs.Dayjs;
+    offsetName(type?: "short" | "long"): string | undefined;
+  }
+
+  interface DayjsTimezone {
+    (date?: _dayjs.ConfigType, timezone?: string): _dayjs.Dayjs;
+    (date: _dayjs.ConfigType, format: string, timezone?: string): _dayjs.Dayjs;
+    guess(): string;
+    setDefault(timezone?: string): void;
+  }
+}
+
+declare module "dayjs" {
+  interface Dayjs {
+    utc(keepLocalTime?: boolean): _dayjs.Dayjs;
+
+    local(): _dayjs.Dayjs;
+
+    isUTC(): boolean;
+
+    utcOffset(offset: number | string, keepLocalTime?: boolean): _dayjs.Dayjs;
+  }
+
+  export function utc(
+    config?: _dayjs.ConfigType,
+    format?: string,
+    strict?: boolean
+  ): _dayjs.Dayjs;
 }

--- a/ui/pnpm-lock.yaml
+++ b/ui/pnpm-lock.yaml
@@ -159,9 +159,6 @@ importers:
       crypto-js:
         specifier: ^4.2.0
         version: 4.2.0
-      dayjs:
-        specifier: ^1.11.7
-        version: 1.11.7
       emoji-mart:
         specifier: ^5.6.0
         version: 5.6.0
@@ -599,6 +596,9 @@ importers:
         specifier: ^4.5.1
         version: 4.5.1(vue@3.5.16(typescript@5.8.3))
     devDependencies:
+      dayjs:
+        specifier: ^1.11.19
+        version: 1.11.19
       uuid:
         specifier: ^13.0.0
         version: 13.0.0
@@ -5629,8 +5629,8 @@ packages:
     resolution: {integrity: sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==}
     engines: {node: '>=18'}
 
-  dayjs@1.11.7:
-    resolution: {integrity: sha512-+Yw9U6YO5TQohxLcIkrXBeY73WP3ejHWVvx8XCk3gxvQDCTEmS48ZrSZCKciI7Bhl/uCMyxYtE9UqRILmFphkQ==}
+  dayjs@1.11.19:
+    resolution: {integrity: sha512-t5EcLVS6QPBNqM2z8fakk/NKel+Xzshgt8FFKAn+qwlD1pzZWxh0nVCrvFK7ZDb6XucZeF9z8C7CBWTRIVApAw==}
 
   de-indent@1.0.2:
     resolution: {integrity: sha512-e/1zu3xH5MQryN2zdVaF0OrdNLUbvWxzMbi+iNA6Bky7l1RoP8a2fIbRocyHclXt/arDrrR6lL3TqFD9pMQTsg==}
@@ -16890,7 +16890,7 @@ snapshots:
       whatwg-mimetype: 4.0.0
       whatwg-url: 14.2.0
 
-  dayjs@1.11.7: {}
+  dayjs@1.11.19: {}
 
   de-indent@1.0.2: {}
 


### PR DESCRIPTION
#### What type of PR is this?

/area ui
/kind feature
/milestone 2.22.x

#### What this PR does / why we need it:

Expose dayjs in utils.date to allow users to call dayjs methods directly, example:

```ts
import { utils } from "@halo-dev/console-shared"

utils.date.dayjs().format("");
```

#### Does this PR introduce a user-facing change?

```release-note
None
```

