### PR TITLE
fix: resolve the style issue of the sercet component

### DIFF
--- a/ui/src/formkit/inputs/secret/SecretSelect.vue
+++ b/ui/src/formkit/inputs/secret/SecretSelect.vue
@@ -126,7 +126,7 @@ const missingKeys = computed(() => {
 </script>
 <template>
   <div
-    class="flex items-center gap-2 rounded-lg px-2.5 py-2 ring-1 ring-gray-100"
+    class="flex items-center gap-2 rounded-lg border border-gray-100 px-2.5 py-2"
   >
     <div
       class="inline-flex size-8 flex-none items-center justify-center rounded-full"

--- a/ui/src/formkit/theme.ts
+++ b/ui/src/formkit/theme.ts
@@ -178,6 +178,7 @@ const theme: Record<string, Record<string, string>> = {
     "dropdown-wrapper": "max-h-96 w-full overflow-auto bg-white",
   },
   secret: {
+    inner: "w-full sm:max-w-lg",
     wrapper: textClassification.wrapper,
     label: textClassification.label,
   },


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/area ui

#### What this PR does / why we need it:

优化解决 sercet 组件 UI 过长且在最后一行时会出现边框被遮挡的问题。

#### Which issue(s) this PR fixes:

Fixes #8263 

#### Does this PR introduce a user-facing change?
```release-note
解决 sercet 组件 UI 过长且处于最后一行时会出现边框被遮挡的问题。
```
