### PR TITLE
fix: filter out tab slots missing id or label

### DIFF
--- a/ui/packages/components/src/components/tabs/Tabs.vue
+++ b/ui/packages/components/src/components/tabs/Tabs.vue
@@ -34,12 +34,15 @@ const emit = defineEmits<{
 const slots = useSlots();
 
 const tabItems = computed(() => {
-  return slots.default?.().map(({ props: slotProps }) => {
-    return {
-      id: slotProps?.[props.idKey],
-      label: slotProps?.[props.labelKey],
-    };
-  });
+  return slots
+    .default?.()
+    .map(({ props: slotProps }) => {
+      return {
+        id: slotProps?.[props.idKey],
+        label: slotProps?.[props.labelKey],
+      };
+    })
+    .filter((item) => item.id !== undefined && item.label !== undefined);
 });
 
 const classes = computed(() => {


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/area ui

#### What this PR does / why we need it:

由于当注释掉或者使用判断语句隐藏掉的 slot 仍旧会出现在 useSlots() 中，因此选择过滤掉 slots 中为 `undefined` slot。

#### Which issue(s) this PR fixes:

Fixes #8349 

#### Does this PR introduce a user-facing change?
```release-note
解决 iconify 组件中存在隐藏的空白页面的问题
```
