### PR TITLE
Use TinyColor string methods for colors

### DIFF
--- a/ui/src/formkit/inputs/color/ColorInput.vue
+++ b/ui/src/formkit/inputs/color/ColorInput.vue
@@ -36,7 +36,6 @@ function formatPayload(color: Payload) {
 
 function formatColorByUnpredictableValue(value: string) {
   const color = new TinyColor(value);
-  debugger;
   switch (format.value) {
     case "rgb":
       return color.toRgbString();


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/area ui
/milestone 2.23.x

#### What this PR does / why we need it:

Replace toHex8() and toHex() with toHex8String() and toHexString() to ensure color formatting returns proper string values. A debugger statement was also added for troubleshooting the color formatting logic.

#### Does this PR introduce a user-facing change?

```release-note
None
```
