### PR TITLE
Normalize email addresses to lowercase during registration and retrieval

### DIFF
--- a/application/src/main/java/run/halo/app/core/user/service/impl/EmailVerificationServiceImpl.java
+++ b/application/src/main/java/run/halo/app/core/user/service/impl/EmailVerificationServiceImpl.java
@@ -61,7 +61,7 @@ public class EmailVerificationServiceImpl implements EmailVerificationService {
                 .flatMap(user -> {
                     var userEmail = user.getSpec().getEmail();
                     var isVerified = user.getSpec().isEmailVerified();
-                    if (StringUtils.equals(userEmail, email) && isVerified) {
+                    if (StringUtils.equalsIgnoreCase(userEmail, email) && isVerified) {
                         return Mono.error(
                             () -> new ServerWebInputException("Email already verified."));
                     }
@@ -126,7 +126,7 @@ public class EmailVerificationServiceImpl implements EmailVerificationService {
 
     Mono<Boolean> isEmailInUse(String username, String emailToVerify) {
         var listOptions = ListOptions.builder()
-            .andQuery(Queries.equal("spec.email", emailToVerify))
+            .andQuery(Queries.equal("spec.email", emailToVerify.toLowerCase()))
             .build();
         return client.listAll(User.class, listOptions, ExtensionUtil.defaultSort())
             .filter(user -> user.getSpec().isEmailVerified())
@@ -137,7 +137,7 @@ public class EmailVerificationServiceImpl implements EmailVerificationService {
     @Override
     public Mono<Void> sendRegisterVerificationCode(String email) {
         Assert.state(StringUtils.isNotBlank(email), "Email must not be blank");
-        return sendVerificationNotification(email, email);
+        return sendVerificationNotification(email.toLowerCase(), email);
     }
 
     @Override
@@ -274,6 +274,10 @@ public class EmailVerificationServiceImpl implements EmailVerificationService {
         }
 
         record UsernameEmail(String username, String email) {
+            public UsernameEmail {
+                // convert to lower case to make it case-insensitive
+                email = StringUtils.lowerCase(email);
+            }
         }
 
         @Data

--- a/application/src/main/java/run/halo/app/infra/SchemeInitializer.java
+++ b/application/src/main/java/run/halo/app/infra/SchemeInitializer.java
@@ -160,7 +160,10 @@ class SchemeInitializer implements SmartLifecycle {
                 .indexFunc(user -> user.getSpec().isEmailVerified())
             );
             indexSpecs.add(IndexSpecs.<User, String>single("spec.email", String.class)
-                .indexFunc(user -> user.getSpec().getEmail())
+                .indexFunc(user -> Optional.ofNullable(user.getSpec().getEmail())
+                    .map(String::toLowerCase)
+                    .orElse(null)
+                )
             );
             indexSpecs.add(IndexSpecs.<User, String>multi(
                         User.USER_RELATED_ROLES_INDEX, String.class

--- a/application/src/test/java/run/halo/app/core/user/service/impl/EmailVerificationServiceImplTest.java
+++ b/application/src/test/java/run/halo/app/core/user/service/impl/EmailVerificationServiceImplTest.java
@@ -2,13 +2,14 @@ package run.halo.app.core.user.service.impl;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static run.halo.app.core.user.service.impl.EmailVerificationServiceImpl.MAX_ATTEMPTS;
 
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
-import run.halo.app.core.user.service.impl.EmailVerificationServiceImpl;
+import run.halo.app.core.user.service.impl.EmailVerificationServiceImpl.EmailVerificationManager.UsernameEmail;
 import run.halo.app.infra.exception.EmailVerificationFailed;
 
 /**
@@ -83,5 +84,12 @@ class EmailVerificationServiceImplTest {
                 .isInstanceOf(EmailVerificationFailed.class)
                 .hasMessage("400 BAD_REQUEST \"Too many attempts. Please try again later.\"");
         }
+    }
+
+    @Test
+    void shouldBeEqualUsernameEmailWithDifferentCase() {
+        var expected = new UsernameEmail("faker", "a@b.com");
+        var got = new UsernameEmail("faker", "A@B.com");
+        assertEquals(expected, got);
     }
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/area core
/milestone 2.22.x

#### What this PR does / why we need it:

This PR normalizes email address to lowercase during registration and retrieval.

#### Which issue(s) this PR fixes:

Fixes https://github.com/halo-dev/halo/issues/8130

#### Does this PR introduce a user-facing change?

```release-note
修复注册时同一个邮箱不同大小写仍然可重复注册的问题
```
