### PR TITLE
fix: resolve the issue of the video node-view-wrapper error

### DIFF
--- a/ui/packages/editor/src/extensions/video/VideoView.vue
+++ b/ui/packages/editor/src/extensions/video/VideoView.vue
@@ -2,7 +2,7 @@
 import { EditorLinkObtain } from "@/components";
 import { useExternalAssetsTransfer } from "@/composables/use-attachment";
 import { i18n } from "@/locales";
-import type { NodeViewProps } from "@/tiptap";
+import { NodeViewWrapper, type NodeViewProps } from "@/tiptap";
 import { VButton } from "@halo-dev/components";
 import { utils, type AttachmentSimple } from "@halo-dev/ui-shared";
 import { computed, ref } from "vue";


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/area editor
/milestone 2.22.x

#### What this PR does / why we need it:

解决 video 缺少 node-view-wrapper 导入的问题。

#### Which issue(s) this PR fixes:

Fixes #7981

#### Does this PR introduce a user-facing change?
```release-note
解决无法在编辑器中插入视频的问题
```
