### PR TITLE
Add BackToTop component and integrate into UI

### DIFF
--- a/ui/console-src/modules/interface/themes/ThemeSetting.vue
+++ b/ui/console-src/modules/interface/themes/ThemeSetting.vue
@@ -1,4 +1,5 @@
 <script lang="ts" setup>
+import BackToTop from "@/components/back-to-top/BackToTop.vue";
 import StickyBlock from "@/components/sticky-block/StickyBlock.vue";
 import type { FormKitSchemaCondition, FormKitSchemaNode } from "@formkit/core";
 import type { Setting, Theme } from "@halo-dev/api-client";
@@ -100,5 +101,7 @@ await suspense();
         {{ $t("core.common.buttons.save") }}
       </VButton>
     </StickyBlock>
+
+    <BackToTop />
   </div>
 </template>

--- a/ui/console-src/modules/system/plugins/components/tabs/Setting.vue
+++ b/ui/console-src/modules/system/plugins/components/tabs/Setting.vue
@@ -1,4 +1,5 @@
 <script lang="ts" setup>
+import BackToTop from "@/components/back-to-top/BackToTop.vue";
 import StickyBlock from "@/components/sticky-block/StickyBlock.vue";
 import type { FormKitSchemaCondition, FormKitSchemaNode } from "@formkit/core";
 import type { Plugin, Setting } from "@halo-dev/api-client";
@@ -107,5 +108,7 @@ const handleSaveConfigMap = async (data: object) => {
         {{ $t("core.common.buttons.save") }}
       </VButton>
     </StickyBlock>
+
+    <BackToTop />
   </div>
 </template>

--- a/ui/src/components/back-to-top/BackToTop.vue
+++ b/ui/src/components/back-to-top/BackToTop.vue
@@ -1,0 +1,30 @@
+<script lang="ts" setup>
+import { IconArrowUpLine } from "@halo-dev/components";
+import { useEventListener } from "@vueuse/core";
+import { ref } from "vue";
+
+const visible = ref(false);
+
+function onWindowScroll() {
+  const isDown = window.scrollY > 300;
+  visible.value = isDown;
+}
+
+function handleScrollToTop() {
+  window.scrollTo({ top: 0, behavior: "smooth" });
+}
+
+useEventListener(window, "scroll", onWindowScroll);
+</script>
+<template>
+  <button
+    class="fixed bottom-8 right-8 z-10 inline-flex size-10 items-center justify-center rounded-full bg-primary transition-all hover:bg-primary/80 hover:shadow active:scale-95 active:bg-primary"
+    :class="{
+      'opacity-100': visible,
+      'opacity-0': !visible,
+    }"
+    @click="handleScrollToTop"
+  >
+    <IconArrowUpLine class="size-6 text-white" />
+  </button>
+</template>


### PR DESCRIPTION
#### What type of PR is this?

/area ui
/kind feature
/milestone 2.23.x

#### What this PR does / why we need it:

<img width="983" height="340" alt="image" src="https://github.com/user-attachments/assets/4ec45cac-8a88-418d-ad25-4fed7f4ae679" />

#### Which issue(s) this PR fixes:

Fixes https://github.com/halo-dev/halo/issues/5025

#### Does this PR introduce a user-facing change?

```release-note
为主题和插件的设置页面添加滚动到顶部按钮
```
