### PR TITLE
Remove unused caching resource resolver from WebFlux configuration

### DIFF
--- a/application/src/main/java/run/halo/app/infra/config/WebFluxConfig.java
+++ b/application/src/main/java/run/halo/app/infra/config/WebFluxConfig.java
@@ -11,7 +11,6 @@ import java.util.Objects;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.autoconfigure.web.WebProperties;
 import org.springframework.boot.autoconfigure.web.reactive.WebFluxRegistrations;
-import org.springframework.cache.concurrent.ConcurrentMapCache;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -33,7 +32,6 @@ import org.springframework.web.reactive.config.WebFluxConfigurer;
 import org.springframework.web.reactive.function.server.RouterFunction;
 import org.springframework.web.reactive.function.server.RouterFunctions;
 import org.springframework.web.reactive.function.server.ServerResponse;
-import org.springframework.web.reactive.resource.CachingResourceResolver;
 import org.springframework.web.reactive.resource.EncodedResourceResolver;
 import org.springframework.web.reactive.resource.PathResourceResolver;
 import org.springframework.web.reactive.result.method.annotation.RequestMappingHandlerAdapter;
@@ -238,9 +236,6 @@ public class WebFluxConfig implements WebFluxConfigurer {
 
     private void applyThumbnailChain(ResourceHandlerRegistration registration) {
         registration.resourceChain(false)
-            .addResolver(
-                new CachingResourceResolver(new ConcurrentMapCache("halo-resource-chain-cache"))
-            )
             .addTransformer(
                 new ThumbnailResourceTransformer(localThumbnailService)
             );


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/area core
/milestone 2.22.x

#### What this PR does / why we need it:

This PR removes unused caching resource resolver from WebFlux configuration for attachment resources only. Because they are deletable rather than static, caching will result in incorrect resource resolution.

#### Which issue(s) this PR fixes:

Fixes https://github.com/halo-dev/halo/issues/8192

#### Does this PR introduce a user-facing change?

```release-note
修复附件删除后再次访问时出现500错误
```

