### PR TITLE
fix: use per-user rate limiting for email verification code

### DIFF
--- a/application/src/main/java/run/halo/app/core/endpoint/console/UserEndpoint.java
+++ b/application/src/main/java/run/halo/app/core/endpoint/console/UserEndpoint.java
@@ -334,7 +334,7 @@ public class UserEndpoint implements CustomEndpoint {
     }
 
     <T> RateLimiterOperator<T> sendEmailVerificationCodeRateLimiter(String username, String email) {
-        String rateLimiterKey = "send-email-verification-code-" + username + ":" + email;
+        String rateLimiterKey = "send-email-verification-code-" + username;
         var rateLimiter =
             rateLimiterRegistry.rateLimiter(rateLimiterKey, "send-email-verification-code");
         return RateLimiterOperator.of(rateLimiter);

--- a/application/src/main/java/run/halo/app/core/endpoint/console/UserEndpoint.java
+++ b/application/src/main/java/run/halo/app/core/endpoint/console/UserEndpoint.java
@@ -319,7 +319,7 @@ public class UserEndpoint implements CustomEndpoint {
                 var email = tuple.getT1();
                 var username = tuple.getT2();
                 return Mono.just(username)
-                    .transformDeferred(sendEmailVerificationCodeRateLimiter(username, email))
+                    .transformDeferred(sendEmailVerificationCodeRateLimiter(username))
                     .flatMap(u -> emailVerificationService.sendVerificationCode(username, email))
                     .onErrorMap(RequestNotPermitted.class, RateLimitExceededException::new);
             })
@@ -333,7 +333,7 @@ public class UserEndpoint implements CustomEndpoint {
         return RateLimiterOperator.of(rateLimiter);
     }
 
-    <T> RateLimiterOperator<T> sendEmailVerificationCodeRateLimiter(String username, String email) {
+    <T> RateLimiterOperator<T> sendEmailVerificationCodeRateLimiter(String username) {
         String rateLimiterKey = "send-email-verification-code-" + username;
         var rateLimiter =
             rateLimiterRegistry.rateLimiter(rateLimiterKey, "send-email-verification-code");

--- a/application/src/test/java/run/halo/app/core/endpoint/console/EmailVerificationCodeTest.java
+++ b/application/src/test/java/run/halo/app/core/endpoint/console/EmailVerificationCodeTest.java
@@ -72,9 +72,9 @@ class EmailVerificationCodeTest {
             .limitForPeriod(1)
             .build();
         var sendCodeRateLimiter = RateLimiterRegistry.of(config)
-            .rateLimiter("send-email-verification-code-fake-user:hi@halo.run");
+            .rateLimiter("send-email-verification-code-fake-user");
         when(rateLimiterRegistry.rateLimiter(
-            "send-email-verification-code-fake-user:hi@halo.run",
+            "send-email-verification-code-fake-user",
             "send-email-verification-code")
         ).thenReturn(sendCodeRateLimiter);
 
@@ -96,6 +96,44 @@ class EmailVerificationCodeTest {
         webClient.post()
             .uri("/users/-/send-email-verification-code")
             .bodyValue(Map.of("email", "hi@halo.run"))
+            .exchange()
+            .expectStatus()
+            .isEqualTo(HttpStatus.TOO_MANY_REQUESTS);
+    }
+
+    @Test
+    void sendEmailVerificationCodeShouldRateLimitPerUserNotPerEmail() {
+        var config = RateLimiterConfig.custom()
+            .limitRefreshPeriod(Duration.ofSeconds(10))
+            .limitForPeriod(1)
+            .build();
+        var sendCodeRateLimiter = RateLimiterRegistry.of(config)
+            .rateLimiter("send-email-verification-code-fake-user");
+        when(rateLimiterRegistry.rateLimiter(
+            "send-email-verification-code-fake-user",
+            "send-email-verification-code")
+        ).thenReturn(sendCodeRateLimiter);
+
+        var user = new User();
+        user.setMetadata(new Metadata());
+        user.getMetadata().setName("fake-user");
+        user.setSpec(new User.UserSpec());
+        user.getSpec().setEmail("hi@halo.run");
+        when(emailVerificationService.sendVerificationCode(anyString(), anyString()))
+            .thenReturn(Mono.empty());
+        // first request with email A passes
+        webClient.post()
+            .uri("/users/-/send-email-verification-code")
+            .bodyValue(Map.of("email", "hi@halo.run"))
+            .exchange()
+            .expectStatus()
+            .isOk();
+
+        // second request with a different email B should also be rate-limited
+        // because the limiter is per-user, not per-email
+        webClient.post()
+            .uri("/users/-/send-email-verification-code")
+            .bodyValue(Map.of("email", "another@halo.run"))
             .exchange()
             .expectStatus()
             .isEqualTo(HttpStatus.TOO_MANY_REQUESTS);


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Fix rate limiting bypass in the `POST /users/-/send-email-verification-code` endpoint.

The `sendEmailVerificationCodeRateLimiter` was using `(username + ":" + email)` as the Resilience4j rate limiter key, which created a **separate rate limiter instance for each unique email address**. An attacker could bypass the 1-per-minute limit by simply changing the email parameter in each request, each time hitting a fresh rate limiter with no accumulated count.

This PR changes the rate limiter key to use only the authenticated username, so each user is properly limited regardless of which email they specify.

#### Which issue(s) this PR fixes:

Fixes #

#### Special notes for your reviewer:

The `send-email-verification-code` config in `application.yaml` defines `limitForPeriod: 1` / `limitRefreshPeriod: 1m`, but the per-email key granularity made it ineffective.

A new test `sendEmailVerificationCodeShouldRateLimitPerUserNotPerEmail` verifies that even a **different** email address in the second request triggers `429 TOO_MANY_REQUESTS`.

#### Does this PR introduce a user-facing change?

```release-note
修复发送邮箱验证码接口的限流绕过漏洞
```
