### PR TITLE
fix: Null reference in API error handler when response has no Content…

### DIFF
--- a/ui/src/setup/setupApiClient.ts
+++ b/ui/src/setup/setupApiClient.ts
@@ -70,9 +70,9 @@ export function setupApiClient() {
       // Catch error requests where the response is text/html,
       // which usually comes from a reverse proxy or WAF
 
-      const contentType = error.response?.headers["content-type"];
+      const contentType = error.response?.headers?.["content-type"];
 
-      if (contentType.toLowerCase().includes("text/html")) {
+      if (contentType?.toLowerCase().includes("text/html")) {
         createHTMLContentModal({
           uniqueId: objectHash(error.response?.data || ""),
           title: error.response?.status.toString(),


### PR DESCRIPTION
…-Type header

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. 如果这是你的第一次，请阅读我们的贡献指南：<https://github.com/halo-dev/halo/blob/main/CONTRIBUTING.md>。
1. If this is your first time, please read our contributor guidelines: <https://github.com/halo-dev/halo/blob/main/CONTRIBUTING.md>.
2. 请根据你解决问题的类型为 Pull Request 添加合适的标签。
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request.
3. 请确保你已经添加并运行了适当的测试。
3. Ensure you have added or ran the appropriate tests for your PR.
4. 如果你的 PR 使用了 LLM 生成代码，请在 PR 中添加相应的说明，我们不反对使用 LLM 辅助开发，但希望你能够先对生成的代码进行审查。
5. If your PR uses LLM generated code, please add a corresponding description in the PR, we do not oppose using LLM to assist development, but we hope you can review the generated code first.
-->

#### What type of PR is this?
/kind improvement

<!--
添加其中一个类别：
Add one of the following kinds:

/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind improvement

适当添加其中一个或多个类别（可选）：
Optionally add one or more of the following kinds if applicable:

/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
修复了当服务器返回错误响应时，全局 API 错误拦截器**缺少** `Content-Type` 标头而导致的崩溃问题。

拦截器会调用 `contentType.toLowerCase()` 来检测 HTML 错误页面（例如，来自反向代理或 WAF 的页面）。如果缺少 `Content-Type`，则 `contentType` 为 `undefined`，这会导致 `TypeError` 并破坏错误处理程序。用户随后不会收到任何提示信息、登录过期对话框，并且会收到未处理的 Promise 拒绝。

此更改通过在读取标头和调用 `toLowerCase()` 时使用可选链来防止标头缺失的情况。当缺少 `Content-Type` 时，处理程序会跳过“在模态框中显示 HTML”分支，并继续执行现有的回退方案（标题/详情提示信息、状态提示信息或通用未知错误）。
#### Which issue(s) this PR fixes:

<!--
PR 合并时自动关闭 issue。
Automatically closes linked issue when PR is merged.

用法：`Fixes #<issue 号>`，或者 `Fixes (粘贴 issue 完整链接)`
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #8396 

#### Special notes for your reviewer:
- **文件：** `ui/src/setup/setupApiClient.ts`
- **更改：** `error.response?.headers["content-type"]` → `error.response?.headers?.["content-type"]`，以及 `contentType.toLowerCase()` → `contentType?.toLowerCase()`。
- 当存在 `Content-Type` 时，行为不变；仅避免在缺少 `Content-Type` 时抛出异常。
#### Does this PR introduce a user-facing change?
是的，但这只是**bug修复**。之前遇到崩溃问题的用户（例如，代理或服务器返回错误时缺少`Content-Type`）现在将看到正常的错误处理（弹出提示或登录过期对话框），而不是出现故障的错误处理程序和未处理的错误。
<!--
如果当前 Pull Request 的修改不会造成用户侧的任何变更，在 `release-note` 代码块儿中填写 `NONE`。
否则请填写用户侧能够理解的 Release Note。如果当前 Pull Request 包含破坏性更新（Break Change），
Release Note 需要以 `action required` 开头。
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->

```release-note
NONE
```
