### PR TITLE
Replace TemplateEngine with SpringTemplateEngine in ThumbnailImgTagPostProcessorTest

### DIFF
--- a/application/src/test/java/run/halo/app/core/attachment/thumbnail/ThumbnailImgTagPostProcessorTest.java
+++ b/application/src/test/java/run/halo/app/core/attachment/thumbnail/ThumbnailImgTagPostProcessorTest.java
@@ -13,11 +13,11 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.thymeleaf.TemplateEngine;
 import org.thymeleaf.context.ITemplateContext;
 import org.thymeleaf.engine.StandardModelFactory;
 import org.thymeleaf.model.AttributeValueQuotes;
 import org.thymeleaf.model.IModelFactory;
+import org.thymeleaf.spring6.SpringTemplateEngine;
 import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
 import run.halo.app.core.attachment.ThumbnailSize;
@@ -38,7 +38,7 @@ class ThumbnailImgTagPostProcessorTest {
 
     @BeforeEach
     void setUp() {
-        var templateEngine = new TemplateEngine();
+        var templateEngine = new SpringTemplateEngine();
         this.modelFactory = new StandardModelFactory(templateEngine.getConfiguration(), HTML);
     }
 


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/are core
/milestone 2.22.x

#### What this PR does / why we need it:

This PR replaces TemplateEngine with SpringTemplateEngine in ThumbnailImgTagPostProcessorTest because ongl dependencies was removed by Thymeleaf Spring6.

If we don't include thymeleaf dependency manually, the unit test will fail as below:

```java
java.lang.NoClassDefFoundError: ognl/PropertyAccessor
	at org.thymeleaf.standard.StandardDialect.getVariableExpressionEvaluator(StandardDialect.java:178)
	at org.thymeleaf.standard.StandardDialect.getExecutionAttributes(StandardDialect.java:392)
	at org.thymeleaf.DialectSetConfiguration.build(DialectSetConfiguration.java:263)
	at org.thymeleaf.EngineConfiguration.<init>(EngineConfiguration.java:123)
	at org.thymeleaf.TemplateEngine.initialize(TemplateEngine.java:341)
	at org.thymeleaf.TemplateEngine.getConfiguration(TemplateEngine.java:411)
	at run.halo.app.core.attachment.thumbnail.ThumbnailImgTagPostProcessorTest.setUp(ThumbnailImgTagPostProcessorTest.java:42)
	at java.base/java.lang.reflect.Method.invoke(Method.java:580)
	at java.base/java.util.ArrayList.forEach(ArrayList.java:1596)
	at java.base/java.util.ArrayList.forEach(ArrayList.java:1596)
Caused by: java.lang.ClassNotFoundException: ognl.PropertyAccessor
	at java.base/jdk.internal.loader.BuiltinClassLoader.loadClass(BuiltinClassLoader.java:641)
	at java.base/jdk.internal.loader.ClassLoaders$AppClassLoader.loadClass(ClassLoaders.java:188)
	at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:526)
	... 10 more
```

> https://github.com/halo-dev/halo/actions/runs/19129978229/job/54668145618

#### Does this PR introduce a user-facing change?

```release-note
None
```

