### PR TITLE
Refactor listByNames method to handle empty name lists and maintain order using a map

### DIFF
--- a/application/src/main/java/run/halo/app/extension/store/ExtensionStoreRepository.java
+++ b/application/src/main/java/run/halo/app/extension/store/ExtensionStoreRepository.java
@@ -1,6 +1,6 @@
 package run.halo.app.extension.store;
 
-import java.util.List;
+import java.util.Collection;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.r2dbc.repository.R2dbcRepository;
 import org.springframework.stereotype.Repository;
@@ -34,7 +34,7 @@ public interface ExtensionStoreRepository extends R2dbcRepository<ExtensionStore
      * @param names names to find
      * @return a flux of extension stores
      */
-    Flux<ExtensionStore> findByNameIn(List<String> names);
+    Flux<ExtensionStore> findByNameIn(Collection<String> names);
 
     Flux<ExtensionStore> findAllByNameStartingWithAndNameGreaterThan(
         String prefix, String nameCursor, Pageable pageable);


### PR DESCRIPTION
#### What type of PR is this?

/kind improvement
/area core
/milestone 2.23.x

#### What this PR does / why we need it:

This PR refactors listByNames method to handle empty name lists and maintains order using a map efficiently.

#### Does this PR introduce a user-facing change?

```release-note
None
```
