### PR TITLE
pref: allow cancellation of selection of parent menu

### DIFF
--- a/ui/console-src/modules/interface/menus/components/MenuItemEditingModal.vue
+++ b/ui/console-src/modules/interface/menus/components/MenuItemEditingModal.vue
@@ -259,6 +259,7 @@ onMounted(() => {
                 )
               "
               type="menuItemSelect"
+              :clearable="true"
               :menu-items="menu.spec.menuItems || []"
             />
 


### PR DESCRIPTION
#### What type of PR is this?

/kind improvement
/area ui
/milestone 2.23.x

#### What this PR does / why we need it:

允许在新建菜单项时，移除选中的上级菜单

#### Which issue(s) this PR fixes:

Fixes #8363 

#### Does this PR introduce a user-facing change?
```release-note
允许在新建菜单项时，移除选中的上级菜单
```
