### PR TITLE
Update stale issues workflow label filter

### DIFF
--- a/.github/workflows/stale-issues.yaml
+++ b/.github/workflows/stale-issues.yaml
@@ -26,6 +26,6 @@ jobs:
           days-before-pr-stale: -1
           days-before-pr-close: -1
           stale-issue-label: "lifecycle/stale"
-          only-issue-labels: "triage/needs-information,priority/awaiting-more-evidence,help wanted"
+          any-of-issue-labels: "triage/needs-information,priority/awaiting-more-evidence,help wanted"
           operations-per-run: 100
           ascending: true


### PR DESCRIPTION
#### What type of PR is this?

None

#### What this PR does / why we need it:

Replaces 'only-issue-labels' with 'any-of-issue-labels' in the stale issues workflow to ensure issues with any of the specified labels are considered, improving label-based filtering.

#### Does this PR introduce a user-facing change?

```release-note
None
```
