### PR TITLE
fix: improve OS version detefix: improve OS version detection for Windows 11 (#6949)ction for Windows 11 (#6949)

### DIFF
--- a/application/src/test/java/run/halo/app/security/device/DeviceServiceImplTest.java
+++ b/application/src/test/java/run/halo/app/security/device/DeviceServiceImplTest.java
@@ -3,9 +3,11 @@ package run.halo.app.security.device;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.stream.Stream;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.springframework.http.HttpHeaders;
 
 /**
  * Tests for {@link DeviceServiceImpl}.
@@ -39,5 +41,45 @@ class DeviceServiceImplTest {
         var info = DeviceServiceImpl.DeviceInfo.parse(userAgent);
         assertThat(info.os()).isEqualTo(expectedOs);
         assertThat(info.browser()).isEqualTo(expectedBrowser);
+    }
+
+    @Test
+    void shouldDetectWindows10WithoutClientHints() {
+        var ua = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 "
+            + "(KHTML, like Gecko) Chrome/126.0.0.0 Safari/537.36";
+        var info = DeviceServiceImpl.DeviceInfo.parse(ua);
+        assertThat(info.os()).isEqualTo("Windows 10");
+        assertThat(info.browser()).isEqualTo("Chrome 126.0");
+    }
+
+    @Test
+    void shouldDetectWindows11WithClientHints() {
+        var ua = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 "
+            + "(KHTML, like Gecko) Chrome/126.0.0.0 Safari/537.36";
+        var headers = new HttpHeaders();
+        headers.set("Sec-CH-UA-Platform-Version", "\"15.0.0\"");
+        var info = DeviceServiceImpl.DeviceInfo.parse(ua, headers);
+        assertThat(info.os()).isEqualTo("Windows 11");
+    }
+
+    @Test
+    void shouldDetectWindows10WithClientHintsLowVersion() {
+        var ua = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 "
+            + "(KHTML, like Gecko) Chrome/126.0.0.0 Safari/537.36";
+        var headers = new HttpHeaders();
+        headers.set("Sec-CH-UA-Platform-Version", "\"10.0.0\"");
+        var info = DeviceServiceImpl.DeviceInfo.parse(ua, headers);
+        assertThat(info.os()).isEqualTo("Windows 10");
+    }
+
+    @Test
+    void shouldDetectOlderWindowsVersions() {
+        var ua7 = "Mozilla/5.0 (Windows NT 6.1; Win64; x64) AppleWebKit/537.36 "
+            + "(KHTML, like Gecko) Chrome/100.0.0.0 Safari/537.36";
+        assertThat(DeviceServiceImpl.DeviceInfo.parse(ua7).os()).isEqualTo("Windows 7");
+
+        var ua81 = "Mozilla/5.0 (Windows NT 6.3; Win64; x64) AppleWebKit/537.36 "
+            + "(KHTML, like Gecko) Chrome/100.0.0.0 Safari/537.36";
+        assertThat(DeviceServiceImpl.DeviceInfo.parse(ua81).os()).isEqualTo("Windows 8.1");
     }
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/kind improvement

#### What this PR does / why we need it:

Windows 11 is incorrectly detected as Windows 10 in device fingerprint info,
because both Windows 10 and 11 report as "Windows NT 10.0" in User-Agent string.

This PR:
1. Adds a Windows NT version-to-friendly-name mapping (e.g., "NT 10.0" → "Windows 10",
   "NT 6.1" → "Windows 7") so the OS info is more user-friendly
2. Adds support for `Sec-CH-UA-Platform-Version` Client Hints header to distinguish
   Windows 11 (platform version >= 13) from Windows 10
3. Adds unit tests for Windows 10/11 detection with and without Client Hints,
   and tests for older Windows versions (7, 8.1)

#### Which issue(s) this PR fixes:

Fixes #6949

#### Special notes for your reviewer:

- The `parse(String userAgent)` method is preserved for backward compatibility.
  A new overload `parse(String userAgent, HttpHeaders headers)` is added.
- Windows 11 detection relies on the `Sec-CH-UA-Platform-Version` header.
  If the header is not present, it falls back to "Windows 10" (safe default).
- The threshold of major version >= 13 for Windows 11 is based on
  [Microsoft's official documentation](https://learn.microsoft.com/en-us/microsoft-edge/web-platform/how-to-detect-win11).

#### Does this PR introduce a user-facing change?

```release-note
修复设备登录信息中 Windows 11 被错误识别为 Windows 10 的问题，
现在支持通过 Client Hints 精准区分 Windows 10/11，
并以用户友好的格式显示 OS 名称（如 "Windows 10" 而非 "Windows NT 10.0"）。
```