### PR TITLE
Fix attachment media type handling and improve thumbnail link retrieval logic

### DIFF
--- a/api/src/main/java/run/halo/app/core/extension/attachment/Attachment.java
+++ b/api/src/main/java/run/halo/app/core/extension/attachment/Attachment.java
@@ -10,6 +10,7 @@ import java.util.Set;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
+import org.jspecify.annotations.Nullable;
 import run.halo.app.extension.AbstractExtension;
 import run.halo.app.extension.GVK;
 
@@ -43,6 +44,7 @@ public class Attachment extends AbstractExtension {
         private String ownerName;
 
         @Schema(description = "Media type of attachment")
+        @Nullable
         private String mediaType;
 
         @Schema(description = "Size of attachment. Unit is Byte", minimum = "0")

--- a/api/src/main/java/run/halo/app/core/extension/service/AttachmentService.java
+++ b/api/src/main/java/run/halo/app/core/extension/service/AttachmentService.java
@@ -94,6 +94,13 @@ public interface AttachmentService {
      */
     Mono<URI> getSharedURL(Attachment attachment, Duration ttl);
 
+    /**
+     * Gets thumbnail links using handlers in plugins. Please make sure the attachment has
+     * permalink.
+     *
+     * @param attachment is created attachment.
+     * @return thumbnail links
+     */
     Mono<Map<ThumbnailSize, URI>> getThumbnailLinks(Attachment attachment);
 
     /**

--- a/application/src/main/java/run/halo/app/core/attachment/thumbnail/ThumbnailUtils.java
+++ b/application/src/main/java/run/halo/app/core/attachment/thumbnail/ThumbnailUtils.java
@@ -6,6 +6,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 import org.apache.commons.io.FilenameUtils;
+import org.jspecify.annotations.Nullable;
 import org.springframework.http.MediaType;
 import org.springframework.util.MimeType;
 import org.springframework.util.StringUtils;
@@ -32,14 +33,14 @@ public enum ThumbnailUtils {
      * @param fileSuffix the file suffix to check (without the dot)
      * @return true if the file suffix is supported, false otherwise
      */
-    public static boolean isSupportedImage(String fileSuffix) {
+    public static boolean isSupportedImage(@Nullable String fileSuffix) {
         if (!StringUtils.hasText(fileSuffix)) {
             return false;
         }
         return SUPPORTED_IMAGE_SUFFIXES.contains(fileSuffix.toLowerCase());
     }
 
-    public static boolean isSupportedImage(MimeType mimeType) {
+    public static boolean isSupportedImage(@Nullable MimeType mimeType) {
         return SUPPORTED_IMAGE_MIME_TYPES.stream()
             .anyMatch(supported -> supported.isCompatibleWith(mimeType));
     }

--- a/application/src/main/java/run/halo/app/core/user/service/impl/DefaultAttachmentService.java
+++ b/application/src/main/java/run/halo/app/core/user/service/impl/DefaultAttachmentService.java
@@ -26,7 +26,6 @@ import org.springframework.web.server.ServerWebInputException;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import run.halo.app.core.attachment.ThumbnailSize;
-import run.halo.app.core.attachment.thumbnail.ThumbnailUtils;
 import run.halo.app.core.extension.attachment.Attachment;
 import run.halo.app.core.extension.attachment.Policy;
 import run.halo.app.core.extension.attachment.endpoint.AttachmentHandler;
@@ -144,10 +143,7 @@ public class DefaultAttachmentService implements AttachmentService {
 
     @Override
     public Mono<Map<ThumbnailSize, URI>> getThumbnailLinks(Attachment attachment) {
-        var mediaType = MediaType.parseMediaType(attachment.getSpec().getMediaType());
-        if (!ThumbnailUtils.isSupportedImage(mediaType)) {
-            return Mono.just(Map.of());
-        }
+
         return client.get(Policy.class, attachment.getSpec().getPolicyName())
             .zipWhen(policy -> client.get(ConfigMap.class, policy.getSpec().getConfigMapName()))
             .flatMap(tuple2 -> {


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/area core
/milestone 2.22.x

#### What this PR does / why we need it:

This PR fixes null attachment media type handling and improve thumbnail link retrieval logic.

#### Which issue(s) this PR fixes:

Fixes https://github.com/halo-dev/halo/issues/8075

#### Does this PR introduce a user-facing change?

```release-note
修复附件缩略图可能生成失败的问题
```
