### PR TITLE
Add new public API clients for category, tag, singlePage, and index

### DIFF
--- a/ui/packages/api-client/entry/api-client.ts
+++ b/ui/packages/api-client/entry/api-client.ts
@@ -10,6 +10,7 @@ import {
   AuthProviderV1alpha1ConsoleApi,
   BackupV1alpha1Api,
   CategoryV1alpha1Api,
+  CategoryV1alpha1PublicApi,
   CommentV1alpha1Api,
   CommentV1alpha1ConsoleApi,
   CommentV1alpha1PublicApi,
@@ -19,6 +20,7 @@ import {
   ExtensionDefinitionV1alpha1Api,
   ExtensionPointDefinitionV1alpha1Api,
   GroupV1alpha1Api,
+  IndexV1alpha1PublicApi,
   IndicesV1alpha1ConsoleApi,
   LocalThumbnailV1alpha1Api,
   MenuItemV1alpha1Api,
@@ -54,6 +56,7 @@ import {
   SettingV1alpha1Api,
   SinglePageV1alpha1Api,
   SinglePageV1alpha1ConsoleApi,
+  SinglePageV1alpha1PublicApi,
   SnapshotV1alpha1Api,
   SnapshotV1alpha1UcApi,
   SubscriptionV1alpha1Api,
@@ -62,6 +65,7 @@ import {
   SystemV1alpha1PublicApi,
   TagV1alpha1Api,
   TagV1alpha1ConsoleApi,
+  TagV1alpha1PublicApi,
   ThemeV1alpha1Api,
   ThemeV1alpha1ConsoleApi,
   ThumbnailV1alpha1Api,
@@ -450,9 +454,24 @@ function createPublicApiClient(axiosInstance: AxiosInstance) {
     menu: new MenuV1alpha1PublicApi(undefined, baseURL, axiosInstance),
     stats: new SystemV1alpha1PublicApi(undefined, baseURL, axiosInstance),
     content: {
+      category: new CategoryV1alpha1PublicApi(
+        undefined,
+        baseURL,
+        axiosInstance
+      ),
+      tag: new TagV1alpha1PublicApi(undefined, baseURL, axiosInstance),
+      singlePage: new SinglePageV1alpha1PublicApi(
+        undefined,
+        baseURL,
+        axiosInstance
+      ),
       post: new PostV1alpha1PublicApi(undefined, baseURL, axiosInstance),
+      /**
+       * @deprecated Use comment instead
+       */
       comment: new CommentV1alpha1PublicApi(undefined, baseURL, axiosInstance),
     },
+    comment: new CommentV1alpha1PublicApi(undefined, baseURL, axiosInstance),
     metrics: {
       metrics: new MetricsV1alpha1PublicApi(undefined, baseURL, axiosInstance),
     },
@@ -461,6 +480,7 @@ function createPublicApiClient(axiosInstance: AxiosInstance) {
       baseURL,
       axiosInstance
     ),
+    index: new IndexV1alpha1PublicApi(undefined, baseURL, axiosInstance),
   };
 }
 


### PR DESCRIPTION
#### What type of PR is this?

/area ui
/kind api-change

#### What this PR does / why we need it:

Introduces CategoryV1alpha1PublicApi, TagV1alpha1PublicApi, SinglePageV1alpha1PublicApi, and IndexV1alpha1PublicApi to the public API client. Updates the createPublicApiClient function to instantiate these new clients, expanding available public API endpoints.

#### Does this PR introduce a user-facing change?

```release-note
None
```
