### PR TITLE
Exclude node_modules from output filter in pnpm install

### DIFF
--- a/ui/build.gradle
+++ b/ui/build.gradle
@@ -17,6 +17,12 @@ idea {
   }
 }
 
+pnpmInstall {
+  nodeModulesOutputFilter {
+    exclude('**')
+  }
+}
+
 tasks.named('clean') {
   dependsOn tasks.named('doClean')
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

This PR adds a `nodeModulesOutputFilter` configuration to the `pnpmInstall` task in the UI build.gradle file to exclude all node_modules files from being tracked in the output. This improves build performance by preventing unnecessary file tracking during the build process.

#### Which issue(s) this PR fixes:

This PR fixes OOM error while checking project. See https://github.com/halo-dev/halo/actions/runs/22426672504/job/64936290141 for more.
#### Special notes for your reviewer:

The change is minimal and focused on build optimization. The `exclude('**')` pattern ensures that no files from node_modules are included in the output filter.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```