### PR TITLE
Improve auth provider logo display styling

### DIFF
--- a/ui/uc-src/modules/profile/tabs/components/AuthProviders.vue
+++ b/ui/uc-src/modules/profile/tabs/components/AuthProviders.vue
@@ -66,11 +66,13 @@ const handleBindAuth = (authProvider: ListedAuthProvider) => {
           <template #start>
             <VEntityField v-if="authProvider.logo">
               <template #description>
-                <img
-                  class="size-8 rounded-lg"
-                  :src="authProvider.logo"
-                  :alt="authProvider.displayName"
-                />
+                <div class="size-8 overflow-hidden rounded-lg">
+                  <img
+                    class="size-full object-cover"
+                    :src="authProvider.logo"
+                    :alt="authProvider.displayName"
+                  />
+                </div>
               </template>
             </VEntityField>
             <VEntityField


### PR DESCRIPTION
#### What type of PR is this?

/area ui
/kind bug
/milestone 2.22.x

#### What this PR does / why we need it:

Fixed an issue where login method icons in the user profile were not displaying on mobile devices

before:

<img width="404" height="318" alt="image" src="https://github.com/user-attachments/assets/10efa635-272d-4e5d-a95b-d72701908093" />

after:

<img width="478" height="323" alt="image" src="https://github.com/user-attachments/assets/09044e9c-84be-4250-9516-f4afc82959b1" />

#### Does this PR introduce a user-facing change?

```release-note
None
```
