### PR TITLE
Refactor the logic of obtaining post cursor

### DIFF
--- a/application/src/main/java/run/halo/app/core/endpoint/theme/PostQueryEndpoint.java
+++ b/application/src/main/java/run/halo/app/core/endpoint/theme/PostQueryEndpoint.java
@@ -85,14 +85,7 @@ public class PostQueryEndpoint implements CustomEndpoint {
     private Mono<ServerResponse> getPostNavigationByName(ServerRequest request) {
         final var name = request.pathVariable("name");
         return postFinder.cursor(name)
-            .doOnNext(result -> {
-                if (result.getCurrent() == null) {
-                    throw new NotFoundException("Post not found");
-                }
-            })
-            .flatMap(result -> ServerResponse.ok().contentType(MediaType.APPLICATION_JSON)
-                .bodyValue(result)
-            );
+            .flatMap(result -> ServerResponse.ok().bodyValue(result));
     }
 
     private Mono<ServerResponse> getPostByName(ServerRequest request) {

--- a/application/src/main/java/run/halo/app/theme/finders/impl/PostFinderImpl.java
+++ b/application/src/main/java/run/halo/app/theme/finders/impl/PostFinderImpl.java
@@ -1,5 +1,6 @@
 package run.halo.app.theme.finders.impl;
 
+import static run.halo.app.extension.PageRequestImpl.ofSize;
 import static run.halo.app.extension.index.query.Queries.equal;
 import static run.halo.app.extension.index.query.Queries.in;
 import static run.halo.app.extension.index.query.Queries.notEqual;
@@ -15,8 +16,6 @@ import org.apache.commons.lang3.BooleanUtils;
 import org.apache.commons.lang3.ObjectUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.data.domain.Sort;
-import org.springframework.lang.NonNull;
-import org.springframework.util.Assert;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import run.halo.app.content.CategoryService;
@@ -27,7 +26,6 @@ import run.halo.app.extension.ListResult;
 import run.halo.app.extension.PageRequest;
 import run.halo.app.extension.PageRequestImpl;
 import run.halo.app.extension.ReactiveExtensionClient;
-import run.halo.app.extension.exception.ExtensionNotFoundException;
 import run.halo.app.extension.index.query.Condition;
 import run.halo.app.extension.index.query.Queries;
 import run.halo.app.extension.router.selector.FieldSelector;
@@ -88,62 +86,71 @@ public class PostFinderImpl implements PostFinder {
         );
     }
 
-    @NonNull
-    static LinkNavigation findPostNavigation(List<String> postNames, String target) {
-        Assert.notNull(target, "Target post name must not be null");
-        for (int i = 0; i < postNames.size(); i++) {
-            var item = postNames.get(i);
-            if (target.equals(item)) {
-                var prevLink = (i > 0) ? postNames.get(i - 1) : null;
-                var nextLink = (i < postNames.size() - 1) ? postNames.get(i + 1) : null;
-                return new LinkNavigation(prevLink, target, nextLink);
-            }
-        }
-        return new LinkNavigation(null, target, null);
-    }
-
     static Sort archiveSort() {
         return Sort.by(Sort.Order.desc("spec.publishTime"),
             Sort.Order.desc("metadata.name")
         );
     }
 
-    private Mono<PostVo> fetchByName(String name) {
-        if (StringUtils.isBlank(name)) {
-            return Mono.empty();
-        }
-        return getByName(name)
-            .onErrorResume(ExtensionNotFoundException.class::isInstance, (error) -> Mono.empty());
-    }
-
     @Override
     public Mono<NavigationPostVo> cursor(String currentName) {
-        // TODO Refine this feature
+        return client.fetch(Post.class, currentName)
+            // make sure the current post is published and has publishing time
+            .filter(p -> Post.isPublished(p.getMetadata()))
+            .filter(p -> p.getSpec() != null && p.getSpec().getPublishTime() != null)
+            .flatMap(currentPost -> {
+                var findPreviousPost = findPreviousPost(currentPost).map(Optional::of)
+                    .defaultIfEmpty(Optional.empty());
+                var findNextPost = findNextPost(currentPost).map(Optional::of)
+                    .defaultIfEmpty(Optional.empty());
+                return Mono.zip(findPreviousPost, findNextPost, (previous, next) ->
+                    NavigationPostVo.builder()
+                        .previous(previous.map(ListedPostVo::from).orElse(null))
+                        .next(next.map(ListedPostVo::from).orElse(null))
+                        .build()
+                );
+            })
+            .switchIfEmpty(Mono.fromSupplier(NavigationPostVo::empty));
+    }
+
+    private Mono<Post> findPreviousPost(Post currentPost) {
+        var publishTime = currentPost.getSpec().getPublishTime();
         return postPredicateResolver.getListOptions()
             .map(listOptions -> ListOptions.builder(listOptions)
-                // Exclude hidden posts
                 .andQuery(notHiddenPostQuery())
+                .andQuery(Queries.lessThan("spec.publishTime", publishTime))
                 .build()
             )
-            .flatMap(listOptions -> client.listNamesBy(Post.class, listOptions,
-                PageRequestImpl.ofSize(1).withSort(defaultSort()))
-            )
-            .flatMap(listResult -> {
-                var postNames = listResult.getItems();
-                var previousNextPair = findPostNavigation(postNames, currentName);
-                String previousPostName = previousNextPair.prev();
-                String nextPostName = previousNextPair.next();
-                var builder = NavigationPostVo.builder();
-                var currentMono = getByName(currentName)
-                    .doOnNext(builder::current);
-                var prevMono = fetchByName(previousPostName)
-                    .doOnNext(builder::previous);
-                var nextMono = fetchByName(nextPostName)
-                    .doOnNext(builder::next);
-                return Mono.when(currentMono, prevMono, nextMono)
-                    .then(Mono.fromSupplier(builder::build));
+            .flatMap(listOptions -> {
+                var sort = Sort.by(
+                    Sort.Order.desc("spec.publishTime"),
+                    Sort.Order.desc("metadata.name")
+                );
+                return client.listBy(
+                    Post.class, listOptions, ofSize(1).withSort(sort)
+                );
             })
-            .defaultIfEmpty(NavigationPostVo.empty());
+            .flatMap(listResult -> Mono.justOrEmpty(listResult.getItems().stream().findFirst()));
+    }
+
+    private Mono<Post> findNextPost(Post currentPost) {
+        var publishTime = currentPost.getSpec().getPublishTime();
+        return postPredicateResolver.getListOptions()
+            .map(listOptions -> ListOptions.builder(listOptions)
+                .andQuery(notHiddenPostQuery())
+                .andQuery(Queries.greaterThan("spec.publishTime", publishTime))
+                .build()
+            )
+            .flatMap(listOptions -> {
+                var sort = Sort.by(
+                    Sort.Order.asc("spec.publishTime"),
+                    Sort.Order.asc("metadata.name")
+                );
+                return client.listBy(
+                    Post.class, listOptions, ofSize(1).withSort(sort)
+                );
+            })
+            .flatMap(listResult -> Mono.justOrEmpty(listResult.getItems().stream().findFirst()));
     }
 
     private static Condition notHiddenPostQuery() {
@@ -301,9 +308,6 @@ public class PostFinderImpl implements PostFinder {
 
     static int sizeNullSafe(Integer size) {
         return ObjectUtils.defaultIfNull(size, 10);
-    }
-
-    record LinkNavigation(String prev, String current, String next) {
     }
 
     @Data

--- a/application/src/main/java/run/halo/app/theme/finders/vo/NavigationPostVo.java
+++ b/application/src/main/java/run/halo/app/theme/finders/vo/NavigationPostVo.java
@@ -4,30 +4,43 @@ import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.NOT_REQUIR
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
-import lombok.Value;
+import org.jspecify.annotations.Nullable;
 
 /**
  * Post navigation vo to hold previous and next item.
  *
+ * @param previous Previous post. It's publishing time is earlier than current post.
+ * @param next Next post. It's publishing time is later than current post.
  * @author guqing
+ * @author johnniang
  * @since 2.0.0
  */
-@Value
 @Builder
-public class NavigationPostVo {
+public record NavigationPostVo(
 
     @Schema(requiredMode = NOT_REQUIRED)
-    PostVo previous;
-
-    PostVo current;
+    @Nullable
+    ListedPostVo previous,
 
     @Schema(requiredMode = NOT_REQUIRED)
-    PostVo next;
+    @Nullable
+    ListedPostVo next
 
+) {
+    /**
+     * Indicates whether it has next post.
+     *
+     * @return true if it has next post, false otherwise
+     */
     public boolean hasNext() {
         return next != null;
     }
 
+    /**
+     * Indicates whether it has previous post.
+     *
+     * @return true if it has previous post, false otherwise
+     */
     public boolean hasPrevious() {
         return previous != null;
     }

--- a/application/src/test/java/run/halo/app/core/endpoint/theme/PostQueryEndpointTest.java
+++ b/application/src/test/java/run/halo/app/core/endpoint/theme/PostQueryEndpointTest.java
@@ -92,7 +92,7 @@ class PostQueryEndpointTest {
         Metadata metadata = new Metadata();
         metadata.setName("test");
         NavigationPostVo navigation = NavigationPostVo.builder()
-            .current(PostVo.builder().metadata(metadata).build())
+            .next(ListedPostVo.builder().metadata(metadata).build())
             .build();
         when(postFinder.cursor(anyString()))
             .thenReturn(Mono.just(navigation));
@@ -102,7 +102,7 @@ class PostQueryEndpointTest {
             .expectStatus().isOk()
             .expectHeader().contentType(MediaType.APPLICATION_JSON)
             .expectBody()
-            .jsonPath("$.current.metadata.name").isEqualTo("test");
+            .jsonPath("$.next.metadata.name").isEqualTo("test");
 
         verify(postFinder).cursor(anyString());
     }

--- a/application/src/test/java/run/halo/app/theme/finders/impl/PostFinderImplTest.java
+++ b/application/src/test/java/run/halo/app/theme/finders/impl/PostFinderImplTest.java
@@ -5,7 +5,6 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
 import java.time.Instant;
-import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -101,37 +100,6 @@ class PostFinderImplTest {
         assertThat(items.get(1).getYear()).isEqualTo("2021");
         assertThat(items.get(1).getMonths()).hasSize(1);
         assertThat(items.get(1).getMonths().get(0).getMonth()).isEqualTo("01");
-    }
-
-    @Test
-    void postPreviousNextPair() {
-        List<String> postNames = new ArrayList<>();
-        for (int i = 0; i < 10; i++) {
-            postNames.add("post-" + i);
-        }
-
-        // post-0, post-1, post-2
-        var previousNextPair = PostFinderImpl.findPostNavigation(postNames, "post-0");
-        assertThat(previousNextPair.prev()).isNull();
-        assertThat(previousNextPair.next()).isEqualTo("post-1");
-
-        previousNextPair = PostFinderImpl.findPostNavigation(postNames, "post-1");
-        assertThat(previousNextPair.prev()).isEqualTo("post-0");
-        assertThat(previousNextPair.next()).isEqualTo("post-2");
-
-        // post-1, post-2, post-3
-        previousNextPair = PostFinderImpl.findPostNavigation(postNames, "post-2");
-        assertThat(previousNextPair.prev()).isEqualTo("post-1");
-        assertThat(previousNextPair.next()).isEqualTo("post-3");
-
-        // post-7, post-8, post-9
-        previousNextPair = PostFinderImpl.findPostNavigation(postNames, "post-8");
-        assertThat(previousNextPair.prev()).isEqualTo("post-7");
-        assertThat(previousNextPair.next()).isEqualTo("post-9");
-
-        previousNextPair = PostFinderImpl.findPostNavigation(postNames, "post-9");
-        assertThat(previousNextPair.prev()).isEqualTo("post-8");
-        assertThat(previousNextPair.next()).isNull();
     }
 
     List<Post> postsForArchives() {


### PR DESCRIPTION
#### What type of PR is this?

/kind improvement
/area core
/area theme
/milestone 2.22.x

#### What this PR does / why we need it:

This PR refactors the logic of obtaining post cursor. 

Please note that the current post is removed and change the type of previous and next post into ListedPostVo instead of PostVo due to useless.

#### Which issue(s) this PR fixes:

Fixes https://github.com/halo-dev/halo/issues/8016

#### Special notes for your reviewer:

Try to install and activate theme `theme-earth` and create multiple posts, then request one of posts and see the previous and next components.

#### Does this PR introduce a user-facing change?

```release-note
优化文章详情页面加载
```

