### PR TITLE
pref: additional file type restrictions for uploading avatars

### DIFF
--- a/application/src/main/java/run/halo/app/core/endpoint/console/UserEndpoint.java
+++ b/application/src/main/java/run/halo/app/core/endpoint/console/UserEndpoint.java
@@ -98,6 +98,8 @@ import run.halo.app.infra.utils.JsonUtils;
 @RequiredArgsConstructor
 public class UserEndpoint implements CustomEndpoint {
 
+    private static final String[] ALLOWED_AVATAR_EXTENSIONS =
+        new String[] {"png", "jpg", "jpeg", "gif"};
     private static final String SELF_USER = "-";
     private static final String USER_AVATAR_GROUP_NAME = "user-avatar-group";
     private static final String DEFAULT_USER_AVATAR_ATTACHMENT_POLICY_NAME = "default-policy";
@@ -394,6 +396,13 @@ public class UserEndpoint implements CustomEndpoint {
                 throw new ServerWebInputException("Invalid part of file");
             }
 
+            boolean isNoneExt = Arrays.stream(ALLOWED_AVATAR_EXTENSIONS)
+                .noneMatch(ext -> filePart.filename().endsWith("." + ext));
+
+            if (isNoneExt) {
+                throw new ServerWebInputException("Only support file with extension: "
+                    + String.join(", ", ALLOWED_AVATAR_EXTENSIONS));
+            }
             return filePart;
         }
     }

--- a/application/src/main/java/run/halo/app/core/endpoint/console/UserEndpoint.java
+++ b/application/src/main/java/run/halo/app/core/endpoint/console/UserEndpoint.java
@@ -394,9 +394,6 @@ public class UserEndpoint implements CustomEndpoint {
                 throw new ServerWebInputException("Invalid part of file");
             }
 
-            if (!filePart.filename().endsWith(".png")) {
-                throw new ServerWebInputException("Only support avatar in PNG format");
-            }
             return filePart;
         }
     }

--- a/application/src/test/java/run/halo/app/core/endpoint/console/UserEndpointTest.java
+++ b/application/src/test/java/run/halo/app/core/endpoint/console/UserEndpointTest.java
@@ -396,34 +396,6 @@ class UserEndpointTest {
     @Nested
     class AvatarUploadTest {
         @Test
-        void respondWithErrorIfTypeNotPNG() {
-
-            var multipartBodyBuilder = new MultipartBodyBuilder();
-            multipartBodyBuilder.part("file", "fake-file")
-                .contentType(MediaType.IMAGE_JPEG)
-                .filename("fake-filename.jpg");
-
-            when(environmentFetcher.fetch(
-                SystemSetting.Attachment.GROUP, SystemSetting.Attachment.class
-            )).thenReturn(Mono.fromSupplier(() -> SystemSetting.Attachment.builder()
-                .avatar(null)
-                .build())
-            );
-            when(environmentFetcher.fetch(
-                SystemSetting.User.GROUP, SystemSetting.User.class)
-            ).thenReturn(Mono.empty());
-
-            webClient
-                .post()
-                .uri("/users/-/avatar")
-                .contentType(MediaType.MULTIPART_FORM_DATA)
-                .body(BodyInserters.fromMultipartData(multipartBodyBuilder.build()))
-                .exchange()
-                .expectStatus()
-                .is4xxClientError();
-        }
-
-        @Test
         void shouldUploadSuccessfully() {
             var currentUser = createUser("fake-user");
 

--- a/application/src/test/java/run/halo/app/core/endpoint/console/UserEndpointTest.java
+++ b/application/src/test/java/run/halo/app/core/endpoint/console/UserEndpointTest.java
@@ -23,6 +23,8 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -395,6 +397,77 @@ class UserEndpointTest {
 
     @Nested
     class AvatarUploadTest {
+        @Test
+        void respondWithErrorIfExtensionNotAllowed() {
+
+            var multipartBodyBuilder = new MultipartBodyBuilder();
+            multipartBodyBuilder.part("file", "fake-file")
+                .contentType(MediaType.parseMediaType("image/bmp"))
+                .filename("fake-filename.bmp");
+
+            when(environmentFetcher.fetch(
+                SystemSetting.Attachment.GROUP, SystemSetting.Attachment.class
+            )).thenReturn(Mono.fromSupplier(() -> SystemSetting.Attachment.builder()
+                .avatar(null)
+                .build())
+            );
+            when(environmentFetcher.fetch(
+                SystemSetting.User.GROUP, SystemSetting.User.class)
+            ).thenReturn(Mono.empty());
+
+            webClient
+                .post()
+                .uri("/users/-/avatar")
+                .contentType(MediaType.MULTIPART_FORM_DATA)
+                .body(BodyInserters.fromMultipartData(multipartBodyBuilder.build()))
+                .exchange()
+                .expectStatus()
+                .is4xxClientError();
+        }
+
+        @ParameterizedTest
+        @ValueSource(strings = {"png", "jpg", "jpeg", "gif"})
+        void shouldAllowAllowedExtensions(String ext) {
+            var currentUser = createUser("fake-user");
+
+            Attachment attachment = new Attachment();
+            Metadata metadata = new Metadata();
+            metadata.setName("fake-attachment");
+            attachment.setMetadata(metadata);
+
+            var multipartBodyBuilder = new MultipartBodyBuilder();
+            multipartBodyBuilder.part("file", "fake-file")
+                .contentType(MediaType.parseMediaType("image/" + ext))
+                .filename("fake-filename." + ext);
+
+            when(environmentFetcher.fetch(
+                SystemSetting.Attachment.GROUP, SystemSetting.Attachment.class
+            )).thenReturn(Mono.fromSupplier(() -> SystemSetting.Attachment.builder()
+                .avatar(null)
+                .build())
+            );
+            when(environmentFetcher.fetch(
+                SystemSetting.User.GROUP, SystemSetting.User.class)
+            ).thenReturn(Mono.empty());
+
+            when(client.get(User.class, "fake-user")).thenReturn(Mono.just(currentUser));
+            when(attachmentService.upload(eq("default-policy"), anyString(), anyString(),
+                any(), any(MediaType.class))).thenReturn(Mono.just(attachment));
+            when(client.update(currentUser)).thenReturn(Mono.just(currentUser));
+
+            webClient.post()
+                .uri("/users/-/avatar")
+                .contentType(MediaType.MULTIPART_FORM_DATA)
+                .body(BodyInserters.fromMultipartData(multipartBodyBuilder.build()))
+                .exchange()
+                .expectStatus()
+                .isOk()
+                .expectBody(User.class).isEqualTo(currentUser);
+
+            verify(client).get(User.class, "fake-user");
+            verify(client).update(currentUser);
+        }
+
         @Test
         void shouldUploadSuccessfully() {
             var currentUser = createUser("fake-user");


### PR DESCRIPTION
#### What type of PR is this?

/kind improvement
/area core

#### What this PR does / why we need it:

增加上传头像的文件类型，当前允许的类型为 `png`、`jpg`、`jpeg`、`gif`。 

#### How to test it?

测试图像上传功能是否会收到影响。

#### Does this PR introduce a user-facing change?
```release-note
扩充上传头像的文件类型限制
```
