### PR TITLE
Add workflow to close stale issues automatically

### DIFF
--- a/.github/workflows/stale-issues.yaml
+++ b/.github/workflows/stale-issues.yaml
@@ -1,0 +1,30 @@
+name: Close Stale Issues
+
+on:
+  schedule:
+    - cron: "30 1 * * *"
+  workflow_dispatch:
+
+permissions:
+  issues: write
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v10
+        with:
+          stale-issue-message: |
+            This issue has been automatically marked as stale because it has not had recent activity.
+            It will be closed if no further activity occurs within the next 2 days.
+            If you believe this issue is still relevant, please provide the requested information.
+          close-issue-message: |
+            This issue has been automatically closed due to inactivity.
+            If you have the requested information, feel free to reopen it or create a new issue.
+          days-before-issue-stale: 60
+          days-before-issue-close: 2
+          days-before-pr-stale: -1
+          days-before-pr-close: -1
+          only-issue-labels: "triage/needs-information"
+          operations-per-run: 100
+          ascending: true


### PR DESCRIPTION
#### What type of PR is this?

None

#### What this PR does / why we need it:

Introduces a GitHub Actions workflow that marks issues labeled 'triage/needs-information' as stale after 60 days of inactivity and closes them after 2 additional days. This helps keep the issue tracker clean by automatically managing inactive issues.

#### Does this PR introduce a user-facing change?

```release-note
None
```
