### PR TITLE
fix: solve the problem that multiple Selects cannot display label correctly

### DIFF
--- a/ui/src/formkit/inputs/array/ArrayInput.vue
+++ b/ui/src/formkit/inputs/array/ArrayInput.vue
@@ -100,7 +100,9 @@ const renderItemLabelValue = (
       if (selectedOption) {
         renderValue = selectedOption.label;
       }
-      return renderValue;
+      return {
+        value: renderValue,
+      };
     }
     case "nativeSelect": {
       let renderValue = value;


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/area ui
/milestone 2.22.x

#### What this PR does / why we need it:

为 formkit children 的多个子节点设置不同的 id，解决由于 id 相同导致的 select 被覆盖进而影响 label 获取。

此 PR 顺便支持了 `nativeSelect` 的 `optgroup`。

#### Which issue(s) this PR fixes:

Fixes #8020 

#### Does this PR introduce a user-facing change?
```release-note
修复表单中同时存在多个 Array 输入类型时，界面显示异常的问题
```
