### PR TITLE
fix: resolve the issue of some selectors being obscured

### DIFF
--- a/ui/src/formkit/inputs/category-select/CategorySelect.vue
+++ b/ui/src/formkit/inputs/category-select/CategorySelect.vue
@@ -7,13 +7,21 @@ import {
 import type { FormKitFrameworkContext } from "@formkit/core";
 import type { Category } from "@halo-dev/api-client";
 import { coreApiClient } from "@halo-dev/api-client";
-import { IconArrowRight } from "@halo-dev/components";
+import { IconArrowRight, VDropdown } from "@halo-dev/components";
 import { utils } from "@halo-dev/ui-shared";
-import { onClickOutside } from "@vueuse/core";
+import { onClickOutside, useResizeObserver } from "@vueuse/core";
 import Fuse from "fuse.js";
 import ShortUniqueId from "short-unique-id";
 import { slugify } from "transliteration";
-import { computed, provide, ref, watch, type PropType, type Ref } from "vue";
+import {
+  computed,
+  provide,
+  ref,
+  useTemplateRef,
+  watch,
+  type PropType,
+  type Ref,
+} from "vue";
 import CategoryListItem from "./components/CategoryListItem.vue";
 import CategoryTag from "./components/CategoryTag.vue";
 import SearchResultListItem from "./components/SearchResultListItem.vue";
@@ -49,11 +57,24 @@ provide<Ref<Category | CategoryTreeNode | undefined>>(
 
 const dropdownVisible = ref(false);
 const text = ref("");
-const wrapperRef = ref<HTMLElement>();
+const wrapperRef = useTemplateRef<HTMLElement>("wrapperRef");
+const popperRef = useTemplateRef<HTMLElement>("popperRef");
 
-onClickOutside(wrapperRef, () => {
-  dropdownVisible.value = false;
+// resolve the issue of the dropdown position when the container size changes
+// https://github.com/Akryum/floating-vue/issues/977#issuecomment-1651898070
+useResizeObserver(wrapperRef, () => {
+  window.dispatchEvent(new Event("resize"));
 });
+
+onClickOutside(
+  wrapperRef,
+  () => {
+    dropdownVisible.value = false;
+  },
+  {
+    ignore: [popperRef],
+  }
+);
 
 // search
 let fuse: Fuse<Category> | undefined = undefined;
@@ -274,76 +295,95 @@ const handleDelete = () => {
 </script>
 
 <template>
-  <div
-    ref="wrapperRef"
-    :class="context.classes['post-categories-wrapper']"
-    @keydown="handleKeydown"
+  <VDropdown
+    :triggers="[]"
+    :shown="dropdownVisible"
+    auto-size
+    :auto-hide="false"
+    container="body"
+    :distance="10"
+    class="w-full"
+    popper-class="post-category-dropdown"
   >
-    <div :class="context.classes['post-categories']">
-      <CategoryTag
-        v-for="(category, index) in selectedCategories"
-        :key="index"
-        :category="category"
-        @select="handleSelect"
-      />
-      <input
-        :value="text"
-        :class="context.classes.input"
-        type="text"
-        @input="onTextInput"
-        @focus="dropdownVisible = true"
-        @keydown.delete="handleDelete"
-      />
-    </div>
+    <div ref="wrapperRef" :class="context.classes['post-categories-wrapper']">
+      <div :class="context.classes['post-categories']">
+        <CategoryTag
+          v-for="(category, index) in selectedCategories"
+          :key="index"
+          :category="category"
+          @select="handleSelect"
+        />
+        <input
+          :value="text"
+          :class="context.classes.input"
+          type="text"
+          @input="onTextInput"
+          @focus="dropdownVisible = true"
+          @keydown="handleKeydown"
+          @keydown.delete="handleDelete"
+        />
+      </div>
 
-    <div
-      :class="context.classes['post-categories-button']"
-      @click="dropdownVisible = !dropdownVisible"
-    >
-      <IconArrowRight class="rotate-90 text-gray-500 hover:text-gray-700" />
+      <div
+        :class="context.classes['post-categories-button']"
+        @click="dropdownVisible = !dropdownVisible"
+      >
+        <IconArrowRight class="rotate-90 text-gray-500 hover:text-gray-700" />
+      </div>
     </div>
-
-    <div v-if="dropdownVisible" :class="context.classes['dropdown-wrapper']">
-      <ul class="p-1">
-        <HasPermission
-          v-if="text.trim()"
-          :permissions="['system:posts:manage']"
-        >
-          <li
-            id="category-create"
-            class="group flex cursor-pointer items-center justify-between rounded p-2"
-            :class="{
-              'bg-gray-100': selectedCategory === undefined,
-            }"
-            @click="handleCreateCategory"
+    <template #popper>
+      <div ref="popperRef" :class="context.classes['dropdown-wrapper']">
+        <ul class="p-1">
+          <HasPermission
+            v-if="text.trim()"
+            :permissions="['system:posts:manage']"
           >
-            <span class="text-xs text-gray-700 group-hover:text-gray-900">
-              {{
-                $t("core.formkit.category_select.creation_label", {
-                  text: text,
-                })
-              }}
-            </span>
-          </li>
-        </HasPermission>
+            <li
+              id="category-create"
+              class="group flex cursor-pointer items-center justify-between rounded p-2"
+              :class="{
+                'bg-gray-100': selectedCategory === undefined,
+              }"
+              @click="handleCreateCategory"
+            >
+              <span class="text-xs text-gray-700 group-hover:text-gray-900">
+                {{
+                  $t("core.formkit.category_select.creation_label", {
+                    text: text,
+                  })
+                }}
+              </span>
+            </li>
+          </HasPermission>
 
-        <template v-if="text">
-          <SearchResultListItem
-            v-for="category in searchResults"
-            :key="category.metadata.name"
-            :category="category"
-            @select="handleSelect"
-          />
-        </template>
-        <template v-else>
-          <CategoryListItem
-            v-for="category in categoriesTree"
-            :key="category.metadata.name"
-            :category="category"
-            @select="handleSelect"
-          />
-        </template>
-      </ul>
-    </div>
-  </div>
+          <template v-if="text">
+            <SearchResultListItem
+              v-for="category in searchResults"
+              :key="category.metadata.name"
+              :category="category"
+              @select="handleSelect"
+            />
+          </template>
+          <template v-else>
+            <CategoryListItem
+              v-for="category in categoriesTree"
+              :key="category.metadata.name"
+              :category="category"
+              @select="handleSelect"
+            />
+          </template>
+        </ul>
+      </div>
+    </template>
+  </VDropdown>
 </template>
+<style lang="scss">
+.post-category-dropdown {
+  .v-popper__arrow-container {
+    display: none;
+  }
+  .v-popper__inner {
+    padding: 0 !important;
+  }
+}
+</style>

--- a/ui/src/formkit/inputs/tag-select/TagSelect.vue
+++ b/ui/src/formkit/inputs/tag-select/TagSelect.vue
@@ -8,13 +8,14 @@ import {
   IconArrowRight,
   IconCheckboxCircle,
   IconClose,
+  VDropdown,
 } from "@halo-dev/components";
 import { utils } from "@halo-dev/ui-shared";
-import { onClickOutside } from "@vueuse/core";
+import { onClickOutside, useResizeObserver } from "@vueuse/core";
 import Fuse from "fuse.js";
 import ShortUniqueId from "short-unique-id";
 import { slugify } from "transliteration";
-import { computed, ref, watch, type PropType } from "vue";
+import { computed, ref, useTemplateRef, watch, type PropType } from "vue";
 
 const props = defineProps({
   context: {
@@ -39,11 +40,24 @@ const multiple = computed(() => {
 const selectedTag = ref<Tag>();
 const dropdownVisible = ref(false);
 const text = ref("");
-const wrapperRef = ref<HTMLElement>();
+const wrapperRef = useTemplateRef<HTMLElement>("wrapperRef");
+const popperRef = useTemplateRef<HTMLElement>("popperRef");
 
-onClickOutside(wrapperRef, () => {
-  dropdownVisible.value = false;
+// resolve the issue of the dropdown position when the container size changes
+// https://github.com/Akryum/floating-vue/issues/977#issuecomment-1651898070
+useResizeObserver(wrapperRef, () => {
+  window.dispatchEvent(new Event("resize"));
 });
+
+onClickOutside(
+  wrapperRef,
+  () => {
+    dropdownVisible.value = false;
+  },
+  {
+    ignore: [popperRef],
+  }
+);
 
 const { tags: postTags, handleFetchTags } = usePostTag();
 
@@ -250,78 +264,102 @@ const handleDelete = () => {
 </script>
 
 <template>
-  <div
-    ref="wrapperRef"
-    :class="context.classes['post-tags-wrapper']"
-    @keydown="handleKeydown"
+  <VDropdown
+    :triggers="[]"
+    :shown="dropdownVisible"
+    auto-size
+    :auto-hide="false"
+    container="body"
+    :distance="10"
+    class="w-full"
+    popper-class="post-tag-dropdown"
   >
-    <div :class="context.classes['post-tags']">
-      <div
-        v-for="(tag, index) in selectedTags"
-        :key="index"
-        :class="context.classes['post-tag-wrapper']"
-      >
-        <PostTag :tag="tag" rounded>
-          <template #rightIcon>
-            <IconClose
-              :class="context.classes['post-tag-close']"
-              @click="handleSelect(tag)"
-            />
-          </template>
-        </PostTag>
-      </div>
-      <input
-        :value="text"
-        :class="context.classes.input"
-        type="text"
-        @input="onTextInput"
-        @focus="dropdownVisible = true"
-        @keydown.delete="handleDelete"
-      />
-    </div>
-
     <div
-      :class="context.classes['post-tags-button']"
-      @click="dropdownVisible = !dropdownVisible"
+      ref="wrapperRef"
+      :class="context.classes['post-tags-wrapper']"
+      @keydown="handleKeydown"
     >
-      <IconArrowRight class="rotate-90 text-gray-500 hover:text-gray-700" />
-    </div>
+      <div :class="context.classes['post-tags']">
+        <div
+          v-for="(tag, index) in selectedTags"
+          :key="index"
+          :class="context.classes['post-tag-wrapper']"
+        >
+          <PostTag :tag="tag" rounded>
+            <template #rightIcon>
+              <IconClose
+                :class="context.classes['post-tag-close']"
+                @click="handleSelect(tag)"
+              />
+            </template>
+          </PostTag>
+        </div>
+        <input
+          :value="text"
+          :class="context.classes.input"
+          type="text"
+          @input="onTextInput"
+          @focus="dropdownVisible = true"
+          @keydown.delete="handleDelete"
+        />
+      </div>
 
-    <div v-if="dropdownVisible" :class="context.classes['dropdown-wrapper']">
-      <ul class="p-1">
-        <HasPermission
-          v-if="text.trim()"
-          :permissions="['system:posts:manage']"
-        >
-          <li
-            id="tag-create"
-            class="group flex cursor-pointer items-center justify-between rounded p-2"
-            :class="{
-              'bg-gray-100': selectedTag === undefined,
-            }"
-            @click="handleCreateTag"
-          >
-            <span class="text-xs text-gray-700 group-hover:text-gray-900">
-              {{ $t("core.formkit.tag_select.creation_label", { text: text }) }}
-            </span>
-          </li>
-        </HasPermission>
-        <li
-          v-for="tag in searchResults"
-          :id="tag.metadata.name"
-          :key="tag.metadata.name"
-          class="group flex cursor-pointer items-center justify-between rounded p-2 hover:bg-gray-100"
-          :class="{
-            'bg-gray-100': selectedTag?.metadata.name === tag.metadata.name,
-          }"
-          @click="handleSelect(tag)"
-        >
-          <div class="inline-flex items-center overflow-hidden">
-            <PostTag :tag="tag" />
-          </div>
-          <IconCheckboxCircle v-if="isSelected(tag)" class="text-primary" />
-        </li>
-      </ul>
+      <div
+        :class="context.classes['post-tags-button']"
+        @click="dropdownVisible = !dropdownVisible"
+      >
+        <IconArrowRight class="rotate-90 text-gray-500 hover:text-gray-700" />
+      </div>
     </div>
-  </div>
+    <template #popper>
+      <div ref="popperRef" :class="context.classes['dropdown-wrapper']">
+        <ul class="p-1">
+          <HasPermission
+            v-if="text.trim()"
+            :permissions="['system:posts:manage']"
+          >
+            <li
+              id="tag-create"
+              class="group flex cursor-pointer items-center justify-between rounded p-2"
+              :class="{
+                'bg-gray-100': selectedTag === undefined,
+              }"
+              @click="handleCreateTag"
+            >
+              <span class="text-xs text-gray-700 group-hover:text-gray-900">
+                {{
+                  $t("core.formkit.tag_select.creation_label", { text: text })
+                }}
+              </span>
+            </li>
+          </HasPermission>
+          <li
+            v-for="tag in searchResults"
+            :id="tag.metadata.name"
+            :key="tag.metadata.name"
+            class="group flex cursor-pointer items-center justify-between rounded p-2 hover:bg-gray-100"
+            :class="{
+              'bg-gray-100': selectedTag?.metadata.name === tag.metadata.name,
+            }"
+            @click="handleSelect(tag)"
+          >
+            <div class="inline-flex items-center overflow-hidden">
+              <PostTag :tag="tag" />
+            </div>
+            <IconCheckboxCircle v-if="isSelected(tag)" class="text-primary" />
+          </li>
+        </ul>
+      </div>
+    </template>
+  </VDropdown>
 </template>
+<style lang="scss">
+.post-tag-dropdown {
+  .v-popper__arrow-container {
+    display: none;
+  }
+  .v-popper__inner {
+    padding: 0 !important;
+  }
+}
+</style>

--- a/ui/src/formkit/theme.ts
+++ b/ui/src/formkit/theme.ts
@@ -165,8 +165,7 @@ const theme: Record<string, Record<string, string>> = {
     "post-tag-close":
       "h-4 w-4 cursor-pointer text-gray-600 hover:text-gray-900",
     "post-tags-button": "inline-flex h-full cursor-pointer items-center px-1",
-    "dropdown-wrapper":
-      "absolute ring-1 ring-gray-100 top-full bottom-auto right-0 z-10 mt-1 max-h-96 w-full overflow-auto rounded bg-white shadow-lg",
+    "dropdown-wrapper": "max-h-96 w-full overflow-auto bg-white",
   },
   categorySelect: {
     ...textClassification,
@@ -176,8 +175,7 @@ const theme: Record<string, Record<string, string>> = {
     "post-categories": "flex w-full flex-wrap items-center",
     "post-categories-button":
       "inline-flex h-full cursor-pointer items-center px-1",
-    "dropdown-wrapper":
-      "absolute ring-1 ring-gray-100 top-full bottom-auto right-0 z-10 mt-1 max-h-96 w-full overflow-auto rounded bg-white shadow-lg",
+    "dropdown-wrapper": "max-h-96 w-full overflow-auto bg-white",
   },
   secret: {
     ...textClassification,


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/area ui
/milestone 2.22.x

#### What this PR does / why we need it:

解决 `tagSelect` 以及 `categorySelect` 在 vmode 中打开且高度不够时，其选项会被遮挡的问题

#### Which issue(s) this PR fixes:

Fixes #8221 

#### Does this PR introduce a user-facing change?
```release-note
解决标签和分类选择器嵌入至弹窗时下拉菜单会被遮挡的问题
```
