### PR TITLE
Avoid appending version to assets directories

### DIFF
--- a/application/src/main/java/run/halo/app/theme/ThemeLinkBuilder.java
+++ b/application/src/main/java/run/halo/app/theme/ThemeLinkBuilder.java
@@ -40,7 +40,8 @@ public class ThemeLinkBuilder extends StandardLinkBuilder {
             var path = PathUtils.combinePath(THEME_PREVIEW_PREFIX, theme.getName(), link);
             var uriComponents = UriComponentsBuilder.fromUriString(path).build();
             if (StringUtils.isNotBlank(theme.getVersion())
-                && uriComponents.getQueryParams().isEmpty()) {
+                && uriComponents.getQueryParams().isEmpty()
+                && !isAssetsDirectoryPath(link)) {
                 return UriComponentsBuilder.fromUriString(path)
                     .queryParam("v", theme.getVersion())
                     .build().toString();
@@ -75,5 +76,18 @@ public class ThemeLinkBuilder extends StandardLinkBuilder {
     private boolean isAssetsRequest(String link) {
         String assetsPrefix = externalUrlSupplier.get().resolve(THEME_ASSETS_PREFIX).toString();
         return link.startsWith(assetsPrefix) || link.startsWith(THEME_ASSETS_PREFIX);
+    }
+
+    private boolean isAssetsDirectoryPath(String link) {
+        var path = UriComponentsBuilder.fromUriString(link).build().getPath();
+        if (path == null) {
+            return false;
+        }
+        if (path.endsWith("/")) {
+            return true;
+        }
+        var lastSegment = StringUtils.substringAfterLast(path, "/");
+        // If the last segment has no dot, treat it as a directory path
+        return StringUtils.isNotBlank(lastSegment) && !StringUtils.contains(lastSegment, '.');
     }
 }

--- a/application/src/main/java/run/halo/app/theme/ThemeLinkBuilder.java
+++ b/application/src/main/java/run/halo/app/theme/ThemeLinkBuilder.java
@@ -41,7 +41,7 @@ public class ThemeLinkBuilder extends StandardLinkBuilder {
             var uriComponents = UriComponentsBuilder.fromUriString(path).build();
             if (StringUtils.isNotBlank(theme.getVersion())
                 && uriComponents.getQueryParams().isEmpty()
-                && !isAssetsDirectoryPath(link)) {
+                && !isDirectoryPath(link)) {
                 return UriComponentsBuilder.fromUriString(path)
                     .queryParam("v", theme.getVersion())
                     .build().toString();
@@ -78,16 +78,18 @@ public class ThemeLinkBuilder extends StandardLinkBuilder {
         return link.startsWith(assetsPrefix) || link.startsWith(THEME_ASSETS_PREFIX);
     }
 
-    private boolean isAssetsDirectoryPath(String link) {
-        var path = UriComponentsBuilder.fromUriString(link).build().getPath();
+    private static boolean isDirectoryPath(String link) {
+        if (link.endsWith("/")) {
+            return true;
+        }
+        var uri = UriComponentsBuilder.fromUriString(link).build();
+        var path = uri.getPath();
         if (path == null) {
             return false;
         }
-        if (path.endsWith("/")) {
-            return true;
-        }
-        var lastSegment = StringUtils.substringAfterLast(path, "/");
+        var pathSegments = uri.getPathSegments();
+        var lastSegment = pathSegments.getLast();
         // If the last segment has no dot, treat it as a directory path
-        return StringUtils.isNotBlank(lastSegment) && !StringUtils.contains(lastSegment, '.');
+        return StringUtils.isNotBlank(lastSegment) && !lastSegment.contains(".");
     }
 }

--- a/application/src/test/java/run/halo/app/theme/ThemeLinkBuilderTest.java
+++ b/application/src/test/java/run/halo/app/theme/ThemeLinkBuilderTest.java
@@ -99,6 +99,26 @@ class ThemeLinkBuilderTest {
     }
 
     @Test
+    void processAssetsDirectoryLinkShouldNotAppendVersion() {
+        ThemeLinkBuilder themeLinkBuilder =
+            new ThemeLinkBuilder(getTheme(true), externalUrlSupplier);
+
+        // Directory-like paths should not get ?v appended to avoid breaking manual concatenation
+        String link = "/assets";
+        String processed = themeLinkBuilder.processLink(null, link);
+        assertThat(processed).isEqualTo("/themes/test-theme/assets");
+
+        link = "/assets/";
+        processed = themeLinkBuilder.processLink(null, link);
+        // Note: combinePath strips the trailing slash
+        assertThat(processed).isEqualTo("/themes/test-theme/assets");
+
+        link = "/assets/js";
+        processed = themeLinkBuilder.processLink(null, link);
+        assertThat(processed).isEqualTo("/themes/test-theme/assets/js");
+    }
+
+    @Test
     void processNullLink() {
         ThemeLinkBuilder themeLinkBuilder =
             new ThemeLinkBuilder(getTheme(false), externalUrlSupplier);


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/area core

#### What this PR does / why we need it:

Do not append the theme version query parameter for directory-like asset links. Add isAssetsDirectoryPath() to detect directory paths (trailing slash or last segment without a dot) and update the condition that adds ?v. Add tests to verify /assets, /assets/, and /assets/js are not suffixed with the version (note: combinePath strips trailing slash). This prevents breaking manual concatenation of asset paths.

See #9896 

#### Which issue(s) this PR fixes:

Fixes #9896 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
修复 2.24.0 自动为主题资源加版本参数功能在部分边缘场景下路径拼接错误的问题
```
