### PR TITLE
Ensure :api uploadBundle task runs after :platform:application uploadBundle task

### DIFF
--- a/api/build.gradle
+++ b/api/build.gradle
@@ -139,3 +139,7 @@ tasks.named('jacocoTestReport') {
         html.required = false
     }
 }
+
+tasks.named('uploadBundle') {
+    mustRunAfter project(':platform:application').tasks.named('uploadBundle')
+}


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup
/area core
/milestone 2.22.x

#### What this PR does / why we need it:

This PR ensures :api uploadBundle task runs after :platform:application uploadBundle task using `mustRunAfter`.

So that we can upload bundle to Maven central by one command `./gradlew uploadBundle -Pversion=2.22.11`.

#### Does this PR introduce a user-facing change?

```release-note
None
```

