### PR TITLE
Update SQL initialization platform to mariadb in application-mariadb.yaml

### DIFF
--- a/application/src/main/resources/application-mariadb.yaml
+++ b/application/src/main/resources/application-mariadb.yaml
@@ -6,4 +6,4 @@ spring:
   sql:
     init:
       mode: always
-      platform: mysql
+      platform: mariadb


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/area core
/milestone 2.22.x

#### What this PR does / why we need it:

This PR updates SQL initialization platform configration to mariadb in application-mariadb.yaml.

#### Does this PR introduce a user-facing change?

```release-note
None
```
