### PR TITLE
Add API client sync and verification job

### DIFF
--- a/.github/workflows/halo.yaml
+++ b/.github/workflows/halo.yaml
@@ -24,45 +24,6 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  changes:
-    if: github.event_name == 'pull_request' || github.event_name == 'push'
-    runs-on: ubuntu-latest
-    outputs:
-      api-client: ${{ steps.filter.outputs.api-client }}
-    steps:
-      - uses: actions/checkout@v4
-      - uses: dorny/paths-filter@v3
-        id: filter
-        with:
-          filters: |
-            api-client:
-              - 'application/src/**'
-              - 'api/src/**'
-              - 'api-docs/openapi/**'
-              - 'ui/packages/api-client/**'
-
-  api-client-sync:
-    if: (github.event_name == 'pull_request' || github.event_name == 'push') && needs.changes.outputs.api-client == 'true'
-    needs: changes
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - name: Setup Environment
-        uses: ./.github/actions/setup-env
-      - name: Install UI dependencies
-        run: ./gradlew pnpmInstall
-      - name: Regenerate OpenAPI docs
-        run: ./gradlew generateOpenApiDocs --no-configuration-cache
-      - name: Regenerate api-client
-        run: cd ui && pnpm run api-client:gen
-      - name: Verify OpenAPI docs and api-client are in sync
-        run: |
-          if ! git diff --exit-code -- api-docs/openapi ui/packages/api-client/src; then
-            echo "::error::OpenAPI docs or api-client generated code is out of sync with the current API. Run './gradlew generateOpenApiDocs --no-configuration-cache' and 'cd ui && pnpm run api-client:gen', then commit the changes under api-docs/openapi and ui/packages/api-client/src."
-            git diff --stat api-docs/openapi ui/packages/api-client/src
-            exit 1
-          fi
-
   test:
     if: github.event_name == 'pull_request' || github.event_name == 'push'
     runs-on: ubuntu-latest

--- a/.github/workflows/openapi-check.yaml
+++ b/.github/workflows/openapi-check.yaml
@@ -1,0 +1,46 @@
+name: OpenAPI Check
+
+on:
+  pull_request:
+    branches:
+      - main
+      - release-*
+    paths:
+      - 'application/src/**'
+      - 'api/src/**'
+      - 'api-docs/openapi/**'
+      - 'ui/packages/api-client/**'
+  push:
+    branches:
+      - main
+      - release-*
+    paths:
+      - 'application/src/**'
+      - 'api/src/**'
+      - 'api-docs/openapi/**'
+      - 'ui/packages/api-client/**'
+
+concurrency:
+  group: ${{github.workflow}} - ${{github.ref}}
+  cancel-in-progress: true
+
+jobs:
+  openapi-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup Environment
+        uses: ./.github/actions/setup-env
+      - name: Install UI dependencies
+        run: ./gradlew pnpmInstall
+      - name: Regenerate OpenAPI docs
+        run: ./gradlew generateOpenApiDocs --no-configuration-cache
+      - name: Regenerate api-client
+        run: cd ui && pnpm run api-client:gen
+      - name: Verify OpenAPI docs and api-client are in sync
+        run: |
+          if ! git diff --exit-code -- api-docs/openapi ui/packages/api-client/src; then
+            echo "::error::OpenAPI docs or api-client generated code is out of sync with the current API. Run './gradlew generateOpenApiDocs --no-configuration-cache' and 'cd ui && pnpm run api-client:gen', then commit the changes under api-docs/openapi and ui/packages/api-client/src."
+            git diff --stat api-docs/openapi ui/packages/api-client/src
+            exit 1
+          fi


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. 如果这是你的第一次，请阅读我们的贡献指南：<https://github.com/halo-dev/halo/blob/main/CONTRIBUTING.md>。
1. If this is your first time, please read our contributor guidelines: <https://github.com/halo-dev/halo/blob/main/CONTRIBUTING.md>.
2. 请根据你解决问题的类型为 Pull Request 添加合适的标签。
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request.
3. 请确保你已经添加并运行了适当的测试。
3. Ensure you have added or ran the appropriate tests for your PR.
4. 如果你的 PR 使用了 LLM 生成代码，请在 PR 中添加相应的说明，我们不反对使用 LLM 辅助开发，但希望你能够先对生成的代码进行审查。
5. If your PR uses LLM generated code, please add a corresponding description in the PR, we do not oppose using LLM to assist development, but we hope you can review the generated code first.
-->

#### What type of PR is this?

/area ui
/kind bug

<!--
添加其中一个类别：
Add one of the following kinds:

/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind improvement

适当添加其中一个或多个类别（可选）：
Optionally add one or more of the following kinds if applicable:

/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

the published `@halo-dev/api-client` npm package was missing APIs because it was sometimes built from stale generated code. This PR adds two safeguards: (1) Release workflow – before publishing UI packages, we run pnpm run api-client:gen so the client is always regenerated from the current `api-docs/openapi/v3_0/aggregated.json,` and the published package is built from that output. (2) CI check – when a PR or push touches `api-docs/openapi/**` or `ui/packages/api-client/**,` a job runs api-client:gen and fails if the generated files under ui/packages/api-client/src have uncommitted changes, so we don’t merge with out-of-sync generated code.

#### Which issue(s) this PR fixes:

<!--
PR 合并时自动关闭 issue。
Automatically closes linked issue when PR is merged.

用法：`Fixes #<issue 号>`，或者 `Fixes (粘贴 issue 完整链接)`
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #8377 

#### Special notes for your reviewer:
- Release: `.github/workflows/release-ui-packages.yaml` – one new step “Regenerate api-client” before “Publish to NPM”. No change to publish logic.
- CI: `.github/workflows/halo.yaml` – new changes job using `dorny/paths-filter@v3` so the sync job runs only when the above paths change; `api-client-sync` runs `api-client:gen` then `git diff --exit-code -- ui/packages/api-client/src` and fails if there is drift.
#### Does this PR introduce a user-facing change?
No. This only changes CI/release behavior. End users will see the fix once a new version of `@halo-dev/api-client` is released to npm with the regenerated client.
<!--
如果当前 Pull Request 的修改不会造成用户侧的任何变更，在 `release-note` 代码块儿中填写 `NONE`。
否则请填写用户侧能够理解的 Release Note。如果当前 Pull Request 包含破坏性更新（Break Change），
Release Note 需要以 `action required` 开头。
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->

```release-note
NONE
```
