### PR TITLE
fix: adjust the position of the search and replace box

### DIFF
--- a/ui/packages/editor/src/extensions/heading/index.ts
+++ b/ui/packages/editor/src/extensions/heading/index.ts
@@ -304,9 +304,6 @@ export const ExtensionHeading = TiptapHeading.extend<ExtensionHeadingOptions>({
       },
     };
   },
-  addExtensions() {
-    return [ExtensionParagraph];
-  },
   addProseMirrorPlugins() {
     let beforeComposition: boolean | undefined = undefined;
     return [

--- a/ui/packages/editor/src/extensions/search-and-replace/SearchAndReplace.vue
+++ b/ui/packages/editor/src/extensions/search-and-replace/SearchAndReplace.vue
@@ -166,7 +166,7 @@ watch(
               ref="searchInput"
               v-model="searchTerm"
               type="text"
-              class="block w-full rounded border !border-solid border-gray-300 bg-gray-50 p-1 !pr-[5.5rem] ps-2 !text-sm !leading-7 text-gray-900 focus:border-blue-500 focus:ring-blue-500"
+              class="block w-full rounded border !border-solid border-gray-300 bg-gray-50 p-2 !pr-[5.5rem] ps-2 !text-sm !leading-7 text-gray-900 focus:border-blue-500 focus:ring-blue-500"
               :placeholder="
                 i18n.global.t(
                   'editor.extensions.search_and_replace.search_placeholder'
@@ -299,7 +299,7 @@ watch(
             <input
               v-model="replaceTerm"
               type="text"
-              class="block w-full rounded border !border-solid border-gray-300 bg-gray-50 p-1 ps-2 !text-sm !leading-7 text-gray-900 focus:border-blue-500 focus:ring-blue-500"
+              class="block w-full rounded border !border-solid border-gray-300 bg-gray-50 p-2 ps-2 !text-sm !leading-7 text-gray-900 focus:border-blue-500 focus:ring-blue-500"
               :placeholder="
                 i18n.global.t(
                   'editor.extensions.search_and_replace.replace_placeholder'

--- a/ui/packages/editor/src/extensions/search-and-replace/SearchAndReplacePlugin.ts
+++ b/ui/packages/editor/src/extensions/search-and-replace/SearchAndReplacePlugin.ts
@@ -41,9 +41,9 @@ export class SearchAndReplacePluginView {
   }
 
   update() {
-    const editorParentElement = this.editor.options.element as HTMLElement;
-    if (!this.init && editorParentElement) {
-      editorParentElement.insertAdjacentElement(
+    const headerParentElement = this.findEditorEntryElement();
+    if (!this.init && headerParentElement) {
+      headerParentElement.insertAdjacentElement(
         "afterbegin",
         this.containerElement
       );
@@ -54,6 +54,22 @@ export class SearchAndReplacePluginView {
 
   destroy() {
     return false;
+  }
+
+  private findEditorEntryElement() {
+    const editorElement = this.editor.options.element as HTMLElement;
+    let currentElement = editorElement;
+    while (currentElement) {
+      if (currentElement.classList.contains("editor-main")) {
+        return currentElement;
+      }
+
+      if (!currentElement.parentElement) {
+        break;
+      }
+      currentElement = currentElement.parentElement;
+    }
+    return null;
   }
 }
 


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/area editor
/milestone 2.22.x

#### What this PR does / why we need it:

将编辑器搜索与替换框的位置定位为 `editor-main`，解决搜索与替换框位置不正确的情况。

同时移除了重复添加的 `ExtensionParagraph` 扩展。

#### Which issue(s) this PR fixes:

Fixes #8022 

#### Does this PR introduce a user-facing change?
```release-note
解决编辑器搜索与替换框位置不正确的情况
```
