### PR TITLE
Fix pagination limit calculation and add test for last page retrieval

### DIFF
--- a/application/src/main/java/run/halo/app/extension/index/DefaultIndexEngine.java
+++ b/application/src/main/java/run/halo/app/extension/index/DefaultIndexEngine.java
@@ -92,7 +92,6 @@ class DefaultIndexEngine implements IndexEngine, DisposableBean {
 
         int offset = (page.getPageNumber() - 1) * page.getPageSize();
         int limit = page.getPageSize();
-
         if (limit <= 0) {
             // return all results for backward compatibility
             var finalResult = result.stream().sorted(comparator).toList();
@@ -100,10 +99,13 @@ class DefaultIndexEngine implements IndexEngine, DisposableBean {
                 page.getPageNumber(), page.getPageSize(), total, finalResult
             );
         }
-        if (offset > total) {
+        if (offset >= total) {
             return new ListResult<>(
                 page.getPageNumber(), page.getPageSize(), total, new LinkedList<>()
             );
+        }
+        if (offset + limit > total) {
+            limit = total - offset;
         }
         var n = offset + limit;
         if (n > 1000) {


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/area core
/milestone 2.22.x

#### What this PR does / why we need it:

This PR fixes pagination limit calculation which can result in incorrect result of the last page.

#### Which issue(s) this PR fixes:

Fixes https://github.com/halo-dev/halo/issues/8137

#### Special notes for your reviewer:

1. Try to create 3 posts
2. Then request <http://localhost:8090/console/posts?size=2&page=2> and see the result

#### Does this PR introduce a user-facing change?

```release-note
修复最后一页数据可能包含上一页部分数据的问题
```

