### PR TITLE
Add route-based quick action support to dashboard

### DIFF
--- a/ui/console-src/modules/dashboard/widgets/presets/core/quick-action/QuickActionItem.vue
+++ b/ui/console-src/modules/dashboard/widgets/presets/core/quick-action/QuickActionItem.vue
@@ -4,16 +4,28 @@ import {
   utils,
   type DashboardWidgetQuickActionItem,
 } from "@halo-dev/ui-shared";
-defineProps<{
+import { useRouter } from "vue-router";
+
+const props = defineProps<{
   item: DashboardWidgetQuickActionItem;
 }>();
+
+const router = useRouter();
+
+function handleClick() {
+  if ("action" in props.item && props.item.action) {
+    props.item.action();
+  } else if ("route" in props.item && props.item.route) {
+    router.push(props.item.route);
+  }
+}
 </script>
 
 <template>
   <template v-if="utils.permission.has(item.permissions || [])">
     <div
       class="group relative cursor-pointer rounded-lg bg-gray-50 p-4 transition-all hover:bg-gray-100"
-      @click="item.action"
+      @click="handleClick"
     >
       <div>
         <span

--- a/ui/console-src/modules/dashboard/widgets/presets/core/quick-action/QuickActionWidget.vue
+++ b/ui/console-src/modules/dashboard/widgets/presets/core/quick-action/QuickActionWidget.vue
@@ -23,7 +23,6 @@ import type { DashboardWidgetQuickActionItem } from "@halo-dev/ui-shared";
 import { OverlayScrollbarsComponent } from "overlayscrollbars-vue";
 import { computed, markRaw, ref, useTemplateRef } from "vue";
 import { useI18n } from "vue-i18n";
-import { useRouter } from "vue-router";
 import QuickActionItem from "./QuickActionItem.vue";
 import ThemePreviewItem from "./ThemePreviewItem.vue";
 import { useDashboardQuickActionExtensionPoint } from "./composables/use-dashboard-extension-point";
@@ -35,7 +34,6 @@ const props = defineProps<{
   };
 }>();
 
-const router = useRouter();
 const { t } = useI18n();
 
 const emit = defineEmits<{
@@ -68,10 +66,8 @@ const presetItems: DashboardWidgetQuickActionItem[] = [
     title: t(
       "core.dashboard.widgets.presets.quickaction.actions.new_post.title"
     ),
-    action: () => {
-      router.push({
-        name: "PostEditor",
-      });
+    route: {
+      name: "PostEditor",
     },
     permissions: ["system:posts:manage"],
   },
@@ -81,10 +77,8 @@ const presetItems: DashboardWidgetQuickActionItem[] = [
     title: t(
       "core.dashboard.widgets.presets.quickaction.actions.new_page.title"
     ),
-    action: () => {
-      router.push({
-        name: "SinglePageEditor",
-      });
+    route: {
+      name: "SinglePageEditor",
     },
     permissions: ["system:singlepages:manage"],
   },
@@ -94,13 +88,11 @@ const presetItems: DashboardWidgetQuickActionItem[] = [
     title: t(
       "core.dashboard.widgets.presets.quickaction.actions.upload_attachment.title"
     ),
-    action: () => {
-      router.push({
-        name: "Attachments",
-        query: {
-          action: "upload",
-        },
-      });
+    route: {
+      name: "Attachments",
+      query: {
+        action: "upload",
+      },
     },
     permissions: ["system:attachments:manage"],
   },
@@ -110,10 +102,8 @@ const presetItems: DashboardWidgetQuickActionItem[] = [
     title: t(
       "core.dashboard.widgets.presets.quickaction.actions.theme_manage.title"
     ),
-    action: () => {
-      router.push({
-        name: "ThemeDetail",
-      });
+    route: {
+      name: "ThemeDetail",
     },
     permissions: ["system:themes:view"],
   },
@@ -123,10 +113,8 @@ const presetItems: DashboardWidgetQuickActionItem[] = [
     title: t(
       "core.dashboard.widgets.presets.quickaction.actions.plugin_manage.title"
     ),
-    action: () => {
-      router.push({
-        name: "Plugins",
-      });
+    route: {
+      name: "Plugins",
     },
     permissions: ["system:plugins:view"],
   },
@@ -136,13 +124,11 @@ const presetItems: DashboardWidgetQuickActionItem[] = [
     title: t(
       "core.dashboard.widgets.presets.quickaction.actions.new_user.title"
     ),
-    action: () => {
-      router.push({
-        name: "Users",
-        query: {
-          action: "create",
-        },
-      });
+    route: {
+      name: "Users",
+      query: {
+        action: "create",
+      },
     },
     permissions: ["system:users:manage"],
   },
@@ -172,7 +158,7 @@ const presetItems: DashboardWidgetQuickActionItem[] = [
         },
       });
     },
-    permissions: ["system:posts:manage"],
+    permissions: ["*"],
   },
 ];
 

--- a/ui/docs/extension-points/dashboard.md
+++ b/ui/docs/extension-points/dashboard.md
@@ -269,9 +269,20 @@ interface DashboardWidgetQuickActionStandardItem
   action: () => void;            // 点击操作（必需）
 }
 
+interface DashboardWidgetQuickActionRouteItem
+  extends DashboardWidgetQuickActionBaseItem {
+  component?: never;             // 不使用自定义组件
+  action?: never;                // 不使用 action 回调
+  icon: Raw<Component>;          // 图标组件（必需）
+  title: string;                 // 标题文本（必需）
+  route: RouteLocationRaw;       // 导航目标路由（必需），可以是路由名称、路径或完整路由配置
+}
+
+
 export type DashboardWidgetQuickActionItem =
   | DashboardWidgetQuickActionComponentItem
-  | DashboardWidgetQuickActionStandardItem;
+  | DashboardWidgetQuickActionStandardItem
+  | DashboardWidgetQuickActionRouteItem;
 ```
 
 ## 权限控制

--- a/ui/packages/shared/src/plugin/types/dashboard-widget.ts
+++ b/ui/packages/shared/src/plugin/types/dashboard-widget.ts
@@ -1,4 +1,5 @@
 import type { Component, Raw } from "vue";
+import type { RouteLocationRaw } from "vue-router";
 
 /**
  * Defines responsive layout configurations for dashboard widgets across different screen sizes.
@@ -279,6 +280,37 @@ interface DashboardWidgetQuickActionStandardItem
 }
 
 /**
+ * A quick action item that navigates to a route when triggered.
+ */
+interface DashboardWidgetQuickActionRouteItem
+  extends DashboardWidgetQuickActionBaseItem {
+  /**
+   * Cannot provide a custom component for route items.
+   */
+  component?: never;
+
+  /**
+   * Cannot provide an action handler for route items.
+   */
+  action?: never;
+
+  /**
+   * Icon component displayed with the action (required for route items).
+   */
+  icon: Raw<Component>;
+
+  /**
+   * Display title for the action (required for route items).
+   */
+  title: string;
+
+  /**
+   * Route to navigate to when the action is triggered (required for route items).
+   */
+  route: RouteLocationRaw;
+}
+
+/**
  * Represents a quick action button that can be added to dashboard widgets.
  *
  * @remarks
@@ -288,4 +320,5 @@ interface DashboardWidgetQuickActionStandardItem
  */
 export type DashboardWidgetQuickActionItem =
   | DashboardWidgetQuickActionComponentItem
-  | DashboardWidgetQuickActionStandardItem;
+  | DashboardWidgetQuickActionStandardItem
+  | DashboardWidgetQuickActionRouteItem;


### PR DESCRIPTION
#### What type of PR is this?

/area ui
/kind improvement
/milestone 2.22.x

#### What this PR does / why we need it:

Introduces DashboardWidgetQuickActionRouteItem type to allow quick actions that navigate to routes instead of executing callbacks.

#### Does this PR introduce a user-facing change?

```release-note
None
```
