### PR TITLE
chore: export Fragment from pm package

### DIFF
--- a/ui/packages/editor/src/tiptap/index.ts
+++ b/ui/packages/editor/src/tiptap/index.ts
@@ -1,13 +1,8 @@
 export * from "./core";
-export {
-  Editor,
-  Fragment,
-  MarkView,
-  type MarkType,
-  type NodeType,
-} from "./core";
+export { Editor, MarkView, type MarkType, type NodeType } from "./core";
 export * from "./pm";
 export {
+  Fragment,
   InputRule as PMInputRule,
   Mark as PMMark,
   Node as PMNode,


### PR DESCRIPTION
#### What type of PR is this?

/kind improvement
/area editor
/milestone 2.22.x

#### What this PR does / why we need it:

将 Fragment 包从 PM 包中导出，而不是 core 包，用于解决 https://github.com/halo-sigs/plugin-hybrid-edit-block/issues/24 的错误

#### How to test it?

测试使用插件 `plugin-hybrid-edit-block` 是否会报错的问题。

#### Does this PR introduce a user-facing change?
```release-note
None
```
