### PR TITLE
Fix incorrect type generation for the Dropdown component

### DIFF
--- a/ui/packages/components/src/components/dropdown/Dropdown.vue
+++ b/ui/packages/components/src/components/dropdown/Dropdown.vue
@@ -41,7 +41,7 @@ defineExpose({
 </script>
 
 <template>
-  <!-- @vue-skip -->
+  <!-- @vue-ignore -->
   <FloatingDropdown
     ref="dropdownRef"
     :placement="placement"


### PR DESCRIPTION
#### What type of PR is this?

/area ui
/kind bug
/milestone 2.22.x

#### What this PR does / why we need it:

Fix incorrect type generation for the Dropdown component

before:

<img width="585" height="114" alt="image" src="https://github.com/user-attachments/assets/ffb2cda4-3374-4967-bbae-2485769fec26" />


after:

<img width="596" height="140" alt="image" src="https://github.com/user-attachments/assets/6b9414fc-7845-4892-9e22-3565df4cd419" />

#### Does this PR introduce a user-facing change?

```release-note
修复 `@halo-dev/components` 的 Dropdown 组件类型问题
```
