### PR TITLE
fix: when pasting a single image it is mistakenly identified as a link

### DIFF
--- a/ui/packages/editor/src/utils/upload.ts
+++ b/ui/packages/editor/src/utils/upload.ts
@@ -202,11 +202,23 @@ export async function uploadExternalLink(
 }
 
 export function isExternalAsset(src: string) {
-  if (src?.startsWith("/")) {
+  if (!src) {
+    return false;
+  }
+
+  if (src.startsWith("/")) {
+    return false;
+  }
+
+  const localProtocols = ["data:", "blob:", "file:"];
+  if (localProtocols.some((protocol) => src.startsWith(protocol))) {
     return false;
   }
 
   const currentOrigin = window.location.origin;
+  if (src.startsWith(currentOrigin)) {
+    return false;
+  }
 
-  return !src?.startsWith(currentOrigin);
+  return src.startsWith("http://") || src.startsWith("https://");
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/area editor
/milestone 2.22.x

#### What this PR does / why we need it:

当前粘贴单张图片时，会错误的将单张图片识别为链接而非文件。

本 PR 修复了这个问题，目前粘贴单张图片时，会将其作为一个图片进行上传处理。
另外修复了当粘贴本地资源文件时，会导致将其错误识别为外部链接的情况。

#### How to test it?

1. 复制一个外链图片。
2. 在编辑器中任意一个位置粘贴。
3. 查看其是否进行了上传

#### Which issue(s) this PR fixes:

Fixes #7912
Fixes https://github.com/halo-dev/halo/issues/7864

#### Does this PR introduce a user-facing change?
```release-note
解决编辑器粘贴富文本内单个图片时无法正确上传的问题
```
