### PR TITLE
pref: add typings for array input slots

### DIFF
--- a/ui/src/formkit/inputs/array/index.ts
+++ b/ui/src/formkit/inputs/array/index.ts
@@ -1,4 +1,7 @@
-import type { FormKitTypeDefinition } from "@formkit/core";
+import type {
+  FormKitFrameworkContext,
+  FormKitTypeDefinition,
+} from "@formkit/core";
 
 import {
   help,
@@ -64,6 +67,12 @@ declare module "@formkit/inputs" {
         type: ArrayItemLabelType;
         label: string;
       }[];
+    };
+  }
+
+  export interface FormKitInputSlots<Props extends FormKitInputs<Props>> {
+    array: {
+      default: FormKitFrameworkContext<Record<string, unknown>>;
     };
   }
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind improvement
/area ui

#### What this PR does / why we need it:

为 array 组件添加 slots 样式，用于解决下述方式中的 `typescript` 报错的问题。

```
<template #default="{ value: contact }">
</template>
```

#### Which issue(s) this PR fixes:

Fixes #8353 

#### Does this PR introduce a user-facing change?
```release-note
为 Array 组件添加 slot 插槽类型
```
