### PR TITLE
Set input to empty string on single attachment removal

### DIFF
--- a/ui/src/formkit/inputs/attachment/AttachmentInput.vue
+++ b/ui/src/formkit/inputs/attachment/AttachmentInput.vue
@@ -83,7 +83,7 @@ const handleRemove = (index: number) => {
   if (multiple.value) {
     props.context.node.input(currentValue.value.filter((_, i) => i !== index));
   } else {
-    props.context.node.input(undefined);
+    props.context.node.input("");
   }
 };
 


### PR DESCRIPTION
#### What type of PR is this?

/area ui
/kind bug
/milestone 2.22.x

#### What this PR does / why we need it:

Modified the logic for removing images in attachment form type to set it as an empty string, keeping consistent with the behavior of the legacy attachment form type

#### Does this PR introduce a user-facing change?

```release-note
修复附件表单类型的移除逻辑，与旧版保持一致
```
