### PR TITLE
Add wrapper class to Dropdown component

### DIFF
--- a/ui/packages/components/src/components/dropdown/Dropdown.vue
+++ b/ui/packages/components/src/components/dropdown/Dropdown.vue
@@ -47,6 +47,7 @@ defineExpose({
     :placement="placement"
     :triggers="triggers"
     :dispose-timeout="null"
+    class="dropdown-wrapper"
     @show="emit('show')"
   >
     <slot />
@@ -64,3 +65,9 @@ defineExpose({
     </template>
   </FloatingDropdown>
 </template>
+
+<style>
+.dropdown-wrapper {
+  display: inline-block;
+}
+</style>


### PR DESCRIPTION
#### What type of PR is this?

/area ui
/kind improvement
/milestone 2.22.x

#### What this PR does / why we need it:

Introduces a 'dropdown-wrapper' class to the Dropdown component and sets its display to inline-block for improved layout control.

#### Does this PR introduce a user-facing change?

```release-note
None
```
