### PR TITLE
Simplify attachment thumbnails handling and make thumbnails nullable

### DIFF
--- a/api/src/main/java/run/halo/app/core/extension/attachment/Attachment.java
+++ b/api/src/main/java/run/halo/app/core/extension/attachment/Attachment.java
@@ -67,6 +67,7 @@ public class Attachment extends AbstractExtension {
             """)
         private String permalink;
 
+        @Nullable
         private Map<String, String> thumbnails;
     }
 }

--- a/application/src/main/java/run/halo/app/core/attachment/reconciler/AttachmentReconciler.java
+++ b/application/src/main/java/run/halo/app/core/attachment/reconciler/AttachmentReconciler.java
@@ -68,19 +68,11 @@ class AttachmentReconciler implements Reconciler<Request> {
                 )
                 .blockOptional(Duration.ofSeconds(10))
                 .orElse(null);
-            Result result = null;
-            if (thumbnails == null) {
-                log.warn("""
-                    Failed to get thumbnails for attachment: {}, \
-                    consider upgrading storage plugins""", request.name()
-                );
-                result = new Result(true, Duration.ofSeconds(10));
-            }
             attachment.getStatus().setThumbnails(thumbnails);
             log.debug("Set attachment thumbnails: {} for {}", thumbnails, request.name());
             client.update(attachment);
             this.eventPublisher.publishEvent(new AttachmentChangedEvent(this, attachment));
-            return result;
+            return Result.doNotRetry();
         }).orElse(null);
     }
 


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup
/area core
/milestone 2.24.x

#### What this PR does / why we need it:

This PR mainly removes warning of not being able to generating thumbnails for attachments.

Please note that I cancel the requeue operation when failed to generate thumbnails.

#### Which issue(s) this PR fixes:

Fixes https://github.com/halo-dev/halo/issues/8429

#### Does this PR introduce a user-facing change?

```release-note
修复附件插件未实现缩略图生成功能时出现大量警告日志的问题
```

