### PR TITLE
Bump UI package versions to 2.22.0

### DIFF
--- a/.github/workflows/release-ui-packages.yaml
+++ b/.github/workflows/release-ui-packages.yaml
@@ -1,18 +1,18 @@
 name: Release UI Packages
 
-permissions:
-  contents: write
-  id-token: write
-
 on:
   release:
     types:
       - published
 
+permissions:
+  contents: write
+  id-token: write
+
 jobs:
   release:
     runs-on: ubuntu-latest
-    if: github.repository == 'halo-dev/halo'
+    if: github.repository == 'halo-dev/halo' && github.event.release.prerelease == false
     steps:
       - uses: actions/checkout@v4
         with:

--- a/ui/packages/api-client/package.json
+++ b/ui/packages/api-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@halo-dev/api-client",
-  "version": "2.21.1",
+  "version": "2.22.0",
   "description": "API Client for Halo 2",
   "homepage": "https://github.com/halo-dev/halo/tree/main/ui/packages/api-client#readme",
   "bugs": {

--- a/ui/packages/components/package.json
+++ b/ui/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@halo-dev/components",
-  "version": "2.21.0",
+  "version": "2.22.0",
   "description": "",
   "keywords": [
     "halo",

--- a/ui/packages/editor/package.json
+++ b/ui/packages/editor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@halo-dev/richtext-editor",
-  "version": "2.21.0",
+  "version": "2.22.0",
   "description": "Default editor for Halo",
   "homepage": "https://github.com/halo-dev/halo/tree/main/ui/packages/editor#readme",
   "bugs": {

--- a/ui/packages/shared/package.json
+++ b/ui/packages/shared/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@halo-dev/ui-shared",
   "type": "module",
-  "version": "2.21.0",
+  "version": "2.22.0",
   "description": "",
   "keywords": [],
   "homepage": "https://github.com/halo-dev/halo/tree/main/ui/packages/shared#readme",

--- a/ui/packages/ui-plugin-bundler-kit/package.json
+++ b/ui/packages/ui-plugin-bundler-kit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@halo-dev/ui-plugin-bundler-kit",
-  "version": "2.21.2",
+  "version": "2.22.0",
   "homepage": "https://github.com/halo-dev/halo/tree/main/ui/packages/ui-plugin-bundler-kit#readme",
   "bugs": {
     "url": "https://github.com/halo-dev/halo/issues"


### PR DESCRIPTION
#### What type of PR is this?

/area ui
/kind cleanup
/milestone 2.22.x

#### What this PR does / why we need it:

Bump UI package versions to 2.22.0

#### Does this PR introduce a user-facing change?

```release-note
None
```
