### PR TITLE
Remove unnecessary subscribeOn calls in ReactiveExtensionClientImpl to streamline data retrieval

### DIFF
--- a/application/src/main/java/run/halo/app/extension/ReactiveExtensionClientImpl.java
+++ b/application/src/main/java/run/halo/app/extension/ReactiveExtensionClientImpl.java
@@ -128,7 +128,6 @@ public class ReactiveExtensionClientImpl implements ReactiveExtensionClient {
         return Mono.fromCallable(
                 () -> indexEngine.retrieveAll(scheme.type(), options, nullSafeSort)
             )
-            .subscribeOn(this.scheduler)
             .flatMapMany(objectKeys -> {
                 var storeNames = StreamSupport.stream(objectKeys.spliterator(), false)
                     .map(objectKey -> ExtensionStoreUtil.buildStoreName(scheme, objectKey))
@@ -159,7 +158,6 @@ public class ReactiveExtensionClientImpl implements ReactiveExtensionClient {
     ) {
         var scheme = schemeManager.get(type);
         return Mono.fromCallable(() -> indexEngine.retrieveAll(scheme.type(), options, sort))
-            .subscribeOn(this.scheduler)
             .flatMapMany(Flux::fromIterable);
     }
 
@@ -169,7 +167,6 @@ public class ReactiveExtensionClientImpl implements ReactiveExtensionClient {
     ) {
         var scheme = schemeManager.get(type);
         return Mono.fromCallable(() -> indexEngine.retrieveTopN(scheme.type(), options, sort, topN))
-            .subscribeOn(this.scheduler)
             .flatMapMany(Flux::fromIterable);
     }
 
@@ -178,7 +175,6 @@ public class ReactiveExtensionClientImpl implements ReactiveExtensionClient {
         PageRequest page) {
         var scheme = schemeManager.get(type);
         return Mono.fromCallable(() -> indexEngine.retrieve(scheme.type(), options, page))
-            .subscribeOn(this.scheduler)
             .flatMap(listResult -> {
                 var storeNames = listResult.get()
                     .map(objectKey -> ExtensionStoreUtil.buildStoreName(scheme, objectKey))
@@ -202,15 +198,13 @@ public class ReactiveExtensionClientImpl implements ReactiveExtensionClient {
     public <E extends Extension> Mono<ListResult<String>> listNamesBy(Class<E> type,
         ListOptions options, PageRequest pageable) {
         var scheme = schemeManager.get(type);
-        return Mono.fromCallable(() -> indexEngine.retrieve(scheme.type(), options, pageable))
-            .subscribeOn(this.scheduler);
+        return Mono.fromCallable(() -> indexEngine.retrieve(scheme.type(), options, pageable));
     }
 
     @Override
     public <E extends Extension> Mono<Long> countBy(Class<E> type, ListOptions options) {
         var scheme = schemeManager.get(type);
-        return Mono.fromCallable(() -> indexEngine.count(scheme.type(), options))
-            .subscribeOn(this.scheduler);
+        return Mono.fromCallable(() -> indexEngine.count(scheme.type(), options));
     }
 
     @Override


### PR DESCRIPTION
#### What type of PR is this?

/kind improvement
/area core
/milestone 2.22.x

#### What this PR does / why we need it:

This PR removes unnecessary subscribeOn calls in ReactiveExtensionClientImpl to streamline data retrieval.

It's safe now because the index engine doesn't have any IO blocking operations.

#### Which issue(s) this PR fixes:

Fixes https://github.com/halo-dev/halo/issues/8081

#### Special notes for your reviewer:

Run Halo with JVM options `-Dreactor.schedulers.defaultPoolSize=1 -Dreactor.schedulers.defaultBoundedElasticSize=1` and request index page.

#### Does this PR introduce a user-facing change?

```release-note
提升系统稳定性
```
