### PR TITLE
Update recommended VS Code extensions

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,8 +1,9 @@
 {
   "recommendations": [
     "dbaeumer.vscode-eslint",
-    "esbenp.prettier-vscode",
     "editorconfig.editorconfig",
-    "vue.volar"
+    "oxc.oxc-vscode",
+    "vue.volar",
+    "bradlc.vscode-tailwindcss"
   ]
 }


### PR DESCRIPTION
#### What type of PR is this?

/area ui
/kind cleanup

#### What this PR does / why we need it:

Remove the esbenp.prettier-vscode recommendation and add oxc.oxc-vscode and bradlc.vscode-tailwindcss to the workspace recommendations. Adjusts the recommended extensions list to include Oxc tooling and Tailwind CSS support.

#### Does this PR introduce a user-facing change?

```release-note
None
```
