### PR TITLE
Restrict unsupported operations in MultiValueIndex and update tests accordingly

### DIFF
--- a/application/src/main/java/run/halo/app/extension/index/MultiValueIndex.java
+++ b/application/src/main/java/run/halo/app/extension/index/MultiValueIndex.java
@@ -4,8 +4,6 @@ import java.io.IOException;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
-import java.util.HashSet;
-import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
@@ -15,7 +13,6 @@ import java.util.concurrent.ConcurrentSkipListMap;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.commons.lang3.StringUtils;
 import org.springframework.dao.DuplicateKeyException;
 import org.springframework.lang.NonNull;
 import org.springframework.lang.Nullable;
@@ -103,24 +100,14 @@ class MultiValueIndex<E extends Extension, K extends Comparable<K>>
 
     @Override
     public Set<String> between(K fromKey, boolean fromInclusive, K toKey, boolean toInclusive) {
-        Assert.isTrue(fromKey.compareTo(toKey) < 0, "fromKey must be less than toKey");
-        return index.subMap(fromKey, fromInclusive, toKey, toInclusive)
-            .values()
-            .stream()
-            .flatMap(Set::stream)
-            .collect(Collectors.toSet());
+        throw new UnsupportedOperationException(
+            "Multi-value index does not support between operation");
     }
 
     @Override
     public Set<String> notBetween(K fromKey, boolean fromInclusive, K toKey, boolean toInclusive) {
-        // check if fromKey is less than toKey
-        Assert.isTrue(fromKey.compareTo(toKey) < 0, "fromKey must be less than toKey");
-        return Stream.concat(
-                index.headMap(fromKey, !fromInclusive).values().stream(),
-                index.tailMap(toKey, !toInclusive).values().stream()
-            )
-            .flatMap(Set::stream)
-            .collect(Collectors.toSet());
+        throw new UnsupportedOperationException(
+            "Multi-value index does not support notBetween operation");
     }
 
     @Override
@@ -141,30 +128,25 @@ class MultiValueIndex<E extends Extension, K extends Comparable<K>>
         if (CollectionUtils.isEmpty(keys)) {
             return all();
         }
-        var keySet = keys instanceof Set<K> ks ? ks : new HashSet<>(keys);
-        return index.entrySet().stream()
-            .filter(entry -> !keySet.contains(entry.getKey()))
-            .map(Map.Entry::getValue)
+        var inResult = in(keys);
+        return index.values().stream()
             .flatMap(Set::stream)
+            .filter(v -> !inResult.contains(v))
             .collect(Collectors.toSet());
     }
 
     @Override
     public Set<String> lessThan(K key, boolean inclusive) {
-        return index.headMap(key, inclusive)
-            .values()
-            .stream()
-            .flatMap(Set::stream)
-            .collect(Collectors.toSet());
+        throw new UnsupportedOperationException(
+            "Multi-value index does not support lessThan operation"
+        );
     }
 
     @Override
     public Set<String> greaterThan(K key, boolean inclusive) {
-        return index.tailMap(key, inclusive)
-            .values()
-            .stream()
-            .flatMap(Set::stream)
-            .collect(Collectors.toSet());
+        throw new UnsupportedOperationException(
+            "Multi-value index does not support greaterThan operation"
+        );
     }
 
     @Override
@@ -182,78 +164,49 @@ class MultiValueIndex<E extends Extension, K extends Comparable<K>>
 
     @Override
     public Set<String> stringContains(String keyword) {
-        ensureStringKeyType();
-        return index.entrySet()
-            .stream()
-            .filter(entry -> StringUtils.containsIgnoreCase(entry.getKey().toString(), keyword))
-            .map(Map.Entry::getValue)
-            .flatMap(Set::stream)
-            .collect(Collectors.toSet());
+        throw new UnsupportedOperationException(
+            "Multi-value index does not support stringContains operation"
+        );
     }
 
     @Override
     public Set<String> stringNotContains(String keyword) {
-        ensureStringKeyType();
-        return index.entrySet()
-            .stream()
-            .filter(entry -> !StringUtils.containsIgnoreCase(entry.getKey().toString(), keyword))
-            .map(Map.Entry::getValue)
-            .flatMap(Set::stream)
-            .collect(Collectors.toSet());
+        throw new UnsupportedOperationException(
+            "Multi-value index does not support stringNotContains operation"
+        );
     }
 
     @Override
     public Set<String> stringStartsWith(String prefix) {
-        ensureStringKeyType();
-        var toKey = prefix + Character.MAX_VALUE;
-        return index.subMap((K) prefix, true, (K) toKey, false)
-            .values()
-            .stream()
-            .flatMap(Set::stream)
-            .collect(Collectors.toSet());
+        throw new UnsupportedOperationException(
+            "Multi-value index does not support stringStartsWith operation"
+        );
     }
 
     @Override
     public Set<String> stringNotStartsWith(String prefix) {
-        ensureStringKeyType();
-        var toKey = prefix + Character.MAX_VALUE;
-        return Stream.concat(
-                index.headMap((K) prefix, false).values().stream(),
-                index.tailMap((K) toKey, true).values().stream()
-            )
-            .flatMap(Set::stream)
-            .collect(Collectors.toSet());
+        throw new UnsupportedOperationException(
+            "Multi-value index does not support stringNotStartsWith operation"
+        );
     }
 
     @Override
     public Set<String> stringEndsWith(String suffix) {
-        ensureStringKeyType();
-        return index.entrySet()
-            .stream()
-            .filter(entry -> StringUtils.endsWithIgnoreCase(entry.getKey().toString(), suffix))
-            .map(Map.Entry::getValue)
-            .flatMap(Set::stream)
-            .collect(Collectors.toSet());
+        throw new UnsupportedOperationException(
+            "Multi-value index does not support stringEndsWith operation"
+        );
     }
 
     @Override
     public Set<String> stringNotEndsWith(String suffix) {
-        ensureStringKeyType();
-        return index.entrySet()
-            .stream()
-            .filter(entry -> !StringUtils.endsWithIgnoreCase(entry.getKey().toString(), suffix))
-            .map(Map.Entry::getValue)
-            .flatMap(Set::stream)
-            .collect(Collectors.toSet());
+        throw new UnsupportedOperationException(
+            "Multi-value index does not support stringNotEndsWith operation"
+        );
     }
 
     @Override
     public Set<String> notEqual(K key) {
-        return index.entrySet().stream()
-            .filter(entry -> !Objects.equals(entry.getKey(), key))
-            .map(Map.Entry::getValue)
-            .flatMap(Set::stream)
-            .collect(Collectors.toSet());
+        return notIn(Collections.singleton(key));
     }
 
     @Override


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/area core

#### What this PR does / why we need it:

This PR fixes the invalid result of `notEqual` and `notIn` methods of multi-value index. Meanwhile, I restrict unsupported operations like `greaterThan` because they are not suitable for mutli-value index.

#### Which issue(s) this PR fixes:

Fixes https://github.com/halo-dev/halo/issues/8184

#### Special notes for your reviewer:

Make sure no places use the unsupported operations.

#### Does this PR introduce a user-facing change?

```release-note
修复多值索引部分查询结果不准确问题
```

