### PR TITLE
Make MenuItem Link Updates Event-Driven Instead of Polling

### DIFF
--- a/api/src/main/java/run/halo/app/core/extension/MenuItem.java
+++ b/api/src/main/java/run/halo/app/core/extension/MenuItem.java
@@ -10,6 +10,7 @@ import java.util.LinkedHashSet;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
+import org.jspecify.annotations.Nullable;
 import run.halo.app.extension.AbstractExtension;
 import run.halo.app.extension.GVK;
 import run.halo.app.extension.Ref;
@@ -21,10 +22,14 @@ import run.halo.app.extension.Ref;
     plural = "menuitems", singular = "menuitem")
 public class MenuItem extends AbstractExtension {
 
+    public static final String REQUEST_TO_UPDATE_ANNO = "halo.run/request-to-update";
+
     @Schema(description = "The spec of menu item.", requiredMode = REQUIRED)
+    @Nullable
     private MenuItemSpec spec;
 
     @Schema(description = "The status of menu item.")
+    @Nullable
     private MenuItemStatus status;
 
     public enum Target {
@@ -68,6 +73,7 @@ public class MenuItem extends AbstractExtension {
         private LinkedHashSet<String> children;
 
         @Schema(description = "Target reference. Like Category, Tag, Post or SinglePage")
+        @Nullable
         private Ref targetRef;
 
     }
@@ -76,9 +82,11 @@ public class MenuItem extends AbstractExtension {
     public static class MenuItemStatus {
 
         @Schema(description = "Calculated Display name of menu item.")
+        @Nullable
         private String displayName;
 
         @Schema(description = "Calculated href of manu item.")
+        @Nullable
         private String href;
 
     }

--- a/api/src/main/java/run/halo/app/core/extension/content/Category.java
+++ b/api/src/main/java/run/halo/app/core/extension/content/Category.java
@@ -33,9 +33,11 @@ public class Category extends AbstractExtension {
     public static final GroupVersionKind GVK = GroupVersionKind.fromExtension(Category.class);
 
     @Schema(requiredMode = REQUIRED)
+    @Nullable
     private CategorySpec spec;
 
     @Schema
+    @Nullable
     private CategoryStatus status;
 
     @JsonIgnore

--- a/api/src/main/java/run/halo/app/core/extension/content/Post.java
+++ b/api/src/main/java/run/halo/app/core/extension/content/Post.java
@@ -12,6 +12,7 @@ import java.util.Objects;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
+import org.jspecify.annotations.Nullable;
 import run.halo.app.extension.AbstractExtension;
 import run.halo.app.extension.GVK;
 import run.halo.app.extension.GroupVersionKind;
@@ -64,9 +65,11 @@ public class Post extends AbstractExtension {
     public static final String ARCHIVE_DAY_LABEL = "content.halo.run/archive-day";
 
     @Schema(requiredMode = RequiredMode.REQUIRED)
+    @Nullable
     private PostSpec spec;
 
     @Schema
+    @Nullable
     private PostStatus status;
 
     @JsonIgnore

--- a/api/src/main/java/run/halo/app/core/extension/content/SinglePage.java
+++ b/api/src/main/java/run/halo/app/core/extension/content/SinglePage.java
@@ -10,6 +10,7 @@ import java.util.Map;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
+import org.jspecify.annotations.Nullable;
 import run.halo.app.extension.AbstractExtension;
 import run.halo.app.extension.GVK;
 import run.halo.app.extension.GroupVersionKind;
@@ -39,9 +40,11 @@ public class SinglePage extends AbstractExtension {
     public static final String VISIBLE_LABEL = "content.halo.run/visible";
 
     @Schema(requiredMode = REQUIRED)
+    @Nullable
     private SinglePageSpec spec;
 
     @Schema
+    @Nullable
     private SinglePageStatus status;
 
     @JsonIgnore

--- a/api/src/main/java/run/halo/app/core/extension/content/Tag.java
+++ b/api/src/main/java/run/halo/app/core/extension/content/Tag.java
@@ -7,6 +7,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
+import org.jspecify.annotations.Nullable;
 import run.halo.app.extension.AbstractExtension;
 import run.halo.app.extension.GVK;
 import run.halo.app.extension.GroupVersionKind;
@@ -30,9 +31,11 @@ public class Tag extends AbstractExtension {
     public static final String REQUIRE_SYNC_ON_STARTUP_INDEX_NAME = "requireSyncOnStartup";
 
     @Schema(requiredMode = REQUIRED)
+    @Nullable
     private TagSpec spec;
 
     @Schema
+    @Nullable
     private TagStatus status;
 
     @Data

--- a/api/src/main/java/run/halo/app/extension/ExtensionOperator.java
+++ b/api/src/main/java/run/halo/app/extension/ExtensionOperator.java
@@ -43,7 +43,7 @@ public interface ExtensionOperator {
 
     @Schema(requiredMode = REQUIRED, implementation = Metadata.class)
     @JsonProperty("metadata")
-    @Nullable MetadataOperator getMetadata();
+    MetadataOperator getMetadata();
 
     void setApiVersion(String apiVersion);
 

--- a/api/src/main/java/run/halo/app/extension/Ref.java
+++ b/api/src/main/java/run/halo/app/extension/Ref.java
@@ -75,4 +75,14 @@ public class Ref {
         return groupKindEquals(ref, gvk) && Objects.equals(ref.getName(), name);
     }
 
+    /**
+     * Convert the ref to a string identifier with format "group/kind/name".
+     *
+     * @param ref the reference object
+     * @return the string identifier
+     */
+    public static String toIdentifier(Ref ref) {
+        return ref.getGroup() + "/" + ref.getKind() + "/" + ref.getName();
+    }
+
 }

--- a/api/src/main/java/run/halo/app/extension/index/SingleValueBuilder.java
+++ b/api/src/main/java/run/halo/app/extension/index/SingleValueBuilder.java
@@ -1,6 +1,7 @@
 package run.halo.app.extension.index;
 
 import java.util.function.Function;
+import org.jspecify.annotations.Nullable;
 import org.springframework.util.Assert;
 import run.halo.app.extension.Extension;
 
@@ -16,14 +17,14 @@ class SingleValueBuilder<E extends Extension, K extends Comparable<K>>
     extends AbstractValueIndexSpecBuilder<E, K, SingleValueIndexSpecBuilder<E, K>>
     implements SingleValueIndexSpecBuilder<E, K> {
 
-    private Function<E, K> indexFunc;
+    private Function<E, @Nullable K> indexFunc;
 
     SingleValueBuilder(String name, Class<K> keyType) {
         super(name, keyType);
     }
 
     @Override
-    public SingleValueBuilder<E, K> indexFunc(Function<E, K> indexFunc) {
+    public SingleValueBuilder<E, K> indexFunc(Function<E, @Nullable K> indexFunc) {
         this.indexFunc = indexFunc;
         return this;
     }
@@ -36,6 +37,7 @@ class SingleValueBuilder<E extends Extension, K extends Comparable<K>>
 
         return new SingleValueIndexSpec<>() {
             @Override
+            @Nullable
             public K getValue(E extension) {
                 return indexFunc.apply(extension);
             }

--- a/api/src/main/java/run/halo/app/extension/index/SingleValueIndexSpecBuilder.java
+++ b/api/src/main/java/run/halo/app/extension/index/SingleValueIndexSpecBuilder.java
@@ -1,6 +1,7 @@
 package run.halo.app.extension.index;
 
 import java.util.function.Function;
+import org.jspecify.annotations.Nullable;
 import run.halo.app.extension.Extension;
 
 /**
@@ -20,6 +21,6 @@ public interface SingleValueIndexSpecBuilder<E extends Extension, K extends Comp
      * @param indexFunc the index function
      * @return the builder itself
      */
-    SingleValueIndexSpecBuilder<E, K> indexFunc(Function<E, K> indexFunc);
+    SingleValueIndexSpecBuilder<E, K> indexFunc(Function<E, @Nullable K> indexFunc);
 
 }

--- a/application/src/main/java/run/halo/app/core/reconciler/CategoryReconciler.java
+++ b/application/src/main/java/run/halo/app/core/reconciler/CategoryReconciler.java
@@ -17,6 +17,7 @@ import run.halo.app.core.extension.content.Category;
 import run.halo.app.core.extension.content.Constant;
 import run.halo.app.core.extension.content.Post;
 import run.halo.app.event.post.CategoryHiddenStateChangeEvent;
+import run.halo.app.event.post.CategoryUpdatedEvent;
 import run.halo.app.extension.ExtensionClient;
 import run.halo.app.extension.ExtensionUtil;
 import run.halo.app.extension.ListOptions;
@@ -53,6 +54,7 @@ public class CategoryReconciler implements Reconciler<Reconciler.Request> {
                         refreshHiddenState(category, false);
                         updateCategoryForPost(category.getMetadata().getName());
                         client.update(category);
+                        eventPublisher.publishEvent(new CategoryUpdatedEvent(this, category));
                     }
                     return;
                 }
@@ -63,6 +65,7 @@ public class CategoryReconciler implements Reconciler<Reconciler.Request> {
                 checkHiddenState(category);
 
                 client.update(category);
+                eventPublisher.publishEvent(new CategoryUpdatedEvent(this, category));
             });
         return Result.doNotRetry();
     }

--- a/application/src/main/java/run/halo/app/core/reconciler/MenuItemReconciler.java
+++ b/application/src/main/java/run/halo/app/core/reconciler/MenuItemReconciler.java
@@ -139,6 +139,24 @@ class MenuItemReconciler implements Reconciler<Request> {
             .orElse(null));
     }
 
+    private void handleCategoryRef(MenuItem menuItem, String categoryName) {
+        var category = client.fetch(Category.class, categoryName).orElse(null);
+        if (category == null || ExtensionUtil.isDeleted(category)) {
+            resetStatus(menuItem);
+            return;
+        }
+        if (menuItem.getStatus() == null) {
+            menuItem.setStatus(new MenuItemStatus());
+        }
+        var status = menuItem.getStatus();
+        status.setHref(Optional.ofNullable(category.getStatus())
+            .map(Category.CategoryStatus::getPermalink)
+            .orElse(null));
+        status.setDisplayName(Optional.ofNullable(category.getSpec())
+            .map(Category.CategorySpec::getDisplayName)
+            .orElse(null));
+    }
+
     @Override
     public Controller setupWith(ControllerBuilder builder) {
         return builder
@@ -210,8 +228,7 @@ class MenuItemReconciler implements Reconciler<Request> {
         if (metadata.getAnnotations() == null) {
             metadata.setAnnotations(new HashMap<>());
         }
-        metadata.getAnnotations()
-            .put(MenuItem.REQUEST_TO_UPDATE_ANNO, Instant.now().toString());
+        metadata.getAnnotations().put(MenuItem.REQUEST_TO_UPDATE_ANNO, Instant.now().toString());
     }
 
     private static void resetStatus(MenuItem menuItem) {
@@ -219,24 +236,6 @@ class MenuItemReconciler implements Reconciler<Request> {
             status.setHref(null);
             status.setDisplayName(null);
         });
-    }
-
-    private void handleCategoryRef(MenuItem menuItem, String categoryName) {
-        var category = client.fetch(Category.class, categoryName).orElse(null);
-        if (category == null || ExtensionUtil.isDeleted(category)) {
-            resetStatus(menuItem);
-            return;
-        }
-        var status = menuItem.getStatus();
-        if (status == null) {
-            status = new MenuItemStatus();
-        }
-        status.setHref(Optional.ofNullable(category.getStatus())
-            .map(Category.CategoryStatus::getPermalink)
-            .orElse(null));
-        status.setDisplayName(Optional.ofNullable(category.getSpec())
-            .map(Category.CategorySpec::getDisplayName)
-            .orElse(null));
     }
 
 }

--- a/application/src/main/java/run/halo/app/core/reconciler/MenuItemReconciler.java
+++ b/application/src/main/java/run/halo/app/core/reconciler/MenuItemReconciler.java
@@ -1,10 +1,14 @@
 package run.halo.app.core.reconciler;
 
-import java.time.Duration;
-import java.util.Objects;
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.Optional;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.event.EventListener;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Component;
-import org.springframework.util.StringUtils;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
 import run.halo.app.core.extension.MenuItem;
 import run.halo.app.core.extension.MenuItem.MenuItemSpec;
 import run.halo.app.core.extension.MenuItem.MenuItemStatus;
@@ -12,54 +16,127 @@ import run.halo.app.core.extension.content.Category;
 import run.halo.app.core.extension.content.Post;
 import run.halo.app.core.extension.content.SinglePage;
 import run.halo.app.core.extension.content.Tag;
+import run.halo.app.event.post.CategoryUpdatedEvent;
+import run.halo.app.event.post.PostDeletedEvent;
+import run.halo.app.event.post.PostUpdatedEvent;
+import run.halo.app.event.post.SinglePageUpdatedEvent;
+import run.halo.app.event.post.TagUpdatedEvent;
 import run.halo.app.extension.ExtensionClient;
+import run.halo.app.extension.ExtensionUtil;
+import run.halo.app.extension.ListOptions;
+import run.halo.app.extension.ReactiveExtensionClient;
 import run.halo.app.extension.Ref;
 import run.halo.app.extension.controller.Controller;
 import run.halo.app.extension.controller.ControllerBuilder;
 import run.halo.app.extension.controller.Reconciler;
 import run.halo.app.extension.controller.Reconciler.Request;
+import run.halo.app.extension.index.query.Queries;
 
 @Slf4j
 @Component
-public class MenuItemReconciler implements Reconciler<Request> {
+class MenuItemReconciler implements Reconciler<Request> {
 
     private final ExtensionClient client;
 
-    public MenuItemReconciler(ExtensionClient client) {
+    private final ReactiveExtensionClient reactiveClient;
+
+    public MenuItemReconciler(ExtensionClient client, ReactiveExtensionClient reactiveClient) {
         this.client = client;
+        this.reactiveClient = reactiveClient;
     }
 
     @Override
     public Result reconcile(Request request) {
-        return client.fetch(MenuItem.class, request.name())
-            .map(menuItem -> {
-                final var spec = menuItem.getSpec();
-
-                if (menuItem.getStatus() == null) {
-                    menuItem.setStatus(new MenuItemStatus());
+        client.fetch(MenuItem.class, request.name())
+            .ifPresent(menuItem -> {
+                if (ExtensionUtil.isDeleted(menuItem)) {
+                    return;
                 }
-                var status = menuItem.getStatus();
+                if (menuItem.getSpec() == null) {
+                    menuItem.setSpec(new MenuItemSpec());
+                }
+                var spec = menuItem.getSpec();
                 var targetRef = spec.getTargetRef();
                 if (targetRef != null) {
                     if (Ref.groupKindEquals(targetRef, Category.GVK)) {
-                        return handleCategoryRef(request.name(), status, targetRef);
+                        handleCategoryRef(menuItem, targetRef.getName());
+                    } else if (Ref.groupKindEquals(targetRef, Tag.GVK)) {
+                        handleTagRef(menuItem, targetRef.getName());
+                    } else if (Ref.groupKindEquals(targetRef, SinglePage.GVK)) {
+                        handleSinglePageSpec(menuItem, targetRef.getName());
+                    } else if (Ref.groupKindEquals(targetRef, Post.GVK)) {
+                        handlePostRef(menuItem, targetRef.getName());
+                    } else {
+                        // Do nothing while the targetRef is not supported, just log an error and
+                        // reset the status.
+                        log.error("Unsupported MenuItem targetRef " + targetRef);
+                        resetStatus(menuItem);
                     }
-                    if (Ref.groupKindEquals(targetRef, Tag.GVK)) {
-                        return handleTagRef(request.name(), status, targetRef);
-                    }
-                    if (Ref.groupKindEquals(targetRef, SinglePage.GVK)) {
-                        return handleSinglePageSpec(request.name(), status, targetRef);
-                    }
-                    if (Ref.groupKindEquals(targetRef, Post.GVK)) {
-                        return handlePostRef(request.name(), status, targetRef);
-                    }
-                    // unsupported ref
-                    log.error("Unsupported MenuItem targetRef " + targetRef);
-                    return Result.doNotRetry();
                 } else {
-                    return handleMenuSpec(request.name(), status, spec);
+                    if (menuItem.getStatus() == null) {
+                        menuItem.setStatus(new MenuItemStatus());
+                    }
+                    var status = menuItem.getStatus();
+                    status.setHref(spec.getHref());
+                    status.setDisplayName(spec.getDisplayName());
                 }
-            }).orElseGet(() -> new Result(false, null));
+                client.update(menuItem);
+            });
+        return Result.doNotRetry();
+    }
+
+    private void handlePostRef(MenuItem menuItem, String postName) {
+        var post = client.fetch(Post.class, postName).orElse(null);
+        if (post == null || ExtensionUtil.isDeleted(post)) {
+            resetStatus(menuItem);
+            return;
+        }
+        if (menuItem.getStatus() == null) {
+            menuItem.setStatus(new MenuItemStatus());
+        }
+        var status = menuItem.getStatus();
+        status.setHref(Optional.ofNullable(post.getStatus())
+            .map(Post.PostStatus::getPermalink)
+            .orElse(null));
+        status.setDisplayName(Optional.ofNullable(post.getSpec())
+            .map(Post.PostSpec::getTitle)
+            .orElse(null));
+    }
+
+    private void handleSinglePageSpec(MenuItem menuItem, String singlePageName) {
+        var singlePage = client.fetch(SinglePage.class, singlePageName).orElse(null);
+        if (singlePage == null || ExtensionUtil.isDeleted(singlePage)) {
+            resetStatus(menuItem);
+            return;
+        }
+        if (menuItem.getStatus() == null) {
+            menuItem.setStatus(new MenuItemStatus());
+        }
+        var status = menuItem.getStatus();
+        status.setHref(Optional.ofNullable(singlePage.getStatus())
+            .map(SinglePage.SinglePageStatus::getPermalink)
+            .orElse(null));
+        status.setDisplayName(Optional.ofNullable(singlePage.getSpec())
+            .map(SinglePage.SinglePageSpec::getTitle)
+            .orElse(null));
+    }
+
+    private void handleTagRef(MenuItem menuItem, String tagName) {
+        var tag = client.fetch(Tag.class, tagName).orElse(null);
+        if (tag == null || ExtensionUtil.isDeleted(tag)) {
+            resetStatus(menuItem);
+            return;
+        }
+        if (menuItem.getStatus() == null) {
+            menuItem.setStatus(new MenuItemStatus());
+        }
+        var status = menuItem.getStatus();
+        status.setHref(Optional.ofNullable(tag.getStatus())
+            .map(Tag.TagStatus::getPermalink)
+            .orElse(null));
+        status.setDisplayName(Optional.ofNullable(tag.getSpec())
+            .map(Tag.TagSpec::getDisplayName)
+            .orElse(null));
     }
 
     @Override
@@ -69,67 +146,97 @@ public class MenuItemReconciler implements Reconciler<Request> {
             .build();
     }
 
-    private Result handleCategoryRef(String menuItemName, MenuItemStatus status, Ref categoryRef) {
-        client.fetch(Category.class, categoryRef.getName())
-            .filter(category -> category.getStatus() != null)
-            .filter(category -> StringUtils.hasText(category.getStatus().getPermalink()))
-            .ifPresent(category -> {
-                status.setHref(category.getStatus().getPermalink());
-                status.setDisplayName(category.getSpec().getDisplayName());
-                updateStatus(menuItemName, status);
-            });
-        return new Result(true, Duration.ofMinutes(1));
+    @EventListener
+    Mono<Void> onCategoryUpdated(CategoryUpdatedEvent event) {
+        log.debug("Received CategoryUpdatedEvent for category {}",
+            event.getCategory().getMetadata().getName());
+        var category = event.getCategory();
+        return findMenuItemsByRef(Ref.of(category))
+            .doOnNext(MenuItemReconciler::requestUpdate)
+            .flatMap(reactiveClient::update)
+            .then();
     }
 
-    private Result handleTagRef(String menuItemName, MenuItemStatus status, Ref tagRef) {
-        client.fetch(Tag.class, tagRef.getName()).filter(tag -> tag.getStatus() != null)
-            .filter(tag -> StringUtils.hasText(tag.getStatus().getPermalink())).ifPresent(tag -> {
-                status.setHref(tag.getStatus().getPermalink());
-                status.setDisplayName(tag.getSpec().getDisplayName());
-                updateStatus(menuItemName, status);
-            });
-        return new Result(true, Duration.ofMinutes(1));
+    @EventListener
+    Mono<Void> onTagUpdated(TagUpdatedEvent event) {
+        log.debug("Received TagUpdatedEvent for tag {}", event.getTag().getMetadata().getName());
+        var tag = event.getTag();
+        return findMenuItemsByRef(Ref.of(tag))
+            .doOnNext(MenuItemReconciler::requestUpdate)
+            .flatMap(reactiveClient::update)
+            .then();
     }
 
-    private Result handlePostRef(String menuItemName, MenuItemStatus status, Ref postRef) {
-        client.fetch(Post.class, postRef.getName()).filter(post -> post.getStatus() != null)
-            .filter(post -> StringUtils.hasText(post.getStatus().getPermalink()))
-            .ifPresent(post -> {
-                status.setHref(post.getStatus().getPermalink());
-                status.setDisplayName(post.getSpec().getTitle());
-                updateStatus(menuItemName, status);
-            });
-        return new Result(true, Duration.ofMinutes(1));
+    @EventListener
+    Mono<Void> onSinglePageUpdated(SinglePageUpdatedEvent event) {
+        log.debug("Received SinglePageUpdatedEvent for single page {}",
+            event.getSinglePage().getMetadata().getName());
+        var singlePage = event.getSinglePage();
+        return findMenuItemsByRef(Ref.of(singlePage))
+            .doOnNext(MenuItemReconciler::requestUpdate)
+            .flatMap(reactiveClient::update)
+            .then();
     }
 
-    private Result handleSinglePageSpec(String menuItemName, MenuItemStatus status, Ref pageRef) {
-        client.fetch(SinglePage.class, pageRef.getName())
-            .filter(page -> page.getStatus() != null)
-            .filter(page -> StringUtils.hasText(page.getStatus().getPermalink()))
-            .ifPresent(page -> {
-                status.setHref(page.getStatus().getPermalink());
-                status.setDisplayName(page.getSpec().getTitle());
-                updateStatus(menuItemName, status);
-            });
-        return new Result(true, Duration.ofMinutes(1));
+    @EventListener
+    Mono<Void> onPostUpdated(PostUpdatedEvent event) {
+        log.debug("Received PostUpdatedEvent for post {}", event.getName());
+        var postName = event.getName();
+        return findMenuItemsByRef(Ref.of(postName, Post.GVK))
+            .doOnNext(MenuItemReconciler::requestUpdate)
+            .flatMap(reactiveClient::update)
+            .then();
     }
 
-    private Result handleMenuSpec(String menuItemName, MenuItemStatus status, MenuItemSpec spec) {
-        if (spec.getHref() != null && StringUtils.hasText(spec.getDisplayName())) {
-            status.setHref(spec.getHref());
-            status.setDisplayName(spec.getDisplayName());
-            updateStatus(menuItemName, status);
+    @EventListener
+    Mono<Void> onPostDeleted(PostDeletedEvent event) {
+        log.debug("Received PostDeletedEvent for post {}", event.getName());
+        var post = event.getPost();
+        return findMenuItemsByRef(Ref.of(post))
+            .doOnNext(MenuItemReconciler::requestUpdate)
+            .flatMap(reactiveClient::update)
+            .then();
+    }
+
+    private Flux<MenuItem> findMenuItemsByRef(Ref ref) {
+        var listOptions = ListOptions.builder()
+            .andQuery(Queries.equal("spec.targetRef", Ref.toIdentifier(ref)))
+            .build();
+        return reactiveClient.listAll(MenuItem.class, listOptions, Sort.unsorted());
+    }
+
+    private static void requestUpdate(MenuItem menuItem) {
+        var metadata = menuItem.getMetadata();
+        if (metadata.getAnnotations() == null) {
+            metadata.setAnnotations(new HashMap<>());
         }
-        return new Result(false, null);
+        metadata.getAnnotations()
+            .put(MenuItem.REQUEST_TO_UPDATE_ANNO, Instant.now().toString());
     }
 
-    private void updateStatus(String menuItemName, MenuItemStatus status) {
-        client.fetch(MenuItem.class, menuItemName)
-            .filter(menuItem -> !Objects.deepEquals(menuItem.getStatus(), status))
-            .ifPresent(menuItem -> {
-                menuItem.setStatus(status);
-                client.update(menuItem);
-            });
+    private static void resetStatus(MenuItem menuItem) {
+        Optional.ofNullable(menuItem.getStatus()).ifPresent(status -> {
+            status.setHref(null);
+            status.setDisplayName(null);
+        });
+    }
+
+    private void handleCategoryRef(MenuItem menuItem, String categoryName) {
+        var category = client.fetch(Category.class, categoryName).orElse(null);
+        if (category == null || ExtensionUtil.isDeleted(category)) {
+            resetStatus(menuItem);
+            return;
+        }
+        var status = menuItem.getStatus();
+        if (status == null) {
+            status = new MenuItemStatus();
+        }
+        status.setHref(Optional.ofNullable(category.getStatus())
+            .map(Category.CategoryStatus::getPermalink)
+            .orElse(null));
+        status.setDisplayName(Optional.ofNullable(category.getSpec())
+            .map(Category.CategorySpec::getDisplayName)
+            .orElse(null));
     }
 
 }

--- a/application/src/main/java/run/halo/app/core/reconciler/SinglePageReconciler.java
+++ b/application/src/main/java/run/halo/app/core/reconciler/SinglePageReconciler.java
@@ -16,6 +16,7 @@ import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
 import org.jsoup.Jsoup;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Component;
 import org.springframework.util.Assert;
@@ -32,6 +33,7 @@ import run.halo.app.core.extension.content.Post;
 import run.halo.app.core.extension.content.SinglePage;
 import run.halo.app.core.extension.content.Snapshot;
 import run.halo.app.core.extension.notification.Subscription;
+import run.halo.app.event.post.SinglePageUpdatedEvent;
 import run.halo.app.extension.ExtensionClient;
 import run.halo.app.extension.ExtensionOperator;
 import run.halo.app.extension.ExtensionUtil;
@@ -80,12 +82,15 @@ public class SinglePageReconciler implements Reconciler<Reconciler.Request> {
 
     private final NotificationCenter notificationCenter;
 
+    private final ApplicationEventPublisher eventPublisher;
+
     @Override
     public Result reconcile(Request request) {
         client.fetch(SinglePage.class, request.name())
             .ifPresent(singlePage -> {
                 if (ExtensionOperator.isDeleted(singlePage)) {
                     cleanUpResourcesAndRemoveFinalizer(request.name());
+                    eventPublisher.publishEvent(new SinglePageUpdatedEvent(this, singlePage));
                     return;
                 }
 
@@ -100,6 +105,7 @@ public class SinglePageReconciler implements Reconciler<Reconciler.Request> {
                 // then
                 reconcileMetadata(request.name());
                 reconcileStatus(request.name());
+                eventPublisher.publishEvent(new SinglePageUpdatedEvent(this, singlePage));
             });
         return new Result(false, null);
     }

--- a/application/src/main/java/run/halo/app/core/reconciler/TagReconciler.java
+++ b/application/src/main/java/run/halo/app/core/reconciler/TagReconciler.java
@@ -7,10 +7,12 @@ import static run.halo.app.extension.index.query.Queries.equal;
 import java.util.Map;
 import java.util.Set;
 import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Component;
 import run.halo.app.content.permalinks.TagPermalinkPolicy;
 import run.halo.app.core.extension.content.Constant;
 import run.halo.app.core.extension.content.Tag;
+import run.halo.app.event.post.TagUpdatedEvent;
 import run.halo.app.extension.ExtensionClient;
 import run.halo.app.extension.ExtensionUtil;
 import run.halo.app.extension.ListOptions;
@@ -31,6 +33,7 @@ public class TagReconciler implements Reconciler<Reconciler.Request> {
     static final String FINALIZER_NAME = "tag-protection";
     private final ExtensionClient client;
     private final TagPermalinkPolicy tagPermalinkPolicy;
+    private final ApplicationEventPublisher eventPublisher;
 
     @Override
     public Result reconcile(Request request) {
@@ -39,6 +42,7 @@ public class TagReconciler implements Reconciler<Reconciler.Request> {
                 if (ExtensionUtil.isDeleted(tag)) {
                     if (removeFinalizers(tag.getMetadata(), Set.of(FINALIZER_NAME))) {
                         client.update(tag);
+                        eventPublisher.publishEvent(new TagUpdatedEvent(this, tag));
                     }
                     return;
                 }
@@ -67,6 +71,7 @@ public class TagReconciler implements Reconciler<Reconciler.Request> {
                 status.setObservedVersion(tag.getMetadata().getVersion() + 1);
 
                 client.update(tag);
+                eventPublisher.publishEvent(new TagUpdatedEvent(this, tag));
             });
         return Result.doNotRetry();
     }

--- a/application/src/main/java/run/halo/app/event/post/CategoryUpdatedEvent.java
+++ b/application/src/main/java/run/halo/app/event/post/CategoryUpdatedEvent.java
@@ -1,0 +1,17 @@
+package run.halo.app.event.post;
+
+import lombok.Getter;
+import org.springframework.context.ApplicationEvent;
+import run.halo.app.core.extension.content.Category;
+
+public class CategoryUpdatedEvent extends ApplicationEvent {
+
+    @Getter
+    private final Category category;
+
+    public CategoryUpdatedEvent(Object source, Category category) {
+        super(source);
+        this.category = category;
+    }
+
+}

--- a/application/src/main/java/run/halo/app/event/post/SinglePageUpdatedEvent.java
+++ b/application/src/main/java/run/halo/app/event/post/SinglePageUpdatedEvent.java
@@ -1,0 +1,17 @@
+package run.halo.app.event.post;
+
+import lombok.Getter;
+import org.springframework.context.ApplicationEvent;
+import run.halo.app.core.extension.content.SinglePage;
+
+public class SinglePageUpdatedEvent extends ApplicationEvent {
+
+    @Getter
+    private final SinglePage singlePage;
+
+    public SinglePageUpdatedEvent(Object source, SinglePage singlePage) {
+        super(source);
+        this.singlePage = singlePage;
+    }
+
+}

--- a/application/src/main/java/run/halo/app/event/post/TagUpdatedEvent.java
+++ b/application/src/main/java/run/halo/app/event/post/TagUpdatedEvent.java
@@ -1,0 +1,16 @@
+package run.halo.app.event.post;
+
+import lombok.Getter;
+import org.springframework.context.ApplicationEvent;
+import run.halo.app.core.extension.content.Tag;
+
+public class TagUpdatedEvent extends ApplicationEvent {
+
+    @Getter
+    private final Tag tag;
+
+    public TagUpdatedEvent(Object source, Tag tag) {
+        super(source);
+        this.tag = tag;
+    }
+}

--- a/application/src/main/java/run/halo/app/infra/SchemeInitializer.java
+++ b/application/src/main/java/run/halo/app/infra/SchemeInitializer.java
@@ -65,6 +65,7 @@ import run.halo.app.core.extension.notification.Subscription;
 import run.halo.app.core.extension.notification.Subscription.InterestReason;
 import run.halo.app.extension.ConfigMap;
 import run.halo.app.extension.MetadataOperator;
+import run.halo.app.extension.Ref;
 import run.halo.app.extension.SchemeManager;
 import run.halo.app.extension.Secret;
 import run.halo.app.extension.index.IndexSpec;
@@ -198,7 +199,15 @@ class SchemeInitializer implements SmartLifecycle {
         schemeManager.register(Secret.class);
         schemeManager.register(Theme.class);
         schemeManager.register(Menu.class);
-        schemeManager.register(MenuItem.class);
+        schemeManager.register(MenuItem.class, indexSpecs -> {
+            indexSpecs.add(IndexSpecs.<MenuItem, String>single("spec.targetRef", String.class)
+                .indexFunc(menuItem -> Optional.ofNullable(menuItem.getSpec())
+                    .map(MenuItem.MenuItemSpec::getTargetRef)
+                    .map(Ref::toIdentifier)
+                    .orElse(null)
+                )
+            );
+        });
         schemeManager.register(Post.class, indexSpecs -> {
             indexSpecs.add(IndexSpecs.<Post, String>single("spec.title", String.class)
                 .indexFunc(post -> Optional.ofNullable(post.getSpec())

--- a/application/src/test/java/run/halo/app/core/reconciler/MenuItemReconcilerTest.java
+++ b/application/src/test/java/run/halo/app/core/reconciler/MenuItemReconcilerTest.java
@@ -2,31 +2,44 @@ package run.halo.app.core.reconciler;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isA;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.times;
+import static org.mockito.ArgumentMatchers.same;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import java.time.Duration;
+import java.time.Instant;
 import java.util.Optional;
 import java.util.function.Consumer;
-import java.util.function.Supplier;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Sort;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
 import run.halo.app.core.extension.MenuItem;
 import run.halo.app.core.extension.MenuItem.MenuItemSpec;
 import run.halo.app.core.extension.content.Category;
+import run.halo.app.core.extension.content.Post;
 import run.halo.app.core.extension.content.SinglePage;
-import run.halo.app.core.reconciler.MenuItemReconciler;
+import run.halo.app.core.extension.content.Tag;
+import run.halo.app.event.post.CategoryUpdatedEvent;
+import run.halo.app.event.post.PostDeletedEvent;
+import run.halo.app.event.post.PostUpdatedEvent;
+import run.halo.app.event.post.SinglePageUpdatedEvent;
+import run.halo.app.event.post.TagUpdatedEvent;
 import run.halo.app.extension.ExtensionClient;
+import run.halo.app.extension.GroupVersionKind;
+import run.halo.app.extension.ListOptions;
 import run.halo.app.extension.Metadata;
+import run.halo.app.extension.ReactiveExtensionClient;
 import run.halo.app.extension.Ref;
 import run.halo.app.extension.controller.Reconciler.Request;
 
@@ -36,6 +49,9 @@ class MenuItemReconcilerTest {
     @Mock
     ExtensionClient client;
 
+    @Mock
+    ReactiveExtensionClient reactiveClient;
+
     @InjectMocks
     MenuItemReconciler reconciler;
 
@@ -43,47 +59,66 @@ class MenuItemReconcilerTest {
     class WhenCategoryRefSet {
 
         @Test
-        void shouldNotUpdateMenuItemIfCategoryNotFound() {
-            Supplier<MenuItem> menuItemSupplier = () -> createMenuItem("fake-name", spec -> {
-                spec.setTargetRef(Ref.of("fake-category", Category.GVK));
-            });
+        void shouldResetMenuItemIfCategoryNotFound() {
+            var menuItem = createMenuItem("fake-name",
+                spec -> spec.setTargetRef(Ref.of("fake-category", Category.GVK)));
+            var status = new MenuItem.MenuItemStatus();
+            menuItem.setStatus(status);
+            status.setHref("fake://old-permalink");
+            status.setDisplayName("Old display name");
 
             when(client.fetch(MenuItem.class, "fake-name"))
-                .thenReturn(Optional.of(menuItemSupplier.get()));
+                .thenReturn(Optional.of(menuItem));
             when(client.fetch(Category.class, "fake-category")).thenReturn(Optional.empty());
 
             var result = reconciler.reconcile(new Request("fake-name"));
 
-            assertTrue(result.reEnqueue());
-            assertEquals(Duration.ofMinutes(1), result.retryAfter());
-            verify(client).fetch(MenuItem.class, "fake-name");
-            verify(client).fetch(Category.class, "fake-category");
-            verify(client, never()).update(isA(MenuItem.class));
+            assertFalse(result.reEnqueue());
+            assertNotNull(menuItem.getStatus());
+            assertNull(menuItem.getStatus().getHref());
+            assertNull(menuItem.getStatus().getDisplayName());
+            verify(client).update(menuItem);
         }
 
         @Test
         void shouldUpdateMenuItemIfCategoryFound() {
-            Supplier<MenuItem> menuItemSupplier = () -> createMenuItem("fake-name", spec -> {
+            var menuItem = createMenuItem("fake-name", spec -> {
                 spec.setTargetRef(Ref.of("fake-category", Category.GVK));
             });
 
             when(client.fetch(MenuItem.class, "fake-name"))
-                .thenReturn(Optional.of(menuItemSupplier.get()))
-                .thenReturn(Optional.of(menuItemSupplier.get()));
+                .thenReturn(Optional.of(menuItem));
             when(client.fetch(Category.class, "fake-category"))
                 .thenReturn(Optional.of(createCategory()));
 
             var result = reconciler.reconcile(new Request("fake-name"));
 
-            assertTrue(result.reEnqueue());
-            assertEquals(Duration.ofMinutes(1), result.retryAfter());
-            verify(client, times(2)).fetch(MenuItem.class, "fake-name");
-            verify(client).fetch(Category.class, "fake-category");
-            verify(client).<MenuItem>update(argThat(menuItem -> {
-                var status = menuItem.getStatus();
-                return status.getHref().equals("fake://permalink")
-                    && status.getDisplayName().equals("Fake Category");
-            }));
+            assertFalse(result.reEnqueue());
+            assertNotNull(menuItem.getStatus());
+            assertEquals("fake://permalink", menuItem.getStatus().getHref());
+            assertEquals("Fake Category", menuItem.getStatus().getDisplayName());
+            verify(client).update(menuItem);
+        }
+
+        @Test
+        void shouldRequestToUpdateWhenCategoryUpdated() {
+            var event = new CategoryUpdatedEvent(this, createCategory());
+
+            var menuItem = createMenuItem("fake-name", spec -> {
+            });
+
+            when(reactiveClient.listAll(
+                same(MenuItem.class), isA(ListOptions.class), eq(Sort.unsorted())
+            )).thenReturn(Flux.just(menuItem));
+            when(reactiveClient.update(menuItem)).thenReturn(Mono.just(menuItem));
+
+            reconciler.onCategoryUpdated(event)
+                .as(StepVerifier::create)
+                .verifyComplete();
+
+            var annotations = menuItem.getMetadata().getAnnotations();
+            assertNotNull(annotations);
+            assertTrue(annotations.containsKey(MenuItem.REQUEST_TO_UPDATE_ANNO));
         }
 
         Category createCategory() {
@@ -108,26 +143,41 @@ class MenuItemReconcilerTest {
 
         @Test
         void shouldUpdateMenuItemIfPageFound() {
-            Supplier<MenuItem> menuItemSupplier = () -> createMenuItem("fake-name",
+            var menuItem = createMenuItem("fake-name",
                 spec -> spec.setTargetRef(Ref.of("fake-page", SinglePage.GVK)));
 
             when(client.fetch(MenuItem.class, "fake-name"))
-                .thenReturn(Optional.of(menuItemSupplier.get()))
-                .thenReturn(Optional.of(menuItemSupplier.get()));
-
+                .thenReturn(Optional.of(menuItem));
             when(client.fetch(SinglePage.class, "fake-page"))
                 .thenReturn(Optional.of(createSinglePage()));
 
             var result = reconciler.reconcile(new Request("fake-name"));
-            assertTrue(result.reEnqueue());
-            assertEquals(Duration.ofMinutes(1), result.retryAfter());
-            verify(client, times(2)).fetch(MenuItem.class, "fake-name");
-            verify(client).fetch(SinglePage.class, "fake-page");
-            verify(client).<MenuItem>update(argThat(menuItem -> {
-                var status = menuItem.getStatus();
-                return status.getHref().equals("fake://permalink")
-                    && status.getDisplayName().equals("fake-title");
-            }));
+
+            assertFalse(result.reEnqueue());
+
+            assertNotNull(menuItem.getStatus());
+            assertEquals("fake://permalink", menuItem.getStatus().getHref());
+            assertEquals("fake-title", menuItem.getStatus().getDisplayName());
+            verify(client).update(menuItem);
+        }
+
+        @Test
+        void shouldRequestToUpdateWhenSinglePageUpdated() {
+            var event = new SinglePageUpdatedEvent(this, createSinglePage());
+            var menuItem = createMenuItem("fake-name", spec -> {
+            });
+
+            when(reactiveClient.listAll(
+                same(MenuItem.class), isA(ListOptions.class), eq(Sort.unsorted())
+            )).thenReturn(Flux.just(menuItem));
+            when(reactiveClient.update(menuItem)).thenReturn(Mono.just(menuItem));
+
+            reconciler.onSinglePageUpdated(event)
+                .as(StepVerifier::create)
+                .verifyComplete();
+            var annotations = menuItem.getMetadata().getAnnotations();
+            assertNotNull(annotations);
+            assertTrue(annotations.containsKey(MenuItem.REQUEST_TO_UPDATE_ANNO));
         }
 
         SinglePage createSinglePage() {
@@ -148,59 +198,267 @@ class MenuItemReconcilerTest {
     }
 
     @Nested
+    class WhenPostRefSet {
+
+        @Test
+        void shouldResetMenuItemIfPostNotFound() {
+            var menuItem = createMenuItem("fake-name",
+                spec -> spec.setTargetRef(Ref.of("fake-post", Post.GVK)));
+            var status = new MenuItem.MenuItemStatus();
+            menuItem.setStatus(status);
+            status.setHref("fake://old-permalink");
+            status.setDisplayName("Old display name");
+
+            when(client.fetch(MenuItem.class, "fake-name"))
+                .thenReturn(Optional.of(menuItem));
+            when(client.fetch(Post.class, "fake-post")).thenReturn(Optional.empty());
+
+            var result = reconciler.reconcile(new Request("fake-name"));
+
+            assertFalse(result.reEnqueue());
+            assertNotNull(menuItem.getStatus());
+            assertNull(menuItem.getStatus().getHref());
+            assertNull(menuItem.getStatus().getDisplayName());
+            verify(client).update(menuItem);
+        }
+
+        @Test
+        void shouldUpdateMenuItemIfPostFound() {
+            var menuItem = createMenuItem("fake-name", spec -> {
+                spec.setTargetRef(Ref.of("fake-post", Post.GVK));
+            });
+
+            when(client.fetch(MenuItem.class, "fake-name"))
+                .thenReturn(Optional.of(menuItem));
+            when(client.fetch(Post.class, "fake-post"))
+                .thenReturn(Optional.of(createPost()));
+
+            var result = reconciler.reconcile(new Request("fake-name"));
+
+            assertFalse(result.reEnqueue());
+            assertNotNull(menuItem.getStatus());
+            assertEquals("fake://permalink", menuItem.getStatus().getHref());
+            assertEquals("Fake Post", menuItem.getStatus().getDisplayName());
+            verify(client).update(menuItem);
+        }
+
+        @Test
+        void shouldRequestToUpdateWhenPostUpdated() {
+            var event = new PostUpdatedEvent(this, "fake-post");
+
+            var menuItem = createMenuItem("fake-name", spec -> {
+            });
+
+            when(reactiveClient.listAll(
+                same(MenuItem.class), isA(ListOptions.class), eq(Sort.unsorted())
+            )).thenReturn(Flux.just(menuItem));
+            when(reactiveClient.update(menuItem)).thenReturn(Mono.just(menuItem));
+
+            reconciler.onPostUpdated(event)
+                .as(StepVerifier::create)
+                .verifyComplete();
+
+            var annotations = menuItem.getMetadata().getAnnotations();
+            assertNotNull(annotations);
+            assertTrue(annotations.containsKey(MenuItem.REQUEST_TO_UPDATE_ANNO));
+        }
+
+        @Test
+        void shouldRequestToUpdateWhenPostDeleted() {
+            var post = createPost();
+            post.getMetadata().setDeletionTimestamp(Instant.now());
+            var event = new PostDeletedEvent(this, post);
+
+            var menuItem = createMenuItem("fake-name", spec -> {
+            });
+
+            when(reactiveClient.listAll(
+                same(MenuItem.class), isA(ListOptions.class), eq(Sort.unsorted())
+            )).thenReturn(Flux.just(menuItem));
+            when(reactiveClient.update(menuItem)).thenReturn(Mono.just(menuItem));
+
+            reconciler.onPostDeleted(event)
+                .as(StepVerifier::create)
+                .verifyComplete();
+
+            var annotations = menuItem.getMetadata().getAnnotations();
+            assertNotNull(annotations);
+            assertTrue(annotations.containsKey(MenuItem.REQUEST_TO_UPDATE_ANNO));
+        }
+
+        Post createPost() {
+            var metadata = new Metadata();
+            metadata.setName("fake-post");
+
+            var spec = new Post.PostSpec();
+            spec.setTitle("Fake Post");
+            var status = new Post.PostStatus();
+            status.setPermalink("fake://permalink");
+
+            var post = new Post();
+            post.setMetadata(metadata);
+            post.setSpec(spec);
+            post.setStatus(status);
+            return post;
+        }
+    }
+
+    @Nested
+    class WhenTagRefSet {
+
+        @Test
+        void shouldUpdateMenuItemIfTagFound() {
+            var menuItem = createMenuItem("fake-name", spec -> {
+                spec.setTargetRef(Ref.of("fake-tag", Tag.GVK));
+            });
+
+            when(client.fetch(MenuItem.class, "fake-name"))
+                .thenReturn(Optional.of(menuItem));
+            when(client.fetch(Tag.class, "fake-tag"))
+                .thenReturn(Optional.of(createTag()));
+
+            var result = reconciler.reconcile(new Request("fake-name"));
+
+            assertFalse(result.reEnqueue());
+            assertNotNull(menuItem.getStatus());
+            assertEquals("fake://permalink", menuItem.getStatus().getHref());
+            assertEquals("Fake Tag", menuItem.getStatus().getDisplayName());
+            verify(client).update(menuItem);
+        }
+
+        @Test
+        void shouldResetMenuItemIfTagNotFound() {
+            var menuItem = createMenuItem("fake-name",
+                spec -> spec.setTargetRef(Ref.of("fake-tag", Tag.GVK)));
+            var status = new MenuItem.MenuItemStatus();
+            menuItem.setStatus(status);
+            status.setHref("fake://old-permalink");
+            status.setDisplayName("Old display name");
+
+            when(client.fetch(MenuItem.class, "fake-name"))
+                .thenReturn(Optional.of(menuItem));
+            when(client.fetch(Tag.class, "fake-tag")).thenReturn(Optional.empty());
+
+            var result = reconciler.reconcile(new Request("fake-name"));
+
+            assertFalse(result.reEnqueue());
+            assertNotNull(menuItem.getStatus());
+            assertNull(menuItem.getStatus().getHref());
+            assertNull(menuItem.getStatus().getDisplayName());
+            verify(client).update(menuItem);
+        }
+
+        @Test
+        void shouldRequestToUpdateWhenTagUpdated() {
+            var tag = createTag();
+            var event = new TagUpdatedEvent(this, tag);
+
+            var menuItem = createMenuItem("fake-name", spec -> {
+            });
+
+            when(reactiveClient.listAll(
+                same(MenuItem.class), isA(ListOptions.class), eq(Sort.unsorted())
+            )).thenReturn(Flux.just(menuItem));
+            when(reactiveClient.update(menuItem)).thenReturn(Mono.just(menuItem));
+
+            reconciler.onTagUpdated(event)
+                .as(StepVerifier::create)
+                .verifyComplete();
+            var annotations = menuItem.getMetadata().getAnnotations();
+            assertNotNull(annotations);
+            assertTrue(annotations.containsKey(MenuItem.REQUEST_TO_UPDATE_ANNO));
+        }
+
+        Tag createTag() {
+            var metadata = new Metadata();
+            metadata.setName("fake-tag");
+
+            var spec = new Tag.TagSpec();
+            spec.setDisplayName("Fake Tag");
+            var status = new Tag.TagStatus();
+            status.setPermalink("fake://permalink");
+
+            var tag = new Tag();
+            tag.setMetadata(metadata);
+            tag.setSpec(spec);
+            tag.setStatus(status);
+            return tag;
+        }
+    }
+
+    @Nested
     class WhenOtherRefsNotSet {
 
         @Test
-        void shouldNotRequeueIfHrefNotSet() {
-            var menuItem = createMenuItem("fake-name", spec -> {
-                spec.setHref(null);
-                spec.setDisplayName("Fake display name");
-            });
-            when(client.fetch(MenuItem.class, "fake-name")).thenReturn(Optional.of(menuItem));
+        void shouldResetIfRefNotSupported() {
+            var menuItem = createMenuItem("fake-name", spec -> spec.setTargetRef(Ref.of("fake-ref",
+                GroupVersionKind.fromAPIVersionAndKind("fake.group/v1", "FakeKind")
+            )));
+            var status = new MenuItem.MenuItemStatus();
+            menuItem.setStatus(status);
+            status.setHref("fake://old-permalink");
+            status.setDisplayName("Old display name");
+
+            when(client.fetch(MenuItem.class, "fake-name"))
+                .thenReturn(Optional.of(menuItem));
 
             var result = reconciler.reconcile(new Request("fake-name"));
-            assertFalse(result.reEnqueue());
 
-            verify(client).fetch(MenuItem.class, "fake-name");
-            verify(client, never()).update(menuItem);
+            assertFalse(result.reEnqueue());
+            assertNotNull(menuItem.getStatus());
+            assertNull(menuItem.getStatus().getHref());
+            assertNull(menuItem.getStatus().getDisplayName());
+            verify(client).update(menuItem);
         }
 
         @Test
-        void shouldNotRequeueIfDisplayNameNotSet() {
+        void shouldResetIfHrefNotSet() {
+            var menuItem =
+                createMenuItem("fake-name", spec -> spec.setDisplayName("Fake display name"));
+            when(client.fetch(MenuItem.class, "fake-name")).thenReturn(Optional.of(menuItem));
+
+            var result = reconciler.reconcile(new Request("fake-name"));
+
+            assertFalse(result.reEnqueue());
+            assertNotNull(menuItem.getStatus());
+            assertNull(menuItem.getStatus().getHref());
+            assertEquals("Fake display name", menuItem.getStatus().getDisplayName());
+            verify(client).update(menuItem);
+        }
+
+        @Test
+        void shouldUpdateIfDisplayNameNotSet() {
             var menuItem = createMenuItem("fake-name", spec -> {
                 spec.setHref("/fake");
-                spec.setDisplayName(null);
             });
             when(client.fetch(MenuItem.class, "fake-name")).thenReturn(Optional.of(menuItem));
-            var result = reconciler.reconcile(new Request("fake-name"));
-            assertFalse(result.reEnqueue());
 
-            verify(client).fetch(MenuItem.class, "fake-name");
-            verify(client, never()).update(menuItem);
+            var result = reconciler.reconcile(new Request("fake-name"));
+
+            assertFalse(result.reEnqueue());
+            assertNotNull(menuItem.getStatus());
+            assertEquals("/fake", menuItem.getStatus().getHref());
+            assertNull(menuItem.getStatus().getDisplayName());
+            verify(client).update(menuItem);
         }
 
         @Test
-        void shouldReconcileIfHrefAndDisplayNameSet() {
-            Supplier<MenuItem> menuItemSupplier = () -> createMenuItem("fake-name", spec -> {
+        void shouldUpdateIfHrefAndDisplayNameSet() {
+            var menuItem = createMenuItem("fake-name", spec -> {
                 spec.setHref("/fake");
                 spec.setDisplayName("Fake display name");
             });
 
             when(client.fetch(MenuItem.class, "fake-name"))
-                .thenReturn(Optional.of(menuItemSupplier.get()))
-                .thenReturn(Optional.of(menuItemSupplier.get()));
+                .thenReturn(Optional.of(menuItem));
 
             var result = reconciler.reconcile(new Request("fake-name"));
-            assertFalse(result.reEnqueue());
 
-            verify(client, times(2)).fetch(MenuItem.class, "fake-name");
-            verify(client).update(argThat(ext -> {
-                if (!(ext instanceof MenuItem menuItem)) {
-                    return false;
-                }
-                return menuItem.getStatus().getHref().equals("/fake")
-                    && menuItem.getStatus().getDisplayName().equals("Fake display name");
-            }));
+            assertFalse(result.reEnqueue());
+            assertNotNull(menuItem.getStatus());
+            assertEquals("/fake", menuItem.getStatus().getHref());
+            assertEquals("Fake display name", menuItem.getStatus().getDisplayName());
+            verify(client).update(menuItem);
         }
     }
 

--- a/application/src/test/java/run/halo/app/core/reconciler/TagReconcilerTest.java
+++ b/application/src/test/java/run/halo/app/core/reconciler/TagReconcilerTest.java
@@ -16,9 +16,9 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationEventPublisher;
 import run.halo.app.content.permalinks.TagPermalinkPolicy;
 import run.halo.app.core.extension.content.Tag;
-import run.halo.app.core.reconciler.TagReconciler;
 import run.halo.app.extension.ExtensionClient;
 import run.halo.app.extension.Metadata;
 
@@ -31,13 +31,16 @@ import run.halo.app.extension.Metadata;
 @ExtendWith(MockitoExtension.class)
 class TagReconcilerTest {
     @Mock
-    private ExtensionClient client;
+    ExtensionClient client;
 
     @Mock
-    private TagPermalinkPolicy tagPermalinkPolicy;
+    TagPermalinkPolicy tagPermalinkPolicy;
+
+    @Mock
+    ApplicationEventPublisher eventPublisher;
 
     @InjectMocks
-    private TagReconciler tagReconciler;
+    TagReconciler tagReconciler;
 
     @Test
     void reconcile() {


### PR DESCRIPTION
#### What type of PR is this?

/kind improvement
/area core
/milestone 2.24.x

#### What this PR does / why we need it:

This PR introduces update events for Category, SinglePage and Tag, and refactors MenuItemReconciler to use them for real-time menu ite updates.

#### Which issue(s) this PR fixes:

Fixes https://github.com/halo-dev/halo/issues/7970

#### Special notes for your reviewer:

1. Try to bind a menu with a tag, category, post or single page respectively.
2. Try to update them respectively.
3. See the menu status

#### Does this PR introduce a user-facing change?

```release-note
None
```

