### PR TITLE
Refactor attachment policy fetching and UI components

### DIFF
--- a/ui/console-src/modules/contents/attachments/AttachmentList.vue
+++ b/ui/console-src/modules/contents/attachments/AttachmentList.vue
@@ -44,7 +44,7 @@ const policyVisible = ref(false);
 const uploadVisible = ref(false);
 const detailVisible = ref(false);
 
-const { policies } = useFetchAttachmentPolicy();
+const { data: policies } = useFetchAttachmentPolicy();
 const { groups } = useFetchAttachmentGroup();
 
 const selectedGroup = useRouteQuery<string | undefined>("group");

--- a/ui/console-src/modules/contents/attachments/components/AttachmentListItem.vue
+++ b/ui/console-src/modules/contents/attachments/components/AttachmentListItem.vue
@@ -34,7 +34,7 @@ const props = withDefaults(
 
 const { attachment } = toRefs(props);
 
-const { policies } = useFetchAttachmentPolicy();
+const { data: policies } = useFetchAttachmentPolicy();
 
 const emit = defineEmits<{
   (event: "select", attachment?: Attachment): void;

--- a/ui/console-src/modules/contents/attachments/components/AttachmentPoliciesListItem.vue
+++ b/ui/console-src/modules/contents/attachments/components/AttachmentPoliciesListItem.vue
@@ -1,0 +1,151 @@
+<script lang="ts" setup>
+import { SYSTEM_PROTECTION } from "@/constants/finalizers";
+import { attachmentPolicyLabels } from "@/constants/labels";
+import {
+  consoleApiClient,
+  coreApiClient,
+  type Policy,
+} from "@halo-dev/api-client";
+import {
+  Dialog,
+  IconEyeOff,
+  Toast,
+  VDropdownItem,
+  VEntity,
+  VEntityField,
+  VStatusDot,
+  VTag,
+} from "@halo-dev/components";
+import { utils } from "@halo-dev/ui-shared";
+import { useQueryClient } from "@tanstack/vue-query";
+import { computed, ref } from "vue";
+import { useI18n } from "vue-i18n";
+import { useFetchAttachmentPolicyTemplate } from "../composables/use-attachment-policy";
+import AttachmentPolicyEditingModal from "./AttachmentPolicyEditingModal.vue";
+
+const queryClient = useQueryClient();
+
+const props = defineProps<{
+  policy: Policy;
+}>();
+
+const { t } = useI18n();
+
+const { data: policyTemplates } = useFetchAttachmentPolicyTemplate();
+
+const templateDisplayName = computed(() => {
+  const policyTemplate = policyTemplates.value?.find(
+    (template) => template.metadata.name === props.policy.spec.templateName
+  );
+  return policyTemplate?.spec?.displayName || "--";
+});
+
+const editingModalVisible = ref(false);
+
+const handleDelete = async () => {
+  const { data } = await consoleApiClient.storage.attachment.searchAttachments({
+    fieldSelector: [`spec.policyName=${props.policy.metadata.name}`],
+  });
+
+  if (data.total > 0) {
+    Dialog.warning({
+      title: t(
+        "core.attachment.policies_modal.operations.can_not_delete.title"
+      ),
+      description: t(
+        "core.attachment.policies_modal.operations.can_not_delete.description"
+      ),
+      confirmText: t("core.common.buttons.confirm"),
+      showCancel: false,
+    });
+    return;
+  }
+
+  Dialog.warning({
+    title: t("core.attachment.policies_modal.operations.delete.title"),
+    description: t(
+      "core.attachment.policies_modal.operations.delete.description"
+    ),
+    confirmType: "danger",
+    confirmText: t("core.common.buttons.confirm"),
+    cancelText: t("core.common.buttons.cancel"),
+    onConfirm: async () => {
+      await coreApiClient.storage.policy.deletePolicy({
+        name: props.policy.metadata.name,
+      });
+
+      Toast.success(t("core.common.toast.delete_success"));
+      queryClient.invalidateQueries({ queryKey: ["attachment-policies"] });
+    },
+  });
+};
+
+const isHidden = computed(() => {
+  return (
+    props.policy.metadata.labels?.[attachmentPolicyLabels.HIDDEN] === "true"
+  );
+});
+
+const isSystemProtection = computed(() => {
+  return props.policy.metadata.finalizers?.includes(SYSTEM_PROTECTION);
+});
+</script>
+<template>
+  <VEntity :key="policy.metadata.name">
+    <template #start>
+      <VEntityField
+        :title="policy.spec.displayName"
+        :description="templateDisplayName"
+      ></VEntityField>
+    </template>
+    <template #end>
+      <VEntityField>
+        <template v-if="isSystemProtection" #description>
+          <VTag>{{ $t("core.common.text.system_protection") }}</VTag>
+        </template>
+      </VEntityField>
+      <VEntityField v-if="isHidden">
+        <template #description>
+          <IconEyeOff class="text-sm transition-all hover:text-blue-600" />
+        </template>
+      </VEntityField>
+      <VEntityField v-if="policy.metadata.deletionTimestamp">
+        <template #description>
+          <VStatusDot
+            v-tooltip="$t('core.common.status.deleting')"
+            state="warning"
+            animate
+          />
+        </template>
+      </VEntityField>
+      <VEntityField>
+        <template #description>
+          <span class="truncate text-xs tabular-nums text-gray-500">
+            {{ utils.date.format(policy.metadata.creationTimestamp) }}
+          </span>
+        </template>
+      </VEntityField>
+    </template>
+    <template #dropdownItems>
+      <VDropdownItem
+        :disabled="isSystemProtection"
+        @click="editingModalVisible = true"
+      >
+        {{ $t("core.common.buttons.edit") }}
+      </VDropdownItem>
+      <VDropdownItem
+        :disabled="isSystemProtection"
+        type="danger"
+        @click="handleDelete"
+      >
+        {{ $t("core.common.buttons.delete") }}
+      </VDropdownItem>
+    </template>
+  </VEntity>
+
+  <AttachmentPolicyEditingModal
+    v-if="editingModalVisible"
+    :policy="policy"
+    @close="editingModalVisible = false"
+  />
+</template>

--- a/ui/console-src/modules/contents/attachments/components/AttachmentPoliciesModal.vue
+++ b/ui/console-src/modules/contents/attachments/components/AttachmentPoliciesModal.vue
@@ -1,108 +1,50 @@
 <script lang="ts" setup>
-import { SYSTEM_PROTECTION } from "@/constants/finalizers";
 import type { Policy, PolicyTemplate } from "@halo-dev/api-client";
-import { consoleApiClient, coreApiClient } from "@halo-dev/api-client";
 import {
-  Dialog,
   IconAddCircle,
-  Toast,
   VButton,
   VDropdown,
   VDropdownItem,
   VEmpty,
-  VEntity,
   VEntityContainer,
-  VEntityField,
   VModal,
   VSpace,
-  VStatusDot,
-  VTag,
 } from "@halo-dev/components";
-import { utils } from "@halo-dev/ui-shared";
 import { ref } from "vue";
-import { useI18n } from "vue-i18n";
 import {
   useFetchAttachmentPolicy,
   useFetchAttachmentPolicyTemplate,
 } from "../composables/use-attachment-policy";
+import AttachmentPoliciesListItem from "./AttachmentPoliciesListItem.vue";
 import AttachmentPolicyEditingModal from "./AttachmentPolicyEditingModal.vue";
 
 const emit = defineEmits<{
   (event: "close"): void;
 }>();
 
-const { t } = useI18n();
-
-const { policies, isLoading, handleFetchPolicies } = useFetchAttachmentPolicy();
-const { policyTemplates } = useFetchAttachmentPolicyTemplate();
+const {
+  data: policies,
+  isLoading,
+  refetch: handleFetchPolicies,
+} = useFetchAttachmentPolicy();
+const { data: policyTemplates } = useFetchAttachmentPolicyTemplate();
 
 const modal = ref<InstanceType<typeof VModal> | null>(null);
 const selectedPolicy = ref<Policy>();
 const selectedTemplateName = ref();
 
-const policyEditingModal = ref(false);
-
-const handleOpenEditingModal = (policy: Policy) => {
-  selectedPolicy.value = policy;
-  policyEditingModal.value = true;
-};
+const creationModalVisible = ref(false);
 
 const handleOpenCreateNewPolicyModal = (policyTemplate: PolicyTemplate) => {
   selectedTemplateName.value = policyTemplate.metadata.name;
-  policyEditingModal.value = true;
+  creationModalVisible.value = true;
 };
 
-const handleDelete = async (policy: Policy) => {
-  const { data } = await consoleApiClient.storage.attachment.searchAttachments({
-    fieldSelector: [`spec.policyName=${policy.metadata.name}`],
-  });
-
-  if (data.total > 0) {
-    Dialog.warning({
-      title: t(
-        "core.attachment.policies_modal.operations.can_not_delete.title"
-      ),
-      description: t(
-        "core.attachment.policies_modal.operations.can_not_delete.description"
-      ),
-      confirmText: t("core.common.buttons.confirm"),
-      showCancel: false,
-    });
-    return;
-  }
-
-  Dialog.warning({
-    title: t("core.attachment.policies_modal.operations.delete.title"),
-    description: t(
-      "core.attachment.policies_modal.operations.delete.description"
-    ),
-    confirmType: "danger",
-    confirmText: t("core.common.buttons.confirm"),
-    cancelText: t("core.common.buttons.cancel"),
-    onConfirm: async () => {
-      await coreApiClient.storage.policy.deletePolicy({
-        name: policy.metadata.name,
-      });
-
-      Toast.success(t("core.common.toast.delete_success"));
-      handleFetchPolicies();
-    },
-  });
-};
-
-const onEditingModalClose = () => {
+const onCreationModalClose = () => {
   selectedPolicy.value = undefined;
   selectedTemplateName.value = undefined;
-  handleFetchPolicies();
-  policyEditingModal.value = false;
+  creationModalVisible.value = false;
 };
-
-function getPolicyTemplateDisplayName(templateName: string) {
-  const policyTemplate = policyTemplates.value?.find(
-    (template) => template.metadata.name === templateName
-  );
-  return policyTemplate?.spec?.displayName || "--";
-}
 </script>
 <template>
   <VModal
@@ -111,6 +53,7 @@ function getPolicyTemplateDisplayName(templateName: string) {
     :title="$t('core.attachment.policies_modal.title')"
     :body-class="['!p-0']"
     :layer-closable="true"
+    :centered="false"
     @close="emit('close')"
   >
     <template #actions>
@@ -160,57 +103,11 @@ function getPolicyTemplateDisplayName(templateName: string) {
       </template>
     </VEmpty>
     <VEntityContainer v-else>
-      <VEntity v-for="policy in policies" :key="policy.metadata.name">
-        <template #start>
-          <VEntityField
-            :title="policy.spec.displayName"
-            :description="
-              getPolicyTemplateDisplayName(policy.spec.templateName)
-            "
-          ></VEntityField>
-        </template>
-        <template #end>
-          <VEntityField>
-            <template
-              v-if="policy.metadata.finalizers?.includes(SYSTEM_PROTECTION)"
-              #description
-            >
-              <VTag>{{ $t("core.common.text.system_protection") }}</VTag>
-            </template>
-          </VEntityField>
-          <VEntityField v-if="policy.metadata.deletionTimestamp">
-            <template #description>
-              <VStatusDot
-                v-tooltip="$t('core.common.status.deleting')"
-                state="warning"
-                animate
-              />
-            </template>
-          </VEntityField>
-          <VEntityField>
-            <template #description>
-              <span class="truncate text-xs tabular-nums text-gray-500">
-                {{ utils.date.format(policy.metadata.creationTimestamp) }}
-              </span>
-            </template>
-          </VEntityField>
-        </template>
-        <template #dropdownItems>
-          <VDropdownItem
-            :disabled="policy.metadata.finalizers?.includes(SYSTEM_PROTECTION)"
-            @click="handleOpenEditingModal(policy)"
-          >
-            {{ $t("core.common.buttons.edit") }}
-          </VDropdownItem>
-          <VDropdownItem
-            :disabled="policy.metadata.finalizers?.includes(SYSTEM_PROTECTION)"
-            type="danger"
-            @click="handleDelete(policy)"
-          >
-            {{ $t("core.common.buttons.delete") }}
-          </VDropdownItem>
-        </template>
-      </VEntity>
+      <AttachmentPoliciesListItem
+        v-for="policy in policies"
+        :key="policy.metadata.name"
+        :policy="policy"
+      />
     </VEntityContainer>
     <template #footer>
       <VButton @click="modal?.close()">
@@ -220,9 +117,9 @@ function getPolicyTemplateDisplayName(templateName: string) {
   </VModal>
 
   <AttachmentPolicyEditingModal
-    v-if="policyEditingModal"
+    v-if="creationModalVisible"
     :policy="selectedPolicy"
     :template-name="selectedTemplateName"
-    @close="onEditingModalClose"
+    @close="onCreationModalClose"
   />
 </template>

--- a/ui/console-src/modules/contents/attachments/components/AttachmentPolicyBadge.vue
+++ b/ui/console-src/modules/contents/attachments/components/AttachmentPolicyBadge.vue
@@ -21,7 +21,7 @@ const props = withDefaults(
   }
 );
 
-const { policyTemplates } = useFetchAttachmentPolicyTemplate();
+const { data: policyTemplates } = useFetchAttachmentPolicyTemplate();
 
 const policyTemplate = computed(() => {
   return policyTemplates.value?.find(

--- a/ui/console-src/modules/contents/attachments/components/AttachmentPolicyEditingModal.vue
+++ b/ui/console-src/modules/contents/attachments/components/AttachmentPolicyEditingModal.vue
@@ -6,11 +6,13 @@ import type { FormKitSchemaCondition, FormKitSchemaNode } from "@formkit/core";
 import type { JsonPatchInner, Policy } from "@halo-dev/api-client";
 import { consoleApiClient, coreApiClient } from "@halo-dev/api-client";
 import { Toast, VButton, VLoading, VModal, VSpace } from "@halo-dev/components";
-import { useQuery } from "@tanstack/vue-query";
+import { useQuery, useQueryClient } from "@tanstack/vue-query";
 import { computed, onMounted, ref, toRaw, toRefs } from "vue";
 import { useI18n } from "vue-i18n";
 
 const CONFIG_MAP_GROUP = "default";
+
+const queryClient = useQueryClient();
 
 const props = withDefaults(
   defineProps<{
@@ -220,6 +222,7 @@ const handleSave = async (data: {
     console.error("Failed to save attachment policy", e);
   } finally {
     isSubmitting.value = false;
+    queryClient.invalidateQueries({ queryKey: ["attachment-policies"] });
   }
 };
 

--- a/ui/console-src/modules/contents/attachments/components/AttachmentUploadModal.vue
+++ b/ui/console-src/modules/contents/attachments/components/AttachmentUploadModal.vue
@@ -40,26 +40,14 @@ const groupEditingModal = ref(false);
 const policyTemplateNameToCreate = ref();
 
 const { groups, handleFetchGroups } = useFetchAttachmentGroup();
-const { policyTemplates } = useFetchAttachmentPolicyTemplate();
-const { policies: allPolicies, handleFetchPolicies } =
+const { data: policyTemplates } = useFetchAttachmentPolicyTemplate();
+const { data: allPolicies, refetch: handleFetchPolicies } =
   useFetchAttachmentPolicy();
 
 const policies = computed(() => {
-  return allPolicies.value
-    ?.filter((policy) => {
-      return policy.metadata.labels?.[attachmentPolicyLabels.HIDDEN] !== "true";
-    })
-    .sort((a, b) => {
-      const priorityA = parseInt(
-        a.metadata.labels?.[attachmentPolicyLabels.PRIORITY] || "0",
-        10
-      );
-      const priorityB = parseInt(
-        b.metadata.labels?.[attachmentPolicyLabels.PRIORITY] || "0",
-        10
-      );
-      return priorityB - priorityA;
-    });
+  return allPolicies.value?.filter((policy) => {
+    return policy.metadata.labels?.[attachmentPolicyLabels.HIDDEN] !== "true";
+  });
 });
 
 onMounted(() => {

--- a/ui/console-src/modules/contents/attachments/components/selector-providers/CoreSelectorProvider.vue
+++ b/ui/console-src/modules/contents/attachments/components/selector-providers/CoreSelectorProvider.vue
@@ -51,7 +51,7 @@ const emit = defineEmits<{
   (event: "change-provider", providerId: string): void;
 }>();
 
-const { policies } = useFetchAttachmentPolicy();
+const { data: policies } = useFetchAttachmentPolicy();
 
 const keyword = ref("");
 const selectedGroup = ref();

--- a/ui/console-src/modules/contents/attachments/components/selector-providers/components/AttachmentSelectorListItem.vue
+++ b/ui/console-src/modules/contents/attachments/components/selector-providers/components/AttachmentSelectorListItem.vue
@@ -21,7 +21,7 @@ const props = withDefaults(
 
 const { attachment } = toRefs(props);
 
-const { policies } = useFetchAttachmentPolicy();
+const { data: policies } = useFetchAttachmentPolicy();
 
 const emit = defineEmits<{
   (event: "select", attachment?: Attachment): void;


### PR DESCRIPTION
#### What type of PR is this?

/area ui
/kind improvement
/milestone 2.22.x

#### What this PR does / why we need it:

This PR adds support for displaying hidden status in the attachment storage policy list and optimizes the related component structure for better maintainability in the future.

<img width="783" height="134" alt="image" src="https://github.com/user-attachments/assets/2074b827-1755-4822-905a-9d0cd601d0c6" />

#### Does this PR introduce a user-facing change?

```release-note
None
```
