### PR TITLE
fix: resolve the issue of rendering errors when the array value is undefined

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -158,7 +158,7 @@
     "axios": "^1.12.2"
   },
   "lint-staged": {
-    "**/*": "oxfmt --no-error-on-unmatched-pattern",
+    "**/*": "vp fmt --check",
     "*.{ts,mts,tsx,vue}": [
       "eslint --fix --max-warnings=0 --no-warn-ignored"
     ]

--- a/ui/src/formkit/inputs/array/ArrayInput.vue
+++ b/ui/src/formkit/inputs/array/ArrayInput.vue
@@ -42,7 +42,7 @@ const nodeProps = ref<Partial<FormKitProps<ArrayProps>>>(props.node.props);
 type FnType = (index: number) => Record<string, unknown>;
 
 function createValue(num: number, fn: FnType): ArrayValue {
-  return new Array(num).fill("").map((_, index) => fn(index));
+  return Array.from({ length: num }, (_, index) => fn(index));
 }
 
 function arrayFeature(node: FormKitNode<ArrayValue>) {
@@ -138,13 +138,15 @@ const parseItemLabel = async (
         } as FormattedItemLabel,
       ];
     }
-    return castRenderedValueArray.map((renderedValue) => {
-      return {
-        type: itemLabel.type,
-        value: isNil(renderedValue.value) ? value : renderedValue.value,
-        ...renderedValue,
-      } as FormattedItemLabel;
-    });
+    return castRenderedValueArray
+      .map((renderedValue) => {
+        return {
+          type: itemLabel.type,
+          value: isNil(renderedValue.value) ? value : renderedValue.value,
+          ...renderedValue,
+        } as FormattedItemLabel;
+      })
+      .filter((item) => isNotNil(item.value));
   }
 };
 


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/area ui

#### What this PR does / why we need it:

解决当 Array Input 中原始字段与渲染字段均为 `undefined` 时，会出现的报错问题。

#### Does this PR introduce a user-facing change?
```release-note
解决 ArrayInput 渲染图片时可能出现的报错问题。
```
