### PR TITLE
Update stale issue labels in workflow

### DIFF
--- a/.github/workflows/stale-issues.yaml
+++ b/.github/workflows/stale-issues.yaml
@@ -26,6 +26,6 @@ jobs:
           days-before-pr-stale: -1
           days-before-pr-close: -1
           stale-issue-label: "lifecycle/stale"
-          only-issue-labels: "triage/needs-information"
+          only-issue-labels: "triage/needs-information,priority/awaiting-more-evidence,help wanted"
           operations-per-run: 100
           ascending: true


### PR DESCRIPTION
#### What type of PR is this?

None

#### What this PR does / why we need it:

Added 'priority/awaiting-more-evidence' and 'help wanted' to the list of labels that trigger the stale issue workflow

#### Does this PR introduce a user-facing change?

```release-note
None
```
