### PR TITLE
fix: alignment method is ineffective for aligning block node

### DIFF
--- a/ui/packages/editor/src/extensions/align/index.ts
+++ b/ui/packages/editor/src/extensions/align/index.ts
@@ -1,0 +1,141 @@
+import ToolbarItem from "@/components/toolbar/ToolbarItem.vue";
+import ToolbarSubItem from "@/components/toolbar/ToolbarSubItem.vue";
+import { i18n } from "@/locales";
+import { Extension, type Editor } from "@/tiptap";
+import type { ExtensionOptions } from "@/types";
+import { markRaw } from "vue";
+import MingcuteAlignCenterLine from "~icons/mingcute/align-center-line";
+import MingcuteAlignJustifyLine from "~icons/mingcute/align-justify-line";
+import MingcuteAlignLeftLine from "~icons/mingcute/align-left-line";
+import MingcuteAlignRightLine from "~icons/mingcute/align-right-line";
+
+const inlineIconComponent = {
+  left: MingcuteAlignLeftLine,
+  center: MingcuteAlignCenterLine,
+  right: MingcuteAlignRightLine,
+  justify: MingcuteAlignJustifyLine,
+};
+
+const blockIconComponent = {
+  start: MingcuteAlignLeftLine,
+  center: MingcuteAlignCenterLine,
+  end: MingcuteAlignRightLine,
+};
+
+const getIcon = (editor: Editor) => {
+  let icon = MingcuteAlignLeftLine;
+  Object.entries(inlineIconComponent).forEach(([key, value]) => {
+    if (editor.isActive({ textAlign: key })) {
+      icon = value;
+      return;
+    }
+  });
+  Object.entries(blockIconComponent).forEach(([key, value]) => {
+    if (editor.isActive({ alignItems: key })) {
+      icon = value;
+      return;
+    }
+  });
+  return icon;
+};
+
+/**
+ * The extension for the align attribute. Including inline and block nodes.
+ */
+export const ExtensionAlign = Extension.create<ExtensionOptions>({
+  name: "align",
+
+  addOptions() {
+    return {
+      ...this.parent?.(),
+      getToolbarItems({ editor }: { editor: Editor }) {
+        return {
+          priority: 180,
+          component: markRaw(ToolbarItem),
+          props: {
+            editor,
+            isActive: false,
+            icon: markRaw(getIcon(editor)),
+            title: i18n.global.t("editor.common.align_method"),
+          },
+          children: [
+            {
+              priority: 0,
+              component: markRaw(ToolbarSubItem),
+              props: {
+                editor,
+                isActive:
+                  editor.isActive({ textAlign: "left" }) ||
+                  editor.isActive({ alignItems: "start" }),
+                icon: markRaw(MingcuteAlignLeftLine),
+                title: i18n.global.t("editor.common.align_left"),
+                action: () => {
+                  console.log(
+                    editor.isActive({ textAlign: "left" }),
+                    editor.isActive({ alignItems: "start" })
+                  );
+                  return editor
+                    .chain()
+                    .focus()
+                    .setTextAlign("left")
+                    .setBlockPosition("start")
+                    .run();
+                },
+              },
+            },
+            {
+              priority: 10,
+              component: markRaw(ToolbarSubItem),
+              props: {
+                editor,
+                isActive:
+                  editor.isActive({ textAlign: "center" }) ||
+                  editor.isActive({ alignItems: "center" }),
+                icon: markRaw(MingcuteAlignCenterLine),
+                title: i18n.global.t("editor.common.align_center"),
+                action: () =>
+                  editor
+                    .chain()
+                    .focus()
+                    .setTextAlign("center")
+                    .setBlockPosition("center")
+                    .run(),
+              },
+            },
+            {
+              priority: 20,
+              component: markRaw(ToolbarSubItem),
+              props: {
+                editor,
+                isActive:
+                  editor.isActive({ textAlign: "right" }) ||
+                  editor.isActive({ alignItems: "end" }),
+                icon: markRaw(MingcuteAlignRightLine),
+                title: i18n.global.t("editor.common.align_right"),
+                action: () =>
+                  editor
+                    .chain()
+                    .focus()
+                    .setTextAlign("right")
+                    .setBlockPosition("end")
+                    .run(),
+              },
+            },
+            {
+              priority: 30,
+              component: markRaw(ToolbarSubItem),
+              props: {
+                editor,
+                isActive: editor.isActive({ textAlign: "justify" }),
+                icon: markRaw(MingcuteAlignJustifyLine),
+                title: i18n.global.t("editor.common.align_justify"),
+                action: () =>
+                  editor.chain().focus().setTextAlign("justify").run(),
+              },
+            },
+          ],
+        };
+      },
+    };
+  },
+});

--- a/ui/packages/editor/src/extensions/audio/AudioView.vue
+++ b/ui/packages/editor/src/extensions/audio/AudioView.vue
@@ -3,12 +3,16 @@ import { EditorLinkObtain } from "@/components";
 import { ResourceReplaceButton } from "@/components/upload";
 import { useExternalAssetsTransfer } from "@/composables/use-attachment";
 import { i18n } from "@/locales";
-import type { NodeViewProps } from "@/tiptap";
-import { NodeViewWrapper } from "@/tiptap";
+import {
+  findParentNodeClosestToPos,
+  NodeViewWrapper,
+  type NodeViewProps,
+} from "@/tiptap";
 import { VButton } from "@halo-dev/components";
 import { utils, type AttachmentSimple } from "@halo-dev/ui-shared";
 import { computed, ref } from "vue";
 import MingcuteMusic2Line from "~icons/mingcute/music-2-line";
+import { ExtensionFigure } from "../figure";
 
 const props = defineProps<NodeViewProps>();
 
@@ -33,8 +37,23 @@ const initialization = computed(() => {
   return !src.value;
 });
 
-const position = computed(() => {
-  return props.node?.attrs.position || "left";
+// Get the align items of the audio from the figure parent
+const alignItems = computed(() => {
+  const pos = props.getPos();
+  if (!pos) {
+    return "start";
+  }
+  const $pos = props.editor.state.doc.resolve(pos);
+  const figureParent = findParentNodeClosestToPos(
+    $pos,
+    (node) => node.type.name === ExtensionFigure.name
+  );
+
+  if (figureParent) {
+    return figureParent.node.attrs.alignItems;
+  }
+
+  return "start";
 });
 
 const editorLinkObtain = ref();
@@ -78,9 +97,7 @@ const isPercentageWidth = computed(() => {
     as="div"
     class="flex w-full"
     :class="{
-      'justify-start': position === 'left',
-      'justify-center': position === 'center',
-      'justify-end': position === 'right',
+      [`justify-${alignItems}`]: true,
     }"
   >
     <div

--- a/ui/packages/editor/src/extensions/audio/BubbleItemAudioPosition.vue
+++ b/ui/packages/editor/src/extensions/audio/BubbleItemAudioPosition.vue
@@ -4,11 +4,12 @@ import BubbleButton from "@/components/bubble/BubbleButton.vue";
 import { i18n } from "@/locales";
 import type { BubbleItemComponentProps } from "@/types";
 import { VDropdown } from "@halo-dev/components";
+import { findParentNode } from "@tiptap/core";
 import { computed } from "vue";
 import MingcuteAlignCenterLine from "~icons/mingcute/align-center-line";
 import MingcuteAlignLeftLine from "~icons/mingcute/align-left-line";
 import MingcuteAlignRightLine from "~icons/mingcute/align-right-line";
-import { ExtensionAudio, ExtensionFigure } from "..";
+import { ExtensionAudio } from "..";
 
 const props = withDefaults(defineProps<BubbleItemComponentProps>(), {
   visible: () => true,
@@ -17,7 +18,7 @@ const props = withDefaults(defineProps<BubbleItemComponentProps>(), {
 const positionOptions = [
   {
     text: i18n.global.t("editor.common.align_left"),
-    value: "left",
+    value: "start",
     icon: MingcuteAlignLeftLine,
   },
   {
@@ -27,7 +28,7 @@ const positionOptions = [
   },
   {
     text: i18n.global.t("editor.common.align_right"),
-    value: "right",
+    value: "end",
     icon: MingcuteAlignRightLine,
   },
 ];
@@ -48,13 +49,18 @@ const currentPosition = computed(() => {
   return positionOption;
 });
 
+const isActive = (blockPosition: string) => {
+  const audioParent = findParentNode(
+    (node) => node.type.name === ExtensionAudio.name
+  )(props.editor.state.selection);
+  if (!audioParent) {
+    return false;
+  }
+  return audioParent.node.attrs.alignItems === blockPosition;
+};
+
 const handleSetPosition = (position: string) => {
-  return props.editor
-    .chain()
-    .focus()
-    .updateAttributes(ExtensionAudio.name, { position })
-    .updateAttributes(ExtensionFigure.name, { position })
-    .run();
+  return props.editor.chain().focus().setBlockPosition(position).run();
 };
 </script>
 <template>
@@ -79,7 +85,7 @@ const handleSetPosition = (position: string) => {
           v-for="option in positionOptions"
           :key="option.value"
           v-close-popper
-          :is-active="editor.isActive({ position: option.value })"
+          :is-active="isActive(option.value)"
           @click="handleSetPosition(option.value)"
         >
           <template #icon>

--- a/ui/packages/editor/src/extensions/audio/index.ts
+++ b/ui/packages/editor/src/extensions/audio/index.ts
@@ -98,20 +98,6 @@ export const ExtensionAudio = Node.create<ExtensionAudioOptions>({
           };
         },
       },
-      position: {
-        default: "left",
-        parseHTML: (element) => {
-          return (
-            element.getAttribute("data-position") ||
-            element.getAttribute("text-align")
-          );
-        },
-        renderHTML: (attributes) => {
-          return {
-            "data-position": attributes.position,
-          };
-        },
-      },
       file: {
         default: null,
         renderHTML() {

--- a/ui/packages/editor/src/extensions/block-position/index.ts
+++ b/ui/packages/editor/src/extensions/block-position/index.ts
@@ -1,0 +1,141 @@
+import { Extension } from "@tiptap/core";
+
+export interface ExtensionBlockPositionOptions {
+  /**
+   * The types where the block position attribute can be applied.
+   * @default []
+   * @example ['figure']
+   */
+  types: string[];
+
+  /**
+   * The positions which are allowed.
+   * @default ['start', 'center', 'end']
+   * @example ['start', 'center']
+   */
+  positions: string[];
+
+  /**
+   * The default position.
+   * @default null
+   * @example 'start'
+   */
+  defaultPosition: string | null;
+}
+
+declare module "@tiptap/core" {
+  interface Commands<ReturnType> {
+    blockPosition: {
+      /**
+       * Set the block position attribute
+       * @param position The position ("start", "center", "end")
+       * @example editor.commands.setBlockPosition('start')
+       */
+      setBlockPosition: (position: string) => ReturnType;
+      /**
+       * Unset the block position attribute
+       * @example editor.commands.unsetBlockPosition()
+       */
+      unsetBlockPosition: () => ReturnType;
+      /**
+       * Toggle the block position attribute
+       * @param alignment The alignment
+       * @example editor.commands.toggleBlockPosition('end')
+       */
+      toggleBlockPosition: (position: string) => ReturnType;
+    };
+  }
+}
+
+/**
+ * This extension allows to set the block position.
+ */
+export const ExtensionBlockPosition =
+  Extension.create<ExtensionBlockPositionOptions>({
+    name: "blockPosition",
+
+    addOptions() {
+      return {
+        types: [],
+        positions: ["start", "center", "end"],
+        defaultPosition: null,
+      };
+    },
+
+    addGlobalAttributes() {
+      return [
+        {
+          types: this.options.types,
+          attributes: {
+            alignItems: {
+              default: this.options.defaultPosition,
+              parseHTML: (element) => {
+                const position = element.style.alignItems;
+
+                return this.options.positions.includes(position)
+                  ? position
+                  : this.options.defaultPosition;
+              },
+              renderHTML: (attributes) => {
+                if (!attributes.alignItems) {
+                  return {};
+                }
+
+                return { style: `align-items: ${attributes.alignItems}` };
+              },
+            },
+          },
+        },
+      ];
+    },
+
+    addCommands() {
+      return {
+        setBlockPosition:
+          (position: string) =>
+          ({ commands }) => {
+            if (!this.options.positions.includes(position)) {
+              return false;
+            }
+
+            return this.options.types
+              .map((type) =>
+                commands.updateAttributes(type, { alignItems: position })
+              )
+              .some((response) => response);
+          },
+
+        unsetBlockPosition:
+          () =>
+          ({ commands }) => {
+            return this.options.types
+              .map((type) => commands.resetAttributes(type, "alignItems"))
+              .some((response) => response);
+          },
+
+        toggleBlockPosition:
+          (position) =>
+          ({ editor, commands }) => {
+            if (!this.options.positions.includes(position)) {
+              return false;
+            }
+
+            if (editor.isActive({ alignItems: position })) {
+              return commands.unsetBlockPosition();
+            }
+            return commands.setBlockPosition(position);
+          },
+      };
+    },
+
+    addKeyboardShortcuts() {
+      return {
+        "Mod-Shift-l": () => this.editor.commands.setBlockPosition("left"),
+        "Mod-Shift-e": () => this.editor.commands.setBlockPosition("center"),
+        "Mod-Shift-r": () => this.editor.commands.setBlockPosition("right"),
+      };
+    },
+  }).configure({
+    types: ["figure"],
+    positions: ["start", "center", "end"],
+  });

--- a/ui/packages/editor/src/extensions/extensions-kit.ts
+++ b/ui/packages/editor/src/extensions/extensions-kit.ts
@@ -8,8 +8,11 @@ import type {
   PlaceholderOptions,
 } from "@tiptap/extensions";
 import { filterDuplicateExtensions } from "../utils";
+import { ExtensionAlign } from "./align";
 import type { ExtensionAudioOptions } from "./audio";
 import { ExtensionAudio } from "./audio";
+import type { ExtensionBlockPositionOptions } from "./block-position";
+import { ExtensionBlockPosition } from "./block-position";
 import {
   ExtensionBlockquote,
   type ExtensionBlockquoteOptions,
@@ -153,6 +156,8 @@ export interface ExtensionsKitOptions {
   upload?: boolean;
   video: Partial<ExtensionVideoOptions> | false;
   listExtra: Partial<ExtensionOptions> | false;
+  blockPosition: Partial<ExtensionBlockPositionOptions> | false;
+  align: Partial<ExtensionOptions> | false;
   customExtensions?: Extensions;
 }
 
@@ -407,6 +412,16 @@ export const ExtensionsKit = Extension.create<ExtensionsKitOptions>({
       internalExtensions.push(
         ExtensionListExtra.configure(this.options.listExtra)
       );
+    }
+
+    if (this.options.blockPosition !== false) {
+      internalExtensions.push(
+        ExtensionBlockPosition.configure(this.options.blockPosition)
+      );
+    }
+
+    if (this.options.align !== false) {
+      internalExtensions.push(ExtensionAlign);
     }
 
     const extensions =

--- a/ui/packages/editor/src/extensions/figure/index.ts
+++ b/ui/packages/editor/src/extensions/figure/index.ts
@@ -54,15 +54,6 @@ export const ExtensionFigure = Node.create<ExtensionFigureOptions>({
           };
         },
       },
-      position: {
-        default: "left",
-        parseHTML: (element) => {
-          return element.getAttribute("data-position");
-        },
-        renderHTML: (attributes) => {
-          return { "data-position": attributes.position };
-        },
-      },
     };
   },
 
@@ -75,17 +66,10 @@ export const ExtensionFigure = Node.create<ExtensionFigureOptions>({
   },
 
   renderHTML({ HTMLAttributes }) {
-    const alignItemsMap: Record<string, string> = {
-      left: "start",
-      center: "center",
-      right: "end",
-    };
-    const alignItems =
-      alignItemsMap[HTMLAttributes["data-position"]] || "start";
     return [
       "figure",
       mergeAttributes(this.options.HTMLAttributes, HTMLAttributes, {
-        style: `display: flex; flex-direction: column; align-items: ${alignItems}`,
+        style: `display: flex; flex-direction: column;`,
       }),
       0,
     ];

--- a/ui/packages/editor/src/extensions/image/BubbleItemImagePosition.vue
+++ b/ui/packages/editor/src/extensions/image/BubbleItemImagePosition.vue
@@ -4,6 +4,7 @@ import BubbleButton from "@/components/bubble/BubbleButton.vue";
 import { i18n } from "@/locales";
 import type { BubbleItemComponentProps } from "@/types";
 import { VDropdown } from "@halo-dev/components";
+import { isActive } from "@tiptap/core";
 import { computed } from "vue";
 import MingcuteAlignCenterLine from "~icons/mingcute/align-center-line";
 import MingcuteAlignLeftLine from "~icons/mingcute/align-left-line";
@@ -17,7 +18,7 @@ const props = withDefaults(defineProps<BubbleItemComponentProps>(), {
 const positionOptions = [
   {
     text: i18n.global.t("editor.common.align_left"),
-    value: "left",
+    value: "start",
     icon: MingcuteAlignLeftLine,
   },
   {
@@ -27,7 +28,7 @@ const positionOptions = [
   },
   {
     text: i18n.global.t("editor.common.align_right"),
-    value: "right",
+    value: "end",
     icon: MingcuteAlignRightLine,
   },
 ];
@@ -48,13 +49,8 @@ const currentPosition = computed(() => {
   return positionOption;
 });
 
-const handleSetPosition = (position: string) => {
-  props.editor
-    .chain()
-    .focus()
-    .updateAttributes(ExtensionImage.name, { position })
-    .updateAttributes(ExtensionFigure.name, { position })
-    .run();
+const handleSetPosition = (blockPosition: string) => {
+  props.editor.chain().focus().setBlockPosition(blockPosition).run();
 };
 </script>
 <template>
@@ -79,7 +75,11 @@ const handleSetPosition = (position: string) => {
           v-for="option in positionOptions"
           :key="option.value"
           v-close-popper
-          :is-active="editor.isActive({ position: option.value })"
+          :is-active="
+            isActive(props.editor.state, ExtensionFigure.name, {
+              alignItems: option.value,
+            })
+          "
           @click="handleSetPosition(option.value)"
         >
           <template #icon>

--- a/ui/packages/editor/src/extensions/image/ImageView.vue
+++ b/ui/packages/editor/src/extensions/image/ImageView.vue
@@ -3,11 +3,16 @@ import { EditorLinkObtain } from "@/components";
 import { ResourceReplaceButton } from "@/components/upload";
 import { useExternalAssetsTransfer } from "@/composables/use-attachment";
 import { i18n } from "@/locales";
-import { NodeViewWrapper, type NodeViewProps } from "@/tiptap";
+import {
+  findParentNodeClosestToPos,
+  NodeViewWrapper,
+  type NodeViewProps,
+} from "@/tiptap";
 import { fileToBase64 } from "@/utils/upload";
 import { IconImageAddLine, VButton } from "@halo-dev/components";
 import { utils, type AttachmentSimple } from "@halo-dev/ui-shared";
 import { computed, onMounted, onUnmounted, ref, watch } from "vue";
+import { ExtensionFigure } from "../figure";
 import { ExtensionImage } from "./index";
 
 const props = defineProps<NodeViewProps>();
@@ -41,8 +46,23 @@ const href = computed({
   },
 });
 
-const position = computed(() => {
-  return props.node?.attrs.position || "left";
+// Get the align items of the image from the figure parent
+const alignItems = computed(() => {
+  const pos = props.getPos();
+  if (!pos) {
+    return "start";
+  }
+  const $pos = props.editor.state.doc.resolve(pos);
+  const figureParent = findParentNodeClosestToPos(
+    $pos,
+    (node) => node.type.name === ExtensionFigure.name
+  );
+
+  if (figureParent) {
+    return figureParent.node.attrs.alignItems;
+  }
+
+  return "start";
 });
 
 const fileBase64 = ref<string>();
@@ -266,9 +286,7 @@ const isPercentageWidth = computed(() => {
     as="div"
     class="flex w-full"
     :class="{
-      'justify-start': position === 'left',
-      'justify-center': position === 'center',
-      'justify-end': position === 'right',
+      [`justify-${alignItems}`]: true,
     }"
   >
     <div

--- a/ui/packages/editor/src/extensions/image/index.ts
+++ b/ui/packages/editor/src/extensions/image/index.ts
@@ -105,20 +105,6 @@ export const ExtensionImage = TiptapImage.extend<ExtensionImageOptions>({
           };
         },
       },
-      position: {
-        default: "left",
-        parseHTML: (element) => {
-          return (
-            element.getAttribute("data-position") ||
-            element.getAttribute("text-align")
-          );
-        },
-        renderHTML: (attributes) => {
-          return {
-            "data-position": attributes.position,
-          };
-        },
-      },
       file: {
         default: null,
         renderHTML() {
@@ -166,7 +152,7 @@ export const ExtensionImage = TiptapImage.extend<ExtensionImageOptions>({
               return;
             }
 
-            let position = "left";
+            let blockPosition = "start";
             let deletePreviousNode = false;
             let previousNodePos = -1;
             let previousNodeSize = 0;
@@ -177,13 +163,15 @@ export const ExtensionImage = TiptapImage.extend<ExtensionImageOptions>({
               previousNode.type.name === ExtensionParagraph.name
             ) {
               if (previousNode.attrs.textAlign) {
-                const positionMap: Record<string, string> = {
-                  left: "left",
+                const textAlignToBlockPositionMap: Record<string, string> = {
+                  left: "start",
                   center: "center",
-                  right: "right",
+                  right: "end",
                   justify: "center",
                 };
-                position = positionMap[previousNode.attrs.textAlign] || "left";
+                blockPosition =
+                  textAlignToBlockPositionMap[previousNode.attrs.textAlign] ??
+                  "start";
               }
               if (previousNode.textContent?.trim().length === 0) {
                 deletePreviousNode = true;
@@ -195,7 +183,7 @@ export const ExtensionImage = TiptapImage.extend<ExtensionImageOptions>({
             const figureNode = newState.schema.nodes.figure.create(
               {
                 contentType: "image",
-                position,
+                alignItems: blockPosition,
               },
               [node]
             );

--- a/ui/packages/editor/src/extensions/text-align/index.ts
+++ b/ui/packages/editor/src/extensions/text-align/index.ts
@@ -1,107 +1,12 @@
-import ToolbarItem from "@/components/toolbar/ToolbarItem.vue";
-import ToolbarSubItem from "@/components/toolbar/ToolbarSubItem.vue";
-import { i18n } from "@/locales";
-import { type Editor } from "@/tiptap";
 import type { ExtensionOptions } from "@/types";
 import TiptapTextAlign, {
   type TextAlignOptions,
 } from "@tiptap/extension-text-align";
-import { markRaw } from "vue";
-import MingcuteAlignCenterLine from "~icons/mingcute/align-center-line";
-import MingcuteAlignJustifyLine from "~icons/mingcute/align-justify-line";
-import MingcuteAlignLeftLine from "~icons/mingcute/align-left-line";
-import MingcuteAlignRightLine from "~icons/mingcute/align-right-line";
-
-const iconComponent = {
-  left: MingcuteAlignLeftLine,
-  center: MingcuteAlignCenterLine,
-  right: MingcuteAlignRightLine,
-  justify: MingcuteAlignJustifyLine,
-};
-
-const getIcon = (editor: Editor) => {
-  let icon = MingcuteAlignLeftLine;
-  Object.entries(iconComponent).forEach(([key, value]) => {
-    if (editor.isActive({ textAlign: key })) {
-      icon = value;
-      return;
-    }
-  });
-  return icon;
-};
 
 export type ExtensionTextAlignOptions = ExtensionOptions &
   Partial<TextAlignOptions>;
 
 export const ExtensionTextAlign =
-  TiptapTextAlign.extend<ExtensionTextAlignOptions>({
-    addOptions() {
-      return {
-        ...this.parent?.(),
-        getToolbarItems({ editor }: { editor: Editor }) {
-          return {
-            priority: 180,
-            component: markRaw(ToolbarItem),
-            props: {
-              editor,
-              isActive: false,
-              icon: markRaw(getIcon(editor)),
-              title: i18n.global.t("editor.common.align_method"),
-            },
-            children: [
-              {
-                priority: 0,
-                component: markRaw(ToolbarSubItem),
-                props: {
-                  editor,
-                  isActive: editor.isActive({ textAlign: "left" }),
-                  icon: markRaw(MingcuteAlignLeftLine),
-                  title: i18n.global.t("editor.common.align_left"),
-                  action: () =>
-                    editor.chain().focus().setTextAlign("left").run(),
-                },
-              },
-              {
-                priority: 10,
-                component: markRaw(ToolbarSubItem),
-                props: {
-                  editor,
-                  isActive: editor.isActive({ textAlign: "center" }),
-                  icon: markRaw(MingcuteAlignCenterLine),
-                  title: i18n.global.t("editor.common.align_center"),
-                  action: () =>
-                    editor.chain().focus().setTextAlign("center").run(),
-                },
-              },
-              {
-                priority: 20,
-                component: markRaw(ToolbarSubItem),
-                props: {
-                  editor,
-                  isActive: editor.isActive({ textAlign: "right" }),
-                  icon: markRaw(MingcuteAlignRightLine),
-                  title: i18n.global.t("editor.common.align_right"),
-                  action: () =>
-                    editor.chain().focus().setTextAlign("right").run(),
-                },
-              },
-              {
-                priority: 30,
-                component: markRaw(ToolbarSubItem),
-                props: {
-                  editor,
-                  isActive: editor.isActive({ textAlign: "justify" }),
-                  icon: markRaw(MingcuteAlignJustifyLine),
-                  title: i18n.global.t("editor.common.align_justify"),
-                  action: () =>
-                    editor.chain().focus().setTextAlign("justify").run(),
-                },
-              },
-            ],
-          };
-        },
-      };
-    },
-  }).configure({
+  TiptapTextAlign.extend<ExtensionTextAlignOptions>().configure({
     types: ["heading", "paragraph"],
   });

--- a/ui/packages/editor/src/extensions/video/BubbleItemVideoPosition.vue
+++ b/ui/packages/editor/src/extensions/video/BubbleItemVideoPosition.vue
@@ -4,11 +4,12 @@ import BubbleButton from "@/components/bubble/BubbleButton.vue";
 import { i18n } from "@/locales";
 import type { BubbleItemComponentProps } from "@/types";
 import { VDropdown } from "@halo-dev/components";
+import { findParentNode } from "@tiptap/core";
 import { computed } from "vue";
 import MingcuteAlignCenterLine from "~icons/mingcute/align-center-line";
 import MingcuteAlignLeftLine from "~icons/mingcute/align-left-line";
 import MingcuteAlignRightLine from "~icons/mingcute/align-right-line";
-import { ExtensionFigure, ExtensionVideo } from "..";
+import { ExtensionVideo } from "..";
 
 const props = withDefaults(defineProps<BubbleItemComponentProps>(), {
   visible: () => true,
@@ -17,7 +18,7 @@ const props = withDefaults(defineProps<BubbleItemComponentProps>(), {
 const positionOptions = [
   {
     text: i18n.global.t("editor.common.align_left"),
-    value: "left",
+    value: "start",
     icon: MingcuteAlignLeftLine,
   },
   {
@@ -27,7 +28,7 @@ const positionOptions = [
   },
   {
     text: i18n.global.t("editor.common.align_right"),
-    value: "right",
+    value: "end",
     icon: MingcuteAlignRightLine,
   },
 ];
@@ -48,13 +49,18 @@ const currentPosition = computed(() => {
   return positionOption;
 });
 
+const isActive = (blockPosition: string) => {
+  const videoParent = findParentNode(
+    (node) => node.type.name === ExtensionVideo.name
+  )(props.editor.state.selection);
+  if (!videoParent) {
+    return false;
+  }
+  return videoParent.node.attrs.alignItems === blockPosition;
+};
+
 const handleSetPosition = (position: string) => {
-  return props.editor
-    .chain()
-    .focus()
-    .updateAttributes(ExtensionVideo.name, { position })
-    .updateAttributes(ExtensionFigure.name, { position })
-    .run();
+  return props.editor.chain().focus().setBlockPosition(position).run();
 };
 </script>
 <template>
@@ -79,7 +85,7 @@ const handleSetPosition = (position: string) => {
           v-for="option in positionOptions"
           :key="option.value"
           v-close-popper
-          :is-active="editor.isActive({ position: option.value })"
+          :is-active="isActive(option.value)"
           @click="handleSetPosition(option.value)"
         >
           <template #icon>

--- a/ui/packages/editor/src/extensions/video/VideoView.vue
+++ b/ui/packages/editor/src/extensions/video/VideoView.vue
@@ -3,11 +3,16 @@ import { EditorLinkObtain } from "@/components";
 import { ResourceReplaceButton } from "@/components/upload";
 import { useExternalAssetsTransfer } from "@/composables/use-attachment";
 import { i18n } from "@/locales";
-import { NodeViewWrapper, type NodeViewProps } from "@/tiptap";
+import {
+  findParentNodeClosestToPos,
+  NodeViewWrapper,
+  type NodeViewProps,
+} from "@/tiptap";
 import { VButton } from "@halo-dev/components";
 import { utils, type AttachmentSimple } from "@halo-dev/ui-shared";
 import { computed, ref } from "vue";
 import MingcuteVideoLine from "~icons/mingcute/video-line";
+import { ExtensionFigure } from "../figure";
 
 const props = defineProps<NodeViewProps>();
 
@@ -30,10 +35,6 @@ const autoplay = computed(() => {
 
 const loop = computed(() => {
   return props.node.attrs.loop;
-});
-
-const position = computed(() => {
-  return props.node?.attrs.position || "left";
 });
 
 const initialization = computed(() => {
@@ -74,6 +75,25 @@ const { isExternalAsset, transferring, handleTransfer } =
 const isPercentageWidth = computed(() => {
   return props.node?.attrs.width?.includes("%");
 });
+
+// Get the align items of the image from the figure parent
+const alignItems = computed(() => {
+  const pos = props.getPos();
+  if (!pos) {
+    return "start";
+  }
+  const $pos = props.editor.state.doc.resolve(pos);
+  const figureParent = findParentNodeClosestToPos(
+    $pos,
+    (node) => node.type.name === ExtensionFigure.name
+  );
+
+  if (figureParent) {
+    return figureParent.node.attrs.alignItems;
+  }
+
+  return "start";
+});
 </script>
 
 <template>
@@ -81,9 +101,7 @@ const isPercentageWidth = computed(() => {
     as="div"
     class="flex w-full"
     :class="{
-      'justify-start': position === 'left',
-      'justify-center': position === 'center',
-      'justify-end': position === 'right',
+      [`justify-${alignItems}`]: true,
     }"
   >
     <div

--- a/ui/packages/editor/src/extensions/video/index.ts
+++ b/ui/packages/editor/src/extensions/video/index.ts
@@ -129,20 +129,6 @@ export const ExtensionVideo = Node.create<ExtensionVideoOptions>({
           };
         },
       },
-      position: {
-        default: "left",
-        parseHTML: (element) => {
-          return (
-            element.getAttribute("data-position") ||
-            element.getAttribute("text-align")
-          );
-        },
-        renderHTML: (attributes) => {
-          return {
-            "data-position": attributes.position,
-          };
-        },
-      },
       file: {
         default: null,
         renderHTML() {
@@ -216,7 +202,7 @@ export const ExtensionVideo = Node.create<ExtensionVideoOptions>({
               return;
             }
 
-            let position = "left";
+            let blockPosition = "start";
             let deletePreviousNode = false;
             let previousNodePos = -1;
             let previousNodeSize = 0;
@@ -227,13 +213,15 @@ export const ExtensionVideo = Node.create<ExtensionVideoOptions>({
               previousNode.type.name === ExtensionParagraph.name
             ) {
               if (previousNode.attrs.textAlign) {
-                const positionMap: Record<string, string> = {
-                  left: "left",
+                const textAlignToBlockPositionMap: Record<string, string> = {
+                  left: "start",
                   center: "center",
-                  right: "right",
+                  right: "end",
                   justify: "center",
                 };
-                position = positionMap[previousNode.attrs.textAlign] || "left";
+                blockPosition =
+                  textAlignToBlockPositionMap[previousNode.attrs.textAlign] ??
+                  "start";
               }
               if (previousNode.textContent?.trim().length === 0) {
                 deletePreviousNode = true;
@@ -245,7 +233,7 @@ export const ExtensionVideo = Node.create<ExtensionVideoOptions>({
             const figureNode = newState.schema.nodes.figure.create(
               {
                 contentType: "video",
-                position,
+                alignItems: blockPosition,
               },
               [node]
             );


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/area editor

#### What this PR does / why we need it:

解决默认编辑器中，顶部工具栏中的对齐工具对图片、视频、音频无效的问题。

#### Which issue(s) this PR fixes:

Fixes #8188

#### Does this PR introduce a user-facing change?
```release-note
解决默认编辑器中顶部工具栏中的对齐工具对图片、视频、音频无效的问题。
```
