### PR TITLE
Add valueOnly prop to Iconify input for string values

### DIFF
--- a/ui/src/formkit/inputs/iconify/feature.ts
+++ b/ui/src/formkit/inputs/iconify/feature.ts
@@ -1,4 +1,5 @@
 import type { FormKitNode } from "@formkit/core";
+import { undefine } from "@formkit/utils";
 
 /**
  * Ensure that the content entered for iconify is correctly set, and use the default value when it is not set.
@@ -8,5 +9,6 @@ export default function iconifyFeature(node: FormKitNode): void {
   node.on("created", () => {
     node.props.format = node.props.format ?? "svg";
     node.props.popperPlacement = node.props.popperPlacement ?? "auto";
+    node.props.valueOnly = undefine(node.props.valueOnly);
   });
 }

--- a/ui/src/formkit/inputs/iconify/index.ts
+++ b/ui/src/formkit/inputs/iconify/index.ts
@@ -8,7 +8,7 @@ export const iconify = createInput(
   defineAsyncComponent(() => import("./IconifyInput.vue")),
   {
     type: "input",
-    props: ["format", "popperPlacement"],
+    props: ["format", "popperPlacement", "valueOnly"],
     features: [initialValue, iconifyFeature],
   }
 );
@@ -17,8 +17,9 @@ declare module "@formkit/inputs" {
   export interface FormKitInputProps<Props extends FormKitInputs<Props>> {
     iconify: {
       type: "iconify";
-      value?: IconifyValue;
+      value?: IconifyValue | string;
       format: IconifyFormat;
+      valueOnly?: boolean;
     };
   }
 }


### PR DESCRIPTION
#### What type of PR is this?

/area ui
/kind api-change
/kind improvement
/milestone 2.22.x

#### What this PR does / why we need it:

In https://github.com/halo-dev/halo/pull/8042, we refactored the data interface for the Iconify form type to use an object for preserving the raw Iconify icon data. However, we later discovered that some business Annotation forms might not support object data types, so this PR adds a property called `value-only` which, when set, returns the data as a string type instead.

#### Does this PR introduce a user-facing change?

```release-note
None
```
