### PR TITLE
Bump @halo-dev/ui-plugin-bundler-kit to 2.23.0

### DIFF
--- a/ui/packages/ui-plugin-bundler-kit/package.json
+++ b/ui/packages/ui-plugin-bundler-kit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@halo-dev/ui-plugin-bundler-kit",
-  "version": "2.22.0",
+  "version": "2.23.0",
   "homepage": "https://github.com/halo-dev/halo/tree/main/ui/packages/ui-plugin-bundler-kit#readme",
   "bugs": {
     "url": "https://github.com/halo-dev/halo/issues"


### PR DESCRIPTION
#### What type of PR is this?

/area ui

#### What this PR does / why we need it:

Bump @halo-dev/ui-plugin-bundler-kit to 2.23.0

#### Does this PR introduce a user-facing change?

```release-note
None
```
