### PR TITLE
Increase max length for title and slug fields

### DIFF
--- a/ui/console-src/modules/contents/pages/components/SinglePageSettingModal.vue
+++ b/ui/console-src/modules/contents/pages/components/SinglePageSettingModal.vue
@@ -326,14 +326,14 @@ async function slugUniqueValidation(node: FormKitNode) {
               :label="$t('core.page.settings.fields.title.label')"
               type="text"
               name="title"
-              validation="required|length:0,100"
+              validation="required|length:0,1024"
             ></FormKit>
             <FormKit
               v-model="formState.spec.slug"
               :label="$t('core.page.settings.fields.slug.label')"
               name="slug"
               type="text"
-              validation="required|length:0,100|slugUniqueValidation"
+              validation="required|length:0,1024|slugUniqueValidation"
               :validation-rules="{ slugUniqueValidation }"
               :validation-messages="{
                 slugUniqueValidation: $t(

--- a/ui/console-src/modules/contents/posts/categories/components/CategoryEditingModal.vue
+++ b/ui/console-src/modules/contents/posts/categories/components/CategoryEditingModal.vue
@@ -245,7 +245,7 @@ async function slugUniqueValidation(node: FormKitNode) {
                 $t('core.post_category.editing_modal.fields.display_name.label')
               "
               type="text"
-              validation="required|length:0,50"
+              validation="required|length:0,512"
             ></FormKit>
             <FormKit
               v-model="formState.spec.slug"
@@ -253,7 +253,7 @@ async function slugUniqueValidation(node: FormKitNode) {
               name="slug"
               :label="$t('core.post_category.editing_modal.fields.slug.label')"
               type="text"
-              validation="required|length:0,50|slugUniqueValidation"
+              validation="required|length:0,512|slugUniqueValidation"
               :validation-rules="{ slugUniqueValidation }"
               :validation-messages="{
                 slugUniqueValidation: $t(

--- a/ui/console-src/modules/contents/posts/components/PostSettingModal.vue
+++ b/ui/console-src/modules/contents/posts/components/PostSettingModal.vue
@@ -340,14 +340,14 @@ const showCancelPublishButton = computed(() => {
               :label="$t('core.post.settings.fields.title.label')"
               type="text"
               name="title"
-              validation="required|length:0,100"
+              validation="required|length:0,1024"
             ></FormKit>
             <FormKit
               v-model="formState.spec.slug"
               :label="$t('core.post.settings.fields.slug.label')"
               name="slug"
               type="text"
-              validation="required|length:0,100|slugUniqueValidation"
+              validation="required|length:0,1024|slugUniqueValidation"
               :validation-rules="{ slugUniqueValidation }"
               :validation-messages="{
                 slugUniqueValidation: $t(

--- a/ui/uc-src/modules/contents/posts/components/PostSettingForm.vue
+++ b/ui/uc-src/modules/contents/posts/components/PostSettingForm.vue
@@ -127,13 +127,13 @@ const publishTimeHelp = computed(() => {
             :label="$t('core.post.settings.fields.title.label')"
             type="text"
             name="title"
-            validation="required|length:0,100"
+            validation="required|length:0,1024"
           ></FormKit>
           <FormKit
             :label="$t('core.post.settings.fields.slug.label')"
             name="slug"
             type="text"
-            validation="required|length:0,100|slugUniqueValidation"
+            validation="required|length:0,1024|slugUniqueValidation"
             :validation-rules="{ slugUniqueValidation }"
             :validation-messages="{
               slugUniqueValidation: $t(


### PR DESCRIPTION
#### What type of PR is this?

/area ui
/kind improvement
/milestone 2.22.x

#### What this PR does / why we need it:

Increase the character length limit for titles and slugs of posts, pages, and categories to provide better compatibility

#### Which issue(s) this PR fixes:

Fixes https://github.com/halo-dev/halo/issues/7977

#### Does this PR introduce a user-facing change?

```release-note
提升文章、页面、分类的标题和 slug 字符串长度限制，以提供更好的兼容性
```
