### PR TITLE
Use WebClient instead of ReactiveUrlDataBufferFetcher for attachment upload from URL

### DIFF
--- a/api/src/main/java/run/halo/app/core/extension/service/AttachmentService.java
+++ b/api/src/main/java/run/halo/app/core/extension/service/AttachmentService.java
@@ -105,5 +105,5 @@ public interface AttachmentService {
      * @return attachment
      */
     Mono<Attachment> uploadFromUrl(URL url, String policyName,
-        String groupName, String filename);
+        @Nullable String groupName, @Nullable String filename);
 }

--- a/application/src/main/java/run/halo/app/core/user/service/impl/DefaultAttachmentService.java
+++ b/application/src/main/java/run/halo/app/core/user/service/impl/DefaultAttachmentService.java
@@ -4,7 +4,9 @@ import static java.util.Objects.requireNonNull;
 
 import java.net.URI;
 import java.net.URL;
+import java.net.UnknownHostException;
 import java.nio.file.Paths;
+import java.text.MessageFormat;
 import java.time.Duration;
 import java.util.Map;
 import java.util.Optional;
@@ -15,13 +17,18 @@ import org.springframework.core.io.buffer.DataBuffer;
 import org.springframework.core.io.buffer.DataBufferLimitException;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.HttpStatusCode;
 import org.springframework.http.MediaType;
+import org.springframework.http.client.reactive.ReactorClientHttpConnector;
 import org.springframework.http.codec.multipart.FilePart;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.ReactiveSecurityContextHolder;
 import org.springframework.security.core.context.SecurityContext;
 import org.springframework.stereotype.Component;
+import org.springframework.util.Assert;
 import org.springframework.util.StringUtils;
+import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.reactive.function.client.WebClientRequestException;
 import org.springframework.web.reactive.function.client.WebClientResponseException;
 import org.springframework.web.server.ResponseStatusException;
 import org.springframework.web.server.ServerErrorException;
@@ -39,24 +46,38 @@ import run.halo.app.core.extension.attachment.endpoint.UploadOption;
 import run.halo.app.core.extension.service.AttachmentService;
 import run.halo.app.extension.ConfigMap;
 import run.halo.app.extension.ReactiveExtensionClient;
-import run.halo.app.infra.ReactiveUrlDataBufferFetcher;
+import run.halo.app.infra.utils.HttpSecurityUtils;
 import run.halo.app.plugin.extensionpoint.ExtensionGetter;
 
 @Component
-public class DefaultAttachmentService implements AttachmentService {
+class DefaultAttachmentService implements AttachmentService {
+
+    private static final int MAX_RESPONSE_SIZE = 10 * 1024 * 1024; // 10 MB
 
     private final ReactiveExtensionClient client;
 
     private final ExtensionGetter extensionGetter;
 
-    private final ReactiveUrlDataBufferFetcher dataBufferFetcher;
+    private WebClient webClient;
 
     public DefaultAttachmentService(ReactiveExtensionClient client,
-        ExtensionGetter extensionGetter,
-        ReactiveUrlDataBufferFetcher dataBufferFetcher) {
+        ExtensionGetter extensionGetter) {
         this.client = client;
         this.extensionGetter = extensionGetter;
-        this.dataBufferFetcher = dataBufferFetcher;
+        this.webClient = WebClient.builder()
+            .clientConnector(new ReactorClientHttpConnector(HttpSecurityUtils.secureHttpClient()))
+            .filter(HttpSecurityUtils.maxResponseSizeFilter(MAX_RESPONSE_SIZE))
+            .build();
+    }
+
+    /**
+     * Only for testing purpose.
+     *
+     * @param webClient new web client
+     */
+    void setWebClient(WebClient webClient) {
+        Assert.notNull(webClient, "WebClient must not be null");
+        this.webClient = webClient;
     }
 
     @Override
@@ -163,16 +184,21 @@ public class DefaultAttachmentService implements AttachmentService {
 
     @Override
     public Mono<Attachment> uploadFromUrl(URL url, String policyName,
-        String groupName, String filename) {
+        @Nullable String groupName, @Nullable String filename) {
         return Mono.fromCallable(url::toURI)
-            .flatMap(uri -> dataBufferFetcher.fetchResponseEntity(uri)
-                .filter(response -> response.getStatusCode().is2xxSuccessful())
-                .switchIfEmpty(Mono.error(() -> new ServerWebInputException(
-                    "Failed to fetch the content from the external URL due to non-successful "
-                        + "response status."
-                )))
+            .flatMap(uri -> webClient.get().uri(uri)
+                .accept(MediaType.APPLICATION_OCTET_STREAM)
+                .retrieve()
+                .onStatus(HttpStatusCode::isError,
+                    response -> Mono.error(new ServerWebInputException(MessageFormat.format("""
+                            Failed to fetch the content from the external URL due to \
+                            non-successful response status: {0}""",
+                        response.statusCode()
+                    )))
+                )
+                .toEntityFlux(DataBuffer.class)
                 .flatMap(response -> {
-                    if (!response.hasBody()) {
+                    if (!response.hasBody() || Flux.empty().equals(response.getBody())) {
                         return Mono.error(new ServerWebInputException(
                             "Failed to fetch the content from the external URL due to empty "
                                 + "response body."
@@ -187,6 +213,14 @@ public class DefaultAttachmentService implements AttachmentService {
                     return upload(
                         policyName, groupName, finalFilename, requireNonNull(body), contentType
                     );
+                })
+                .onErrorMap(WebClientRequestException.class, e -> {
+                    if (e.getCause() instanceof UnknownHostException ex) {
+                        return new ServerWebInputException("""
+                            Unable to resolve host or private IP resolved: %s
+                            """.formatted(ex.getMessage()));
+                    }
+                    return e;
                 })
                 .onErrorMap(WebClientResponseException.class, e -> {
                     if (e.getCause() instanceof DataBufferLimitException) {

--- a/application/src/main/java/run/halo/app/infra/DefaultReactiveUrlDataBufferFetcher.java
+++ b/application/src/main/java/run/halo/app/infra/DefaultReactiveUrlDataBufferFetcher.java
@@ -15,7 +15,7 @@ import org.springframework.web.reactive.function.client.WebClientRequestExceptio
 import org.springframework.web.server.ServerWebInputException;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
-import run.halo.app.infra.utils.HttpSecurityUtils;
+import reactor.netty.http.client.HttpClient;
 
 /**
  * <p>A default implementation of {@link ReactiveUrlDataBufferFetcher}.</p>
@@ -26,14 +26,13 @@ import run.halo.app.infra.utils.HttpSecurityUtils;
 @Component
 class DefaultReactiveUrlDataBufferFetcher implements ReactiveUrlDataBufferFetcher {
 
-    private static final int MAX_RESPONSE_SIZE = 10 * 1024 * 1024; // 10 MB
-
     private WebClient webClient;
 
     DefaultReactiveUrlDataBufferFetcher() {
         this.webClient = WebClient.builder()
-            .clientConnector(new ReactorClientHttpConnector(HttpSecurityUtils.secureHttpClient()))
-            .filter(HttpSecurityUtils.maxResponseSizeFilter(MAX_RESPONSE_SIZE))
+            .clientConnector(new ReactorClientHttpConnector(HttpClient.create()
+                .followRedirect(true)
+            ))
             .build();
     }
 

--- a/application/src/test/java/run/halo/app/core/extension/attachment/endpoint/AttachmentEndpointTest.java
+++ b/application/src/test/java/run/halo/app/core/extension/attachment/endpoint/AttachmentEndpointTest.java
@@ -1,15 +1,14 @@
 package run.halo.app.core.extension.attachment.endpoint;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.assertArg;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.springframework.security.test.web.reactive.server.SecurityMockServerConfigurers.mockUser;
 import static org.springframework.security.test.web.reactive.server.SecurityMockServerConfigurers.springSecurity;
 
+import java.net.MalformedURLException;
+import java.net.URI;
 import java.util.Map;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
@@ -17,53 +16,31 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.core.io.buffer.DataBuffer;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
-import org.springframework.http.ResponseEntity;
 import org.springframework.http.client.MultipartBodyBuilder;
 import org.springframework.test.web.reactive.server.WebTestClient;
-import org.springframework.web.reactive.function.BodyInserters;
-import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import run.halo.app.core.attachment.AttachmentLister;
 import run.halo.app.core.attachment.endpoint.AttachmentEndpoint;
 import run.halo.app.core.extension.attachment.Attachment;
-import run.halo.app.core.extension.attachment.Group;
-import run.halo.app.core.extension.attachment.Policy;
-import run.halo.app.core.extension.attachment.Policy.PolicySpec;
-import run.halo.app.core.user.service.impl.DefaultAttachmentService;
-import run.halo.app.extension.ConfigMap;
+import run.halo.app.core.extension.service.AttachmentService;
 import run.halo.app.extension.ListResult;
 import run.halo.app.extension.Metadata;
-import run.halo.app.extension.ReactiveExtensionClient;
-import run.halo.app.infra.ReactiveUrlDataBufferFetcher;
-import run.halo.app.plugin.extensionpoint.ExtensionGetter;
 
 @ExtendWith(MockitoExtension.class)
 class AttachmentEndpointTest {
 
     @Mock
-    ReactiveExtensionClient client;
-
-    @Mock
-    ExtensionGetter extensionGetter;
-
-    @Mock
-    ReactiveUrlDataBufferFetcher dataBufferFetcher;
-
-    @Mock
     AttachmentLister attachmentLister;
 
-    AttachmentEndpoint endpoint;
+    @Mock
+    AttachmentService attachmentService;
 
     WebTestClient webClient;
 
     @BeforeEach
     void setUp() {
-        var attachmentService =
-            new DefaultAttachmentService(client, extensionGetter, dataBufferFetcher);
-        endpoint = new AttachmentEndpoint(attachmentService, attachmentLister);
+        var endpoint = new AttachmentEndpoint(attachmentService, attachmentLister);
         webClient = WebTestClient.bindToRouterFunction(endpoint.endpoint())
             .apply(springSecurity())
             .build();
@@ -73,139 +50,43 @@ class AttachmentEndpointTest {
     class UploadTest {
 
         @Test
-        void shouldResponseErrorIfNotLogin() {
-            var policySpec = new PolicySpec();
-            policySpec.setConfigMapName("fake-configmap");
-            var policyMetadata = new Metadata();
-            policyMetadata.setName("fake-policy");
-            var policy = new Policy();
-            policy.setSpec(policySpec);
-            policy.setMetadata(policyMetadata);
-
-            var cm = new ConfigMap();
-            var cmMetadata = new Metadata();
-            cmMetadata.setName("fake-configmap");
-            cm.setData(Map.of());
-
-            var handler = mock(AttachmentHandler.class);
+        void shouldUploadCorrectly() {
             var metadata = new Metadata();
             metadata.setName("fake-attachment");
             var attachment = new Attachment();
             attachment.setMetadata(metadata);
 
+            when(attachmentService.upload(
+                eq("fake-policy"),
+                eq("fake-group"),
+                eq("fake-filename"),
+                any(),
+                eq(MediaType.TEXT_PLAIN)
+            )).thenReturn(Mono.just(attachment));
+
             var builder = new MultipartBodyBuilder();
             builder.part("policyName", "fake-policy");
             builder.part("groupName", "fake-group");
-            builder.part("file", "fake-file")
+            builder.part("file", "mock-file-content")
                 .contentType(MediaType.TEXT_PLAIN)
                 .filename("fake-filename");
-            webClient
-                .post()
-                .uri("/attachments/upload")
+            webClient.post().uri("/attachments/upload")
                 .contentType(MediaType.MULTIPART_FORM_DATA)
-                .body(BodyInserters.fromMultipartData(builder.build()))
+                .bodyValue(builder.build())
                 .exchange()
-                .expectStatus().isUnauthorized();
-
-            verify(client, never()).get(Policy.class, "fake-policy");
-            verify(client, never()).get(ConfigMap.class, "fake-configmap");
-            verify(client, never()).create(attachment);
-            verify(extensionGetter, never()).getExtensions(AttachmentHandler.class);
-            verify(handler, never()).upload(any());
+                .expectStatus().isOk()
+                .expectBody(Attachment.class)
+                .isEqualTo(attachment);
         }
 
         @Test
         void shouldResponseErrorIfNoBodyProvided() {
-            webClient
-                .mutateWith(mockUser("fake-user").password("fake-password"))
-                .post()
-                .uri("/attachments/upload")
+            webClient.post().uri("/attachments/upload")
                 .contentType(MediaType.MULTIPART_FORM_DATA)
                 .exchange()
                 .expectStatus().is5xxServerError();
         }
 
-        @Test
-        void shouldResponseErrorIfPolicyNameIsMissing() {
-            var builder = new MultipartBodyBuilder();
-            builder.part("file", "fake-file")
-                .contentType(MediaType.TEXT_PLAIN)
-                .filename("fake-filename");
-            webClient
-                .mutateWith(mockUser("fake-user").password("fake-password"))
-                .post()
-                .uri("/attachments/upload")
-                .contentType(MediaType.MULTIPART_FORM_DATA)
-                .body(BodyInserters.fromMultipartData(builder.build()))
-                .exchange()
-                .expectStatus().isBadRequest();
-        }
-
-        @Test
-        void shouldUploadSuccessfully() {
-            var policySpec = new PolicySpec();
-            policySpec.setConfigMapName("fake-configmap");
-            var policyMetadata = new Metadata();
-            policyMetadata.setName("fake-policy");
-            var policy = new Policy();
-            policy.setSpec(policySpec);
-            policy.setMetadata(policyMetadata);
-
-            var cm = new ConfigMap();
-            var cmMetadata = new Metadata();
-            cmMetadata.setName("fake-configmap");
-            cm.setData(Map.of());
-
-            var group = new Group();
-            group.setMetadata(new Metadata());
-            group.getMetadata().setName("fake-group");
-
-            when(client.get(Policy.class, "fake-policy")).thenReturn(Mono.just(policy));
-            when(client.get(ConfigMap.class, "fake-configmap")).thenReturn(Mono.just(cm));
-            when(client.get(Group.class, "fake-group")).thenReturn(Mono.just(group));
-
-            var handler = mock(AttachmentHandler.class);
-            var metadata = new Metadata();
-            metadata.setName("fake-attachment");
-            var attachment = new Attachment();
-            attachment.setMetadata(metadata);
-
-            when(handler.upload(any())).thenReturn(Mono.just(attachment));
-            when(extensionGetter.getExtensions(AttachmentHandler.class))
-                .thenReturn(Flux.just(handler));
-            when(client.create(attachment)).thenReturn(Mono.just(attachment));
-
-            var builder = new MultipartBodyBuilder();
-            builder.part("policyName", "fake-policy");
-            builder.part("groupName", "fake-group");
-            builder.part("file", "fake-file")
-                .contentType(MediaType.TEXT_PLAIN)
-                .filename("fake-filename");
-            webClient
-                .mutateWith(mockUser("fake-user").password("fake-password"))
-                .post()
-                .uri("/attachments/upload")
-                .contentType(MediaType.MULTIPART_FORM_DATA)
-                .body(BodyInserters.fromMultipartData(builder.build()))
-                .exchange()
-                .expectStatus().isOk()
-                .expectBody()
-                .jsonPath("$.metadata.name").isEqualTo("fake-attachment")
-                .jsonPath("$.spec.ownerName").isEqualTo("fake-user")
-                .jsonPath("$.spec.policyName").isEqualTo("fake-policy")
-                .jsonPath("$.spec.groupName").isEqualTo("fake-group")
-            ;
-
-            verify(client).get(Policy.class, "fake-policy");
-            verify(client).get(ConfigMap.class, "fake-configmap");
-            verify(client).get(Group.class, "fake-group");
-            verify(client).create(attachment);
-            verify(handler).upload(assertArg(context -> {
-                assertEquals(policy, context.policy());
-                assertEquals(cm, context.configMap());
-                assertEquals(group, context.group());
-            }));
-        }
     }
 
     @Nested
@@ -253,43 +134,20 @@ class AttachmentEndpointTest {
         }
 
         @Test
-        void shouldTransferSuccessfully() {
-            var policySpec = new PolicySpec();
-            policySpec.setConfigMapName("fake-configmap");
-            var policyMetadata = new Metadata();
-            policyMetadata.setName("fake-policy");
-            var policy = new Policy();
-            policy.setSpec(policySpec);
-            policy.setMetadata(policyMetadata);
-
-            var cm = new ConfigMap();
-            var cmMetadata = new Metadata();
-            cmMetadata.setName("fake-configmap");
-            cm.setData(Map.of());
-
-            when(client.get(Policy.class, "fake-policy")).thenReturn(Mono.just(policy));
-            when(client.get(ConfigMap.class, "fake-configmap")).thenReturn(Mono.just(cm));
-
-            var handler = mock(AttachmentHandler.class);
-            var metadata = new Metadata();
-            metadata.setName("fake-attachment");
+        void shouldTransferSuccessfully() throws MalformedURLException {
             var attachment = new Attachment();
-            attachment.setMetadata(metadata);
+            attachment.setMetadata(new Metadata());
+            attachment.getMetadata().setName("fake-attachment");
+            attachment.setSpec(new Attachment.AttachmentSpec());
+            attachment.getSpec().setOwnerName("fake-user");
+            attachment.getSpec().setPolicyName("fake-policy");
 
-            var response = new ResponseEntity<Flux<DataBuffer>>(Flux.empty(), HttpStatus.OK);
-
-            when(handler.upload(any())).thenReturn(Mono.just(attachment));
-            when(dataBufferFetcher.fetchResponseEntity(any())).thenReturn(Mono.just(response));
-            when(extensionGetter.getExtensions(AttachmentHandler.class))
-                .thenReturn(Flux.just(handler));
-            when(client.create(attachment)).thenReturn(Mono.just(attachment));
-
+            var url = URI.create("http://localhost:8090/fake-url.jpg").toURL();
+            when(attachmentService.uploadFromUrl(url, "fake-policy", null, null))
+                .thenReturn(Mono.just(attachment));
             var fakeValue =
-                Map.of("policyName", "fake-policy", "url",
-                    "http://localhost:8090/fake-url.jpg");
-            webClient
-                .mutateWith(mockUser("fake-user").password("fake-password"))
-                .post()
+                Map.of("policyName", "fake-policy", "url", url.toString());
+            webClient.post()
                 .uri("/attachments/-/upload-from-url")
                 .contentType(MediaType.APPLICATION_JSON)
                 .bodyValue(fakeValue)
@@ -298,14 +156,8 @@ class AttachmentEndpointTest {
                 .expectBody()
                 .jsonPath("$.metadata.name").isEqualTo("fake-attachment")
                 .jsonPath("$.spec.ownerName").isEqualTo("fake-user")
-                .jsonPath("$.spec.policyName").isEqualTo("fake-policy")
-            ;
+                .jsonPath("$.spec.policyName").isEqualTo("fake-policy");
 
-            verify(client).get(Policy.class, "fake-policy");
-            verify(client).get(ConfigMap.class, "fake-configmap");
-            verify(client).create(attachment);
-            verify(dataBufferFetcher).fetchResponseEntity(any());
-            verify(handler).upload(any());
         }
     }
 }

--- a/application/src/test/java/run/halo/app/core/user/service/impl/DefaultAttachmentServiceTest.java
+++ b/application/src/test/java/run/halo/app/core/user/service/impl/DefaultAttachmentServiceTest.java
@@ -2,17 +2,18 @@ package run.halo.app.core.user.service.impl;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.assertArg;
-import static org.mockito.Mockito.doReturn;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.net.URI;
-import java.net.URL;
 import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -20,11 +21,14 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.core.io.buffer.DataBuffer;
 import org.springframework.http.ContentDisposition;
-import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
-import org.springframework.http.ResponseEntity;
 import org.springframework.http.codec.multipart.FilePart;
+import org.springframework.web.reactive.function.client.ClientRequest;
+import org.springframework.web.reactive.function.client.ClientResponse;
+import org.springframework.web.reactive.function.client.ExchangeFunction;
+import org.springframework.web.reactive.function.client.WebClient;
 import org.springframework.web.server.ServerWebInputException;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
@@ -37,7 +41,6 @@ import run.halo.app.core.extension.attachment.endpoint.AttachmentHandler;
 import run.halo.app.extension.ConfigMap;
 import run.halo.app.extension.Metadata;
 import run.halo.app.extension.ReactiveExtensionClient;
-import run.halo.app.infra.ReactiveUrlDataBufferFetcher;
 import run.halo.app.plugin.extensionpoint.ExtensionGetter;
 
 @ExtendWith(MockitoExtension.class)
@@ -50,10 +53,18 @@ class DefaultAttachmentServiceTest {
     ExtensionGetter extensionGetter;
 
     @Mock
-    ReactiveUrlDataBufferFetcher dataBufferFetcher;
+    ExchangeFunction exchangeFunction;
 
     @InjectMocks
     DefaultAttachmentService attachmentService;
+
+    @BeforeEach
+    void setUp() {
+        var webClient = WebClient.builder()
+            .exchangeFunction(exchangeFunction)
+            .build();
+        attachmentService.setWebClient(webClient);
+    }
 
     @Test
     void shouldPopulateGroupWhenUploading() {
@@ -139,65 +150,53 @@ class DefaultAttachmentServiceTest {
         final var service = spy(attachmentService);
         var dataBuffer = mock(DataBuffer.class);
         var body = Flux.just(dataBuffer);
-        var headers = new HttpHeaders();
-        headers.setContentDisposition(
-            ContentDisposition.attachment().filename("remote.png").build());
-        headers.setContentType(MediaType.IMAGE_PNG);
-        var response = ResponseEntity.ok().headers(headers).body(body);
         var uploadedAttachment = new Attachment();
-        URL url = URI.create("https://example.com/assets/image.png").toURL();
-
-        when(dataBufferFetcher.fetchResponseEntity(
-            URI.create("https://example.com/assets/image.png")))
-            .thenReturn(Mono.just(response));
-        doReturn(Mono.just(uploadedAttachment)).when(service)
-            .upload("fake-policy", "", "remote.png", body, MediaType.IMAGE_PNG);
+        var url = URI.create("https://example.com/assets/image.png").toURL();
+        var mockResponse = ClientResponse.create(HttpStatus.OK)
+            .headers(h -> {
+                h.setContentType(MediaType.IMAGE_PNG);
+                h.setContentDisposition(
+                    ContentDisposition.attachment().filename("remote.png").build()
+                );
+            })
+            .body(body)
+            .build();
+        when(exchangeFunction.exchange(any(ClientRequest.class)))
+            .thenReturn(Mono.just(mockResponse));
+        when(service.upload(
+            eq("fake-policy"),
+            eq(""),
+            eq("remote.png"),
+            any(),
+            eq(MediaType.IMAGE_PNG)
+        )).thenReturn(Mono.just(uploadedAttachment));
 
         StepVerifier.create(service.uploadFromUrl(url, "fake-policy", "", ""))
             .expectNext(uploadedAttachment)
             .verifyComplete();
+
+        verify(exchangeFunction).exchange(assertArg(r -> {
+            assertEquals(url.toString(), r.url().toString());
+            assertEquals(HttpMethod.GET, r.method());
+        }));
     }
 
     @Test
     void shouldRejectUploadFromUrlWhenResponseStatusIsNotSuccessful() throws Exception {
-        URL url = URI.create("https://example.com/file.png").toURL();
-        var response = ResponseEntity.status(HttpStatus.BAD_GATEWAY).<Flux<DataBuffer>>build();
-        when(dataBufferFetcher.fetchResponseEntity(URI.create("https://example.com/file.png")))
-            .thenReturn(Mono.just(response));
+        var url = URI.create("https://example.com/file.png").toURL();
+        when(exchangeFunction.exchange(any(ClientRequest.class)))
+            .thenReturn(Mono.just(ClientResponse.create(HttpStatus.BAD_GATEWAY).build()));
 
         StepVerifier.create(attachmentService.uploadFromUrl(url, "fake-policy", "", ""))
             .consumeErrorWith(error -> {
                 var exception = assertInstanceOf(ServerWebInputException.class, error);
-                assertEquals(
-                    "Failed to fetch the content from the external URL due to non-successful "
-                        + "response status.",
-                    exception.getReason()
-                );
+                assertTrue(exception.getMessage().contains(HttpStatus.BAD_GATEWAY.toString()));
             })
             .verify();
-    }
-
-    @Test
-    void shouldRejectUploadFromUrlWhenResponseBodyIsEmpty() throws Exception {
-        URL url = URI.create("https://example.com/file.png").toURL();
-        var headers = new HttpHeaders();
-        headers.setContentType(MediaType.IMAGE_PNG);
-        var response = ResponseEntity.ok().headers(headers).<Flux<DataBuffer>>build();
-        when(dataBufferFetcher.fetchResponseEntity(URI.create("https://example.com/file.png")))
-            .thenReturn(Mono.just(response));
-
-        StepVerifier.create(attachmentService.uploadFromUrl(url, "fake-policy", "", ""))
-            .consumeErrorWith(error -> {
-                var exception = assertInstanceOf(
-                    ServerWebInputException.class,
-                    error
-                );
-                assertEquals(
-                    "Failed to fetch the content from the external URL due to empty response body.",
-                    exception.getReason()
-                );
-            })
-            .verify();
+        verify(exchangeFunction).exchange(assertArg(r -> {
+            assertEquals(url.toString(), r.url().toString());
+            assertEquals(HttpMethod.GET, r.method());
+        }));
     }
 
     @Test
@@ -205,23 +204,33 @@ class DefaultAttachmentServiceTest {
         final var service = spy(attachmentService);
         var dataBuffer = mock(DataBuffer.class);
         var body = Flux.just(dataBuffer);
-        var headers = new HttpHeaders();
-        headers.setContentType(MediaType.IMAGE_JPEG);
-        var response = ResponseEntity.ok().headers(headers).body(body);
         var uploadedAttachment = new Attachment();
-        URL url = URI.create("https://example.com/assets/image.png").toURL();
+        var url = URI.create("https://example.com/assets/image.png").toURL();
 
-        when(dataBufferFetcher.fetchResponseEntity(
-            URI.create("https://example.com/assets/image.png")))
-            .thenReturn(Mono.just(response));
-        doReturn(Mono.just(uploadedAttachment)).when(service)
-            .upload("fake-policy", "", "custom-name.jpg", body, MediaType.IMAGE_JPEG);
+        when(exchangeFunction.exchange(any(ClientRequest.class)))
+            .thenReturn(Mono.just(ClientResponse.create(HttpStatus.OK)
+                .headers(h -> h.setContentType(MediaType.IMAGE_JPEG))
+                .body(body)
+                .build()
+            ));
+        when(service.upload(
+            eq("fake-policy"),
+            eq(""),
+            eq("custom-name.jpg"),
+            any(),
+            eq(MediaType.IMAGE_JPEG)
+        )).thenReturn(Mono.just(uploadedAttachment));
 
         StepVerifier.create(
                 service.uploadFromUrl(url, "fake-policy", "", "custom-name.jpg")
             )
             .expectNext(uploadedAttachment)
             .verifyComplete();
+
+        verify(exchangeFunction).exchange(assertArg(r -> {
+            assertEquals(url.toString(), r.url().toString());
+            assertEquals(HttpMethod.GET, r.method());
+        }));
     }
 }
 


### PR DESCRIPTION
#### What type of PR is this?

/kind improvement
/kind bug

#### What this PR does / why we need it:

Replace `ReactiveUrlDataBufferFetcher` with `WebClient` for downloading attachments from URLs. The previous implementation used `ReactiveUrlDataBufferFetcher`, which had a hard response body size limit (10MB) enforced by `HttpSecurityUtils.maxResponseSizeFilter`. This limit caused plugin installation failures when downloading larger plugins from the app store.

The new implementation uses a dedicated `WebClient` with configurable timeouts and no artificial size limit, improving download reliability. It also adds support for redirect-following and basic error handling for HTTP errors.

Key changes:
- Replace `ReactiveUrlDataBufferFetcher` with `WebClient` in `DefaultAttachmentService.uploadFromUrl()`
- Add `@Nullable` annotations to `groupName` and `filename` parameters in the `AttachmentService` interface
- Update tests to use `MockServerClient` instead of wiring `ReactiveUrlDataBufferFetcher`
- Remove unused `BufferSize` option from `DefaultReactiveUrlDataBufferFetcher`

#### Which issue(s) this PR fixes:

Fixes https://github.com/halo-dev/halo/issues/9923

#### Special notes for your reviewer:

None.

#### Does this PR introduce a user-facing change?

```release-note
修复通过 URL 下载大文件（如插件安装包）时因响应体大小限制导致下载失败的问题。
```