### PR TITLE
Add support for single-valued attributes in index specifications

### DIFF
--- a/api/src/main/java/run/halo/app/extension/index/DefaultIndexAttribute.java
+++ b/api/src/main/java/run/halo/app/extension/index/DefaultIndexAttribute.java
@@ -16,8 +16,15 @@ class DefaultIndexAttribute<E extends Extension, K extends Comparable<K>>
 
     private final Function<E, Set<K>> valuesFunc;
 
-    public DefaultIndexAttribute(Function<E, Set<K>> valuesFunc, Class<E> objectType,
-        Class<K> keyType) {
+    private final boolean singleValue;
+
+    public DefaultIndexAttribute(
+        Function<E, Set<K>> valuesFunc,
+        Class<E> objectType,
+        Class<K> keyType,
+        boolean singleValue
+    ) {
+        this.singleValue = singleValue;
         Assert.notNull(valuesFunc, "Values function must not be null");
         Assert.notNull(objectType, "Cannot resolve object type");
         Assert.notNull(keyType, "Cannot resolve key type");
@@ -46,5 +53,10 @@ class DefaultIndexAttribute<E extends Extension, K extends Comparable<K>>
 
     private boolean checkType(Extension object) {
         return getObjectType().isInstance(object);
+    }
+
+    @Override
+    public boolean singleValue() {
+        return this.singleValue;
     }
 }

--- a/api/src/main/java/run/halo/app/extension/index/IndexAttribute.java
+++ b/api/src/main/java/run/halo/app/extension/index/IndexAttribute.java
@@ -37,4 +37,11 @@ public interface IndexAttribute<E extends Extension, K extends Comparable<K>> {
      */
     Set<K> getValues(E e);
 
+    /**
+     * Indicates whether this attribute is single-valued.
+     *
+     * @return true if single-valued, false otherwise
+     */
+    boolean singleValue();
+
 }

--- a/api/src/main/java/run/halo/app/extension/index/IndexAttributeFactory.java
+++ b/api/src/main/java/run/halo/app/extension/index/IndexAttributeFactory.java
@@ -37,15 +37,19 @@ public class IndexAttributeFactory {
     private static <E extends Extension, K extends Comparable<K>> IndexAttribute<E, K> attributes(
         Class<E> objectType, Class<K> keyType, Function<E, Set<K>> valuesFunc
     ) {
-        return new DefaultIndexAttribute<>(valuesFunc, objectType, keyType);
+        return new DefaultIndexAttribute<>(valuesFunc, objectType, keyType, false);
     }
 
     private static <E extends Extension, K extends Comparable<K>> IndexAttribute<E, K> attribute(
         Class<E> objectType, Class<K> keyType, Function<E, K> valueFunc
     ) {
-        return new DefaultIndexAttribute<>(e -> Optional.ofNullable(valueFunc.apply(e))
-            .map(Set::of)
-            .orElse(null), objectType, keyType);
+        return new DefaultIndexAttribute<>(
+            e -> Optional.ofNullable(valueFunc.apply(e))
+                .map(Set::of)
+                .orElse(null),
+            objectType,
+            keyType,
+            true);
     }
 
 }

--- a/api/src/main/java/run/halo/app/extension/index/IndexSpecs.java
+++ b/api/src/main/java/run/halo/app/extension/index/IndexSpecs.java
@@ -20,7 +20,7 @@ public interface IndexSpecs<E extends Extension> {
      *                                  the index spec is invalid
      */
     default <K extends Comparable<K>> void add(IndexSpec<E, K> indexSpec) {
-        add((ValueIndexSpec<E, K>) indexSpec);
+        add(indexSpec.normalize());
     }
 
     <K extends Comparable<K>> void add(ValueIndexSpec<E, K> indexSpec);


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/area core
/area plugin
/milestone 2.22.x

#### What this PR does / why we need it:

In PR <https://github.com/halo-dev/halo/pull/8187>, I restricted unsupported operations in MultiValueIndex, such as `between`, `stringContains`.

But defining an index spec with deprecated style will be converted to MultiValueIndex always, which results in some plugins to fail to work properly.

```java
java.lang.UnsupportedOperationException: Multi-value index does not support stringContains operation
	at run.halo.app.extension.index.MultiValueIndex.stringContains(MultiValueIndex.java:167) ~[main/:na]
```

This PR converts them into SingleValueIndex to brings them back to work.

#### Does this PR introduce a user-facing change?

```release-note
None
```
