### PR TITLE
Remove memory limit from JVM options in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ COPY --from=builder application/spring-boot-loader/ ./
 COPY --from=builder application/snapshot-dependencies/ ./
 COPY --from=builder application/application/ ./
 
-ENV JVM_OPTS="-Xmx256m -Xms256m" \
+ENV JVM_OPTS="" \
     HALO_WORK_DIR="/root/.halo2" \
     SPRING_CONFIG_LOCATION="optional:classpath:/;optional:file:/root/.halo2/" \
     TZ=Asia/Shanghai
@@ -25,4 +25,4 @@ RUN ln -sf /usr/share/zoneinfo/$TZ /etc/localtime \
 
 Expose 8090
 
-ENTRYPOINT ["sh", "-c", "java -Dreactor.schedulers.defaultBoundedElasticOnVirtualThreads=true ${JVM_OPTS} org.springframework.boot.loader.launch.JarLauncher ${0} ${@}"]
+ENTRYPOINT ["sh", "-c", "java ${JVM_OPTS} org.springframework.boot.loader.launch.JarLauncher ${0} ${@}"]


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup
/area core
/milestone 2.22.x

#### What this PR does / why we need it:

This PR removes memory limit and `-Dreactor.schedulers.defaultBoundedElasticOnVirtualThreas` from JVM options in Dockerfile .

#### Which issue(s) this PR fixes:

Fixes https://github.com/halo-dev/halo/issues/7754

#### Does this PR introduce a user-facing change?

```release-note
移除默认内存限制
```

