### PR TITLE
Add random post retrieval method to PostFinder

### DIFF
--- a/application/src/main/java/run/halo/app/theme/finders/PostFinder.java
+++ b/application/src/main/java/run/halo/app/theme/finders/PostFinder.java
@@ -1,12 +1,12 @@
 package run.halo.app.theme.finders;
 
+import java.util.List;
 import java.util.Map;
 import org.jspecify.annotations.Nullable;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import run.halo.app.core.extension.content.Post;
 import run.halo.app.extension.ListResult;
-import run.halo.app.theme.finders.impl.PostFinderImpl.PostQuery;
 import run.halo.app.theme.finders.vo.ContentVo;
 import run.halo.app.theme.finders.vo.ListedPostVo;
 import run.halo.app.theme.finders.vo.NavigationPostVo;
@@ -37,9 +37,18 @@ public interface PostFinder {
     Flux<ListedPostVo> listAll();
 
     /**
+     * Gets random posts.
+     *
+     * @param maxSize the max size of random posts. It should be between 1 and 100.
+     * @return a list of random posts with size less than or equal to {@code maxSize}.
+     */
+    Mono<List<ListedPostVo>> random(int maxSize);
+
+    /**
      * Lists posts by query params.
      *
-     * @param params query params see {@link PostQuery}
+     * @param params query params see
+     * {@link run.halo.app.theme.finders.impl.PostFinderImpl.PostQuery}
      */
     Mono<ListResult<ListedPostVo>> list(Map<String, Object> params);
 
@@ -59,4 +68,5 @@ public interface PostFinder {
     Mono<ListResult<PostArchiveVo>> archives(Integer page, Integer size, String year);
 
     Mono<ListResult<PostArchiveVo>> archives(Integer page, Integer size, String year, String month);
+
 }

--- a/application/src/main/java/run/halo/app/theme/finders/impl/PostFinderImpl.java
+++ b/application/src/main/java/run/halo/app/theme/finders/impl/PostFinderImpl.java
@@ -14,8 +14,10 @@ import lombok.AllArgsConstructor;
 import lombok.Data;
 import org.apache.commons.lang3.BooleanUtils;
 import org.apache.commons.lang3.ObjectUtils;
+import org.apache.commons.lang3.RandomUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.data.domain.Sort;
+import org.springframework.util.Assert;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import run.halo.app.content.CategoryService;
@@ -52,7 +54,7 @@ import run.halo.app.theme.router.ReactiveQueryPostPredicateResolver;
  */
 @Finder("postFinder")
 @AllArgsConstructor
-public class PostFinderImpl implements PostFinder {
+class PostFinderImpl implements PostFinder {
 
     private final ReactiveExtensionClient client;
 
@@ -300,6 +302,25 @@ public class PostFinderImpl implements PostFinder {
             .collectList()
             .flatMap(postPublicQueryService::convertToListedVos)
             .flatMapMany(Flux::fromIterable);
+    }
+
+    @Override
+    public Mono<List<ListedPostVo>> random(int maxSize) {
+        Assert.isTrue(maxSize > 0 && maxSize <= 100, "Size must be between 1 and 100");
+        return postPredicateResolver.getListOptions()
+            .flatMap(listOptions -> client.countBy(Post.class, listOptions)
+                .filter(total -> total > 0)
+                .flatMap(total -> {
+                    // calculate random page number
+                    var totalPages = (int) Math.ceil((double) total / maxSize);
+                    var page = RandomUtils.insecure().randomInt(1, totalPages + 1);
+                    var pageRequest = PageRequestImpl.of(page, maxSize, defaultSort());
+                    return client.listBy(Post.class, listOptions, pageRequest)
+                        .map(ListResult::getItems)
+                        .flatMap(postPublicQueryService::convertToListedVos);
+                })
+                .switchIfEmpty(Mono.fromSupplier(List::of))
+            );
     }
 
     static int pageNullSafe(Integer page) {

--- a/application/src/test/java/run/halo/app/theme/finders/impl/PostFinderImplTest.java
+++ b/application/src/test/java/run/halo/app/theme/finders/impl/PostFinderImplTest.java
@@ -2,6 +2,10 @@ package run.halo.app.theme.finders.impl;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isA;
+import static org.mockito.ArgumentMatchers.same;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import java.time.Instant;
@@ -17,9 +21,11 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.data.domain.Sort;
 import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
 import run.halo.app.content.PostService;
 import run.halo.app.core.counter.CounterService;
 import run.halo.app.core.extension.content.Post;
+import run.halo.app.extension.ListOptions;
 import run.halo.app.extension.ListResult;
 import run.halo.app.extension.Metadata;
 import run.halo.app.extension.PageRequest;
@@ -32,6 +38,7 @@ import run.halo.app.theme.finders.vo.ListedPostVo;
 import run.halo.app.theme.finders.vo.PostArchiveVo;
 import run.halo.app.theme.finders.vo.PostArchiveYearMonthVo;
 import run.halo.app.theme.router.DefaultQueryPostPredicateResolver;
+import run.halo.app.theme.router.ReactiveQueryPostPredicateResolver;
 
 /**
  * Tests for {@link PostFinderImpl}.
@@ -62,6 +69,9 @@ class PostFinderImplTest {
 
     @Mock
     private PostPublicQueryService publicQueryService;
+
+    @Mock
+    ReactiveQueryPostPredicateResolver postPredicateResolver;
 
     @InjectMocks
     private PostFinderImpl postFinder;
@@ -100,6 +110,37 @@ class PostFinderImplTest {
         assertThat(items.get(1).getYear()).isEqualTo("2021");
         assertThat(items.get(1).getMonths()).hasSize(1);
         assertThat(items.get(1).getMonths().get(0).getMonth()).isEqualTo("01");
+    }
+
+    @Test
+    void shouldReturnEmptyRandomPostsIfNoPostsFound() {
+        var listOptions = mock(ListOptions.class);
+        when(postPredicateResolver.getListOptions()).thenReturn(Mono.just(listOptions));
+        when(client.countBy(Post.class, listOptions)).thenReturn(Mono.just(0L));
+        postFinder.random(10)
+            .as(StepVerifier::create)
+            .expectNext(List.of())
+            .verifyComplete();
+    }
+
+    @Test
+    void shouldReturnRandomPosts() {
+        var listOptions = mock(ListOptions.class);
+        when(postPredicateResolver.getListOptions()).thenReturn(Mono.just(listOptions));
+        when(client.countBy(Post.class, listOptions)).thenReturn(Mono.just(100L));
+        var post1 = post(1);
+        var post2 = post(2);
+        when(client.listBy(same(Post.class), same(listOptions), isA(PageRequest.class)))
+            .thenReturn(Mono.just(new ListResult<>(0, 10, 100, List.of(post1, post2))));
+        var postVo1 = ListedPostVo.from(post1);
+        var postVo2 = ListedPostVo.from(post2);
+        when(publicQueryService.convertToListedVos(eq(List.of(post1, post2))))
+            .thenReturn(Mono.just(List.of(postVo1, postVo2)));
+
+        postFinder.random(10)
+            .as(StepVerifier::create)
+            .expectNext(List.of(postVo1, postVo2))
+            .verifyComplete();
     }
 
     List<Post> postsForArchives() {


### PR DESCRIPTION
#### What type of PR is this?

/kind feature
/kind api-change
/area theme
/milestone 2.24.x

#### What this PR does / why we need it:

This PR adds random psot retrival method of PostFinder.

#### Which issue(s) this PR fixes:

Fixes https://github.com/halo-dev/halo/issues/7327

#### Special notes for your reviewer:

Usage example:

```html
     th:with="posts = ${postFinder.random(1)}"
```

#### Does this PR introduce a user-facing change?

```release-note
None
```

