### PR TITLE
Adjust default comment sort order

### DIFF
--- a/ui/console-src/modules/contents/comments/composables/use-comments-fetch.ts
+++ b/ui/console-src/modules/contents/comments/composables/use-comments-fetch.ts
@@ -38,8 +38,8 @@ export default function useCommentsFetch(
         .filter(Boolean) as string[];
 
       const defaultSort = [
-        "status.lastReplyTime,desc",
         "metadata.creationTimestamp,desc",
+        "status.lastReplyTime,desc",
       ];
 
       const { data } = await consoleApiClient.content.comment.listComments({


### PR DESCRIPTION
#### What type of PR is this?

/area ui
/kind bug
/milestone 2.23.x

#### What this PR does / why we need it:

Fixes the default sorting issue in the comment management list, which was mainly caused by https://github.com/halo-dev/halo/pull/8371. This was preventing new comments from showing up at the top.

#### Does this PR introduce a user-facing change?

```release-note
None
```
