### PR TITLE
Set z-index for commands menu positioning

### DIFF
--- a/ui/packages/editor/src/extensions/commands-menu/commands.ts
+++ b/ui/packages/editor/src/extensions/commands-menu/commands.ts
@@ -144,7 +144,7 @@ const updatePosition = (editor: Editor, element: HTMLElement) => {
     element.style.position = strategy;
     element.style.left = `${x}px`;
     element.style.top = `${y}px`;
-    element.style.zIndex = "10000";
+    element.style.zIndex = "1000";
   });
 };
 


### PR DESCRIPTION
#### What type of PR is this?

/area ui
/area editor
/kind improvement


#### What this PR does / why we need it:

Adds a z-index of 1000 to the commands menu element to ensure it appears above other UI elements when positioned.

#### Does this PR introduce a user-facing change?

```release-note
None
```
