### PR TITLE
Move max-in-memory-size configuration under http.codecs in application.yaml

### DIFF
--- a/application/src/main/resources/application.yaml
+++ b/application/src/main/resources/application.yaml
@@ -18,8 +18,9 @@ spring:
     init:
       mode: always
       platform: h2
-  codec:
-    max-in-memory-size: 10MB
+  http:
+    codecs:
+      max-in-memory-size: 10MB
   messages:
     basename: config.i18n.messages
   web:


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup
/area core
/milestone 2.22.x

#### What this PR does / why we need it:

The old configuration property `spring.codec.max-in-memory-size` was deprecated. We are recommended using `spring.http.codecs.max-in-memory-size` instead.

See https://github.com/spring-projects/spring-boot/commit/f039c73db7f5e387701e3a6fd46fb99cb9a630a6 for more.

#### Does this PR introduce a user-facing change?

```release-note
None
```

