### PR TITLE
Replace useI18n with global i18n in use-attachment

### DIFF
--- a/ui/packages/editor/src/composables/use-attachment.ts
+++ b/ui/packages/editor/src/composables/use-attachment.ts
@@ -1,15 +1,14 @@
+import { i18n } from "@/locales";
 import { ucApiClient } from "@halo-dev/api-client";
 import { Toast } from "@halo-dev/components";
 import { stores, type AttachmentSimple } from "@halo-dev/ui-shared";
 import { computed, ref, type Ref } from "vue";
-import { useI18n } from "vue-i18n";
 
 export function useExternalAssetsTransfer(
   src: Ref<string | undefined>,
   callback: (attachment: AttachmentSimple) => void
 ) {
   const { globalInfo } = stores.globalInfo();
-  const { t } = useI18n();
 
   const isExternalAsset = computed(() => {
     if (src.value?.startsWith("/")) {
@@ -43,7 +42,7 @@ export function useExternalAssetsTransfer(
       alt: data.spec.displayName,
     });
 
-    Toast.success(t("editor.common.toast.save_success"));
+    Toast.success(i18n.global.t("editor.common.toast.save_success"));
 
     transferring.value = false;
   }


### PR DESCRIPTION
#### What type of PR is this?

/area ui
/kind bug
/milestone 2.22.x

#### What this PR does / why we need it:

<img width="479" height="179" alt="image" src="https://github.com/user-attachments/assets/d65ef87a-a7e3-466c-9c8c-881eacd70fc7" />

#### Does this PR introduce a user-facing change?

```release-note
修复编辑器转存单个图片时的成功提示信息不正确的问题
```
