### PR TITLE
Fix thumbnail resource handling by using file path instead of URI

### DIFF
--- a/application/src/main/java/run/halo/app/core/attachment/thumbnail/ThumbnailResourceTransformer.java
+++ b/application/src/main/java/run/halo/app/core/attachment/thumbnail/ThumbnailResourceTransformer.java
@@ -1,7 +1,6 @@
 package run.halo.app.core.attachment.thumbnail;
 
 import java.io.IOException;
-import java.nio.file.Path;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.core.io.PathResource;
 import org.springframework.core.io.Resource;
@@ -41,7 +40,7 @@ public class ThumbnailResourceTransformer implements ResourceTransformer {
         }
         var size = ThumbnailSize.fromWidth(width);
         try {
-            var source = Path.of(resource.getURI());
+            var source = resource.getFile().toPath();
             return localThumbnailService.generate(source, size)
                 .switchIfEmpty(Mono.fromSupplier(() -> new PathResource(source)))
                 .flatMap(transformed -> transformerChain.transform(exchange, transformed));

--- a/application/src/test/java/run/halo/app/core/attachment/thumbnail/ThumbnailResourceTransformerTest.java
+++ b/application/src/test/java/run/halo/app/core/attachment/thumbnail/ThumbnailResourceTransformerTest.java
@@ -91,7 +91,7 @@ class ThumbnailResourceTransformerTest {
         var sourcePath = attachmentRoot.resolve("upload").resolve("halo.png");
         when(this.resource.isFile()).thenReturn(true);
         when(this.resource.getFilename()).thenReturn(sourcePath.getFileName().toString());
-        when(this.resource.getURI()).thenReturn(sourcePath.toUri());
+        when(this.resource.getFile()).thenReturn(sourcePath.toFile());
         thumbnailResourceTransformer = spy(thumbnailResourceTransformer);
 
         when(localThumbnailService.generate(sourcePath, ThumbnailSize.S)).thenReturn(Mono.empty());
@@ -117,7 +117,7 @@ class ThumbnailResourceTransformerTest {
         var sourcePath = attachmentRoot.resolve("upload").resolve("halo.png");
         when(this.resource.isFile()).thenReturn(true);
         when(this.resource.getFilename()).thenReturn(sourcePath.getFileName().toString());
-        when(this.resource.getURI()).thenReturn(sourcePath.toUri());
+        when(this.resource.getFile()).thenReturn(sourcePath.toFile());
         thumbnailResourceTransformer = spy(thumbnailResourceTransformer);
 
         var generatedResource = mock(Resource.class);


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/area core
/milestone 2.22.x

#### What this PR does / why we need it:

This PR fixes thumbnail resource handling by using file path instead of URI.

#### Which issue(s) this PR fixes:

Fixes https://github.com/halo-dev/halo/issues/8132
Fixes https://github.com/halo-dev/halo/issues/8152 

#### Special notes for your reviewer:

1. Use Windows operating system
2. Start Halo and upload a picture
3. See its thumbnails

#### Does this PR introduce a user-facing change?

```release-note
修复 Windows 和 Linux 下无法正常访问缩略图的问题
```
