### PR TITLE
Remove z-index from BasicLayout sidebar styles

### DIFF
--- a/ui/console-src/layouts/BasicLayout.vue
+++ b/ui/console-src/layouts/BasicLayout.vue
@@ -142,7 +142,6 @@ onMounted(() => {
   height: 100%;
   background-color: theme("colors.white");
   box-shadow: theme("boxShadow.DEFAULT");
-  z-index: 999;
   overflow-y: auto;
   display: none;
   flex-direction: column;

--- a/ui/uc-src/layouts/BasicLayout.vue
+++ b/ui/uc-src/layouts/BasicLayout.vue
@@ -111,7 +111,6 @@ onMounted(() => {
   height: 100%;
   background-color: theme("colors.white");
   box-shadow: theme("boxShadow.DEFAULT");
-  z-index: 999;
   overflow-y: auto;
   display: none;
   flex-direction: column;


### PR DESCRIPTION
#### What type of PR is this?

/area ui
/kind improvement
/milestone 2.22.x

#### What this PR does / why we need it:

Remove the z-index style from the sidebar. It doesn’t seem to serve any real purpose and ends up interfering with other pop-up layers on the page.

#### Does this PR introduce a user-facing change?

```release-note
None
```
