### PR TITLE
Add empty messages object to i18n config

### DIFF
--- a/ui/src/locales/index.ts
+++ b/ui/src/locales/index.ts
@@ -72,18 +72,16 @@ export async function setLanguage(_language?: string): Promise<void> {
         i18n.global.setLocaleMessage(language, messages.default || messages);
       } catch (error) {
         console.error(`Failed to load locale file for ${language}:`, error);
-        await loadFallbackLocale();
-        return;
       }
     } else {
       console.warn(`Locale not found for ${language}, using fallback`);
-      await loadFallbackLocale();
-      return;
     }
   }
 
   i18n.global.locale.value = language;
   utils.date.setLocale(language);
+
+  await loadFallbackLocale();
 }
 
 async function loadFallbackLocale(): Promise<void> {
@@ -106,8 +104,6 @@ async function loadFallbackLocale(): Promise<void> {
       }
     }
   }
-
-  i18n.global.locale.value = fallback;
 }
 
 export function setupI18n(app: App): void {


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/area ui
/milestone 2.22.x

#### What this PR does / why we need it:

Initialized the messages property as an empty object in the i18n configuration to ensure proper setup and avoid potential runtime issues.

#### Which issue(s) this PR fixes:

Fixes #8060 

#### Does this PR introduce a user-facing change?

```release-note
None
```
