### PR TITLE
Pass formData prop to AnnotationsForm context

### DIFF
--- a/ui/console-src/modules/contents/pages/components/SinglePageSettingModal.vue
+++ b/ui/console-src/modules/contents/pages/components/SinglePageSettingModal.vue
@@ -460,6 +460,7 @@ async function slugUniqueValidation(node: FormKitNode) {
         <AnnotationsForm
           :key="formState.metadata.name"
           ref="annotationsFormRef"
+          :form-data="formState"
           :value="formState.metadata.annotations"
           kind="SinglePage"
           group="content.halo.run"

--- a/ui/console-src/modules/contents/posts/categories/components/CategoryEditingModal.vue
+++ b/ui/console-src/modules/contents/posts/categories/components/CategoryEditingModal.vue
@@ -378,6 +378,7 @@ async function slugUniqueValidation(node: FormKitNode) {
         <AnnotationsForm
           :key="formState.metadata.name"
           ref="annotationsFormRef"
+          :form-data="formState"
           :value="formState.metadata.annotations"
           kind="Category"
           group="content.halo.run"

--- a/ui/console-src/modules/contents/posts/components/PostSettingModal.vue
+++ b/ui/console-src/modules/contents/posts/components/PostSettingModal.vue
@@ -494,6 +494,7 @@ const showCancelPublishButton = computed(() => {
           ref="annotationsFormRef"
           :value="formState.metadata.annotations"
           kind="Post"
+          :form-data="formState"
           group="content.halo.run"
         />
       </div>

--- a/ui/console-src/modules/contents/posts/tags/components/TagEditingModal.vue
+++ b/ui/console-src/modules/contents/posts/tags/components/TagEditingModal.vue
@@ -274,6 +274,7 @@ async function slugUniqueValidation(node: FormKitNode) {
           :key="formState.metadata.name"
           ref="annotationsFormRef"
           :value="formState.metadata.annotations"
+          :form-data="formState"
           kind="Tag"
           group="content.halo.run"
         />

--- a/ui/console-src/modules/interface/menus/components/MenuItemEditingModal.vue
+++ b/ui/console-src/modules/interface/menus/components/MenuItemEditingModal.vue
@@ -369,6 +369,7 @@ onMounted(() => {
           ref="annotationsFormRef"
           :value="formState.metadata.annotations"
           kind="MenuItem"
+          :form-data="formState"
           group=""
         />
       </div>

--- a/ui/console-src/modules/system/users/components/UserEditingModal.vue
+++ b/ui/console-src/modules/system/users/components/UserEditingModal.vue
@@ -143,6 +143,7 @@ const handleUpdateUser = async () => {
           :key="formState.metadata.name"
           ref="annotationsFormRef"
           :value="formState.metadata.annotations"
+          :form-data="formState"
           kind="User"
           group=""
         />

--- a/ui/src/components/form/AnnotationsForm.vue
+++ b/ui/src/components/form/AnnotationsForm.vue
@@ -33,15 +33,17 @@ const props = withDefaults(
     value?: {
       [key: string]: string;
     } | null;
+    formData?: unknown;
   }>(),
   {
     value: null,
+    formData: undefined,
   }
 );
 
 const annotationSettings = ref<AnnotationSetting[]>([] as AnnotationSetting[]);
 
-const avaliableAnnotationSettings = computed(() => {
+const availableAnnotationSettings = computed(() => {
   return annotationSettings.value.filter((setting) => {
     if (!setting.metadata.labels?.["theme.halo.run/theme-name"]) {
       return true;
@@ -87,7 +89,7 @@ const customAnnotations = computed(() => {
 const handleProcessCustomAnnotations = () => {
   let formSchemas: FormKitSchemaNode[] = [];
 
-  avaliableAnnotationSettings.value.forEach((annotationSetting) => {
+  availableAnnotationSettings.value.forEach((annotationSetting) => {
     formSchemas = formSchemas.concat(
       annotationSetting.spec?.formSchema as FormKitSchemaNode[]
     );
@@ -169,7 +171,7 @@ const specFormInvalid = ref(true);
 const customFormInvalid = ref(true);
 
 const handleSubmit = async () => {
-  if (avaliableAnnotationSettings.value.length) {
+  if (availableAnnotationSettings.value.length) {
     submitForm(specFormId);
   } else {
     specFormInvalid.value = false;
@@ -212,7 +214,7 @@ function onCustomFormToggle(e: Event) {
 <template>
   <div class="flex flex-col gap-3 divide-y divide-gray-100">
     <FormKit
-      v-if="annotations && avaliableAnnotationSettings.length > 0"
+      v-if="annotations && availableAnnotationSettings.length > 0"
       :id="specFormId"
       v-model="annotations"
       type="form"
@@ -221,7 +223,7 @@ function onCustomFormToggle(e: Event) {
       @submit="specFormInvalid = false"
     >
       <template
-        v-for="(annotationSetting, index) in avaliableAnnotationSettings"
+        v-for="(annotationSetting, index) in availableAnnotationSettings"
       >
         <FormKitSchema
           v-if="annotationSetting.spec?.formSchema"
@@ -229,6 +231,9 @@ function onCustomFormToggle(e: Event) {
           :schema="
             annotationSetting.spec?.formSchema as FormKitSchemaDefinition
           "
+          :data="{
+            formData,
+          }"
         />
       </template>
     </FormKit>
@@ -265,7 +270,7 @@ function onCustomFormToggle(e: Event) {
         :id="customFormId"
         type="form"
         :preserve="true"
-        :form-class="`${avaliableAnnotationSettings.length ? 'py-4' : ''}`"
+        :form-class="`${availableAnnotationSettings.length ? 'py-4' : ''}`"
         @submit-invalid="onCustomFormSubmitCheck"
         @submit="customFormInvalid = false"
       >


### PR DESCRIPTION
#### What type of PR is this?

/area ui
/kind feature
/milestone 2.22.x

#### What this PR does / why we need it:

Inject the current formData into the context of Annotation Form to support conditionally displaying form fields based on formData in form definitions. Use case example:

When a theme provides multiple rendering templates for posts, if a specific template requires some additional data, we may need to render different Annotation form fields based on the template selected by the user, since we don't want to display all Annotation Form fields for all posts.

```yaml
apiVersion: v1alpha1
kind: AnnotationSetting
metadata:
  generateName: annotation-setting-
spec:
  targetRef:
    group: content.halo.run
    kind: Post
  formSchema:
    - $formkit: text
      name: weather
      key: weather
      if: "$formData.spec.template == 'diary.html'" # Only show the current weather input box when the rendering template is a diary
      label: Current weather
    - $formkit: text
      name: posting_link
      key: posting_link
      if: "$formData.spec.template == 'job.html'" # Only display the job posting link when the rendering template is for job information.
      label: Job posting link
```

#### Does this PR introduce a user-facing change?

```release-note
为文章、页面等元数据表单注入当前表单的数据，以便在元数据定义中判断是否需要显示表单项
```
