### PR TITLE
Remove deprecated Maven repository URLs from build.gradle

### DIFF
--- a/api/build.gradle
+++ b/api/build.gradle
@@ -45,8 +45,6 @@ jar {
 
 repositories {
     mavenCentral()
-    maven { url = 'https://repo.spring.io/milestone' }
-    maven { url = 'https://s01.oss.sonatype.org/content/repositories/snapshots' }
 }
 
 dependencies {

--- a/application/build.gradle
+++ b/application/build.gradle
@@ -47,9 +47,6 @@ checkstyle {
 repositories {
     mavenCentral()
 
-    maven { url = 'https://repo.spring.io/milestone' }
-    maven { url = 'https://s01.oss.sonatype.org/content/repositories/snapshots' }
-
     flatDir {
         dir layout.projectDirectory.dir('libs')
     }


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup
/area core

#### What this PR does / why we need it:

This PR removes deprecated(OSSRH sunset) Maven repository URLs from build.gradle.

See https://central.sonatype.org/pages/ossrh-eol/ for more.

#### Does this PR introduce a user-facing change?

```release-note
None
```

