### PR TITLE
Remove default value for visibility in API schemas and related classes

### DIFF
--- a/api-docs/openapi/v3_0/aggregated.json
+++ b/api-docs/openapi/v3_0/aggregated.json
@@ -20678,8 +20678,7 @@
               "PUBLIC",
               "INTERNAL",
               "PRIVATE"
-            ],
-            "default": "PUBLIC"
+            ]
           }
         }
       },
@@ -22495,8 +22494,7 @@
               "PUBLIC",
               "INTERNAL",
               "PRIVATE"
-            ],
-            "default": "PUBLIC"
+            ]
           }
         }
       },

--- a/api-docs/openapi/v3_0/apis_console.api_v1alpha1.json
+++ b/api-docs/openapi/v3_0/apis_console.api_v1alpha1.json
@@ -5491,8 +5491,7 @@
               "PUBLIC",
               "INTERNAL",
               "PRIVATE"
-            ],
-            "default": "PUBLIC"
+            ]
           }
         }
       },
@@ -6033,8 +6032,7 @@
               "PUBLIC",
               "INTERNAL",
               "PRIVATE"
-            ],
-            "default": "PUBLIC"
+            ]
           }
         }
       },

--- a/api-docs/openapi/v3_0/apis_extension.api_v1alpha1.json
+++ b/api-docs/openapi/v3_0/apis_extension.api_v1alpha1.json
@@ -12880,8 +12880,7 @@
               "PUBLIC",
               "INTERNAL",
               "PRIVATE"
-            ],
-            "default": "PUBLIC"
+            ]
           }
         }
       },
@@ -14260,8 +14259,7 @@
               "PUBLIC",
               "INTERNAL",
               "PRIVATE"
-            ],
-            "default": "PUBLIC"
+            ]
           }
         }
       },

--- a/api-docs/openapi/v3_0/apis_public.api_v1alpha1.json
+++ b/api-docs/openapi/v3_0/apis_public.api_v1alpha1.json
@@ -2640,8 +2640,7 @@
               "PUBLIC",
               "INTERNAL",
               "PRIVATE"
-            ],
-            "default": "PUBLIC"
+            ]
           }
         }
       },
@@ -3220,8 +3219,7 @@
               "PUBLIC",
               "INTERNAL",
               "PRIVATE"
-            ],
-            "default": "PUBLIC"
+            ]
           }
         }
       },

--- a/api-docs/openapi/v3_0/apis_uc.api_v1alpha1.json
+++ b/api-docs/openapi/v3_0/apis_uc.api_v1alpha1.json
@@ -2561,8 +2561,7 @@
               "PUBLIC",
               "INTERNAL",
               "PRIVATE"
-            ],
-            "default": "PUBLIC"
+            ]
           }
         }
       },

--- a/api/src/main/java/run/halo/app/core/extension/content/Post.java
+++ b/api/src/main/java/run/halo/app/core/extension/content/Post.java
@@ -139,7 +139,7 @@ public class Post extends AbstractExtension {
         @Schema(requiredMode = RequiredMode.REQUIRED, defaultValue = "true")
         private Boolean allowComment;
 
-        @Schema(requiredMode = RequiredMode.REQUIRED, defaultValue = "PUBLIC")
+        @Schema(requiredMode = RequiredMode.REQUIRED)
         private VisibleEnum visible;
 
         @Schema(requiredMode = RequiredMode.REQUIRED, defaultValue = "0")

--- a/api/src/main/java/run/halo/app/core/extension/content/SinglePage.java
+++ b/api/src/main/java/run/halo/app/core/extension/content/SinglePage.java
@@ -95,7 +95,7 @@ public class SinglePage extends AbstractExtension {
         @Schema(requiredMode = REQUIRED, defaultValue = "true")
         private Boolean allowComment;
 
-        @Schema(requiredMode = REQUIRED, defaultValue = "PUBLIC")
+        @Schema(requiredMode = REQUIRED)
         private Post.VisibleEnum visible;
 
         @Schema(requiredMode = REQUIRED, defaultValue = "0")


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup
/area core
/milestone 2.23.x

#### What this PR does / why we need it:

This PR removes default value for visibility in API schemas and related classes to prevent random order of the schema output.

Currently, we don't even know what's the root cause. But it doesn't matter.

#### Which issue(s) this PR fixes:

See https://github.com/halo-dev/halo/actions/runs/23841263320/job/69497186948 for more.

#### Does this PR introduce a user-facing change?

```release-note
None
```

