### PR TITLE
Fix random post retrieval to always return requested size

### DIFF
--- a/application/src/main/java/run/halo/app/theme/finders/impl/PostFinderImpl.java
+++ b/application/src/main/java/run/halo/app/theme/finders/impl/PostFinderImpl.java
@@ -5,10 +5,13 @@ import static run.halo.app.extension.index.query.Queries.equal;
 import static run.halo.app.extension.index.query.Queries.in;
 import static run.halo.app.extension.index.query.Queries.notEqual;
 
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.ThreadLocalRandom;
 import java.util.stream.Collectors;
 import lombok.AllArgsConstructor;
 import lombok.Data;
@@ -315,13 +318,13 @@ class PostFinderImpl implements PostFinder {
                     var effectiveSize = Math.min(maxSize, totalInt);
                     var totalPages = (int) Math.ceil((double) totalInt / effectiveSize);
                     var page = RandomUtils.insecure().randomInt(1, totalPages + 1);
-                    var sort = defaultSort();
+                    var sort = Sort.unsorted();
                     var firstRequest = PageRequestImpl.of(page, effectiveSize, sort);
                     return client.listBy(Post.class, listOptions, firstRequest)
                         .map(ListResult::getItems)
                         .flatMap(items -> {
-                            if (items.size() >= effectiveSize) {
-                                return postPublicQueryService.convertToListedVos(items);
+                            if (items.size() >= effectiveSize || total <= effectiveSize) {
+                                return Mono.just(items);
                             }
                             // wrap around to the beginning to fill up to effectiveSize
                             var remaining = effectiveSize - items.size();
@@ -329,12 +332,18 @@ class PostFinderImpl implements PostFinder {
                             return client.listBy(Post.class, listOptions, wrapRequest)
                                 .map(ListResult::getItems)
                                 .flatMap(wrapItems -> {
-                                    var combined = new java.util.ArrayList<>(items);
+                                    var combined = new ArrayList<>(items);
                                     combined.addAll(wrapItems);
-                                    return postPublicQueryService.convertToListedVos(combined);
+                                    return Mono.just(combined);
                                 });
                         });
                 })
+                .map(items -> {
+                    var randomItems = new ArrayList<>(items);
+                    Collections.shuffle(randomItems, ThreadLocalRandom.current());
+                    return randomItems;
+                })
+                .flatMap(postPublicQueryService::convertToListedVos)
                 .switchIfEmpty(Mono.fromSupplier(List::of))
             );
     }

--- a/application/src/main/java/run/halo/app/theme/finders/impl/PostFinderImpl.java
+++ b/application/src/main/java/run/halo/app/theme/finders/impl/PostFinderImpl.java
@@ -318,7 +318,7 @@ class PostFinderImpl implements PostFinder {
                     var effectiveSize = Math.min(maxSize, totalInt);
                     var totalPages = (int) Math.ceil((double) totalInt / effectiveSize);
                     var page = RandomUtils.insecure().randomInt(1, totalPages + 1);
-                    var sort = Sort.unsorted();
+                    var sort = defaultSort();
                     var firstRequest = PageRequestImpl.of(page, effectiveSize, sort);
                     return client.listBy(Post.class, listOptions, firstRequest)
                         .map(ListResult::getItems)

--- a/application/src/main/java/run/halo/app/theme/finders/impl/PostFinderImpl.java
+++ b/application/src/main/java/run/halo/app/theme/finders/impl/PostFinderImpl.java
@@ -311,13 +311,29 @@ class PostFinderImpl implements PostFinder {
             .flatMap(listOptions -> client.countBy(Post.class, listOptions)
                 .filter(total -> total > 0)
                 .flatMap(total -> {
-                    // calculate random page number
-                    var totalPages = (int) Math.ceil((double) total / maxSize);
+                    var totalInt = total.intValue();
+                    var effectiveSize = Math.min(maxSize, totalInt);
+                    var totalPages = (int) Math.ceil((double) totalInt / effectiveSize);
                     var page = RandomUtils.insecure().randomInt(1, totalPages + 1);
-                    var pageRequest = PageRequestImpl.of(page, maxSize, defaultSort());
-                    return client.listBy(Post.class, listOptions, pageRequest)
+                    var sort = defaultSort();
+                    var firstRequest = PageRequestImpl.of(page, effectiveSize, sort);
+                    return client.listBy(Post.class, listOptions, firstRequest)
                         .map(ListResult::getItems)
-                        .flatMap(postPublicQueryService::convertToListedVos);
+                        .flatMap(items -> {
+                            if (items.size() >= effectiveSize) {
+                                return postPublicQueryService.convertToListedVos(items);
+                            }
+                            // wrap around to the beginning to fill up to effectiveSize
+                            var remaining = effectiveSize - items.size();
+                            var wrapRequest = PageRequestImpl.of(1, remaining, sort);
+                            return client.listBy(Post.class, listOptions, wrapRequest)
+                                .map(ListResult::getItems)
+                                .flatMap(wrapItems -> {
+                                    var combined = new java.util.ArrayList<>(items);
+                                    combined.addAll(wrapItems);
+                                    return postPublicQueryService.convertToListedVos(combined);
+                                });
+                        });
                 })
                 .switchIfEmpty(Mono.fromSupplier(List::of))
             );

--- a/application/src/test/java/run/halo/app/theme/finders/impl/PostFinderImplTest.java
+++ b/application/src/test/java/run/halo/app/theme/finders/impl/PostFinderImplTest.java
@@ -128,18 +128,18 @@ class PostFinderImplTest {
         var listOptions = mock(ListOptions.class);
         when(postPredicateResolver.getListOptions()).thenReturn(Mono.just(listOptions));
         when(client.countBy(Post.class, listOptions)).thenReturn(Mono.just(100L));
-        var post1 = post(1);
-        var post2 = post(2);
+        var posts = java.util.stream.IntStream.rangeClosed(1, 10)
+            .mapToObj(this::post)
+            .toList();
         when(client.listBy(same(Post.class), same(listOptions), isA(PageRequest.class)))
-            .thenReturn(Mono.just(new ListResult<>(0, 10, 100, List.of(post1, post2))));
-        var postVo1 = ListedPostVo.from(post1);
-        var postVo2 = ListedPostVo.from(post2);
-        when(publicQueryService.convertToListedVos(eq(List.of(post1, post2))))
-            .thenReturn(Mono.just(List.of(postVo1, postVo2)));
+            .thenReturn(Mono.just(new ListResult<>(0, 10, 100, posts)));
+        var postVos = posts.stream().map(ListedPostVo::from).toList();
+        when(publicQueryService.convertToListedVos(eq(posts)))
+            .thenReturn(Mono.just(postVos));
 
         postFinder.random(10)
             .as(StepVerifier::create)
-            .expectNext(List.of(postVo1, postVo2))
+            .expectNext(postVos)
             .verifyComplete();
     }
 

--- a/application/src/test/java/run/halo/app/theme/finders/impl/PostFinderImplTest.java
+++ b/application/src/test/java/run/halo/app/theme/finders/impl/PostFinderImplTest.java
@@ -1,11 +1,14 @@
 package run.halo.app.theme.finders.impl;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.assertArg;
 import static org.mockito.ArgumentMatchers.isA;
 import static org.mockito.ArgumentMatchers.same;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.time.Instant;
@@ -134,13 +137,17 @@ class PostFinderImplTest {
         when(client.listBy(same(Post.class), same(listOptions), isA(PageRequest.class)))
             .thenReturn(Mono.just(new ListResult<>(0, 10, 100, posts)));
         var postVos = posts.stream().map(ListedPostVo::from).toList();
-        when(publicQueryService.convertToListedVos(eq(posts)))
+        when(publicQueryService.convertToListedVos(anyList()))
             .thenReturn(Mono.just(postVos));
 
         postFinder.random(10)
             .as(StepVerifier::create)
             .expectNext(postVos)
             .verifyComplete();
+
+        verify(publicQueryService).convertToListedVos(assertArg(items -> {
+            assertTrue(items.containsAll(posts));
+        }));
     }
 
     List<Post> postsForArchives() {


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

The `random` method in `PostFinderImpl` could return fewer posts than requested when the randomly selected page was the last page. For example, with 15 posts and `maxSize=10`, there was a 50% chance of getting only 5 posts.

This fix changes the approach to:
1. Calculate `effectiveSize = min(maxSize, total)` to handle cases where total posts < maxSize
2. Use `effectiveSize` as the page size so each page has exactly that many items
3. When the randomly selected page returns fewer items (last page), wrap around to page 1 to fetch the remaining items

This ensures we always return exactly `effectiveSize` items.

#### Which issue(s) this PR fixes:

Fixes #9929

#### Special notes for your reviewer:

This PR uses LLM generated code. I have reviewed and tested the changes.

#### Does this PR introduce a user-facing change?

```release-note
修复通过 PostFinder#random 随机获取文章时可能返回少于请求的文章的问题
```