### PR TITLE
Update plugin-shiki and hyperlink-card plugin versions

### DIFF
--- a/application/build.gradle
+++ b/application/build.gradle
@@ -153,8 +153,8 @@ tasks.register('downloadPluginPresets', Download) {
             'https://github.com/halo-dev/plugin-search-widget/releases/download/v1.7.0/plugin-search-widget-1.7.0.jar'                 : 'plugin-search-widget.jar',
             'https://github.com/halo-dev/plugin-sitemap/releases/download/v1.1.2/plugin-sitemap-1.1.2.jar'                             : 'plugin-sitemap.jar',
             'https://github.com/halo-dev/plugin-feed/releases/download/v1.5.0/plugin-feed-1.5.0.jar'                                   : 'plugin-feed.jar',
-            'https://github.com/halo-sigs/plugin-shiki/releases/download/v1.0.1/plugin-shiki-1.0.1.jar'                                : 'plugin-shiki.jar',
-            'https://github.com/halo-sigs/plugin-editor-hyperlink-card/releases/download/v1.5.2/plugin-editor-hyperlink-card-1.5.2.jar': 'plugin-editor-hyperlink-card.jar',
+            'https://github.com/halo-sigs/plugin-shiki/releases/download/v1.0.11/plugin-shiki-1.0.11.jar'                              : 'plugin-shiki.jar',
+            'https://github.com/halo-sigs/plugin-editor-hyperlink-card/releases/download/v1.6.0/plugin-editor-hyperlink-card-1.6.0.jar': 'plugin-editor-hyperlink-card.jar',
 
             // Currently, plugin-app-store is not open source, so we need to download it from the official website.
             // Please see https://github.com/halo-dev/plugin-app-store/issues/55


### PR DESCRIPTION
#### What type of PR is this?

/area ui
/kind cleanup
/milestone 2.22.x

#### What this PR does / why we need it:

Bumped plugin-shiki to v1.0.11 and plugin-editor-hyperlink-card to v1.6.0 in the downloadPluginPresets task to use the latest releases.

#### Does this PR introduce a user-facing change?

```release-note
None
```
