### PR TITLE
Ensure remember-me token is removed after device revocation and improve device resolution logic

### DIFF
--- a/api/src/main/java/run/halo/app/security/device/DeviceService.java
+++ b/api/src/main/java/run/halo/app/security/device/DeviceService.java
@@ -3,6 +3,7 @@ package run.halo.app.security.device;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.server.ServerWebExchange;
 import reactor.core.publisher.Mono;
+import run.halo.app.core.extension.Device;
 
 public interface DeviceService {
 
@@ -13,4 +14,13 @@ public interface DeviceService {
     Mono<Void> revoke(String principalName, String deviceId);
 
     Mono<Void> revoke(String username);
+
+    /**
+     * Resolve the current device from the request.
+     *
+     * @param exchange the current server web exchange
+     * @return the current device, or empty if not found or session ID mismatch
+     * @since 2.24.1
+     */
+    Mono<Device> resolveCurrentDevice(ServerWebExchange exchange);
 }

--- a/api/src/main/java/run/halo/app/security/device/DeviceService.java
+++ b/api/src/main/java/run/halo/app/security/device/DeviceService.java
@@ -16,10 +16,10 @@ public interface DeviceService {
     Mono<Void> revoke(String username);
 
     /**
-     * Resolve the current device from the request.
+     * Resolve the current device from the request. This method won't check current session ID.
      *
      * @param exchange the current server web exchange
-     * @return the current device, or empty if not found or session ID mismatch
+     * @return the current device, or empty if not found
      * @since 2.24.1
      */
     Mono<Device> resolveCurrentDevice(ServerWebExchange exchange);

--- a/application/src/main/java/run/halo/app/security/LoginHandlerEnhancerImpl.java
+++ b/application/src/main/java/run/halo/app/security/LoginHandlerEnhancerImpl.java
@@ -37,21 +37,17 @@ class LoginHandlerEnhancerImpl implements LoginHandlerEnhancer {
     @Override
     public Mono<Void> onLoginSuccess(ServerWebExchange exchange,
         Authentication successfulAuthentication) {
-        return Mono.when(
-                rememberMeServices.loginSuccess(exchange, successfulAuthentication),
-                deviceService.loginSuccess(exchange, successfulAuthentication),
-                oauth2LoginHandlerEnhancer.loginSuccess(exchange, successfulAuthentication),
-                userLoginOrLogoutProcessing.loginProcessing(successfulAuthentication.getName())
-            )
+        return rememberMeServices.loginSuccess(exchange, successfulAuthentication)
+            .then(deviceService.loginSuccess(exchange, successfulAuthentication))
+            .then(oauth2LoginHandlerEnhancer.loginSuccess(exchange, successfulAuthentication))
+            .then(userLoginOrLogoutProcessing.loginProcessing(successfulAuthentication.getName()))
             .then(parameterRequestCache.removeParameter(exchange, USERNAME_PARAMETER_NAME));
     }
 
     @Override
     public Mono<Void> onLoginFailure(ServerWebExchange exchange,
         AuthenticationException exception) {
-        return Mono.when(
-            parameterRequestCache.saveParameter(exchange, USERNAME_PARAMETER_NAME),
-            rememberMeServices.loginFail(exchange)
-        );
+        return parameterRequestCache.saveParameter(exchange, USERNAME_PARAMETER_NAME)
+            .then(rememberMeServices.loginFail(exchange));
     }
 }

--- a/application/src/main/java/run/halo/app/security/authentication/rememberme/PersistentTokenBasedRememberMeServices.java
+++ b/application/src/main/java/run/halo/app/security/authentication/rememberme/PersistentTokenBasedRememberMeServices.java
@@ -103,7 +103,7 @@ public class PersistentTokenBasedRememberMeServices extends TokenBasedRememberMe
         var presentedToken = cookieTokens[1];
         return this.tokenRepository.getTokenForSeries(presentedSeries)
             // No series match, so we can't authenticate using this cookie
-            .switchIfEmpty(Mono.error(new RememberMeAuthenticationException(
+            .switchIfEmpty(Mono.error(() -> new RememberMeAuthenticationException(
                 "No persistent token found for series id: " + presentedSeries))
             )
             // Device must be validated before we can trust the token, as the token is only valid
@@ -130,8 +130,9 @@ public class PersistentTokenBasedRememberMeServices extends TokenBasedRememberMe
                 // *same* series number.
                 log.debug("Refreshing persistent login token for user '{}', series '{}'",
                     token.getUsername(), token.getSeries());
-                var newToken = new PersistentRememberMeToken(token.getUsername(), token.getSeries(),
-                    token.getTokenValue(), new Date());
+                var newToken = new PersistentRememberMeToken(
+                    token.getUsername(), token.getSeries(), generateTokenData(), new Date()
+                );
                 return Mono.just(newToken);
             })
             .flatMap(newToken -> updateToken(newToken)

--- a/application/src/main/java/run/halo/app/security/authentication/rememberme/PersistentTokenBasedRememberMeServices.java
+++ b/application/src/main/java/run/halo/app/security/authentication/rememberme/PersistentTokenBasedRememberMeServices.java
@@ -5,6 +5,7 @@ import java.time.Instant;
 import java.util.Arrays;
 import java.util.Base64;
 import java.util.Date;
+import java.util.Objects;
 import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.Authentication;
@@ -21,6 +22,7 @@ import org.springframework.web.server.ServerWebExchange;
 import reactor.core.publisher.Mono;
 import run.halo.app.security.LoginParameterRequestCache;
 import run.halo.app.security.SecurityConstant;
+import run.halo.app.security.device.DeviceService;
 
 /**
  * <p>{@link RememberMeServices} implementation based on Barry Jaspan's <a href=
@@ -67,12 +69,15 @@ public class PersistentTokenBasedRememberMeServices extends TokenBasedRememberMe
 
     private final PersistentRememberMeTokenRepository tokenRepository;
 
+    private final DeviceService deviceService;
+
     public PersistentTokenBasedRememberMeServices(
         CookieSignatureKeyResolver cookieSignatureKeyResolver,
         ReactiveUserDetailsService userDetailsService,
         RememberMeCookieResolver rememberMeCookieResolver,
         PersistentRememberMeTokenRepository tokenRepository,
-        LoginParameterRequestCache parameterRequestCache) {
+        LoginParameterRequestCache parameterRequestCache,
+        DeviceService deviceService) {
         super(
             cookieSignatureKeyResolver,
             userDetailsService,
@@ -81,6 +86,7 @@ public class PersistentTokenBasedRememberMeServices extends TokenBasedRememberMe
         );
         this.random = new SecureRandom();
         this.tokenRepository = tokenRepository;
+        this.deviceService = deviceService;
         setParameterName(SecurityConstant.REMEMBER_ME_PARAMETER_NAME);
     }
 
@@ -88,17 +94,21 @@ public class PersistentTokenBasedRememberMeServices extends TokenBasedRememberMe
     protected Mono<UserDetails> processAutoLoginCookie(String[] cookieTokens,
         ServerWebExchange exchange) {
         if (cookieTokens.length != 2) {
-            throw new InvalidCookieException(
-                "Cookie token did not contain " + 2 + " tokens, but contained '"
-                    + Arrays.asList(cookieTokens) + "'");
+            return Mono.error(new InvalidCookieException(
+                "Cookie token did not contain %d tokens, but contained '%s'".formatted(
+                    2, Arrays.asList(cookieTokens))
+            ));
         }
-        String presentedSeries = cookieTokens[0];
-        String presentedToken = cookieTokens[1];
+        var presentedSeries = cookieTokens[0];
+        var presentedToken = cookieTokens[1];
         return this.tokenRepository.getTokenForSeries(presentedSeries)
             // No series match, so we can't authenticate using this cookie
             .switchIfEmpty(Mono.error(new RememberMeAuthenticationException(
                 "No persistent token found for series id: " + presentedSeries))
             )
+            // Device must be validated before we can trust the token, as the token is only valid
+            // for a specific device.
+            .delayUntil(token -> validateDevice(exchange, token))
             .flatMap(token -> {
                 // We have a match for this user/series combination
                 if (!presentedToken.equals(token.getTokenValue())) {
@@ -135,6 +145,18 @@ public class PersistentTokenBasedRememberMeServices extends TokenBasedRememberMe
             );
     }
 
+    private Mono<Void> validateDevice(ServerWebExchange exchange, PersistentRememberMeToken token) {
+        return deviceService.resolveCurrentDevice(exchange)
+            .switchIfEmpty(Mono.error(() -> new RememberMeAuthenticationException(
+                "Unable to determine device for remember-me authentication"
+            )))
+            .filter(d -> Objects.equals(d.getSpec().getRememberMeSeriesId(), token.getSeries()))
+            .switchIfEmpty(Mono.error(() -> new RememberMeAuthenticationException(
+                "Remember-me series ID does not match current device's series ID"
+            )))
+            .then();
+    }
+
     private boolean isTokenExpired(PersistentRememberMeToken token) {
         return isTokenExpired(token.getDate().getTime() + getTokenValidityMillis());
     }
@@ -157,9 +179,9 @@ public class PersistentTokenBasedRememberMeServices extends TokenBasedRememberMe
         Authentication successfulAuthentication) {
         String username = successfulAuthentication.getName();
         log.debug("Creating new persistent login for user {}", username);
-        PersistentRememberMeToken persistentToken =
-            new PersistentRememberMeToken(username, generateSeriesData(),
-                generateTokenData(), new Date());
+        var persistentToken = new PersistentRememberMeToken(
+            username, generateSeriesData(), generateTokenData(), new Date()
+        );
         return this.tokenRepository.createNewToken(persistentToken)
             .doOnSuccess(unused -> addCookie(persistentToken, exchange))
             .onErrorResume(Throwable.class, ex -> {

--- a/application/src/main/java/run/halo/app/security/authentication/rememberme/RememberMeCookieResolverImpl.java
+++ b/application/src/main/java/run/halo/app/security/authentication/rememberme/RememberMeCookieResolverImpl.java
@@ -8,6 +8,7 @@ import org.springframework.lang.Nullable;
 import org.springframework.stereotype.Component;
 import org.springframework.util.Assert;
 import org.springframework.web.server.ServerWebExchange;
+import reactor.core.publisher.Mono;
 import run.halo.app.infra.properties.HaloProperties;
 
 @Getter
@@ -32,14 +33,18 @@ public class RememberMeCookieResolverImpl implements RememberMeCookieResolver {
     @Override
     public void setRememberMeCookie(ServerWebExchange exchange, String value) {
         Assert.notNull(value, "'value' is required");
-        exchange.getResponse().getCookies()
-            .set(getCookieName(), initCookie(exchange, value).build());
+        exchange.getResponse().beforeCommit(() -> Mono.fromRunnable(() -> {
+            var cookie = initCookie(exchange, value).build();
+            exchange.getResponse().getCookies().set(getCookieName(), cookie);
+        }));
     }
 
     @Override
     public void expireCookie(ServerWebExchange exchange) {
-        ResponseCookie cookie = initCookie(exchange, "").maxAge(0).build();
-        exchange.getResponse().getCookies().set(this.cookieName, cookie);
+        exchange.getResponse().beforeCommit(() -> Mono.fromRunnable(() -> {
+            var cookie = initCookie(exchange, "").maxAge(0).build();
+            exchange.getResponse().getCookies().set(this.cookieName, cookie);
+        }));
     }
 
     private ResponseCookie.ResponseCookieBuilder initCookie(ServerWebExchange exchange,

--- a/application/src/main/java/run/halo/app/security/authentication/rememberme/TokenBasedRememberMeServices.java
+++ b/application/src/main/java/run/halo/app/security/authentication/rememberme/TokenBasedRememberMeServices.java
@@ -382,10 +382,6 @@ class TokenBasedRememberMeServices implements ServerLogoutHandler, RememberMeSer
         return null;
     }
 
-    private boolean isInstanceOfUserDetails(Authentication authentication) {
-        return authentication.getPrincipal() instanceof UserDetails;
-    }
-
     protected Mono<String> getKey() {
         return cookieSignatureKeyResolver.resolveSigningKey();
     }

--- a/application/src/main/java/run/halo/app/security/authentication/rememberme/TokenBasedRememberMeServices.java
+++ b/application/src/main/java/run/halo/app/security/authentication/rememberme/TokenBasedRememberMeServices.java
@@ -14,6 +14,7 @@ import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
+import org.jspecify.annotations.Nullable;
 import org.springframework.security.authentication.AccountStatusException;
 import org.springframework.security.authentication.AccountStatusUserDetailsChecker;
 import org.springframework.security.authentication.RememberMeAuthenticationToken;
@@ -350,28 +351,30 @@ class TokenBasedRememberMeServices implements ServerLogoutHandler, RememberMeSer
     protected Mono<String> makeTokenSignature(long tokenExpiryTime, String username,
         String password, String algorithm) {
         return getKey()
-            .handle((key, sink) -> {
-                String data = username + ":" + tokenExpiryTime + ":" + password + ":" + key;
-                try {
-                    MessageDigest digest = MessageDigest.getInstance(algorithm);
-                    sink.next(new String(Hex.encode(digest.digest(data.getBytes()))));
-                } catch (NoSuchAlgorithmException ex) {
-                    sink.error(
-                        new IllegalStateException("No " + algorithm + " algorithm available!"));
-                }
-            });
+            .flatMap(key -> Mono.fromCallable(() -> {
+                var data = username + ":" + tokenExpiryTime + ":" + password + ":" + key;
+                var digest = MessageDigest.getInstance(algorithm);
+                return new String(Hex.encode(digest.digest(data.getBytes())));
+            }))
+            .onErrorMap(NoSuchAlgorithmException.class, ex ->
+                new IllegalStateException("No " + algorithm + " algorithm available!", ex)
+            );
     }
 
     protected String retrieveUserName(Authentication authentication) {
-        if (isInstanceOfUserDetails(authentication)) {
-            return ((UserDetails) authentication.getPrincipal()).getUsername();
+        var principal = authentication.getPrincipal();
+        Assert.notNull(principal, "Authentication principal cannot be null");
+        if (principal instanceof UserDetails userDetails) {
+            return userDetails.getUsername();
         }
-        return authentication.getPrincipal().toString();
+        return principal.toString();
     }
 
+    @Nullable
     protected String retrievePassword(Authentication authentication) {
-        if (isInstanceOfUserDetails(authentication)) {
-            return ((UserDetails) authentication.getPrincipal()).getPassword();
+        var principal = authentication.getPrincipal();
+        if (principal instanceof UserDetails userDetails) {
+            return userDetails.getPassword();
         }
         if (authentication.getCredentials() != null) {
             return authentication.getCredentials().toString();

--- a/application/src/main/java/run/halo/app/security/device/DeviceSecurityConfigurer.java
+++ b/application/src/main/java/run/halo/app/security/device/DeviceSecurityConfigurer.java
@@ -15,6 +15,6 @@ class DeviceSecurityConfigurer implements SecurityConfigurer {
     @Override
     public void configure(ServerHttpSecurity http) {
         var filter = new DeviceSessionFilter(deviceService);
-        http.addFilterAfter(filter, SecurityWebFiltersOrder.REACTOR_CONTEXT);
+        http.addFilterBefore(filter, SecurityWebFiltersOrder.AUTHENTICATION);
     }
 }

--- a/application/src/main/java/run/halo/app/security/device/DeviceServiceImpl.java
+++ b/application/src/main/java/run/halo/app/security/device/DeviceServiceImpl.java
@@ -10,6 +10,7 @@ import java.time.Instant;
 import java.util.Objects;
 import java.util.UUID;
 import java.util.function.Function;
+import java.util.function.Predicate;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import lombok.RequiredArgsConstructor;
@@ -31,6 +32,7 @@ import org.springframework.web.server.ServerWebExchange;
 import reactor.core.publisher.Mono;
 import reactor.util.retry.Retry;
 import run.halo.app.core.extension.Device;
+import run.halo.app.extension.ExtensionUtil;
 import run.halo.app.extension.ListOptions;
 import run.halo.app.extension.Metadata;
 import run.halo.app.extension.ReactiveExtensionClient;
@@ -90,9 +92,16 @@ class DeviceServiceImpl implements DeviceService {
     private Mono<Device> updateWithRetry(String deviceId, String username,
         Function<Device, Mono<Device>> updateFunction) {
         return Mono.defer(() -> client.fetch(Device.class, deviceId)
-                .filter(device -> device.getSpec().getPrincipalName().equals(username))
-                .flatMap(updateFunction)
-                .flatMap(client::update)
+                .flatMap(device -> {
+                    if (!Objects.equals(username, device.getSpec().getPrincipalName())) {
+                        log.debug(
+                            "Principal name mismatch for device {}, expected {}, actual {}, "
+                                + "revoking device",
+                            deviceId, username, device.getSpec().getPrincipalName());
+                        return doRevoke(device).then(Mono.empty());
+                    }
+                    return updateFunction.apply(device).flatMap(client::update);
+                })
             )
             .retryWhen(Retry.backoff(8, Duration.ofMillis(100))
                 .filter(OptimisticLockingFailureException.class::isInstance));
@@ -110,7 +119,10 @@ class DeviceServiceImpl implements DeviceService {
             var deviceUa = existingDevice.getSpec().getUserAgent();
             if (!Objects.equals(deviceUa, userAgent)) {
                 // User agent changed, create a new device
-                return Mono.empty();
+                log.debug(
+                    "User agent changed for device {}, expected {}, actual {}, revoking device",
+                    existingDevice.getMetadata().getName(), deviceUa, userAgent);
+                return doRevoke(existingDevice).then(Mono.empty());
             }
             var sessionId = existingDevice.getSpec().getSessionId();
             return exchange.getSession()
@@ -126,9 +138,11 @@ class DeviceServiceImpl implements DeviceService {
                     existingDevice.getSpec().setSessionId(session.getId());
                     existingDevice.getSpec().setLastAccessedTime(session.getLastAccessTime());
                     existingDevice.getSpec().setLastAuthenticatedTime(Instant.now());
+                    existingDevice.getSpec().setRememberMeSeriesId(
+                        exchange.getAttribute(REMEMBER_ME_SERIES_REQUEST_NAME)
+                    );
                 })
-                .thenReturn(existingDevice)
-                .delayUntil(this::removeRememberMeToken);
+                .thenReturn(existingDevice);
         });
     }
 
@@ -158,9 +172,7 @@ class DeviceServiceImpl implements DeviceService {
         }
         var deviceId = deviceIdCookie.getValue();
         return client.fetch(Device.class, deviceId)
-            .filterWhen(d -> exchange.getSession()
-                .map(session -> session.getId().equals(d.getSpec().getSessionId()))
-            );
+            .filter(Predicate.not(ExtensionUtil::isDeleted));
     }
 
     private Mono<Void> doRevoke(Device device) {
@@ -196,7 +208,8 @@ class DeviceServiceImpl implements DeviceService {
                         .setLastAuthenticatedTime(Instant.now())
                         .setIpAddress(getClientIp(exchange.getRequest()))
                         .setRememberMeSeriesId(
-                            exchange.getAttribute(REMEMBER_ME_SERIES_REQUEST_NAME))
+                            exchange.getAttribute(REMEMBER_ME_SERIES_REQUEST_NAME)
+                        )
                     );
                     device.getStatus()
                         .setOs(deviceInfo.os())

--- a/application/src/main/java/run/halo/app/security/device/DeviceServiceImpl.java
+++ b/application/src/main/java/run/halo/app/security/device/DeviceServiceImpl.java
@@ -7,6 +7,7 @@ import static run.halo.app.security.authentication.rememberme.PersistentTokenBas
 import java.security.Principal;
 import java.time.Duration;
 import java.time.Instant;
+import java.util.Objects;
 import java.util.UUID;
 import java.util.function.Function;
 import java.util.regex.Matcher;
@@ -14,6 +15,7 @@ import java.util.regex.Pattern;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
+import org.jspecify.annotations.Nullable;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.dao.OptimisticLockingFailureException;
 import org.springframework.http.HttpHeaders;
@@ -38,7 +40,7 @@ import run.halo.app.security.authentication.rememberme.PersistentRememberMeToken
 @Slf4j
 @Component
 @RequiredArgsConstructor
-public class DeviceServiceImpl implements DeviceService {
+class DeviceServiceImpl implements DeviceService {
     private final ReactiveExtensionClient client;
     private final DeviceCookieResolver deviceCookieResolver;
     private final ReactiveSessionRepository<?> sessionRepository;
@@ -66,7 +68,7 @@ public class DeviceServiceImpl implements DeviceService {
             return Mono.empty();
         }
         return ReactiveSecurityContextHolder.getContext()
-            .map(SecurityContext::getAuthentication)
+            .mapNotNull(SecurityContext::getAuthentication)
             .filter(trustResolver::isAuthenticated)
             .map(Principal::getName)
             .flatMap(username -> {
@@ -103,43 +105,39 @@ public class DeviceServiceImpl implements DeviceService {
             return Mono.empty();
         }
         var principalName = authentication.getName();
-        return updateWithRetry(deviceIdCookie.getValue(), principalName,
-            (Device existingDevice) -> {
-                var sessionId = existingDevice.getSpec().getSessionId();
-                return exchange.getSession()
-                    .flatMap(session -> {
-                        var userAgent =
-                            exchange.getRequest().getHeaders().getFirst(HttpHeaders.USER_AGENT);
-                        var deviceUa = existingDevice.getSpec().getUserAgent();
-                        if (!StringUtils.equals(deviceUa, userAgent)) {
-                            // User agent changed, create a new device
-                            return Mono.empty();
-                        }
-                        return Mono.just(session);
-                    })
-                    .flatMap(session -> {
-                        if (session.getId().equals(sessionId)) {
-                            return Mono.just(session);
-                        }
-                        return sessionRepository.deleteById(sessionId).thenReturn(session);
-                    })
-                    .map(session -> {
-                        existingDevice.getSpec().setSessionId(session.getId());
-                        existingDevice.getSpec().setLastAccessedTime(session.getLastAccessTime());
-                        existingDevice.getSpec().setLastAuthenticatedTime(Instant.now());
-                        return existingDevice;
-                    })
-                    .flatMap(this::removeRememberMeToken);
-            });
+        return updateWithRetry(deviceIdCookie.getValue(), principalName, existingDevice -> {
+            var userAgent = getUserAgent(exchange);
+            var deviceUa = existingDevice.getSpec().getUserAgent();
+            if (!Objects.equals(deviceUa, userAgent)) {
+                // User agent changed, create a new device
+                return Mono.empty();
+            }
+            var sessionId = existingDevice.getSpec().getSessionId();
+            return exchange.getSession()
+                .delayUntil(session -> {
+                    if (session.getId().equals(sessionId)) {
+                        return Mono.empty();
+                    }
+                    log.debug("Session ID changed for device {}, deleting old session {}",
+                        existingDevice.getMetadata().getName(), sessionId);
+                    return sessionRepository.deleteById(sessionId);
+                })
+                .doOnNext(session -> {
+                    existingDevice.getSpec().setSessionId(session.getId());
+                    existingDevice.getSpec().setLastAccessedTime(session.getLastAccessTime());
+                    existingDevice.getSpec().setLastAuthenticatedTime(Instant.now());
+                })
+                .thenReturn(existingDevice)
+                .delayUntil(this::removeRememberMeToken);
+        });
     }
 
     @Override
     public Mono<Void> revoke(String principalName, String deviceId) {
         return client.fetch(Device.class, deviceId)
             .filter(device -> device.getSpec().getPrincipalName().equals(principalName))
-            .flatMap(this::removeRememberMeToken)
-            .flatMap(client::delete)
-            .flatMap(revoked -> sessionRepository.deleteById(revoked.getSpec().getSessionId()));
+            .delayUntil(this::doRevoke)
+            .then();
     }
 
     @Override
@@ -148,22 +146,38 @@ public class DeviceServiceImpl implements DeviceService {
             .andQuery(Queries.equal("spec.principalName", username))
             .build();
         return client.listAll(Device.class, listOptions, defaultSort())
-            .flatMap(this::removeRememberMeToken)
-            .flatMap(device -> sessionRepository.deleteById(device.getSpec().getSessionId())
-                .thenReturn(device)
-            )
-            .flatMap(client::delete)
+            .delayUntil(this::doRevoke)
             .then();
     }
 
-    private Mono<Device> removeRememberMeToken(Device device) {
+    @Override
+    public Mono<Device> resolveCurrentDevice(ServerWebExchange exchange) {
+        var deviceIdCookie = deviceCookieResolver.resolveCookie(exchange);
+        if (deviceIdCookie == null) {
+            return Mono.empty();
+        }
+        var deviceId = deviceIdCookie.getValue();
+        return client.fetch(Device.class, deviceId)
+            .filterWhen(d -> exchange.getSession()
+                .map(session -> session.getId().equals(d.getSpec().getSessionId()))
+            );
+    }
+
+    private Mono<Void> doRevoke(Device device) {
+        return removeRememberMeToken(device)
+            .then(sessionRepository.deleteById(device.getSpec().getSessionId()))
+            .then(client.delete(device))
+            .then();
+    }
+
+    private Mono<Void> removeRememberMeToken(Device device) {
         var seriesId = device.getSpec().getRememberMeSeriesId();
         if (StringUtils.isBlank(seriesId)) {
-            return Mono.just(device);
+            return Mono.empty();
         }
-        log.debug("Removing remember-me token for seriesId: {}", seriesId);
-        return rememberMeTokenRepository.removeToken(seriesId)
-            .thenReturn(device);
+        log.debug("Removing remember-me token for seriesId: {} for device {}",
+            seriesId, device.getMetadata().getName());
+        return rememberMeTokenRepository.removeToken(seriesId);
     }
 
     Mono<Device> createDevice(ServerWebExchange exchange, Authentication authentication) {
@@ -174,8 +188,7 @@ public class DeviceServiceImpl implements DeviceService {
                     device.setMetadata(new Metadata());
                     device.getMetadata().setName(generateDeviceId());
 
-                    var userAgent =
-                        exchange.getRequest().getHeaders().getFirst(HttpHeaders.USER_AGENT);
+                    var userAgent = getUserAgent(exchange);
                     var deviceInfo = DeviceInfo.parse(userAgent);
                     device.setSpec(new Device.Spec()
                         .setUserAgent(userAgent)
@@ -202,6 +215,11 @@ public class DeviceServiceImpl implements DeviceService {
     String generateDeviceId() {
         return UUID.randomUUID().toString()
             .replace("-", "").toLowerCase();
+    }
+
+    @Nullable
+    private static String getUserAgent(ServerWebExchange exchange) {
+        return exchange.getRequest().getHeaders().getFirst(HttpHeaders.USER_AGENT);
     }
 
     record DeviceInfo(String browser, String os) {

--- a/application/src/test/java/run/halo/app/security/authentication/rememberme/PersistentTokenBasedRememberMeServicesTest.java
+++ b/application/src/test/java/run/halo/app/security/authentication/rememberme/PersistentTokenBasedRememberMeServicesTest.java
@@ -27,6 +27,9 @@ import org.springframework.security.web.authentication.rememberme.PersistentReme
 import org.springframework.security.web.authentication.rememberme.RememberMeAuthenticationException;
 import org.springframework.security.web.server.WebFilterExchange;
 import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+import run.halo.app.core.extension.Device;
+import run.halo.app.security.device.DeviceService;
 
 /**
  * Tests for {@link PersistentTokenBasedRememberMeServices}.
@@ -47,6 +50,9 @@ class PersistentTokenBasedRememberMeServicesTest {
 
     @Mock
     private PersistentRememberMeTokenRepository tokenRepository;
+
+    @Mock
+    DeviceService deviceService;
 
     @InjectMocks
     private PersistentTokenBasedRememberMeServices persistentTokenBasedRememberMeServices;
@@ -85,6 +91,12 @@ class PersistentTokenBasedRememberMeServicesTest {
                         new Date()))
                 );
             when(tokenRepository.removeUserTokens(eq("test"))).thenReturn(Mono.empty());
+            when(deviceService.resolveCurrentDevice(exchange)).thenReturn(Mono.fromSupplier(() -> {
+                var device = new Device();
+                device.setSpec(new Device.Spec());
+                device.getSpec().setRememberMeSeriesId("fake-series");
+                return device;
+            }));
             assertThatThrownBy(() -> persistentTokenBasedRememberMeServices.processAutoLoginCookie(
                 new String[] {"fake-series", "token-value"},
                 exchange).block())
@@ -103,6 +115,12 @@ class PersistentTokenBasedRememberMeServicesTest {
                         new Date(Instant.now().minusSeconds(10).toEpochMilli())))
                 );
             when(rememberMeCookieResolver.getCookieMaxAge()).thenReturn(Duration.ofSeconds(5));
+            when(deviceService.resolveCurrentDevice(exchange)).thenReturn(Mono.fromSupplier(() -> {
+                var device = new Device();
+                device.setSpec(new Device.Spec());
+                device.getSpec().setRememberMeSeriesId("fake-series");
+                return device;
+            }));
             assertThatThrownBy(() -> persistentTokenBasedRememberMeServices.processAutoLoginCookie(
                 new String[] {"fake-series", "token-value"},
                 exchange).block())
@@ -129,14 +147,61 @@ class PersistentTokenBasedRememberMeServicesTest {
                 });
 
             when(userDetailsService.findByUsername(eq("test"))).thenReturn(Mono.empty());
+            when(deviceService.resolveCurrentDevice(exchange)).thenReturn(Mono.fromSupplier(() -> {
+                var device = new Device();
+                device.setSpec(new Device.Spec());
+                device.getSpec().setRememberMeSeriesId("fake-series");
+                return device;
+            }));
 
             persistentTokenBasedRememberMeServices.processAutoLoginCookie(
-                    new String[] {"fake-series", "token-value"}, exchange)
-                .block();
+                    new String[] {"fake-series", "token-value"}, exchange
+                )
+                .as(StepVerifier::create)
+                .verifyComplete();
 
             verify(rememberMeCookieResolver).setRememberMeCookie(eq(exchange),
                 eq(persistentTokenBasedRememberMeServices.encodeCookie(
                     new String[] {"fake-series", generatedTokenValue.get()})));
+        }
+
+        @Test
+        void shouldFailWhenDeviceNotFound() {
+            var exchange = MockServerWebExchange.from(MockServerHttpRequest.get("/"));
+            when(tokenRepository.getTokenForSeries(eq("fake-series")))
+                .thenReturn(Mono.just(
+                    new PersistentRememberMeToken("test", "fake-series", "token-value",
+                        new Date()))
+                );
+            when(deviceService.resolveCurrentDevice(exchange)).thenReturn(Mono.empty());
+            persistentTokenBasedRememberMeServices.processAutoLoginCookie(
+                    new String[] {"fake-series", "token-value"},
+                    exchange
+                )
+                .as(StepVerifier::create)
+                .verifyError(RememberMeAuthenticationException.class);
+        }
+
+        @Test
+        void shouldFailWhenDeviceSeriesIdNotMatch() {
+            var exchange = MockServerWebExchange.from(MockServerHttpRequest.get("/"));
+            when(tokenRepository.getTokenForSeries(eq("fake-series")))
+                .thenReturn(Mono.just(
+                    new PersistentRememberMeToken("test", "fake-series", "token-value",
+                        new Date()))
+                );
+            when(deviceService.resolveCurrentDevice(exchange)).thenReturn(Mono.fromSupplier(() -> {
+                var device = new Device();
+                device.setSpec(new Device.Spec());
+                device.getSpec().setRememberMeSeriesId("other-series");
+                return device;
+            }));
+            persistentTokenBasedRememberMeServices.processAutoLoginCookie(
+                    new String[] {"fake-series", "token-value"},
+                    exchange
+                )
+                .as(StepVerifier::create)
+                .verifyError(RememberMeAuthenticationException.class);
         }
     }
 


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/kind improvement
/area core
/milestone 2.24.x

#### What this PR does / why we need it:

This PR ensures remember-me token is removed after device revocationn, enhances auto-login with remember-me by checking device and improves device resolution logic.

#### Which issue(s) this PR fixes:

Fixes https://github.com/halo-dev/halo/issues/8300

#### Special notes for your reviewer:

1. Try to revoke current device, then refresh current page
2. Try to login with remember-me, then delete device id and refresh current page

#### Does this PR introduce a user-facing change?

```release-note
修复登录时勾选记住我后撤销设备后不起作用的问题
```

