### PR TITLE
Build UI packages before publishing

### DIFF
--- a/.github/workflows/release-ui-packages.yaml
+++ b/.github/workflows/release-ui-packages.yaml
@@ -21,4 +21,4 @@ jobs:
         uses: ./.github/actions/setup-env
       - run: ./gradlew pnpmInstall
       - name: Publish to NPM
-        run: cd ui && pnpm run publish:packages
+        run: cd ui && pnpm build:packages && pnpm run publish:packages


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/area ui

#### What this PR does / why we need it:

Add a pnpm build:packages step to the release-ui-packages workflow so UI packages are built prior to running pnpm run publish:packages. Ensures artifacts are compiled before publishing to NPM to avoid releasing unbuilt packages.

#### Does this PR introduce a user-facing change?

```release-note
None 
```
