### PR TITLE
[release-2.23] Fix "Finder with name 'xxx' is already registered" on plugin re-registration (#9853)

### DIFF
--- a/application/src/main/java/run/halo/app/theme/finders/DefaultFinderRegistry.java
+++ b/application/src/main/java/run/halo/app/theme/finders/DefaultFinderRegistry.java
@@ -89,6 +89,10 @@ public class DefaultFinderRegistry implements FinderRegistry, InitializingBean {
 
     @Override
     public void register(String pluginId, ApplicationContext pluginContext) {
+        // Ensure any stale finders from this plugin are removed before registering new ones.
+        // This handles the case where a previous registration was not properly cleaned up
+        // (e.g., when a plugin context refresh partially succeeded and then failed).
+        unregister(pluginId);
         pluginContext.getBeansWithAnnotation(Finder.class)
             .forEach((beanName, finder) -> {
                 var finderName = getFinderName(finder);

--- a/application/src/test/java/run/halo/app/theme/finders/FinderRegistryTest.java
+++ b/application/src/test/java/run/halo/app/theme/finders/FinderRegistryTest.java
@@ -2,6 +2,7 @@ package run.halo.app.theme.finders;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.when;
 
 import java.util.Map;
 import org.junit.jupiter.api.BeforeEach;
@@ -59,6 +60,45 @@ class FinderRegistryTest {
         finderRegistry.putFinder(new FakeFinder());
         Map<String, Object> finders = finderRegistry.getFinders();
         assertThat(finders).hasSize(1);
+    }
+
+    @Test
+    void registerAndUnregisterPlugin() {
+        var pluginContext = org.mockito.Mockito.mock(ApplicationContext.class);
+        var finder = new FakeFinder();
+        when(pluginContext.getBeansWithAnnotation(Finder.class))
+            .thenReturn(Map.of("fakeFinder", finder));
+
+        finderRegistry.register("plugin-a", pluginContext);
+        assertThat(finderRegistry.get("test")).isNotNull();
+
+        finderRegistry.unregister("plugin-a");
+        assertThat(finderRegistry.get("test")).isNull();
+    }
+
+    @Test
+    void reRegisterCleansStaleFinders() {
+        var pluginContext = org.mockito.Mockito.mock(ApplicationContext.class);
+        var finder1 = new FakeFinder();
+        when(pluginContext.getBeansWithAnnotation(Finder.class))
+            .thenReturn(Map.of("fakeFinder", finder1));
+
+        // First registration (simulates a previous plugin start that registered finders)
+        finderRegistry.register("plugin-a", pluginContext);
+        assertThat(finderRegistry.get("test")).isEqualTo(finder1);
+
+        // Simulate stale state: unregister was never called (e.g., context closed without
+        // firing ContextClosedEvent due to a failed refresh after ContextRefreshedEvent)
+        // Now re-register with new finders (e.g., after plugin upgrade)
+        var newPluginContext = org.mockito.Mockito.mock(ApplicationContext.class);
+        var finder2 = new FakeFinder();
+        when(newPluginContext.getBeansWithAnnotation(Finder.class))
+            .thenReturn(Map.of("fakeFinder", finder2));
+
+        // register should not throw "Finder with name 'test' is already registered"
+        finderRegistry.register("plugin-a", newPluginContext);
+        // The new finder should be registered
+        assertThat(finderRegistry.get("test")).isEqualTo(finder2);
     }
 
     @Finder("test")


### PR DESCRIPTION
Cherry pick from https://github.com/halo-dev/halo/pull/9853

```release-note
修复部分包含 Finder API 的插件可能在升级后无法正常启动的问题
```