### PR TITLE
Refactor session management by introducing a dedicated SessionConfiguration class

### DIFF
--- a/application/src/main/java/run/halo/app/infra/config/SessionConfiguration.java
+++ b/application/src/main/java/run/halo/app/infra/config/SessionConfiguration.java
@@ -1,0 +1,57 @@
+package run.halo.app.infra.config;
+
+import java.util.concurrent.ConcurrentHashMap;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.autoconfigure.session.SessionProperties;
+import org.springframework.boot.autoconfigure.web.ServerProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.session.ReactiveFindByIndexNameSessionRepository;
+import org.springframework.session.ReactiveSessionRepository;
+import org.springframework.session.Session;
+import org.springframework.session.config.annotation.web.server.EnableSpringWebSession;
+import org.springframework.session.security.SpringSessionBackedReactiveSessionRegistry;
+import run.halo.app.security.session.InMemoryReactiveIndexedSessionRepository;
+import run.halo.app.security.session.ReactiveIndexedSessionRepository;
+
+/**
+ * Configuration for Spring Web Session.
+ *
+ * @param <S> the type of Session
+ * @author johnniang
+ * @since 2.22.11
+ */
+@Configuration
+@EnableSpringWebSession
+class SessionConfiguration<S extends Session> {
+
+    @Bean
+    SpringSessionBackedReactiveSessionRegistry<S> reactiveSessionRegistry(
+        ReactiveSessionRepository<S> sessionRepository,
+        ReactiveFindByIndexNameSessionRepository<S> indexedSessionRepository
+    ) {
+        return new SpringSessionBackedReactiveSessionRegistry<>(
+            sessionRepository, indexedSessionRepository
+        );
+    }
+
+    @Configuration
+    @ConditionalOnProperty(
+        value = "halo.session.store-type", havingValue = "in-memory", matchIfMissing = true
+    )
+    static class InMemorySessionConfig {
+
+        @Bean
+        ReactiveIndexedSessionRepository<? extends Session> inMemorySessionRepository(
+            SessionProperties sessionProperties, ServerProperties serverProperties
+        ) {
+            var repository =
+                new InMemoryReactiveIndexedSessionRepository(new ConcurrentHashMap<>());
+            var timeout = sessionProperties.determineTimeout(
+                () -> serverProperties.getReactive().getSession().getTimeout());
+            repository.setDefaultMaxInactiveInterval(timeout);
+            return repository;
+        }
+
+    }
+}

--- a/application/src/main/java/run/halo/app/infra/config/WebServerSecurityConfig.java
+++ b/application/src/main/java/run/halo/app/infra/config/WebServerSecurityConfig.java
@@ -3,12 +3,8 @@ package run.halo.app.infra.config;
 import static org.springframework.security.web.server.util.matcher.ServerWebExchangeMatchers.pathMatchers;
 
 import java.util.HashMap;
-import java.util.concurrent.ConcurrentHashMap;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.ObjectProvider;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
-import org.springframework.boot.autoconfigure.session.SessionProperties;
-import org.springframework.boot.autoconfigure.web.ServerProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpMethod;
@@ -25,9 +21,6 @@ import org.springframework.security.web.server.context.WebSessionServerSecurityC
 import org.springframework.security.web.server.savedrequest.ServerRequestCache;
 import org.springframework.security.web.server.util.matcher.AndServerWebExchangeMatcher;
 import org.springframework.security.web.server.util.matcher.NegatedServerWebExchangeMatcher;
-import org.springframework.session.Session;
-import org.springframework.session.config.annotation.web.server.EnableSpringWebSession;
-import org.springframework.session.security.SpringSessionBackedReactiveSessionRegistry;
 import run.halo.app.core.user.service.RoleService;
 import run.halo.app.core.user.service.UserService;
 import run.halo.app.infra.AnonymousUserConst;
@@ -38,8 +31,6 @@ import run.halo.app.security.authentication.CryptoService;
 import run.halo.app.security.authentication.SecurityConfigurer;
 import run.halo.app.security.authentication.impl.RsaKeyService;
 import run.halo.app.security.authorization.AuthorityUtils;
-import run.halo.app.security.session.InMemoryReactiveIndexedSessionRepository;
-import run.halo.app.security.session.ReactiveIndexedSessionRepository;
 
 /**
  * Security configuration for WebFlux.
@@ -47,7 +38,6 @@ import run.halo.app.security.session.ReactiveIndexedSessionRepository;
  * @author johnniang
  */
 @Configuration
-@EnableSpringWebSession
 @EnableWebFluxSecurity
 @EnableReactiveMethodSecurity
 @RequiredArgsConstructor
@@ -116,27 +106,6 @@ public class WebServerSecurityConfig {
     @Bean
     ServerSecurityContextRepository securityContextRepository() {
         return new WebSessionServerSecurityContextRepository();
-    }
-
-    @Bean
-    @ConditionalOnMissingBean
-    ReactiveIndexedSessionRepository<? extends Session> reactiveSessionRepository(
-        SessionProperties sessionProperties, ServerProperties serverProperties
-    ) {
-        var repository = new InMemoryReactiveIndexedSessionRepository(new ConcurrentHashMap<>());
-        var timeout = sessionProperties.determineTimeout(
-            () -> serverProperties.getReactive().getSession().getTimeout());
-        repository.setDefaultMaxInactiveInterval(timeout);
-        return repository;
-    }
-
-    @Bean
-    <S extends Session> SpringSessionBackedReactiveSessionRegistry<S> reactiveSessionRegistry(
-        ReactiveIndexedSessionRepository<S> sessionRepository
-    ) {
-        return new SpringSessionBackedReactiveSessionRegistry<>(
-            sessionRepository, sessionRepository
-        );
     }
 
     @Bean

--- a/application/src/test/java/run/halo/app/infra/config/SessionConfigurationTest.java
+++ b/application/src/test/java/run/halo/app/infra/config/SessionConfigurationTest.java
@@ -1,0 +1,70 @@
+package run.halo.app.infra.config;
+
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.UnsatisfiedDependencyException;
+import org.springframework.boot.autoconfigure.session.SessionProperties;
+import org.springframework.boot.autoconfigure.web.ServerProperties;
+import org.springframework.boot.test.context.runner.ReactiveWebApplicationContextRunner;
+import org.springframework.session.ReactiveFindByIndexNameSessionRepository;
+import run.halo.app.security.session.ReactiveIndexedSessionRepository;
+
+class SessionConfigurationTest {
+
+    @Test
+    void shouldLoadContextIfNoStoreTypeProvided() {
+        var contextRunner = new ReactiveWebApplicationContextRunner()
+            .withUserConfiguration(SessionConfiguration.class)
+            .withBean(SessionProperties.class)
+            .withBean(ServerProperties.class);
+        contextRunner.run(context -> {
+            assertNull(context.getStartupFailure());
+            assertTrue(context.isActive());
+            assertInstanceOf(
+                ReactiveIndexedSessionRepository.class,
+                context.getBean(ReactiveIndexedSessionRepository.class)
+            );
+            assertInstanceOf(
+                ReactiveIndexedSessionRepository.class,
+                context.getBean(ReactiveFindByIndexNameSessionRepository.class)
+            );
+        });
+    }
+
+    @Test
+    void shouldLoadContextIfStoreTypeIsInMemory() {
+        var contextRunner = new ReactiveWebApplicationContextRunner()
+            .withUserConfiguration(SessionConfiguration.class)
+            .withBean(SessionProperties.class)
+            .withBean(ServerProperties.class)
+            .withPropertyValues("halo.session.store-type=in-memory");
+        contextRunner.run(context -> {
+            assertNull(context.getStartupFailure());
+            assertTrue(context.isActive());
+            assertInstanceOf(
+                ReactiveIndexedSessionRepository.class,
+                context.getBean(ReactiveIndexedSessionRepository.class)
+            );
+            assertInstanceOf(
+                ReactiveIndexedSessionRepository.class,
+                context.getBean(ReactiveFindByIndexNameSessionRepository.class)
+            );
+        });
+    }
+
+    @Test
+    void shouldFailToLoadContextIfStoreTypeIsInvalid() {
+        var contextRunner = new ReactiveWebApplicationContextRunner()
+            .withUserConfiguration(SessionConfiguration.class)
+            .withBean(SessionProperties.class)
+            .withBean(ServerProperties.class)
+            .withPropertyValues("halo.session.store-type=invalid-type");
+        contextRunner.run(context ->
+            assertInstanceOf(UnsatisfiedDependencyException.class, context.getStartupFailure())
+        );
+    }
+
+}


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/area core
/milestone 2.22.x

#### What this PR does / why we need it:

This PR refactors session management by introducing a dedicated SessionConfiguration class with conditional InMemorySessionConfig inside.

If property `halo.session.store-type` is not configured or configured as `in-memory`, the in-memory session repository will be used.

#### Which issue(s) this PR fixes:

See https://github.com/halo-dev/halo/issues/8241 for more.

#### Special notes for your reviewer:

Make sure all session functionalities works very well.

#### Does this PR introduce a user-facing change?

```release-note
None
```

