### PR TITLE
Refactor actuator endpoints to use reactive programming and improve database metadata handling

### DIFF
--- a/application/src/main/java/run/halo/app/infra/actuator/DatabaseInfoContributor.java
+++ b/application/src/main/java/run/halo/app/infra/actuator/DatabaseInfoContributor.java
@@ -4,48 +4,58 @@ import io.r2dbc.spi.Connection;
 import io.r2dbc.spi.ConnectionFactory;
 import io.r2dbc.spi.ConnectionMetadata;
 import java.time.Duration;
-import java.util.HashMap;
 import java.util.Map;
-import java.util.Objects;
+import lombok.extern.slf4j.Slf4j;
+import org.jspecify.annotations.Nullable;
+import org.springframework.beans.factory.InitializingBean;
 import org.springframework.boot.actuate.info.Info;
 import org.springframework.boot.actuate.info.InfoContributor;
 import org.springframework.stereotype.Component;
 import reactor.core.publisher.Mono;
 import run.halo.app.infra.utils.ReactiveUtils;
 
+@Slf4j
 @Component
-public class DatabaseInfoContributor implements InfoContributor {
+class DatabaseInfoContributor implements InfoContributor, InitializingBean {
+
     private static final Duration BLOCKING_TIMEOUT = ReactiveUtils.DEFAULT_TIMEOUT;
+
     private static final String DATABASE_INFO_KEY = "database";
 
     private final ConnectionFactory connectionFactory;
+
+    @Nullable
+    private ConnectionMetadata connectionMetadata;
 
     public DatabaseInfoContributor(ConnectionFactory connectionFactory) {
         this.connectionFactory = connectionFactory;
     }
 
     @Override
-    public void contribute(Info.Builder builder) {
-        builder.withDetail(DATABASE_INFO_KEY, contributorMap());
-    }
-
-    public Map<String, Object> contributorMap() {
-        var map = new HashMap<String, Object>();
-        var connectionMetadata = getConnectionMetadata().block(BLOCKING_TIMEOUT);
-        if (Objects.isNull(connectionMetadata)) {
-            return map;
+    public void afterPropertiesSet() throws Exception {
+        var connectionMetadata = Mono.usingWhen(
+                this.connectionFactory.create(),
+                connection -> Mono.just(connection.getMetadata()),
+                Connection::close
+            )
+            .blockOptional(BLOCKING_TIMEOUT)
+            .orElseThrow(() -> new IllegalStateException("Unable to get database metadata"));
+        if (log.isDebugEnabled()) {
+            log.debug("Database Metadata initialized: name={}, version={}",
+                connectionMetadata.getDatabaseProductName(),
+                connectionMetadata.getDatabaseVersion());
         }
-        map.put("name", connectionMetadata.getDatabaseProductName());
-        map.put("version", connectionMetadata.getDatabaseVersion());
-        return map;
+        this.connectionMetadata = connectionMetadata;
     }
 
-    private Mono<ConnectionMetadata> getConnectionMetadata() {
-        return Mono.usingWhen(this.connectionFactory.create(),
-            conn -> Mono.just(conn.getMetadata()),
-            Connection::close,
-            (conn, t) -> conn.close(),
-            Connection::close
-        );
+    @Override
+    public void contribute(Info.Builder builder) {
+        if (this.connectionMetadata != null) {
+            builder.withDetail(DATABASE_INFO_KEY, Map.of(
+                "name", this.connectionMetadata.getDatabaseProductName(),
+                "version", this.connectionMetadata.getDatabaseVersion()
+            ));
+        }
     }
+
 }

--- a/application/src/main/java/run/halo/app/infra/actuator/GlobalInfoEndpoint.java
+++ b/application/src/main/java/run/halo/app/infra/actuator/GlobalInfoEndpoint.java
@@ -1,16 +1,16 @@
 package run.halo.app.infra.actuator;
 
-import java.time.Duration;
 import org.springframework.boot.actuate.endpoint.annotation.ReadOperation;
 import org.springframework.boot.actuate.endpoint.web.annotation.WebEndpoint;
 import org.springframework.stereotype.Component;
+import reactor.core.publisher.Mono;
 
 /**
  * Global info endpoint.
  */
 @WebEndpoint(id = "globalinfo")
 @Component
-public class GlobalInfoEndpoint {
+class GlobalInfoEndpoint {
 
     private final GlobalInfoService globalInfoService;
 
@@ -19,8 +19,8 @@ public class GlobalInfoEndpoint {
     }
 
     @ReadOperation
-    public GlobalInfo globalInfo() {
-        return globalInfoService.getGlobalInfo().block(Duration.ofMinutes(1));
+    public Mono<GlobalInfo> globalInfo() {
+        return globalInfoService.getGlobalInfo();
     }
 
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind improvement
/area core
/milestone 2.22.x

#### What this PR does / why we need it:

This PR refactors acutator endpoints to use reactive programming and improve database metadata handling.

#### Which issue(s) this PR fixes:

Fixes https://github.com/halo-dev/halo/issues/7655

#### Special notes for your reviewer:

Try to run Halo with JVM options `-Dreactor.schedulers.defaultPoolSize=1 -Dreactor.schedulers.defaultBoundedElasticSize=2` and request <http://localhost:8090/actuator/globalinfo> and <http://localhost:8090/actuator/info>.

#### Does this PR introduce a user-facing change?

```release-note
提升 Actuator 接口的稳定性
```
