### PR TITLE
pref: refactor image resizing to only update width attribute

### DIFF
--- a/ui/packages/editor/src/extensions/image/ImageView.vue
+++ b/ui/packages/editor/src/extensions/image/ImageView.vue
@@ -91,7 +91,6 @@ const resetUpload = () => {
   if (file) {
     props.updateAttributes({
       width: undefined,
-      height: undefined,
       file: undefined,
     });
   }
@@ -116,7 +115,6 @@ function onImageLoaded(event: Event) {
       .chain()
       .updateAttributes(ExtensionImage.name, {
         width: `${target.naturalWidth}px`,
-        height: `${target.naturalHeight}px`,
       })
       .updateFigureContainerWidth(`${target.naturalWidth}px`)
       .setNodeSelection(props.getPos() || 0)
@@ -184,14 +182,9 @@ function setupResizeListener() {
       );
 
       const width = newWidth.toFixed(0) + "px";
-      const height =
-        aspectRatio.value > 0
-          ? (newWidth / aspectRatio.value).toFixed(0) + "px"
-          : "auto";
-
       props.editor
         .chain()
-        .updateAttributes(ExtensionImage.name, { width, height })
+        .updateAttributes(ExtensionImage.name, { width })
         .updateFigureContainerWidth(width)
         .setNodeSelection(props.getPos() || 0)
         .focus()
@@ -296,6 +289,11 @@ const isPercentageWidth = computed(() => {
           :alt="alt"
           :href="href"
           :width="isPercentageWidth ? '100%' : node.attrs.width"
+          :height="node.attrs.height"
+          :style="{
+            width: isPercentageWidth ? '100%' : node.attrs.width,
+            height: node.attrs.height,
+          }"
           class="max-w-full rounded-md"
           @load="onImageLoaded"
         />


### PR DESCRIPTION
#### What type of PR is this?

/kind improvement
/area editor
/milestone 2.22.x

#### What this PR does / why we need it:

优化编辑器图片默认策略，仅在手动设置高度时为最终渲染的图片设置 `height` 属性。

如果已有高度，则建议将其移除。

#### Which issue(s) this PR fixes:

Fixes #8018 

#### Does this PR introduce a user-facing change?
```release-note
优化编辑器中图片的大小设置，默认不为其设置 `height` 
```
