### PR TITLE
Add path aliases for halo-dev packages

### DIFF
--- a/ui/tsconfig.app.json
+++ b/ui/tsconfig.app.json
@@ -16,10 +16,10 @@
       "@/*": ["./src/*"],
       "@uc/*": ["./uc-src/*"],
       "@console/*": ["./console-src/*"],
-      "@halo-dev/api-client": ["./packages/api-client/entry/index.ts"],
-      "@halo-dev/components": ["./packages/components/src/index.ts"],
-      "@halo-dev/richtext-editor": ["./packages/editor/src/index.ts"],
-      "@halo-dev/ui-shared": ["./packages/shared/src/index.ts"]
+      "@halo-dev/api-client": ["./packages/api-client/dist/index"],
+      "@halo-dev/components": ["./packages/components/dist/index"],
+      "@halo-dev/richtext-editor": ["./packages/editor/dist/index"],
+      "@halo-dev/ui-shared": ["./packages/shared/dist/index"]
     },
     "ignoreDeprecations": "5.0",
     "types": ["unplugin-icons/types/vue"]


### PR DESCRIPTION
#### What type of PR is this?

/area ui
/kind improvement
/milestone 2.22.x

#### What this PR does / why we need it:

Fix subpackage import path issue

before:

<img width="580" height="121" alt="image" src="https://github.com/user-attachments/assets/fe850c72-a755-4c4a-8162-92e6f1f3ee9a" />

after:

<img width="576" height="136" alt="image" src="https://github.com/user-attachments/assets/0ef854a9-b0f3-4aa0-a361-c29dad7d454b" />

#### Does this PR introduce a user-facing change?

```release-note
None
```
