### PR TITLE
fix: resolve the issue of file loss during batch copying or drag-and-drop uploading

### DIFF
--- a/ui/packages/editor/src/extensions/upload/index.ts
+++ b/ui/packages/editor/src/extensions/upload/index.ts
@@ -63,9 +63,7 @@ export const ExtensionUpload = Extension.create({
 
             if (files.length) {
               event.preventDefault();
-              files.forEach((file) => {
-                handleFileEvent({ editor, file });
-              });
+              handleFileEvent(editor, files);
               return true;
             }
 
@@ -90,13 +88,11 @@ export const ExtensionUpload = Extension.create({
             const files = Array.from(event.dataTransfer.files) as File[];
             if (files.length) {
               event.preventDefault();
-              files.forEach((file: File) => {
-                // TODO: For drag-and-drop uploaded files,
-                // perhaps it is necessary to determine the
-                // current position of the drag-and-drop
-                // instead of inserting them directly at the cursor.
-                handleFileEvent({ editor, file });
-              });
+              // TODO: For drag-and-drop uploaded files,
+              // perhaps it is necessary to determine the
+              // current position of the drag-and-drop
+              // instead of inserting them directly at the cursor.
+              handleFileEvent(editor, files);
               return true;
             }
 

--- a/ui/packages/editor/src/utils/upload.ts
+++ b/ui/packages/editor/src/utils/upload.ts
@@ -13,13 +13,34 @@ export interface FileProps {
 }
 
 /**
+ * Creates an editor node from a file.
+ *
+ * @param editor - Editor instance
+ * @param file - File to be uploaded
+ * @returns - Editor node
+ */
+export const createEditorNodeFormFile = (editor: Editor, file: File) => {
+  if (file.type.startsWith("image/")) {
+    return uploadImage(editor, file);
+  }
+
+  if (file.type.startsWith("video/")) {
+    return uploadVideo(editor, file);
+  }
+
+  if (file.type.startsWith("audio/")) {
+    return uploadAudio(editor, file);
+  }
+};
+
+/**
  * Handles file events, determining if the file is an image and triggering the appropriate upload process.
  *
  * @param {FileProps} { file, editor } - File and editor instances
  * @returns {boolean} - True if a file is handled, otherwise false
  */
-export const handleFileEvent = ({ file, editor }: FileProps) => {
-  if (!file) {
+export const handleFileEvent = (editor: Editor, files: File[]) => {
+  if (!files.length) {
     return false;
   }
 
@@ -32,61 +53,54 @@ export const handleFileEvent = ({ file, editor }: FileProps) => {
     return false;
   }
 
-  if (file.type.startsWith("image/")) {
-    uploadImage({ file, editor });
-    return true;
-  }
+  const nodes = files
+    .map((file) => createEditorNodeFormFile(editor, file))
+    .filter((node) => node !== undefined);
 
-  if (file.type.startsWith("video/")) {
-    uploadVideo({ file, editor });
-    return true;
+  if (nodes.length) {
+    const tr = editor.view.state.tr;
+    tr.insert(editor.view.state.selection.from, nodes);
+    editor.view.dispatch(tr);
   }
-
-  if (file.type.startsWith("audio/")) {
-    uploadAudio({ file, editor });
-    return true;
-  }
-
-  return true;
 };
 
 /**
  * Uploads an image file and inserts it into the editor.
  *
- * @param {FileProps} { file, editor } - File to be uploaded and the editor instance
+ * @param editor - Editor instance
+ * @param file - File to be uploaded
  */
-export const uploadImage = ({ file, editor }: FileProps) => {
-  const { view } = editor;
-  const node = view.props.state.schema.nodes[ExtensionImage.name].create({
+export const uploadImage = (editor: Editor, file: File) => {
+  const { state } = editor;
+  return state.schema.nodes[ExtensionImage.name].create({
     file: file,
   });
-  editor.view.dispatch(editor.view.state.tr.replaceSelectionWith(node));
 };
 
 /**
  * Uploads a video file and inserts it into the editor.
  *
- * @param {FileProps} { file, editor } - File to be uploaded and the editor instance
+ * @param editor - Editor instance
+ * @param file - File to be uploaded
  */
-export const uploadVideo = ({ file, editor }: FileProps) => {
-  const { view } = editor;
-  const node = view.props.state.schema.nodes[ExtensionVideo.name].create({
+export const uploadVideo = (editor: Editor, file: File) => {
+  const { state } = editor;
+  return state.schema.nodes[ExtensionVideo.name].create({
     file: file,
   });
-  editor.view.dispatch(editor.view.state.tr.replaceSelectionWith(node));
 };
 
 /**
  * Uploads an audio file and inserts it into the editor.
  *
- * @param {FileProps} { file, editor } - File to be uploaded and the editor instance
+ * @param editor - Editor instance
+ * @param file - File to be uploaded
  */
-export const uploadAudio = ({ file, editor }: FileProps) => {
-  const { view } = editor;
-  const node = view.props.state.schema.nodes[ExtensionAudio.name].create({
+export const uploadAudio = (editor: Editor, file: File) => {
+  const { state } = editor;
+  return state.schema.nodes[ExtensionAudio.name].create({
     file: file,
   });
-  editor.view.dispatch(editor.view.state.tr.replaceSelectionWith(node));
 };
 
 export interface UploadFetchResponse {


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/area editor
/area ui

#### What this PR does / why we need it:

解决在编辑器中复制或粘贴两张以上图片时，始终会被覆盖一张图片的问题。

#### How to test it?

1. 复制两张以上图片
2. 在编辑器中进行粘贴
3. 查看图片数量是否正确。

#### Which issue(s) this PR fixes:

Fixes #8332 

#### Does this PR introduce a user-facing change?
```release-note
解决在编辑器中复制或粘贴图片时首张图片会被覆盖的问题
```
