### PR TITLE
Add support for group information in attachment upload process

### DIFF
--- a/api/src/main/java/run/halo/app/core/extension/attachment/endpoint/AttachmentHandler.java
+++ b/api/src/main/java/run/halo/app/core/extension/attachment/endpoint/AttachmentHandler.java
@@ -3,11 +3,13 @@ package run.halo.app.core.extension.attachment.endpoint;
 import java.net.URI;
 import java.time.Duration;
 import java.util.Map;
+import org.jspecify.annotations.Nullable;
 import org.pf4j.ExtensionPoint;
 import org.springframework.http.codec.multipart.FilePart;
 import reactor.core.publisher.Mono;
 import run.halo.app.core.attachment.ThumbnailSize;
 import run.halo.app.core.extension.attachment.Attachment;
+import run.halo.app.core.extension.attachment.Group;
 import run.halo.app.core.extension.attachment.Policy;
 import run.halo.app.extension.ConfigMap;
 
@@ -76,6 +78,16 @@ public interface AttachmentHandler extends ExtensionPoint {
         Policy policy();
 
         ConfigMap configMap();
+
+        /**
+         * Gets the group info if available.
+         *
+         * @return the group info, or null if not available
+         */
+        @Nullable
+        default Group group() {
+            return null;
+        }
 
     }
 

--- a/api/src/main/java/run/halo/app/core/extension/attachment/endpoint/UploadOption.java
+++ b/api/src/main/java/run/halo/app/core/extension/attachment/endpoint/UploadOption.java
@@ -1,15 +1,20 @@
 package run.halo.app.core.extension.attachment.endpoint;
 
+import lombok.Builder;
+import org.jspecify.annotations.Nullable;
 import org.springframework.core.io.buffer.DataBuffer;
 import org.springframework.http.MediaType;
 import org.springframework.http.codec.multipart.FilePart;
 import reactor.core.publisher.Flux;
+import run.halo.app.core.extension.attachment.Group;
 import run.halo.app.core.extension.attachment.Policy;
 import run.halo.app.extension.ConfigMap;
 
+@Builder
 public record UploadOption(FilePart file,
                            Policy policy,
-                           ConfigMap configMap) implements AttachmentHandler.UploadContext {
+                           ConfigMap configMap,
+                           @Nullable Group group) implements AttachmentHandler.UploadContext {
 
     public static UploadOption from(String filename,
         Flux<DataBuffer> content,
@@ -17,7 +22,7 @@ public record UploadOption(FilePart file,
         Policy policy,
         ConfigMap configMap) {
         var filePart = new SimpleFilePart(filename, content, mediaType);
-        return new UploadOption(filePart, policy, configMap);
+        return new UploadOption(filePart, policy, configMap, null);
     }
 
 }

--- a/application/src/main/java/run/halo/app/core/endpoint/uc/AttachmentUcEndpoint.java
+++ b/application/src/main/java/run/halo/app/core/endpoint/uc/AttachmentUcEndpoint.java
@@ -18,7 +18,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Objects;
 import java.util.function.Consumer;
-import lombok.Builder;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.apache.commons.lang3.StringUtils;
@@ -176,21 +175,6 @@ public class AttachmentUcEndpoint implements CustomEndpoint {
                         .bodyValue(listResult)
                     );
             });
-    }
-
-    @Builder
-    record UploadContext(String owner, String storagePolicy, FilePart filePart) {
-    }
-
-    public record UcUploadRequest(MultiValueMap<String, Part> formData) {
-
-        @Schema(description = "The file to upload.", requiredMode = REQUIRED)
-        public FilePart getFile() {
-            if (formData.getFirst("file") instanceof FilePart file) {
-                return file;
-            }
-            throw new ServerWebInputException("Invalid part of file");
-        }
     }
 
     @Getter

--- a/application/src/main/java/run/halo/app/core/user/service/impl/DefaultAttachmentService.java
+++ b/application/src/main/java/run/halo/app/core/user/service/impl/DefaultAttachmentService.java
@@ -27,6 +27,7 @@ import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import run.halo.app.core.attachment.ThumbnailSize;
 import run.halo.app.core.extension.attachment.Attachment;
+import run.halo.app.core.extension.attachment.Group;
 import run.halo.app.core.extension.attachment.Policy;
 import run.halo.app.core.extension.attachment.endpoint.AttachmentHandler;
 import run.halo.app.core.extension.attachment.endpoint.DeleteOption;
@@ -62,16 +63,25 @@ public class DefaultAttachmentService implements AttachmentService {
         @Nullable String groupName,
         @NonNull FilePart filePart,
         @Nullable Consumer<Attachment> beforeCreating) {
-        return client.get(Policy.class, policyName)
-            .flatMap(policy -> {
-                var configMapName = policy.getSpec().getConfigMapName();
-                if (!StringUtils.hasText(configMapName)) {
-                    return Mono.error(new ServerWebInputException(
-                        "ConfigMap name not found in Policy " + policyName));
-                }
-                return client.get(ConfigMap.class, configMapName)
-                    .map(configMap -> new UploadOption(filePart, policy, configMap));
-            })
+        var builder = UploadOption.builder();
+        builder.file(filePart);
+        var getPolicyAndConfigMap = client.get(Policy.class, policyName)
+            .doOnNext(builder::policy)
+            .mapNotNull(p -> p.getSpec().getConfigMapName())
+            .filter(StringUtils::hasText)
+            .switchIfEmpty(Mono.error(() -> new ServerWebInputException(
+                "ConfigMap name not found in Policy " + policyName
+            )))
+            .flatMap(configMapName -> client.get(ConfigMap.class, configMapName))
+            .doOnNext(builder::configMap)
+            .then();
+
+        var getGroup = Mono.justOrEmpty(groupName)
+            .filter(StringUtils::hasText)
+            .flatMap(name -> client.get(Group.class, name))
+            .doOnNext(builder::group)
+            .then();
+        return Mono.when(getPolicyAndConfigMap, getGroup).then(Mono.fromSupplier(builder::build))
             .flatMap(uploadContext -> extensionGetter.getExtensions(AttachmentHandler.class)
                 .concatMap(handler -> handler.upload(uploadContext))
                 .next())


### PR DESCRIPTION
#### What type of PR is this?

/kind feature
/area core
/area plugin
/milestone 2.22.x

#### What this PR does / why we need it:

This PR adds support for group information in attachment upload process. Attachment plugins can handle group information during upload process.

#### Which issue(s) this PR fixes:

Fixes https://github.com/halo-dev/halo/issues/8238

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
开发者相关：附件插件上传上下文新增附件分组信息
```

