### PR TITLE
Enhance color input with manual editing and HSL support

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -54,6 +54,7 @@
     "@codemirror/language": "^6.11.3",
     "@codemirror/state": "^6.5.2",
     "@codemirror/view": "^6.38.8",
+    "@ctrl/tinycolor": "^4.2.0",
     "@emoji-mart/data": "^1.2.1",
     "@formkit/addons": "^1.6.9",
     "@formkit/core": "^1.6.9",

--- a/ui/pnpm-lock.yaml
+++ b/ui/pnpm-lock.yaml
@@ -53,6 +53,9 @@ importers:
       '@codemirror/view':
         specifier: ^6.38.8
         version: 6.38.8
+      '@ctrl/tinycolor':
+        specifier: ^4.2.0
+        version: 4.2.0
       '@emoji-mart/data':
         specifier: ^1.2.1
         version: 1.2.1
@@ -873,6 +876,10 @@ packages:
   '@ctrl/tinycolor@3.6.1':
     resolution: {integrity: sha512-SITSV6aIXsuVNV3f3O0f2n/cgyEDWoSqtZMYiAmcsYHydcKrOz3gUxB/iXd/Qf08+IZX4KpgNbvUdMBmWz+kcA==}
     engines: {node: '>=10'}
+
+  '@ctrl/tinycolor@4.2.0':
+    resolution: {integrity: sha512-kzyuwOAQnXJNLS9PSyrk0CWk35nWJW/zl/6KvnTBMFK65gm7U1/Z5BqjxeapjZCIhQcM/DsrEmcbRwDyXyXK4A==}
+    engines: {node: '>=14'}
 
   '@emnapi/core@1.7.1':
     resolution: {integrity: sha512-o1uhUASyo921r2XtHYOHy7gdkGLge8ghBEQHMWmyJFoXlpU58kIrhhN3w26lpQb6dspetweapMn2CSNwQ8I4wg==}
@@ -7282,6 +7289,8 @@ snapshots:
   '@csstools/css-tokenizer@3.0.4': {}
 
   '@ctrl/tinycolor@3.6.1': {}
+
+  '@ctrl/tinycolor@4.2.0': {}
 
   '@emnapi/core@1.7.1':
     dependencies:

--- a/ui/src/formkit/inputs/color/ColorInput.vue
+++ b/ui/src/formkit/inputs/color/ColorInput.vue
@@ -1,9 +1,11 @@
 <script lang="ts" setup>
 import { Sketch, type Payload } from "@ckpack/vue-color";
+import { TinyColor } from "@ctrl/tinycolor";
 import type { FormKitFrameworkContext } from "@formkit/core";
-import { VDropdown } from "@halo-dev/components";
+import { IconClose, VButton, VDropdown } from "@halo-dev/components";
 import Color from "colorjs.io";
-import { computed, type PropType } from "vue";
+import { computed, useTemplateRef, type PropType } from "vue";
+import RiCodeSSlashLine from "~icons/ri/code-s-slash-line";
 import type { ColorFormat } from "./types";
 
 const props = defineProps({
@@ -16,17 +18,33 @@ const props = defineProps({
 const format = computed(() => props.context.format as ColorFormat);
 
 function onColorChange(color: Payload) {
-  props.context.node.input(formatColor(color));
+  props.context.node.input(formatPayload(color));
 }
 
-function formatColor(color: Payload) {
+function formatPayload(color: Payload) {
   switch (format.value) {
     case "rgb":
-      return `rgb(${color.rgba.r} ${color.rgba.g} ${color.rgba.b} / ${color.rgba.a})`;
+      return new TinyColor(color.rgba).toRgbString();
     case "hex8":
       return color.hex8;
+    case "hsl":
+      return new TinyColor(color.hsl).toHslString();
     default:
       return color.hex;
+  }
+}
+
+function formatColorByUnpredictableValue(value: string) {
+  const color = new TinyColor(value);
+  switch (format.value) {
+    case "rgb":
+      return color.toRgbString();
+    case "hex8":
+      return color.toHex8();
+    case "hsl":
+      return color.toHslString();
+    default:
+      return color.toHex();
   }
 }
 
@@ -43,31 +61,88 @@ const isHighContrast = computed(() => {
     return false; // Default to low contrast on error
   }
 });
+
+const editFormDropdown =
+  useTemplateRef<InstanceType<typeof VDropdown>>("editFormDropdown");
+
+function onEditFormSubmit({ value }: { value: string }) {
+  props.context.node.input(formatColorByUnpredictableValue(value));
+  editFormDropdown.value?.hide();
+}
 </script>
 
 <template>
-  <VDropdown class="inline-flex" popper-class="[&_.v-popper\_\_inner]:!p-0">
-    <button
-      type="button"
-      aria-label="Choose color"
-      class="inline-flex h-8 items-center justify-center rounded-lg bg-white px-2 transition-all hover:opacity-80 hover:shadow active:opacity-70"
-      :style="{
-        backgroundColor: context._value,
-      }"
-      :class="[
-        { 'text-white': isHighContrast },
-        { 'text-gray-900 ring-1 ring-gray-200': !isHighContrast },
-      ]"
-    >
-      <span class="text-sm">{{
-        context._value || $t("core.formkit.color.placeholder")
-      }}</span>
-    </button>
-    <template #popper>
-      <Sketch
-        :model-value="context._value"
-        @update:model-value="onColorChange"
-      />
-    </template>
-  </VDropdown>
+  <div class="group/color-input inline-flex items-center gap-2">
+    <VDropdown class="inline-flex" popper-class="[&_.v-popper\_\_inner]:!p-0">
+      <button
+        type="button"
+        aria-label="Choose color"
+        class="inline-flex h-8 items-center justify-center rounded-lg bg-white px-2 transition-all hover:opacity-80 hover:shadow active:opacity-70"
+        :style="{
+          backgroundColor: context._value,
+        }"
+        :class="[
+          { 'text-white': isHighContrast },
+          { 'text-gray-900 ring-1 ring-gray-200': !isHighContrast },
+        ]"
+      >
+        <span class="text-sm">
+          {{ context._value || $t("core.formkit.color.placeholder") }}
+        </span>
+      </button>
+      <template #popper>
+        <Sketch
+          :model-value="context._value || '#000'"
+          @update:model-value="onColorChange"
+        />
+      </template>
+    </VDropdown>
+
+    <div class="inline-flex items-center gap-1.5">
+      <VDropdown ref="editFormDropdown" class="inline-flex">
+        <template #default="{ shown }">
+          <button
+            v-tooltip="$t('core.formkit.color.operations.edit')"
+            type="button"
+            :aria-label="$t('core.formkit.color.operations.edit')"
+            class="text-gray-500 opacity-0 transition-all hover:text-gray-900 group-hover/color-input:opacity-100"
+            :class="{ '!text-gray-900 !opacity-100': shown }"
+          >
+            <RiCodeSSlashLine />
+          </button>
+        </template>
+        <template #popper>
+          <div class="w-96">
+            <FormKit
+              id="color-edit-form"
+              type="form"
+              ignore
+              name="color-edit-form"
+              @submit="onEditFormSubmit"
+            >
+              <FormKit type="text" :model-value="context._value" name="value" />
+            </FormKit>
+            <div class="mt-4">
+              <VButton
+                type="secondary"
+                @click="$formkit.submit('color-edit-form')"
+              >
+                {{ $t("core.common.buttons.save") }}
+              </VButton>
+            </div>
+          </div>
+        </template>
+      </VDropdown>
+      <button
+        v-if="context._value"
+        v-tooltip="$t('core.common.buttons.delete')"
+        type="button"
+        :aria-label="$t('core.common.buttons.delete')"
+        class="text-gray-500 opacity-0 transition-all hover:text-gray-900 group-hover/color-input:opacity-100"
+        @click="context.node.input(undefined)"
+      >
+        <IconClose />
+      </button>
+    </div>
+  </div>
 </template>

--- a/ui/src/formkit/inputs/color/types.ts
+++ b/ui/src/formkit/inputs/color/types.ts
@@ -1,1 +1,1 @@
-export type ColorFormat = "rgb" | "hex" | "hex8";
+export type ColorFormat = "rgb" | "hex" | "hex8" | "hsl";

--- a/ui/src/formkit/inputs/iconify/Icon.vue
+++ b/ui/src/formkit/inputs/iconify/Icon.vue
@@ -1,5 +1,5 @@
 <script lang="ts" setup>
-import { IconClose, VButton, VDropdown } from "@halo-dev/components";
+import { VButton, VDropdown } from "@halo-dev/components";
 import { Icon as IconifyIcon } from "@iconify/vue";
 import { refDefault } from "@vueuse/shared";
 import { inject, ref, useTemplateRef, type Ref } from "vue";
@@ -139,9 +139,6 @@ async function handleConfirm() {
               :label="$t('core.formkit.iconify.option_color')"
               ignore
             >
-              <template v-if="color !== ''" #suffixIcon>
-                <IconClose aria-label="Clear color" @click="color = ''" />
-              </template>
             </FormKit>
           </FormKit>
           <VButton :loading="isFetching" @click="handleConfirm()">

--- a/ui/src/locales/_missing_translations_es.yaml
+++ b/ui/src/locales/_missing_translations_es.yaml
@@ -741,6 +741,8 @@ core:
   formkit:
     color:
       placeholder: Select color
+      operations:
+        edit: Edit color manually
     select:
       no_data: No data
     validation:

--- a/ui/src/locales/en.yaml
+++ b/ui/src/locales/en.yaml
@@ -1867,6 +1867,8 @@ core:
   formkit:
     color:
       placeholder: Select color
+      operations:
+        edit: Edit color manually
     select:
       no_data: No data
     category_select:

--- a/ui/src/locales/zh-CN.yaml
+++ b/ui/src/locales/zh-CN.yaml
@@ -1777,6 +1777,8 @@ core:
         title: 编辑条目
     color:
       placeholder: 选择颜色
+      operations:
+        edit: 手动编辑颜色
   common:
     buttons:
       save: 保存

--- a/ui/src/locales/zh-TW.yaml
+++ b/ui/src/locales/zh-TW.yaml
@@ -1757,6 +1757,8 @@ core:
         edit: 手動編輯圖標
     color:
       placeholder: 選擇顏色
+      operations:
+        edit: 手動編輯顏色
     array:
       empty_text: 沒有條目
       image_tooltip: 查看圖片：{value}


### PR DESCRIPTION
#### What type of PR is this?

/area ui
/kind improvement
/milestone 2.22.x

#### What this PR does / why we need it:

Refactored ColorInput.vue to support manual color value editing and HSL format

#### Which issue(s) this PR fixes:

Fixes https://github.com/halo-dev/halo/issues/8011

#### Does this PR introduce a user-facing change?

```release-note
FormKit Color 支持 hsl 格式，并支持手动编辑色值
```
