### PR TITLE
Refactor authorization configuration to enhance access control and add cancel link in TOTP forms

### DIFF
--- a/application/src/main/resources/templates/challenges/two-factor/totp.html
+++ b/application/src/main/resources/templates/challenges/two-factor/totp.html
@@ -1,15 +1,26 @@
 <!doctype html>
 <html
     xmlns:th="https://www.thymeleaf.org"
-    th:replace="~{gateway_fragments/layout :: layout(title = |#{title} - ${site.title}|, head = null, body = ~{::body})}"
+    th:replace="~{gateway_fragments/layout :: layout(title = |#{title} - ${site.title}|, head = ~{::head}, body = ~{::body})}"
 >
     <th:block th:fragment="body">
-        <div class="gateway-wrapper">
+        <div class="gateway-wrapper totp-page-wrapper">
             <div th:replace="~{gateway_fragments/common::haloLogo}"></div>
             <div class="halo-form-wrapper">
                 <h1 class="form-title" th:text="#{title}"></h1>
                 <form th:replace="~{gateway_fragments/totp::form}"></form>
             </div>
         </div>
+    </th:block>
+
+    <th:block th:fragment="head">
+        <style>
+            .totp-page-wrapper .cancel-link {
+                color: var(--color-link);
+                font-size: var(--text-sm);
+                text-decoration: none;
+                text-align: center;
+            }
+        </style>
     </th:block>
 </html>

--- a/application/src/main/resources/templates/gateway_fragments/totp.html
+++ b/application/src/main/resources/templates/gateway_fragments/totp.html
@@ -27,4 +27,7 @@
     <div class="form-item">
         <button type="submit" th:text="#{form.submit}"></button>
     </div>
+    <div class="form-item">
+        <a th:href="@{/logout}" class="cancel-link" th:text="#{form.cancel}"></a>
+    </div>
 </form>

--- a/application/src/main/resources/templates/gateway_fragments/totp.properties
+++ b/application/src/main/resources/templates/gateway_fragments/totp.properties
@@ -1,3 +1,4 @@
 form.messages.invalidError=错误的验证码
 form.code.label=验证码
 form.submit=验证
+form.cancel=取消

--- a/application/src/main/resources/templates/gateway_fragments/totp_en.properties
+++ b/application/src/main/resources/templates/gateway_fragments/totp_en.properties
@@ -1,3 +1,4 @@
 form.messages.invalidError=Invalid TOTP code
 form.code.label=TOTP Code
 form.submit=Verify
+form.cancel=Cancel

--- a/application/src/main/resources/templates/gateway_fragments/totp_es.properties
+++ b/application/src/main/resources/templates/gateway_fragments/totp_es.properties
@@ -1,3 +1,4 @@
 form.messages.invalidError=Código de verificación incorrecto
 form.code.label=Código de Verificación
 form.submit=Verificar
+form.cancel=Cancelar

--- a/application/src/main/resources/templates/gateway_fragments/totp_zh_TW.properties
+++ b/application/src/main/resources/templates/gateway_fragments/totp_zh_TW.properties
@@ -1,3 +1,4 @@
 form.messages.invalidError=錯誤的驗證碼
 form.code.label=驗證碼
 form.submit=驗證
+form.cancel=取消


### PR DESCRIPTION
#### What type of PR is this?

/kind improvement
/area core
/milestone 2.22.x

#### What this PR does / why we need it:

This PR refactors authorization configuration to enhance access control and add cancel link in TOTP forms.

So that we can cancel TOTP authentication by being able to redirect to logout page.

#### Which issue(s) this PR fixes:

Fixes https://github.com/halo-dev/halo/issues/8172

#### Special notes for your reviewer:

1. Try to configure TOTP for your own account
2. Try to logout and login
3. Click the cancel link and you will be redirected to logout page
4. Try to click the logout button

#### Does this PR introduce a user-facing change?

```release-note
优化二步验证登录体验
```

