### PR TITLE
Add expand/collapse for editor cover image

### DIFF
--- a/ui/packages/editor/src/styles/base.scss
+++ b/ui/packages/editor/src/styles/base.scss
@@ -65,7 +65,7 @@
       padding-left: $editorHorizontalPadding;
       padding-right: $editorHorizontalPadding;
       padding-top: $editorVerticalPadding;
-      padding-bottom: 30vh;
+      padding-bottom: 50vh;
       max-width: $editorContentMaxWidth;
       margin: 0 auto;
 

--- a/ui/src/components/editor/DefaultEditor.vue
+++ b/ui/src/components/editor/DefaultEditor.vue
@@ -58,7 +58,9 @@ import LucideHeading3 from "~icons/lucide/heading-3";
 import LucideHeading4 from "~icons/lucide/heading-4";
 import LucideHeading5 from "~icons/lucide/heading-5";
 import LucideHeading6 from "~icons/lucide/heading-6";
+import MingcuteFoldVerticalLine from "~icons/mingcute/fold-vertical-line";
 import MingcuteLayoutRightLine from "~icons/mingcute/layout-right-line";
+import MingcuteUnfoldVerticalLine from "~icons/mingcute/unfold-vertical-line";
 
 const { t } = useI18n();
 
@@ -374,6 +376,8 @@ onCoverInputChange((files) => {
       uploadProgress.value = 0;
     });
 });
+
+const expandedCover = ref(false);
 </script>
 
 <template>
@@ -398,7 +402,11 @@ onCoverInputChange((files) => {
         <div class="group">
           <div
             v-if="cover || uploadProgress"
-            class="group/cover aspect-h-7 aspect-w-16 overflow-hidden rounded-lg"
+            class="group/cover aspect-w-16 overflow-hidden rounded-lg transition-all"
+            :class="{
+              'aspect-h-9': expandedCover,
+              'aspect-h-4': !expandedCover,
+            }"
           >
             <img
               v-if="cover"
@@ -417,14 +425,26 @@ onCoverInputChange((files) => {
               <VLoading class="!py-3" />
               <span class="text-sm">{{ uploadProgress }}%</span>
             </div>
-            <HasPermission
-              :permissions="[
-                'system:attachments:view',
-                'uc:attachments:manage',
-              ]"
+
+            <div
+              class="top-0 flex h-12 items-center justify-end gap-2 bg-gradient-to-b from-gray-300 to-transparent px-2 opacity-0 transition-all group-hover/cover:opacity-100"
             >
-              <div
-                class="!bottom-2 !left-auto !right-2 !top-auto !size-auto opacity-0 shadow-lg transition-opacity group-hover/cover:opacity-100"
+              <VButton size="sm" ghost @click="expandedCover = !expandedCover">
+                <template #icon>
+                  <MingcuteUnfoldVerticalLine v-if="!expandedCover" />
+                  <MingcuteFoldVerticalLine v-else />
+                </template>
+                {{
+                  expandedCover
+                    ? $t("core.common.buttons.fold")
+                    : $t("core.common.buttons.unfold")
+                }}
+              </VButton>
+              <HasPermission
+                :permissions="[
+                  'system:attachments:view',
+                  'uc:attachments:manage',
+                ]"
               >
                 <VDropdown>
                   <VButton type="secondary" size="sm">
@@ -460,8 +480,8 @@ onCoverInputChange((files) => {
                     </VDropdownItem>
                   </template>
                 </VDropdown>
-              </div>
-            </HasPermission>
+              </HasPermission>
+            </div>
           </div>
           <HasPermission
             :permissions="['system:attachments:view', 'uc:attachments:manage']"

--- a/ui/src/constants/regex.ts
+++ b/ui/src/constants/regex.ts
@@ -1,2 +1,1 @@
 export const PASSWORD_REGEX = /^[A-Za-z0-9!@#$%^&*.?]+$/;
-

--- a/ui/src/locales/_missing_translations_es.yaml
+++ b/ui/src/locales/_missing_translations_es.yaml
@@ -802,6 +802,8 @@ core:
       enable: Enable
       continue: Continue
       retry: Retry
+      unfold: Unfold
+      fold: Fold
     toast:
       disable_success: Disabled successfully
       enable_success: Enabled successfully

--- a/ui/src/locales/en.yaml
+++ b/ui/src/locales/en.yaml
@@ -1968,6 +1968,8 @@ core:
       enable: Enable
       continue: Continue
       retry: Retry
+      unfold: Unfold
+      fold: Fold
     radio:
       "yes": "Yes"
       "no": "No"

--- a/ui/src/locales/zh-CN.yaml
+++ b/ui/src/locales/zh-CN.yaml
@@ -1820,6 +1820,8 @@ core:
       enable: 启用
       continue: 继续
       retry: 重试
+      unfold: 展开
+      fold: 收起
     radio:
       "yes": 是
       "no": 否

--- a/ui/src/locales/zh-TW.yaml
+++ b/ui/src/locales/zh-TW.yaml
@@ -1805,6 +1805,8 @@ core:
       enable: 启用
       continue: 繼續
       retry: 重試
+      unfold: 展開
+      fold: 收起
     radio:
       "yes": 是
       "no": 否


### PR DESCRIPTION
#### What type of PR is this?

/area ui
/kind improvement
/milestone 2.22.x

#### What this PR does / why we need it:

Reduce the cover image height and add support for expanding it to a full‑size view

<img width="1088" height="345" alt="image" src="https://github.com/user-attachments/assets/dc5bea54-76a8-463e-b27b-12f3547d8529" />

#### Which issue(s) this PR fixes:

Fixes https://github.com/halo-dev/halo/issues/8010

#### Does this PR introduce a user-facing change?

```release-note
降低文章编辑器中封面的高度，并支持展开图片
```
