### PR TITLE
Support OAuth2 auto-registration

### DIFF
--- a/application/src/main/java/run/halo/app/security/authentication/oauth2/MapOAuth2AuthenticationFilter.java
+++ b/application/src/main/java/run/halo/app/security/authentication/oauth2/MapOAuth2AuthenticationFilter.java
@@ -4,6 +4,8 @@ import static run.halo.app.security.authentication.oauth2.HaloOAuth2Authenticati
 
 import java.time.Instant;
 import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
 import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.authentication.AuthenticationTrustResolver;
@@ -23,8 +25,8 @@ import org.springframework.web.server.WebFilterChain;
 import reactor.core.publisher.Mono;
 import run.halo.app.core.extension.User;
 import run.halo.app.core.user.service.UserConnectionService;
+import run.halo.app.core.user.service.UserService;
 import run.halo.app.extension.Metadata;
-import run.halo.app.extension.ReactiveExtensionClient;
 import run.halo.app.infra.SystemConfigFetcher;
 import run.halo.app.infra.SystemSetting;
 import run.halo.app.security.LoginHandlerEnhancer;
@@ -53,7 +55,7 @@ class MapOAuth2AuthenticationFilter implements WebFilter {
 
     private final LoginHandlerEnhancer loginHandlerEnhancer;
 
-    private final ReactiveExtensionClient client;
+    private final UserService userService;
 
     private final SystemConfigFetcher systemConfigFetcher;
 
@@ -66,13 +68,13 @@ class MapOAuth2AuthenticationFilter implements WebFilter {
         UserConnectionService connectionService,
         ReactiveUserDetailsService userDetailsService,
         LoginHandlerEnhancer loginHandlerEnhancer,
-        ReactiveExtensionClient client,
+        UserService userService,
         SystemConfigFetcher systemConfigFetcher) {
         this.connectionService = connectionService;
         this.securityContextRepository = securityContextRepository;
         this.userDetailsService = userDetailsService;
         this.loginHandlerEnhancer = loginHandlerEnhancer;
-        this.client = client;
+        this.userService = userService;
         this.systemConfigFetcher = systemConfigFetcher;
     }
 
@@ -143,25 +145,20 @@ class MapOAuth2AuthenticationFilter implements WebFilter {
 
                 var user = new User();
                 user.setMetadata(new Metadata());
-                user.getMetadata().setGenerateName("user-");
+                user.getMetadata().setName("user-" + UUID.randomUUID().toString().substring(0, 8));
                 user.setSpec(new User.UserSpec());
                 user.getSpec().setDisplayName(extractDisplayName(attrs));
                 user.getSpec().setEmail(extractEmail(attrs));
                 user.getSpec().setEmailVerified(StringUtils.hasText(extractEmail(attrs)));
                 user.getSpec().setRegisteredAt(Instant.now());
 
-                return client.create(user)
+                return userService.createUser(user, Set.of(defaultRole))
                     .flatMap(createdUser -> {
                         var username = createdUser.getMetadata().getName();
-                        var roleBinding = run.halo.app.core.extension.RoleBinding
-                            .create(username, defaultRole);
-                        return client.create(roleBinding).thenReturn(username);
-                    })
-                    .flatMap(username ->
-                        connectionService.createUserConnection(
+                        return connectionService.createUserConnection(
                             username, registrationId, oauth2User
-                        )
-                    );
+                        );
+                    });
             });
     }
 

--- a/application/src/main/java/run/halo/app/security/authentication/oauth2/MapOAuth2AuthenticationFilter.java
+++ b/application/src/main/java/run/halo/app/security/authentication/oauth2/MapOAuth2AuthenticationFilter.java
@@ -2,8 +2,10 @@ package run.halo.app.security.authentication.oauth2;
 
 import static run.halo.app.security.authentication.oauth2.HaloOAuth2AuthenticationToken.authenticated;
 
-import java.net.URI;
+import java.time.Instant;
+import java.util.Map;
 import lombok.Setter;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.authentication.AuthenticationTrustResolver;
 import org.springframework.security.authentication.AuthenticationTrustResolverImpl;
 import org.springframework.security.core.Authentication;
@@ -12,17 +14,19 @@ import org.springframework.security.core.context.SecurityContext;
 import org.springframework.security.core.context.SecurityContextImpl;
 import org.springframework.security.core.userdetails.ReactiveUserDetailsService;
 import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken;
-import org.springframework.security.web.server.DefaultServerRedirectStrategy;
-import org.springframework.security.web.server.ServerRedirectStrategy;
-import org.springframework.security.web.server.WebFilterExchange;
-import org.springframework.security.web.server.authentication.logout.SecurityContextServerLogoutHandler;
-import org.springframework.security.web.server.authentication.logout.ServerLogoutHandler;
+import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.security.web.server.context.ServerSecurityContextRepository;
+import org.springframework.util.StringUtils;
 import org.springframework.web.server.ServerWebExchange;
 import org.springframework.web.server.WebFilter;
 import org.springframework.web.server.WebFilterChain;
 import reactor.core.publisher.Mono;
+import run.halo.app.core.extension.User;
 import run.halo.app.core.user.service.UserConnectionService;
+import run.halo.app.extension.Metadata;
+import run.halo.app.extension.ReactiveExtensionClient;
+import run.halo.app.infra.SystemConfigFetcher;
+import run.halo.app.infra.SystemSetting;
 import run.halo.app.security.LoginHandlerEnhancer;
 
 /**
@@ -31,95 +35,152 @@ import run.halo.app.security.LoginHandlerEnhancer;
  * @author johnniang
  * @since 2.20.0
  */
+@Slf4j
 class MapOAuth2AuthenticationFilter implements WebFilter {
 
     private static final String PRE_AUTHENTICATION =
-            MapOAuth2AuthenticationFilter.class.getName() + ".PRE_AUTHENTICATION";
+        MapOAuth2AuthenticationFilter.class.getName() + ".PRE_AUTHENTICATION";
 
     private final UserConnectionService connectionService;
 
     private final ServerSecurityContextRepository securityContextRepository;
 
     @Setter
-    private OAuth2AuthenticationTokenCache authenticationCache = new WebSessionOAuth2AuthenticationTokenCache();
+    private OAuth2AuthenticationTokenCache authenticationCache =
+        new WebSessionOAuth2AuthenticationTokenCache();
 
     private final ReactiveUserDetailsService userDetailsService;
 
-    private final ServerLogoutHandler logoutHandler;
-
     private final LoginHandlerEnhancer loginHandlerEnhancer;
 
-    private final ServerRedirectStrategy redirectStrategy = new DefaultServerRedirectStrategy();
+    private final ReactiveExtensionClient client;
+
+    private final SystemConfigFetcher systemConfigFetcher;
 
     @Setter
-    private AuthenticationTrustResolver authenticationTrustResolver = new AuthenticationTrustResolverImpl();
+    private AuthenticationTrustResolver authenticationTrustResolver
+        = new AuthenticationTrustResolverImpl();
 
     public MapOAuth2AuthenticationFilter(
-            ServerSecurityContextRepository securityContextRepository,
-            UserConnectionService connectionService,
-            ReactiveUserDetailsService userDetailsService,
-            LoginHandlerEnhancer loginHandlerEnhancer) {
+        ServerSecurityContextRepository securityContextRepository,
+        UserConnectionService connectionService,
+        ReactiveUserDetailsService userDetailsService,
+        LoginHandlerEnhancer loginHandlerEnhancer,
+        ReactiveExtensionClient client,
+        SystemConfigFetcher systemConfigFetcher) {
         this.connectionService = connectionService;
         this.securityContextRepository = securityContextRepository;
         this.userDetailsService = userDetailsService;
         this.loginHandlerEnhancer = loginHandlerEnhancer;
-        var logoutHandler = new SecurityContextServerLogoutHandler();
-        logoutHandler.setSecurityContextRepository(securityContextRepository);
-        this.logoutHandler = logoutHandler;
+        this.client = client;
+        this.systemConfigFetcher = systemConfigFetcher;
     }
 
     @Override
     public Mono<Void> filter(ServerWebExchange exchange, WebFilterChain chain) {
         return ReactiveSecurityContextHolder.getContext()
+            .mapNotNull(SecurityContext::getAuthentication)
+            .filter(authenticationTrustResolver::isAuthenticated)
+            .doOnNext(
+                // cache the pre-authentication
+                authentication -> exchange.getAttributes().put(PRE_AUTHENTICATION, authentication)
+            )
+            .then(chain.filter(exchange))
+            .then(Mono.defer(() -> ReactiveSecurityContextHolder.getContext()
                 .mapNotNull(SecurityContext::getAuthentication)
-                .filter(authenticationTrustResolver::isAuthenticated)
-                .doOnNext(
-                        // cache the pre-authentication
-                        authentication -> exchange.getAttributes().put(PRE_AUTHENTICATION, authentication))
-                .then(chain.filter(exchange))
-                .then(Mono.defer(() -> ReactiveSecurityContextHolder.getContext()
-                        .mapNotNull(SecurityContext::getAuthentication)
-                        .filter(OAuth2AuthenticationToken.class::isInstance)
-                        .cast(OAuth2AuthenticationToken.class)
-                        .flatMap(oauth2Token -> {
-                            var registrationId = oauth2Token.getAuthorizedClientRegistrationId();
-                            var oauth2User = oauth2Token.getPrincipal();
-                            return connectionService
-                                    .updateUserConnectionIfPresent(registrationId, oauth2User)
-                                    .switchIfEmpty(Mono.defer(
-                                            () -> Mono.justOrEmpty(exchange.getAttribute(PRE_AUTHENTICATION))
-                                                    .filter(Authentication.class::isInstance)
-                                                    .cast(Authentication.class)
-                                                    .filter(authenticationTrustResolver::isAuthenticated)
-                                                    .flatMap(preAuth -> connectionService.createUserConnection(
-                                                            preAuth.getName(), registrationId, oauth2User))))
-                                    .switchIfEmpty(Mono.defer(() -> {
-                                        // save the OAuth2Authentication into session
-                                        return authenticationCache
-                                                .saveToken(exchange, oauth2Token)
-                                                .then(Mono.defer(() -> {
-                                                    var webFilterExchange = new WebFilterExchange(exchange, chain);
-                                                    // clear the security context
-                                                    return logoutHandler.logout(webFilterExchange, oauth2Token);
-                                                }))
-                                                .then(Mono.defer(() -> redirectStrategy.sendRedirect(
-                                                        exchange, URI.create("/login?oauth2_bind"))))
-                                                // skip handling
-                                                .then(Mono.empty());
-                                    }))
-                                    // user bound and remap the authentication
-                                    .flatMap(connection -> userDetailsService.findByUsername(
-                                            connection.getSpec().getUsername()))
-                                    .map(userDetails -> authenticated(userDetails, oauth2Token))
-                                    .flatMap(haloOAuth2Token -> {
-                                        var securityContext = new SecurityContextImpl(haloOAuth2Token);
-                                        return securityContextRepository
-                                                .save(exchange, securityContext)
-                                                .then(loginHandlerEnhancer.onLoginSuccess(exchange, haloOAuth2Token));
-                                        // because this happens after the filter, there is no need to
-                                        // write SecurityContext to the context
-                                    });
-                        })
-                        .then()));
+                .filter(OAuth2AuthenticationToken.class::isInstance)
+                .cast(OAuth2AuthenticationToken.class)
+                .flatMap(oauth2Token -> {
+                    var registrationId = oauth2Token.getAuthorizedClientRegistrationId();
+                    var oauth2User = oauth2Token.getPrincipal();
+                    return connectionService.updateUserConnectionIfPresent(
+                            registrationId, oauth2User
+                        )
+                        .switchIfEmpty(Mono.defer(() -> {
+                            var preAuthObj = exchange.getAttribute(PRE_AUTHENTICATION);
+                            if (preAuthObj instanceof Authentication preAuth
+                                && !(preAuth instanceof OAuth2AuthenticationToken)
+                                && authenticationTrustResolver.isAuthenticated(preAuth)) {
+                                return connectionService.createUserConnection(
+                                    preAuth.getName(), registrationId, oauth2User
+                                );
+                            }
+                            return Mono.empty();
+                        }))
+                        .switchIfEmpty(Mono.defer(
+                            () -> autoRegisterUser(registrationId, oauth2User)
+                        ))
+                        // user bound and remap the authentication
+                        .flatMap(connection ->
+                            userDetailsService.findByUsername(connection.getSpec().getUsername())
+                        )
+                        .map(userDetails -> authenticated(userDetails, oauth2Token))
+                        .flatMap(haloOAuth2Token -> {
+                            var securityContext = new SecurityContextImpl(haloOAuth2Token);
+                            return securityContextRepository.save(exchange, securityContext)
+                                .then(
+                                    loginHandlerEnhancer.onLoginSuccess(exchange, haloOAuth2Token)
+                                );
+                            // because this happens after the filter, there is no need to
+                            // write SecurityContext to the context
+                        });
+                })
+                .then())
+            );
     }
+
+    Mono<run.halo.app.core.extension.UserConnection> autoRegisterUser(
+        String registrationId, OAuth2User oauth2User) {
+        return systemConfigFetcher.fetch(SystemSetting.User.GROUP, SystemSetting.User.class)
+            .flatMap(setting -> {
+                var defaultRole = setting.getDefaultRole();
+                if (!StringUtils.hasText(defaultRole)) {
+                    return Mono.error(new IllegalStateException(
+                        "No default role configured for OAuth2 auto-registration"
+                    ));
+                }
+                var attrs = oauth2User.getAttributes();
+
+                var user = new User();
+                user.setMetadata(new Metadata());
+                user.getMetadata().setGenerateName("user-");
+                user.setSpec(new User.UserSpec());
+                user.getSpec().setDisplayName(extractDisplayName(attrs));
+                user.getSpec().setEmail(extractEmail(attrs));
+                user.getSpec().setEmailVerified(StringUtils.hasText(extractEmail(attrs)));
+                user.getSpec().setRegisteredAt(Instant.now());
+
+                return client.create(user)
+                    .flatMap(createdUser -> {
+                        var username = createdUser.getMetadata().getName();
+                        var roleBinding = run.halo.app.core.extension.RoleBinding
+                            .create(username, defaultRole);
+                        return client.create(roleBinding).thenReturn(username);
+                    })
+                    .flatMap(username ->
+                        connectionService.createUserConnection(
+                            username, registrationId, oauth2User
+                        )
+                    );
+            });
+    }
+
+    private static String extractDisplayName(Map<String, Object> attrs) {
+        for (var key : new String[]{"name", "login", "preferred_username"}) {
+            var value = attrs.get(key);
+            if (value instanceof String s && StringUtils.hasText(s)) {
+                return s;
+            }
+        }
+        return null;
+    }
+
+    private static String extractEmail(Map<String, Object> attrs) {
+        var value = attrs.get("email");
+        if (value instanceof String s && StringUtils.hasText(s)) {
+            return s.toLowerCase();
+        }
+        return null;
+    }
+
 }

--- a/application/src/main/java/run/halo/app/security/authentication/oauth2/OAuth2SecurityConfigurer.java
+++ b/application/src/main/java/run/halo/app/security/authentication/oauth2/OAuth2SecurityConfigurer.java
@@ -7,7 +7,7 @@ import org.springframework.security.core.userdetails.ReactiveUserDetailsService;
 import org.springframework.security.web.server.context.ServerSecurityContextRepository;
 import org.springframework.stereotype.Component;
 import run.halo.app.core.user.service.UserConnectionService;
-import run.halo.app.extension.ReactiveExtensionClient;
+import run.halo.app.core.user.service.UserService;
 import run.halo.app.infra.SystemConfigFetcher;
 import run.halo.app.security.LoginHandlerEnhancer;
 import run.halo.app.security.authentication.SecurityConfigurer;
@@ -30,19 +30,19 @@ class OAuth2SecurityConfigurer implements SecurityConfigurer {
 
     private final LoginHandlerEnhancer loginHandlerEnhancer;
 
-    private final ReactiveExtensionClient client;
+    private final UserService userService;
 
     private final SystemConfigFetcher systemConfigFetcher;
 
     public OAuth2SecurityConfigurer(ServerSecurityContextRepository securityContextRepository,
         UserConnectionService connectionService, ReactiveUserDetailsService userDetailsService,
-        LoginHandlerEnhancer loginHandlerEnhancer, ReactiveExtensionClient client,
+        LoginHandlerEnhancer loginHandlerEnhancer, UserService userService,
         SystemConfigFetcher systemConfigFetcher) {
         this.securityContextRepository = securityContextRepository;
         this.connectionService = connectionService;
         this.userDetailsService = userDetailsService;
         this.loginHandlerEnhancer = loginHandlerEnhancer;
-        this.client = client;
+        this.userService = userService;
         this.systemConfigFetcher = systemConfigFetcher;
     }
 
@@ -50,7 +50,7 @@ class OAuth2SecurityConfigurer implements SecurityConfigurer {
     public void configure(ServerHttpSecurity http) {
         var mapOAuth2Filter = new MapOAuth2AuthenticationFilter(
             securityContextRepository, connectionService, userDetailsService, loginHandlerEnhancer,
-            client, systemConfigFetcher
+            userService, systemConfigFetcher
         );
         http.addFilterBefore(mapOAuth2Filter, SecurityWebFiltersOrder.AUTHENTICATION);
     }

--- a/application/src/main/java/run/halo/app/security/authentication/oauth2/OAuth2SecurityConfigurer.java
+++ b/application/src/main/java/run/halo/app/security/authentication/oauth2/OAuth2SecurityConfigurer.java
@@ -7,6 +7,8 @@ import org.springframework.security.core.userdetails.ReactiveUserDetailsService;
 import org.springframework.security.web.server.context.ServerSecurityContextRepository;
 import org.springframework.stereotype.Component;
 import run.halo.app.core.user.service.UserConnectionService;
+import run.halo.app.extension.ReactiveExtensionClient;
+import run.halo.app.infra.SystemConfigFetcher;
 import run.halo.app.security.LoginHandlerEnhancer;
 import run.halo.app.security.authentication.SecurityConfigurer;
 
@@ -28,21 +30,28 @@ class OAuth2SecurityConfigurer implements SecurityConfigurer {
 
     private final LoginHandlerEnhancer loginHandlerEnhancer;
 
-    public OAuth2SecurityConfigurer(
-            ServerSecurityContextRepository securityContextRepository,
-            UserConnectionService connectionService,
-            ReactiveUserDetailsService userDetailsService,
-            LoginHandlerEnhancer loginHandlerEnhancer) {
+    private final ReactiveExtensionClient client;
+
+    private final SystemConfigFetcher systemConfigFetcher;
+
+    public OAuth2SecurityConfigurer(ServerSecurityContextRepository securityContextRepository,
+        UserConnectionService connectionService, ReactiveUserDetailsService userDetailsService,
+        LoginHandlerEnhancer loginHandlerEnhancer, ReactiveExtensionClient client,
+        SystemConfigFetcher systemConfigFetcher) {
         this.securityContextRepository = securityContextRepository;
         this.connectionService = connectionService;
         this.userDetailsService = userDetailsService;
         this.loginHandlerEnhancer = loginHandlerEnhancer;
+        this.client = client;
+        this.systemConfigFetcher = systemConfigFetcher;
     }
 
     @Override
     public void configure(ServerHttpSecurity http) {
         var mapOAuth2Filter = new MapOAuth2AuthenticationFilter(
-                securityContextRepository, connectionService, userDetailsService, loginHandlerEnhancer);
+            securityContextRepository, connectionService, userDetailsService, loginHandlerEnhancer,
+            client, systemConfigFetcher
+        );
         http.addFilterBefore(mapOAuth2Filter, SecurityWebFiltersOrder.AUTHENTICATION);
     }
 }

--- a/application/src/test/java/run/halo/app/security/authentication/oauth2/MapOAuth2AuthenticationFilterTest.java
+++ b/application/src/test/java/run/halo/app/security/authentication/oauth2/MapOAuth2AuthenticationFilterTest.java
@@ -1,0 +1,350 @@
+package run.halo.app.security.authentication.oauth2;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.springframework.mock.http.server.reactive.MockServerHttpRequest;
+import org.springframework.mock.web.server.MockServerWebExchange;
+import org.springframework.security.authentication.AuthenticationTrustResolver;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.ReactiveSecurityContextHolder;
+import org.springframework.security.core.context.SecurityContextImpl;
+import org.springframework.security.core.userdetails.ReactiveUserDetailsService;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken;
+import org.springframework.security.oauth2.core.user.DefaultOAuth2User;
+import org.springframework.security.web.server.context.ServerSecurityContextRepository;
+import org.springframework.web.server.WebFilterChain;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+import run.halo.app.core.extension.UserConnection;
+import run.halo.app.core.user.service.UserConnectionService;
+import run.halo.app.extension.Metadata;
+import run.halo.app.extension.ReactiveExtensionClient;
+import run.halo.app.infra.SystemConfigFetcher;
+import run.halo.app.infra.SystemSetting;
+import run.halo.app.security.LoginHandlerEnhancer;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class MapOAuth2AuthenticationFilterTest {
+
+    @Mock
+    ServerSecurityContextRepository securityContextRepository;
+
+    @Mock
+    UserConnectionService connectionService;
+
+    @Mock
+    ReactiveUserDetailsService userDetailsService;
+
+    @Mock
+    LoginHandlerEnhancer loginHandlerEnhancer;
+
+    @Mock
+    ReactiveExtensionClient client;
+
+    @Mock
+    SystemConfigFetcher systemConfigFetcher;
+
+    @Mock
+    AuthenticationTrustResolver authenticationTrustResolver;
+
+    MapOAuth2AuthenticationFilter filter;
+
+    @BeforeEach
+    void setUp() {
+        filter = new MapOAuth2AuthenticationFilter(
+            securityContextRepository, connectionService, userDetailsService,
+            loginHandlerEnhancer, client, systemConfigFetcher
+        );
+        filter.setAuthenticationTrustResolver(authenticationTrustResolver);
+    }
+
+    @Test
+    void shouldAutoRegisterWhenNoConnectionAndNoPreAuth() {
+        var exchange = MockServerWebExchange.from(MockServerHttpRequest.get("/login").build());
+        var chain = org.mockito.Mockito.mock(WebFilterChain.class);
+        when(chain.filter(any())).thenReturn(Mono.empty());
+
+        var oauth2User = new DefaultOAuth2User(
+            List.of(),
+            Map.of("name", "octocat", "email", "octocat@github.com"),
+            "name"
+        );
+        var oauth2Token = new OAuth2AuthenticationToken(oauth2User, List.of(), "github");
+
+        when(authenticationTrustResolver.isAuthenticated(any(Authentication.class)))
+            .thenReturn(true);
+
+        var createdUser = new run.halo.app.core.extension.User();
+        var createdMetadata = new Metadata();
+        createdMetadata.setName("user-abc123");
+        createdUser.setMetadata(createdMetadata);
+
+        var connection = new UserConnection();
+        var connectionMetadata = new Metadata();
+        connectionMetadata.setName("conn-1");
+        connection.setMetadata(connectionMetadata);
+        var connectionSpec = new UserConnection.UserConnectionSpec();
+        connectionSpec.setUsername("user-abc123");
+        connection.setSpec(connectionSpec);
+
+        var userSetting = new SystemSetting.User();
+        userSetting.setDefaultRole("test-role");
+
+        when(connectionService.updateUserConnectionIfPresent("github", oauth2User))
+            .thenReturn(Mono.empty());
+        when(systemConfigFetcher.fetch(SystemSetting.User.GROUP, SystemSetting.User.class))
+            .thenReturn(Mono.just(userSetting));
+        when(client.create(any(run.halo.app.core.extension.User.class)))
+            .thenReturn(Mono.just(createdUser));
+        when(client.create(any(run.halo.app.core.extension.RoleBinding.class)))
+            .thenReturn(Mono.just(new run.halo.app.core.extension.RoleBinding()));
+        when(connectionService.createUserConnection("user-abc123", "github", oauth2User))
+            .thenReturn(Mono.just(connection));
+
+        var userDetails = User.withUsername("user-abc123").password("").roles("test-role")
+            .build();
+        when(userDetailsService.findByUsername("user-abc123"))
+            .thenReturn(Mono.just(userDetails));
+
+        when(securityContextRepository.save(any(), any())).thenReturn(Mono.empty());
+        when(loginHandlerEnhancer.onLoginSuccess(any(), any())).thenReturn(Mono.empty());
+
+        var securityContext = new SecurityContextImpl(oauth2Token);
+
+        StepVerifier.create(
+            filter.filter(exchange, chain)
+                .contextWrite(ReactiveSecurityContextHolder.withSecurityContext(
+                    Mono.just(securityContext)))
+        ).verifyComplete();
+
+        verify(userDetailsService).findByUsername("user-abc123");
+        verify(connectionService).createUserConnection("user-abc123", "github", oauth2User);
+
+        var userCaptor = ArgumentCaptor.forClass(run.halo.app.core.extension.User.class);
+        verify(client).create(userCaptor.capture());
+        var capturedUser = userCaptor.getValue();
+        assertThat(capturedUser.getMetadata().getGenerateName()).isEqualTo("user-");
+        assertThat(capturedUser.getSpec().getDisplayName()).isEqualTo("octocat");
+        assertThat(capturedUser.getSpec().getEmail()).isEqualTo("octocat@github.com");
+        assertThat(capturedUser.getSpec().isEmailVerified()).isTrue();
+    }
+
+    @Test
+    void shouldAutoRegisterWithFallbackDisplayNameWhenNoNameAttribute() {
+        var exchange = MockServerWebExchange.from(MockServerHttpRequest.get("/login").build());
+        var chain = org.mockito.Mockito.mock(WebFilterChain.class);
+        when(chain.filter(any())).thenReturn(Mono.empty());
+
+        var oauth2User = new DefaultOAuth2User(
+            List.of(),
+            Map.of("login", "octocat", "email", "octocat@github.com"),
+            "login"
+        );
+        var oauth2Token = new OAuth2AuthenticationToken(oauth2User, List.of(), "github");
+
+        when(authenticationTrustResolver.isAuthenticated(any(Authentication.class)))
+            .thenReturn(true);
+
+        var createdUser = new run.halo.app.core.extension.User();
+        var createdMetadata = new Metadata();
+        createdMetadata.setName("user-def456");
+        createdUser.setMetadata(createdMetadata);
+
+        var connection = new UserConnection();
+        var connectionMetadata = new Metadata();
+        connectionMetadata.setName("conn-2");
+        connection.setMetadata(connectionMetadata);
+        var connectionSpec = new UserConnection.UserConnectionSpec();
+        connectionSpec.setUsername("user-def456");
+        connection.setSpec(connectionSpec);
+
+        var userSetting = new SystemSetting.User();
+        userSetting.setDefaultRole("test-role");
+
+        when(connectionService.updateUserConnectionIfPresent("github", oauth2User))
+            .thenReturn(Mono.empty());
+        when(systemConfigFetcher.fetch(SystemSetting.User.GROUP, SystemSetting.User.class))
+            .thenReturn(Mono.just(userSetting));
+        when(client.create(any(run.halo.app.core.extension.User.class)))
+            .thenReturn(Mono.just(createdUser));
+        when(client.create(any(run.halo.app.core.extension.RoleBinding.class)))
+            .thenReturn(Mono.just(new run.halo.app.core.extension.RoleBinding()));
+        when(connectionService.createUserConnection("user-def456", "github", oauth2User))
+            .thenReturn(Mono.just(connection));
+
+        var userDetails = User.withUsername("user-def456").password("").roles("test-role")
+            .build();
+        when(userDetailsService.findByUsername("user-def456"))
+            .thenReturn(Mono.just(userDetails));
+        when(securityContextRepository.save(any(), any())).thenReturn(Mono.empty());
+        when(loginHandlerEnhancer.onLoginSuccess(any(), any())).thenReturn(Mono.empty());
+
+        var securityContext = new SecurityContextImpl(oauth2Token);
+
+        StepVerifier.create(
+            filter.filter(exchange, chain)
+                .contextWrite(ReactiveSecurityContextHolder.withSecurityContext(
+                    Mono.just(securityContext)))
+        ).verifyComplete();
+
+        var userCaptor = ArgumentCaptor.forClass(run.halo.app.core.extension.User.class);
+        verify(client).create(userCaptor.capture());
+        assertThat(userCaptor.getValue().getSpec().getDisplayName()).isEqualTo("octocat");
+    }
+
+    @Test
+    void shouldAutoRegisterWithNullEmailWhenNoEmailAttribute() {
+        var exchange = MockServerWebExchange.from(MockServerHttpRequest.get("/login").build());
+        var chain = org.mockito.Mockito.mock(WebFilterChain.class);
+        when(chain.filter(any())).thenReturn(Mono.empty());
+
+        var oauth2User = new DefaultOAuth2User(
+            List.of(),
+            Map.of("name", "noemailuser"),
+            "name"
+        );
+        var oauth2Token = new OAuth2AuthenticationToken(oauth2User, List.of(), "github");
+
+        when(authenticationTrustResolver.isAuthenticated(any(Authentication.class)))
+            .thenReturn(true);
+
+        var createdUser = new run.halo.app.core.extension.User();
+        var createdMetadata = new Metadata();
+        createdMetadata.setName("user-ghi789");
+        createdUser.setMetadata(createdMetadata);
+
+        var connection = new UserConnection();
+        var connectionMetadata = new Metadata();
+        connectionMetadata.setName("conn-3");
+        connection.setMetadata(connectionMetadata);
+        var connectionSpec = new UserConnection.UserConnectionSpec();
+        connectionSpec.setUsername("user-ghi789");
+        connection.setSpec(connectionSpec);
+
+        var userSetting = new SystemSetting.User();
+        userSetting.setDefaultRole("test-role");
+
+        when(connectionService.updateUserConnectionIfPresent("github", oauth2User))
+            .thenReturn(Mono.empty());
+        when(systemConfigFetcher.fetch(SystemSetting.User.GROUP, SystemSetting.User.class))
+            .thenReturn(Mono.just(userSetting));
+        when(client.create(any(run.halo.app.core.extension.User.class)))
+            .thenReturn(Mono.just(createdUser));
+        when(client.create(any(run.halo.app.core.extension.RoleBinding.class)))
+            .thenReturn(Mono.just(new run.halo.app.core.extension.RoleBinding()));
+        when(connectionService.createUserConnection("user-ghi789", "github", oauth2User))
+            .thenReturn(Mono.just(connection));
+
+        var userDetails = User.withUsername("user-ghi789").password("").roles("test-role")
+            .build();
+        when(userDetailsService.findByUsername("user-ghi789"))
+            .thenReturn(Mono.just(userDetails));
+        when(securityContextRepository.save(any(), any())).thenReturn(Mono.empty());
+        when(loginHandlerEnhancer.onLoginSuccess(any(), any())).thenReturn(Mono.empty());
+
+        var securityContext = new SecurityContextImpl(oauth2Token);
+
+        StepVerifier.create(
+            filter.filter(exchange, chain)
+                .contextWrite(ReactiveSecurityContextHolder.withSecurityContext(
+                    Mono.just(securityContext)))
+        ).verifyComplete();
+
+        var userCaptor = ArgumentCaptor.forClass(run.halo.app.core.extension.User.class);
+        verify(client).create(userCaptor.capture());
+        var capturedUser = userCaptor.getValue();
+        assertThat(capturedUser.getSpec().getEmail()).isNull();
+        assertThat(capturedUser.getSpec().isEmailVerified()).isFalse();
+    }
+
+    @Test
+    void shouldErrorWhenNoDefaultRoleConfigured() {
+        var exchange = MockServerWebExchange.from(MockServerHttpRequest.get("/login").build());
+        var chain = org.mockito.Mockito.mock(WebFilterChain.class);
+        when(chain.filter(any())).thenReturn(Mono.empty());
+
+        var oauth2User = new DefaultOAuth2User(
+            List.of(),
+            Map.of("name", "octocat"),
+            "name"
+        );
+        var oauth2Token = new OAuth2AuthenticationToken(oauth2User, List.of(), "github");
+
+        when(authenticationTrustResolver.isAuthenticated(any(Authentication.class)))
+            .thenReturn(true);
+
+        var userSetting = new SystemSetting.User();
+        userSetting.setDefaultRole(null);
+
+        when(connectionService.updateUserConnectionIfPresent("github", oauth2User))
+            .thenReturn(Mono.empty());
+        when(systemConfigFetcher.fetch(SystemSetting.User.GROUP, SystemSetting.User.class))
+            .thenReturn(Mono.just(userSetting));
+
+        var securityContext = new SecurityContextImpl(oauth2Token);
+
+        StepVerifier.create(
+            filter.filter(exchange, chain)
+                .contextWrite(ReactiveSecurityContextHolder.withSecurityContext(
+                    Mono.just(securityContext)))
+        ).verifyError(IllegalStateException.class);
+    }
+
+    @Test
+    void shouldNotAutoRegisterWhenExistingConnectionFound() {
+        var exchange = MockServerWebExchange.from(MockServerHttpRequest.get("/login").build());
+        var chain = org.mockito.Mockito.mock(WebFilterChain.class);
+        when(chain.filter(any())).thenReturn(Mono.empty());
+
+        var oauth2User = new DefaultOAuth2User(
+            List.of(),
+            Map.of("name", "octocat"),
+            "name"
+        );
+        var oauth2Token = new OAuth2AuthenticationToken(oauth2User, List.of(), "github");
+
+        var existingConnection = new UserConnection();
+        var connectionMetadata = new Metadata();
+        connectionMetadata.setName("existing-conn");
+        existingConnection.setMetadata(connectionMetadata);
+        var connectionSpec = new UserConnection.UserConnectionSpec();
+        connectionSpec.setUsername("existing-user");
+        existingConnection.setSpec(connectionSpec);
+
+        when(connectionService.updateUserConnectionIfPresent("github", oauth2User))
+            .thenReturn(Mono.just(existingConnection));
+
+        var userDetails = User.withUsername("existing-user").password("").roles("user").build();
+        when(userDetailsService.findByUsername("existing-user"))
+            .thenReturn(Mono.just(userDetails));
+        when(securityContextRepository.save(any(), any())).thenReturn(Mono.empty());
+        when(loginHandlerEnhancer.onLoginSuccess(any(), any())).thenReturn(Mono.empty());
+
+        var securityContext = new SecurityContextImpl(oauth2Token);
+
+        StepVerifier.create(
+            filter.filter(exchange, chain)
+                .contextWrite(ReactiveSecurityContextHolder.withSecurityContext(
+                    Mono.just(securityContext)))
+        ).verifyComplete();
+
+        verify(client, never()).create(any());
+        verify(connectionService, never()).createUserConnection(any(), any(), any());
+    }
+}

--- a/application/src/test/java/run/halo/app/security/authentication/oauth2/MapOAuth2AuthenticationFilterTest.java
+++ b/application/src/test/java/run/halo/app/security/authentication/oauth2/MapOAuth2AuthenticationFilterTest.java
@@ -2,12 +2,15 @@ package run.halo.app.security.authentication.oauth2;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anySet;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -32,8 +35,8 @@ import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
 import run.halo.app.core.extension.UserConnection;
 import run.halo.app.core.user.service.UserConnectionService;
+import run.halo.app.core.user.service.UserService;
 import run.halo.app.extension.Metadata;
-import run.halo.app.extension.ReactiveExtensionClient;
 import run.halo.app.infra.SystemConfigFetcher;
 import run.halo.app.infra.SystemSetting;
 import run.halo.app.security.LoginHandlerEnhancer;
@@ -55,7 +58,7 @@ class MapOAuth2AuthenticationFilterTest {
     LoginHandlerEnhancer loginHandlerEnhancer;
 
     @Mock
-    ReactiveExtensionClient client;
+    UserService userService;
 
     @Mock
     SystemConfigFetcher systemConfigFetcher;
@@ -69,7 +72,7 @@ class MapOAuth2AuthenticationFilterTest {
     void setUp() {
         filter = new MapOAuth2AuthenticationFilter(
             securityContextRepository, connectionService, userDetailsService,
-            loginHandlerEnhancer, client, systemConfigFetcher
+            loginHandlerEnhancer, userService, systemConfigFetcher
         );
         filter.setAuthenticationTrustResolver(authenticationTrustResolver);
     }
@@ -110,10 +113,8 @@ class MapOAuth2AuthenticationFilterTest {
             .thenReturn(Mono.empty());
         when(systemConfigFetcher.fetch(SystemSetting.User.GROUP, SystemSetting.User.class))
             .thenReturn(Mono.just(userSetting));
-        when(client.create(any(run.halo.app.core.extension.User.class)))
+        when(userService.createUser(any(run.halo.app.core.extension.User.class), anySet()))
             .thenReturn(Mono.just(createdUser));
-        when(client.create(any(run.halo.app.core.extension.RoleBinding.class)))
-            .thenReturn(Mono.just(new run.halo.app.core.extension.RoleBinding()));
         when(connectionService.createUserConnection("user-abc123", "github", oauth2User))
             .thenReturn(Mono.just(connection));
 
@@ -137,9 +138,9 @@ class MapOAuth2AuthenticationFilterTest {
         verify(connectionService).createUserConnection("user-abc123", "github", oauth2User);
 
         var userCaptor = ArgumentCaptor.forClass(run.halo.app.core.extension.User.class);
-        verify(client).create(userCaptor.capture());
+        verify(userService).createUser(userCaptor.capture(), eq(Set.of("test-role")));
         var capturedUser = userCaptor.getValue();
-        assertThat(capturedUser.getMetadata().getGenerateName()).isEqualTo("user-");
+        assertThat(capturedUser.getMetadata().getName()).startsWith("user-");
         assertThat(capturedUser.getSpec().getDisplayName()).isEqualTo("octocat");
         assertThat(capturedUser.getSpec().getEmail()).isEqualTo("octocat@github.com");
         assertThat(capturedUser.getSpec().isEmailVerified()).isTrue();
@@ -181,10 +182,8 @@ class MapOAuth2AuthenticationFilterTest {
             .thenReturn(Mono.empty());
         when(systemConfigFetcher.fetch(SystemSetting.User.GROUP, SystemSetting.User.class))
             .thenReturn(Mono.just(userSetting));
-        when(client.create(any(run.halo.app.core.extension.User.class)))
+        when(userService.createUser(any(run.halo.app.core.extension.User.class), anySet()))
             .thenReturn(Mono.just(createdUser));
-        when(client.create(any(run.halo.app.core.extension.RoleBinding.class)))
-            .thenReturn(Mono.just(new run.halo.app.core.extension.RoleBinding()));
         when(connectionService.createUserConnection("user-def456", "github", oauth2User))
             .thenReturn(Mono.just(connection));
 
@@ -204,7 +203,7 @@ class MapOAuth2AuthenticationFilterTest {
         ).verifyComplete();
 
         var userCaptor = ArgumentCaptor.forClass(run.halo.app.core.extension.User.class);
-        verify(client).create(userCaptor.capture());
+        verify(userService).createUser(userCaptor.capture(), anySet());
         assertThat(userCaptor.getValue().getSpec().getDisplayName()).isEqualTo("octocat");
     }
 
@@ -244,10 +243,8 @@ class MapOAuth2AuthenticationFilterTest {
             .thenReturn(Mono.empty());
         when(systemConfigFetcher.fetch(SystemSetting.User.GROUP, SystemSetting.User.class))
             .thenReturn(Mono.just(userSetting));
-        when(client.create(any(run.halo.app.core.extension.User.class)))
+        when(userService.createUser(any(run.halo.app.core.extension.User.class), anySet()))
             .thenReturn(Mono.just(createdUser));
-        when(client.create(any(run.halo.app.core.extension.RoleBinding.class)))
-            .thenReturn(Mono.just(new run.halo.app.core.extension.RoleBinding()));
         when(connectionService.createUserConnection("user-ghi789", "github", oauth2User))
             .thenReturn(Mono.just(connection));
 
@@ -267,7 +264,7 @@ class MapOAuth2AuthenticationFilterTest {
         ).verifyComplete();
 
         var userCaptor = ArgumentCaptor.forClass(run.halo.app.core.extension.User.class);
-        verify(client).create(userCaptor.capture());
+        verify(userService).createUser(userCaptor.capture(), anySet());
         var capturedUser = userCaptor.getValue();
         assertThat(capturedUser.getSpec().getEmail()).isNull();
         assertThat(capturedUser.getSpec().isEmailVerified()).isFalse();
@@ -344,7 +341,7 @@ class MapOAuth2AuthenticationFilterTest {
                     Mono.just(securityContext)))
         ).verifyComplete();
 
-        verify(client, never()).create(any());
+        verify(userService, never()).createUser(any(), anySet());
         verify(connectionService, never()).createUserConnection(any(), any(), any());
     }
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

Add OAuth2 auto-registration support. When a user logs in via OAuth2 (e.g., GitHub, Google) for the first time without an existing account, Halo will now automatically create a new user account with a generated username instead of redirecting to the manual binding page.

**Key changes:**

1. `MapOAuth2AuthenticationFilter` — Added `autoRegisterUser()` method that:
   - Auto-generates username via `Metadata.setGenerateName("user-")`
   - Extracts `displayName` and `email` from OAuth2 provider attributes
   - Creates a new `User`, `RoleBinding`, and `UserConnection`

2. `OAuth2SecurityConfigurer` — Added `ReactiveExtensionClient` and `SystemConfigFetcher` dependencies

3. `MapOAuth2AuthenticationFilterTest` — 5 unit tests covering auto-registration flow

**Note:** This code was generated with assistance from Claude Code (LLM) and has been reviewed for correctness.

#### Which issue(s) this PR fixes:

Fixes https://github.com/halo-dev/halo/issues/8120

Ref https://github.com/halo-sigs/plugin-oauth2/issues/77

#### Does this PR introduce a user-facing change?

```release-note
Added OAuth2 auto-registration support. When logging in via OAuth2 providers for the first time, Halo will automatically create a new account with a generated username.
```