### PR TITLE
Refactor comment components to use async imports

### DIFF
--- a/ui/console-src/modules/contents/comments/components/SubjectQueryCommentListModal.vue
+++ b/ui/console-src/modules/contents/comments/components/SubjectQueryCommentListModal.vue
@@ -1,7 +1,6 @@
 <script lang="ts" setup>
 import { VButton, VModal } from "@halo-dev/components";
 import { useTemplateRef } from "vue";
-import SubjectQueryCommentList from "./SubjectQueryCommentList.vue";
 
 const props = defineProps<{
   subjectRefKey: string;

--- a/ui/console-src/modules/contents/comments/module.ts
+++ b/ui/console-src/modules/contents/comments/module.ts
@@ -1,14 +1,22 @@
 import BasicLayout from "@console/layouts/BasicLayout.vue";
-import { IconMessage } from "@halo-dev/components";
+import { IconMessage, VLoading } from "@halo-dev/components";
 import { definePlugin } from "@halo-dev/ui-shared";
-import { markRaw } from "vue";
-import CommentList from "./CommentList.vue";
-import SubjectQueryCommentList from "./components/SubjectQueryCommentList.vue";
+import { defineAsyncComponent, markRaw } from "vue";
 import SubjectQueryCommentListModal from "./components/SubjectQueryCommentListModal.vue";
+
+declare module "vue" {
+  interface GlobalComponents {
+    SubjectQueryCommentList: (typeof import("./components/SubjectQueryCommentList.vue"))["default"];
+    SubjectQueryCommentListModal: (typeof import("./components/SubjectQueryCommentListModal.vue"))["default"];
+  }
+}
 
 export default definePlugin({
   components: {
-    SubjectQueryCommentList,
+    SubjectQueryCommentList: defineAsyncComponent({
+      loader: () => import("./components/SubjectQueryCommentList.vue"),
+      loadingComponent: VLoading,
+    }),
     SubjectQueryCommentListModal,
   },
   routes: [
@@ -32,7 +40,7 @@ export default definePlugin({
         {
           path: "",
           name: "Comments",
-          component: CommentList,
+          component: () => import("./CommentList.vue"),
         },
       ],
     },

--- a/ui/console-src/modules/contents/pages/components/entity-fields/TitleField.vue
+++ b/ui/console-src/modules/contents/pages/components/entity-fields/TitleField.vue
@@ -1,6 +1,5 @@
 <script lang="ts" setup>
 import { singlePageLabels } from "@/constants/labels";
-import SubjectQueryCommentListModal from "@console/modules/contents/comments/components/SubjectQueryCommentListModal.vue";
 import type { ListedSinglePage } from "@halo-dev/api-client";
 import {
   IconExternalLinkLine,

--- a/ui/console-src/modules/contents/posts/components/entity-fields/TitleField.vue
+++ b/ui/console-src/modules/contents/posts/components/entity-fields/TitleField.vue
@@ -1,6 +1,5 @@
 <script lang="ts" setup>
 import { postLabels } from "@/constants/labels";
-import SubjectQueryCommentListModal from "@console/modules/contents/comments/components/SubjectQueryCommentListModal.vue";
 import type { ListedPost } from "@halo-dev/api-client";
 import {
   IconExternalLinkLine,

--- a/ui/console-src/modules/dashboard/widgets/presets/posts/components/PostListItem.vue
+++ b/ui/console-src/modules/dashboard/widgets/presets/posts/components/PostListItem.vue
@@ -1,6 +1,5 @@
 <script lang="ts" setup>
 import { postLabels } from "@/constants/labels";
-import SubjectQueryCommentListModal from "@console/modules/contents/comments/components/SubjectQueryCommentListModal.vue";
 import type { ListedPost } from "@halo-dev/api-client";
 import {
   IconExternalLinkLine,


### PR DESCRIPTION
#### What type of PR is this?

/area ui
/kind improvement
/milestone 2.22.x

#### What this PR does / why we need it:

Refactor comment components to use async imports.

before:

<img width="705" height="274" alt="image" src="https://github.com/user-attachments/assets/2e424722-90e4-4333-80f8-ef494f1e763d" />

after:

<img width="703" height="243" alt="image" src="https://github.com/user-attachments/assets/17045d1b-54fe-4a0b-860c-62ab47e9338f" />

#### Does this PR introduce a user-facing change?

```release-note
优化 Console 和 UC 的加载速度
```
