### PR TITLE
Support references without version in comment subjects

### DIFF
--- a/api/src/main/java/run/halo/app/extension/Ref.java
+++ b/api/src/main/java/run/halo/app/extension/Ref.java
@@ -5,19 +5,21 @@ import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.util.Objects;
 import lombok.Data;
+import org.jspecify.annotations.Nullable;
 import org.springframework.lang.NonNull;
 
 @Data
 @Schema(description = "Extension reference object. The name is mandatory")
 public class Ref {
 
-    @Schema(description = "Extension group")
+    @Schema(description = "Extension group", requiredMode = REQUIRED)
     private String group;
 
     @Schema(description = "Extension version")
+    @Nullable
     private String version;
 
-    @Schema(description = "Extension kind")
+    @Schema(description = "Extension kind", requiredMode = REQUIRED)
     private String kind;
 
     @Schema(requiredMode = REQUIRED, description = "Extension name. This field is mandatory")

--- a/application/src/main/java/run/halo/app/content/comment/PostCommentSubject.java
+++ b/application/src/main/java/run/halo/app/content/comment/PostCommentSubject.java
@@ -1,11 +1,11 @@
 package run.halo.app.content.comment;
 
+import java.util.Objects;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 import org.springframework.util.Assert;
 import reactor.core.publisher.Mono;
 import run.halo.app.core.extension.content.Post;
-import run.halo.app.extension.GroupVersionKind;
 import run.halo.app.extension.ReactiveExtensionClient;
 import run.halo.app.extension.Ref;
 import run.halo.app.infra.ExternalLinkProcessor;
@@ -41,8 +41,8 @@ public class PostCommentSubject implements CommentSubject<Post> {
     @Override
     public boolean supports(Ref ref) {
         Assert.notNull(ref, "Subject ref must not be null.");
-        GroupVersionKind groupVersionKind =
-            new GroupVersionKind(ref.getGroup(), ref.getVersion(), ref.getKind());
-        return GroupVersionKind.fromExtension(Post.class).equals(groupVersionKind);
+        var gvk = Post.GVK;
+        return Objects.equals(gvk.group(), ref.getGroup())
+            && Objects.equals(gvk.kind(), ref.getKind());
     }
 }

--- a/application/src/main/java/run/halo/app/content/comment/SinglePageCommentSubject.java
+++ b/application/src/main/java/run/halo/app/content/comment/SinglePageCommentSubject.java
@@ -1,11 +1,11 @@
 package run.halo.app.content.comment;
 
+import java.util.Objects;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 import org.springframework.util.Assert;
 import reactor.core.publisher.Mono;
 import run.halo.app.core.extension.content.SinglePage;
-import run.halo.app.extension.GroupVersionKind;
 import run.halo.app.extension.ReactiveExtensionClient;
 import run.halo.app.extension.Ref;
 import run.halo.app.infra.ExternalLinkProcessor;
@@ -42,8 +42,8 @@ public class SinglePageCommentSubject implements CommentSubject<SinglePage> {
     @Override
     public boolean supports(Ref ref) {
         Assert.notNull(ref, "Subject ref must not be null.");
-        GroupVersionKind groupVersionKind =
-            new GroupVersionKind(ref.getGroup(), ref.getVersion(), ref.getKind());
-        return GroupVersionKind.fromExtension(SinglePage.class).equals(groupVersionKind);
+        var gvk = SinglePage.GVK;
+        return Objects.equals(gvk.group(), ref.getGroup())
+            && Objects.equals(gvk.kind(), ref.getKind());
     }
 }

--- a/application/src/test/java/run/halo/app/content/comment/PostCommentSubjectTest.java
+++ b/application/src/test/java/run/halo/app/content/comment/PostCommentSubjectTest.java
@@ -1,6 +1,7 @@
 package run.halo.app.content.comment;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
@@ -13,6 +14,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
 import run.halo.app.content.TestPost;
+import run.halo.app.core.extension.content.Constant;
 import run.halo.app.core.extension.content.Post;
 import run.halo.app.extension.FakeExtension;
 import run.halo.app.extension.Metadata;
@@ -63,5 +65,14 @@ class PostCommentSubjectTest {
         fakeExtension.getMetadata().setName("test");
         supports = postCommentSubject.supports(Ref.of(fakeExtension));
         assertThat(supports).isFalse();
+    }
+
+    @Test
+    void shouldSupportRefWithoutVersion() {
+        var ref = new Ref();
+        ref.setName("fake-post");
+        ref.setGroup(Constant.GROUP);
+        ref.setKind(Post.KIND);
+        assertTrue(postCommentSubject.supports(ref));
     }
 }

--- a/application/src/test/java/run/halo/app/content/comment/SinglePageCommentSubjectTest.java
+++ b/application/src/test/java/run/halo/app/content/comment/SinglePageCommentSubjectTest.java
@@ -1,6 +1,7 @@
 package run.halo.app.content.comment;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.times;
@@ -14,6 +15,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
+import run.halo.app.core.extension.content.Constant;
 import run.halo.app.core.extension.content.SinglePage;
 import run.halo.app.extension.FakeExtension;
 import run.halo.app.extension.Metadata;
@@ -72,4 +74,15 @@ class SinglePageCommentSubjectTest {
         supports = singlePageCommentSubject.supports(Ref.of(fakeExtension));
         assertThat(supports).isFalse();
     }
+
+
+    @Test
+    void shouldSupportRefWithoutVersion() {
+        var ref = new Ref();
+        ref.setName("fake-post");
+        ref.setGroup(Constant.GROUP);
+        ref.setKind(SinglePage.KIND);
+        assertTrue(singlePageCommentSubject.supports(ref));
+    }
+
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/area core
/milestone 2.22.x

#### What this PR does / why we need it:

This PR supports references without version in comment subjects.

#### Which issue(s) this PR fixes:

Fixes https://github.com/halo-dev/halo/issues/7890

#### Special notes for your reviewer:

1. Try to create a comment
2. Delete field `spec.subjectRef.version` using DataStudio plugin
3. See the comment list page

#### Does this PR introduce a user-facing change?

```release-note
修复评论管理列表可能无法正常访问的问题
```
