### PR TITLE
improvement: optimize R2dbcConfiguration for better performance

### DIFF
--- a/application/src/main/java/run/halo/app/infra/config/R2dbcConfiguration.java
+++ b/application/src/main/java/run/halo/app/infra/config/R2dbcConfiguration.java
@@ -6,7 +6,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.r2dbc.mapping.R2dbcMappingContext;
 
-@Configuration
+@Configuration(proxyBeanMethods = false)
 class R2dbcConfiguration {
 
     /**
@@ -22,10 +22,14 @@ class R2dbcConfiguration {
      * <a href="https://github.com/spring-projects/spring-data-relational/issues/1993">this issue
      * </a> for more details.
      *
+     * <p>
+     * Use static method to ensure that the BeanPostProcessor is registered before any
+     * R2dbcMappingContext beans are initialized.
+     *
      * @return the bean post processor
      */
     @Bean
-    BeanPostProcessor r2dbcMappingContextQuoteModifier() {
+    static BeanPostProcessor r2dbcMappingContextQuoteModifier() {
         return new BeanPostProcessor() {
             @Override
             public Object postProcessBeforeInitialization(Object bean, String beanName)


### PR DESCRIPTION
/kind improvement

#### What this PR does / why we need it:

This PR optimizes the R2dbcConfiguration class for better performance and proper Spring bean initialization:

1. **Set `proxyBeanMethods = false`**: Avoids unnecessary CGLIB proxying overhead since there are no inter-bean method calls within this configuration class.

2. **Make BeanPostProcessor static**: Ensures that the `r2dbcMappingContextQuoteModifier` BeanPostProcessor is registered before any R2dbcMappingContext beans are initialized, following Spring's best practices for BeanPostProcessor registration.

3. **Improved documentation**: Added clear documentation explaining why the static method is used.

Also fix the warning below during startup:

```java
2026-02-06T16:06:16.673+08:00  WARN 956032 --- [main] trationDelegate$BeanPostProcessorChecker : Bean 'r2dbcConfiguration' of type [run.halo.app.infra.config.R2dbcConfiguration] is not eligible for getting processed by all BeanPostProcessors (for example: not eligible for auto-proxying). The currently created BeanPostProcessor [r2dbcMappingContextQuoteModifier] is declared through a non-static factory method on that class; consider declaring it as static instead.
```

#### Which issue(s) this PR fixes:

Fixes #

#### Special notes for your reviewer:

These are standard Spring Boot optimizations:
- The `proxyBeanMethods = false` is a common optimization for configuration classes that don't have inter-bean dependencies
- Static BeanPostProcessor methods are a Spring best practice to ensure proper bean lifecycle management

#### Does this PR introduce a user-facing change?

```release-note
NONE
```