### PR TITLE
Make the posts in index lazy to load

### DIFF
--- a/application/src/main/java/run/halo/app/theme/router/factories/IndexRouteFactory.java
+++ b/application/src/main/java/run/halo/app/theme/router/factories/IndexRouteFactory.java
@@ -4,6 +4,7 @@ import static org.springframework.web.reactive.function.server.RequestPredicates
 import static org.springframework.web.reactive.function.server.RequestPredicates.accept;
 import static run.halo.app.theme.router.PageUrlUtils.totalPage;
 
+import java.time.Duration;
 import java.util.Map;
 import lombok.AllArgsConstructor;
 import org.springframework.http.MediaType;
@@ -14,9 +15,11 @@ import org.springframework.web.reactive.function.server.RouterFunctions;
 import org.springframework.web.reactive.function.server.ServerRequest;
 import org.springframework.web.reactive.function.server.ServerResponse;
 import org.springframework.web.server.i18n.LocaleContextResolver;
+import org.thymeleaf.context.LazyContextVariable;
 import reactor.core.publisher.Mono;
 import run.halo.app.infra.SystemConfigurableEnvironmentFetcher;
 import run.halo.app.infra.SystemSetting;
+import run.halo.app.infra.utils.ReactiveUtils;
 import run.halo.app.theme.DefaultTemplateEnum;
 import run.halo.app.theme.finders.PostFinder;
 import run.halo.app.theme.finders.vo.ListedPostVo;
@@ -36,6 +39,8 @@ import run.halo.app.theme.router.UrlContextListResult;
 @AllArgsConstructor
 public class IndexRouteFactory implements RouteFactory {
 
+    private static final Duration BLOCKING_TIMEOUT = ReactiveUtils.DEFAULT_TIMEOUT;
+
     private final PostFinder postFinder;
     private final SystemConfigurableEnvironmentFetcher environmentFetcher;
     private final TitleVisibilityIdentifyCalculator titleVisibilityIdentifyCalculator;
@@ -50,10 +55,18 @@ public class IndexRouteFactory implements RouteFactory {
     }
 
     HandlerFunction<ServerResponse> handlerFunction() {
-        return request -> ServerResponse.ok()
-            .render(DefaultTemplateEnum.INDEX.getValue(),
-                Map.of("posts", postList(request),
-                    ModelConst.TEMPLATE_ID, DefaultTemplateEnum.INDEX.getValue()));
+        return request -> {
+            var posts = new LazyContextVariable<UrlContextListResult<ListedPostVo>>() {
+                @Override
+                protected UrlContextListResult<ListedPostVo> loadValue() {
+                    return postList(request).block(BLOCKING_TIMEOUT);
+                }
+            };
+            return ServerResponse.ok().render(DefaultTemplateEnum.INDEX.getValue(), Map.of(
+                "posts", posts,
+                ModelConst.TEMPLATE_ID, DefaultTemplateEnum.INDEX.getValue()
+            ));
+        };
     }
 
     private Mono<UrlContextListResult<ListedPostVo>> postList(ServerRequest request) {


### PR DESCRIPTION
#### What type of PR is this?

/kind improvement
/area theme
/milestone 2.22.x

#### What this PR does / why we need it:

`posts` query will be always executed even if we don't use the variable `posts` in the `index` template.

This PR use lazy context variable to load `posts` model as needed.

#### Which issue(s) this PR fixes:

Fixes https://github.com/halo-dev/halo/issues/7924

#### Special notes for your reviewer:

Try to remove `posts` variable in the `index` template and check if the system queries the `posts` data.

#### Does this PR introduce a user-facing change?

```release-note
当首页没有使用文章列表变量时，不再查询数据库，以提升性能
```

