### PR TITLE
Add copy error message button to plugin detail

### DIFF
--- a/ui/console-src/modules/system/plugins/components/tabs/Detail.vue
+++ b/ui/console-src/modules/system/plugins/components/tabs/Detail.vue
@@ -12,10 +12,12 @@ import {
   VButton,
   VDescription,
   VDescriptionItem,
+  VSpace,
   VSwitch,
 } from "@halo-dev/components";
 import { utils } from "@halo-dev/ui-shared";
 import { useQuery } from "@tanstack/vue-query";
+import { useClipboard } from "@vueuse/core";
 import type { Ref } from "vue";
 import { computed, inject, ref } from "vue";
 import { rbacAnnotations } from "@/constants/annotations";
@@ -88,6 +90,10 @@ const errorAlertVisible = computed(() => {
 const lastCondition = computed(() => {
   return plugin?.value?.status?.conditions?.[0];
 });
+
+const { copy, copied } = useClipboard({
+  legacy: true,
+});
 </script>
 
 <template>
@@ -122,9 +128,22 @@ const lastCondition = computed(() => {
           </div>
         </template>
         <template #actions>
-          <VButton size="sm" @click="conditionsModalVisible = true">
-            {{ $t("core.plugin.detail.operations.view_conditions.button") }}
-          </VButton>
+          <VSpace>
+            <VButton size="sm" @click="conditionsModalVisible = true">
+              {{ $t("core.plugin.detail.operations.view_conditions.button") }}
+            </VButton>
+            <VButton size="sm" @click="copy(lastCondition.message || '')">
+              {{
+                copied
+                  ? $t(
+                      "core.plugin.detail.operations.copy_error_message.copied"
+                    )
+                  : $t(
+                      "core.plugin.detail.operations.copy_error_message.button"
+                    )
+              }}
+            </VButton>
+          </VSpace>
         </template>
       </VAlert>
     </div>

--- a/ui/src/locales/en.json
+++ b/ui/src/locales/en.json
@@ -597,6 +597,8 @@
   "core.plugin.detail.fields.load_location": "Storage Location",
   "core.plugin.detail.fields.issues": "Issues feedback",
   "core.plugin.detail.fields.creation_time": "Installation Time",
+  "core.plugin.detail.operations.copy_error_message.button": "Copy error message",
+  "core.plugin.detail.operations.copy_error_message.copied": "Copied",
   "core.plugin.detail.operations.view_conditions.button": "View recent status",
   "core.plugin.loader.toast.entry_load_failed": "Failed to load plugin entry file",
   "core.plugin.loader.toast.style_load_failed": "Failed to load plugin stylesheet file",

--- a/ui/src/locales/es.json
+++ b/ui/src/locales/es.json
@@ -1228,5 +1228,7 @@
   "core.formkit.secret.includes_keys": "Incluye campos: {keys}",
   "core.formkit.secret.no_fields": "No hay campos",
   "core.formkit.secret.required_keys_tip": "Los campos requeridos para el elemento del formulario actual incluyen:",
-  "core.dashboard.widgets.presets.upvotes_stats.title": "Me gusta"
+  "core.dashboard.widgets.presets.upvotes_stats.title": "Me gusta",
+  "core.plugin.detail.operations.copy_error_message.button": "Copiar mensaje de error",
+  "core.plugin.detail.operations.copy_error_message.copied": "Copiado"
 }

--- a/ui/src/locales/zh-CN.json
+++ b/ui/src/locales/zh-CN.json
@@ -604,6 +604,8 @@
   "core.plugin.detail.fields.load_location": "存储位置",
   "core.plugin.detail.fields.issues": "问题反馈",
   "core.plugin.detail.fields.creation_time": "安装时间",
+  "core.plugin.detail.operations.copy_error_message.button": "复制错误信息",
+  "core.plugin.detail.operations.copy_error_message.copied": "已复制",
   "core.plugin.detail.operations.view_conditions.button": "查看最近状态",
   "core.plugin.loader.toast.entry_load_failed": "加载插件入口文件失败",
   "core.plugin.loader.toast.style_load_failed": "加载插件样式文件失败",

--- a/ui/src/locales/zh-TW.json
+++ b/ui/src/locales/zh-TW.json
@@ -1228,5 +1228,7 @@
   "core.formkit.secret.includes_keys": "包含字段：{keys}",
   "core.formkit.secret.no_fields": "沒有字段",
   "core.formkit.secret.required_keys_tip": "當前表單項所需的密鈅字段包括：",
-  "core.dashboard.widgets.presets.upvotes_stats.title": "點讚"
+  "core.dashboard.widgets.presets.upvotes_stats.title": "點讚",
+  "core.plugin.detail.operations.copy_error_message.button": "複製錯誤訊息",
+  "core.plugin.detail.operations.copy_error_message.copied": "已複製"
 }


### PR DESCRIPTION
#### What type of PR is this?

/area ui
/kind improvement
/milestone 2.23.x

#### What this PR does / why we need it:

Added a copy button at the bottom of error messages on the plugin page so users can easily copy and report errors to plugin authors.

<img width="556" height="223" alt="image" src="https://github.com/user-attachments/assets/c4dae9c8-c95a-4ff4-b7ba-8d930c5f260a" />

#### Does this PR introduce a user-facing change?

```release-note
None
```
