### PR TITLE
Bump pf4j version to 3.15.0

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -21,7 +21,7 @@ apache-commons-lang3 = 'org.apache.commons:commons-lang3:3.20.0'
 apache-tika-core = 'org.apache.tika:tika-core:3.2.3'
 
 encoding-base62 = 'io.seruco.encoding:base62:0.1.3'
-pf4j = 'org.pf4j:pf4j:3.14.1'
+pf4j = 'org.pf4j:pf4j:3.15.0'
 guava = 'com.google.guava:guava:33.5.0-jre'
 java-diff-utils = 'io.github.java-diff-utils:java-diff-utils:4.16'
 jsoup = 'org.jsoup:jsoup:1.22.1'


### PR DESCRIPTION
#### What type of PR is this?

/kind improvement
/area core
/area plugin
/milestone 2.23.x

#### What this PR does / why we need it:

This PR bumps PF4J versiont to [3.15.0](https://github.com/pf4j/pf4j/releases/tag/release-3.15.0).

#### Does this PR introduce a user-facing change?

```release-note
升级 PF4J 至 3.15.0
```

