### PR TITLE
Add confirmType 'danger' to destructive dialogs

### DIFF
--- a/ui/console-src/modules/contents/attachments/components/AttachmentPoliciesModal.vue
+++ b/ui/console-src/modules/contents/attachments/components/AttachmentPoliciesModal.vue
@@ -76,6 +76,7 @@ const handleDelete = async (policy: Policy) => {
     description: t(
       "core.attachment.policies_modal.operations.delete.description"
     ),
+    confirmType: "danger",
     confirmText: t("core.common.buttons.confirm"),
     cancelText: t("core.common.buttons.cancel"),
     onConfirm: async () => {

--- a/ui/console-src/modules/contents/pages/SinglePageSnapshots.vue
+++ b/ui/console-src/modules/contents/pages/SinglePageSnapshots.vue
@@ -82,6 +82,7 @@ function handleCleanup() {
     description: t("core.page_snapshots.operations.cleanup.description"),
     confirmText: t("core.common.buttons.confirm"),
     cancelText: t("core.common.buttons.cancel"),
+    confirmType: "danger",
     async onConfirm() {
       const { releaseSnapshot, baseSnapshot, headSnapshot } =
         singlePage.value?.spec || {};

--- a/ui/console-src/modules/contents/pages/components/SnapshotListItem.vue
+++ b/ui/console-src/modules/contents/pages/components/SnapshotListItem.vue
@@ -51,6 +51,7 @@ function handleDelete() {
     description: t("core.page_snapshots.operations.delete.description"),
     confirmText: t("core.common.buttons.confirm"),
     cancelText: t("core.common.buttons.cancel"),
+    confirmType: "danger",
     async onConfirm() {
       await consoleApiClient.content.singlePage.deleteSinglePageContent({
         name: props.singlePage?.metadata.name as string,

--- a/ui/console-src/modules/contents/posts/PostSnapshots.vue
+++ b/ui/console-src/modules/contents/posts/PostSnapshots.vue
@@ -81,6 +81,7 @@ function handleCleanup() {
     description: t("core.post_snapshots.operations.cleanup.description"),
     confirmText: t("core.common.buttons.confirm"),
     cancelText: t("core.common.buttons.cancel"),
+    confirmType: "danger",
     async onConfirm() {
       const { releaseSnapshot, baseSnapshot, headSnapshot } =
         post.value?.spec || {};

--- a/ui/console-src/modules/contents/posts/components/SnapshotListItem.vue
+++ b/ui/console-src/modules/contents/posts/components/SnapshotListItem.vue
@@ -49,6 +49,7 @@ function handleDelete() {
     description: t("core.post_snapshots.operations.delete.description"),
     confirmText: t("core.common.buttons.confirm"),
     cancelText: t("core.common.buttons.cancel"),
+    confirmType: "danger",
     async onConfirm() {
       await consoleApiClient.content.post.deletePostContent({
         name: props.post?.metadata.name as string,

--- a/ui/console-src/modules/interface/themes/components/operation/UninstallOperationItem.vue
+++ b/ui/console-src/modules/interface/themes/components/operation/UninstallOperationItem.vue
@@ -25,6 +25,7 @@ const handleUninstall = async (deleteExtensions?: boolean) => {
     description: t("core.common.dialog.descriptions.cannot_be_recovered"),
     confirmText: t("core.common.buttons.confirm"),
     cancelText: t("core.common.buttons.cancel"),
+    confirmType: "danger",
     onConfirm: async () => {
       try {
         await coreApiClient.theme.theme.deleteTheme({

--- a/ui/uc-src/modules/profile/components/PersonalAccessTokenListItem.vue
+++ b/ui/uc-src/modules/profile/components/PersonalAccessTokenListItem.vue
@@ -30,6 +30,9 @@ function handleDelete() {
   Dialog.warning({
     title: t("core.uc_profile.pat.operations.delete.title"),
     description: t("core.uc_profile.pat.operations.delete.description"),
+    confirmType: "danger",
+    confirmText: t("core.common.buttons.confirm"),
+    cancelText: t("core.common.buttons.cancel"),
     async onConfirm() {
       await ucApiClient.security.personalAccessToken.deletePat({
         name: props.token.metadata.name,
@@ -45,6 +48,9 @@ function handleRevoke() {
   Dialog.warning({
     title: t("core.uc_profile.pat.operations.revoke.title"),
     description: t("core.uc_profile.pat.operations.revoke.description"),
+    confirmType: "danger",
+    confirmText: t("core.common.buttons.confirm"),
+    cancelText: t("core.common.buttons.cancel"),
     async onConfirm() {
       await ucApiClient.security.personalAccessToken.revokePat({
         name: props.token.metadata.name,

--- a/ui/uc-src/modules/profile/tabs/Detail.vue
+++ b/ui/uc-src/modules/profile/tabs/Detail.vue
@@ -47,6 +47,7 @@ const handleUnbindAuth = (authProvider: ListedAuthProvider) => {
     }),
     confirmText: t("core.common.buttons.confirm"),
     cancelText: t("core.common.buttons.cancel"),
+    confirmType: "danger",
     onConfirm: async () => {
       await axios.put(`${authProvider.unbindingUrl}`, {
         withCredentials: true,


### PR DESCRIPTION
#### What type of PR is this?

/area ui
/kind improvement
/milestone 2.22.x

#### What this PR does / why we need it:

Add confirmType 'danger' to destructive dialogs

#### Does this PR introduce a user-facing change?

```release-note
None
```

