### PR TITLE
Disable confirm button when no attachments selected

### DIFF
--- a/ui/console-src/modules/contents/attachments/components/AttachmentSelectorModal.vue
+++ b/ui/console-src/modules/contents/attachments/components/AttachmentSelectorModal.vue
@@ -91,9 +91,14 @@ const handleConfirm = () => {
 };
 
 const confirmDisabled = computed(() => {
+  if (!selected.value.length) {
+    return true;
+  }
+
   if (props.min === undefined) {
     return false;
   }
+
   return selected.value.length < props.min;
 });
 

--- a/ui/uc-src/modules/contents/attachments/components/AttachmentSelectorModal.vue
+++ b/ui/uc-src/modules/contents/attachments/components/AttachmentSelectorModal.vue
@@ -91,9 +91,14 @@ const handleConfirm = () => {
 };
 
 const confirmDisabled = computed(() => {
+  if (!selected.value.length) {
+    return true;
+  }
+
   if (props.min === undefined) {
     return false;
   }
+
   return selected.value.length < props.min;
 });
 


### PR DESCRIPTION
#### What type of PR is this?

/area ui
/kind improvement
/milestone 2.22.x

#### What this PR does / why we need it:

Updated AttachmentSelectorModal to ensure the confirm button is disabled if no attachments are selected, regardless of the min prop. This improves UX by preventing confirmation with an empty selection.

#### Does this PR introduce a user-facing change?

```release-note
None
```
