### PR TITLE
Fix the problem of not being able to remember me

### DIFF
--- a/api/src/main/java/run/halo/app/core/extension/Device.java
+++ b/api/src/main/java/run/halo/app/core/extension/Device.java
@@ -47,6 +47,7 @@ public class Device extends AbstractExtension {
         @Schema(maxLength = 500)
         private String userAgent;
 
+        @Nullable
         private String rememberMeSeriesId;
 
         private Instant lastAccessedTime;

--- a/application/src/main/java/run/halo/app/security/device/DeviceServiceImpl.java
+++ b/application/src/main/java/run/halo/app/security/device/DeviceServiceImpl.java
@@ -82,6 +82,9 @@ class DeviceServiceImpl implements DeviceService {
                         .flatMap(session -> {
                             device.getSpec().setSessionId(session.getId());
                             device.getSpec().setLastAccessedTime(session.getLastAccessTime());
+                            device.getSpec().setRememberMeSeriesId(
+                                exchange.getAttribute(REMEMBER_ME_SERIES_REQUEST_NAME)
+                            );
                             return sessionRepository.deleteById(oldSessionId);
                         })
                         .thenReturn(device);


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/area core
/milestone 2.24.x

#### What this PR does / why we need it:

This PR stores rememberMeSeriesId in device spec during session update and mark field nullable.

This bug was introduced by <https://github.com/halo-dev/halo/pull/9899>.

#### Special notes for your reviewer:

1. Try to log in with remember-me checked
2. Try to close browser and open it

#### Does this PR introduce a user-facing change?

```release-note
None
```
