### PR TITLE
fix: array component does not support multiple image selection

### DIFF
--- a/ui/src/formkit/inputs/array/renderers/attachment.ts
+++ b/ui/src/formkit/inputs/array/renderers/attachment.ts
@@ -1,0 +1,16 @@
+import type { FormKitNode } from "@formkit/core";
+import type { LabelValueResult } from "./types";
+
+export async function renderAttachmentLabelValue({
+  value,
+}: {
+  node: FormKitNode<unknown>;
+  value: unknown;
+}): Promise<LabelValueResult | LabelValueResult[]> {
+  const castValueArray = Array.isArray(value) ? value : [value];
+  return castValueArray.map((v) => {
+    return {
+      value: v,
+    };
+  });
+}

--- a/ui/src/formkit/inputs/array/renderers/index.ts
+++ b/ui/src/formkit/inputs/array/renderers/index.ts
@@ -1,5 +1,6 @@
 import type { FormKitNode } from "@formkit/core";
 import { isNil } from "es-toolkit";
+import { renderAttachmentLabelValue } from "./attachment";
 import { renderCategorySelectLabelValue } from "./category-select";
 import { renderCheckboxLabelValue } from "./checkbox";
 import { renderIconifyLabelValue } from "./iconify";
@@ -33,6 +34,7 @@ const rendererRegistry = new Map<string, LabelValueRenderer>([
   ["toggle", renderToggleLabelValue],
   ["tagSelect", renderTagSelectLabelValue],
   ["categorySelect", renderCategorySelectLabelValue],
+  ["attachment", renderAttachmentLabelValue],
 ]);
 
 /**
@@ -51,7 +53,7 @@ export function registerRenderer(
 export async function renderItemLabelValue(
   node: FormKitNode<unknown>,
   value: unknown
-): Promise<LabelValueResult> {
+): Promise<LabelValueResult | LabelValueResult[]> {
   const originalType = node.props.originalType;
   const renderer = rendererRegistry.get(originalType);
   if (renderer) {

--- a/ui/src/formkit/inputs/array/renderers/types.ts
+++ b/ui/src/formkit/inputs/array/renderers/types.ts
@@ -5,4 +5,7 @@ export type LabelValueResult = { value?: unknown } & Record<string, unknown>;
 export type LabelValueRenderer = (params: {
   node: FormKitNode<unknown>;
   value: unknown;
-}) => Promise<LabelValueResult> | LabelValueResult;
+}) =>
+  | Promise<LabelValueResult | LabelValueResult[]>
+  | LabelValueResult
+  | LabelValueResult[];


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/area ui

#### What this PR does / why we need it:

解决 array 组件无法处理 `attachement` 之类可多选的图片组件的渲染。

#### Which issue(s) this PR fixes:

Fixes #8354 

#### Does this PR introduce a user-facing change?
```release-note
解决 Array 无法支持图片多选的渲染问题
```
