### PR TITLE
feat: expose version matching capability to theme templates via #halo.matchVersion

### DIFF
--- a/application/src/main/java/run/halo/app/theme/TemplateEngineManager.java
+++ b/application/src/main/java/run/halo/app/theme/TemplateEngineManager.java
@@ -13,6 +13,7 @@ import org.thymeleaf.templateresolver.FileTemplateResolver;
 import org.thymeleaf.templateresolver.ITemplateResolver;
 import reactor.core.publisher.Mono;
 import run.halo.app.infra.ExternalUrlSupplier;
+import run.halo.app.infra.SystemVersionSupplier;
 import run.halo.app.theme.dialect.HaloProcessorDialect;
 import run.halo.app.theme.engine.HaloTemplateEngine;
 import run.halo.app.theme.engine.PluginClassloaderTemplateResolver;
@@ -50,16 +51,20 @@ public class TemplateEngineManager {
 
     private final ThemeResolver themeResolver;
 
+    private final SystemVersionSupplier systemVersionSupplier;
+
     public TemplateEngineManager(ThymeleafProperties thymeleafProperties,
         ExternalUrlSupplier externalUrlSupplier,
         PluginManager pluginManager, ObjectProvider<ITemplateResolver> templateResolvers,
-        ObjectProvider<IDialect> dialects, ThemeResolver themeResolver) {
+        ObjectProvider<IDialect> dialects, ThemeResolver themeResolver,
+        SystemVersionSupplier systemVersionSupplier) {
         this.thymeleafProperties = thymeleafProperties;
         this.externalUrlSupplier = externalUrlSupplier;
         this.pluginManager = pluginManager;
         this.templateResolvers = templateResolvers;
         this.dialects = dialects;
         this.themeResolver = themeResolver;
+        this.systemVersionSupplier = systemVersionSupplier;
         engineCache = new ConcurrentLruCache<>(CACHE_SIZE_LIMIT, this::templateEngineGenerator);
     }
 
@@ -108,7 +113,7 @@ public class TemplateEngineManager {
                 return ReactiveSpelVariableExpressionEvaluator.INSTANCE;
             }
         });
-        engine.addDialect(new HaloProcessorDialect());
+        engine.addDialect(new HaloProcessorDialect(systemVersionSupplier));
 
         templateResolvers.orderedStream().forEach(engine::addTemplateResolver);
 

--- a/application/src/main/java/run/halo/app/theme/dialect/HaloExpressionObjectFactory.java
+++ b/application/src/main/java/run/halo/app/theme/dialect/HaloExpressionObjectFactory.java
@@ -1,9 +1,12 @@
 package run.halo.app.theme.dialect;
 
+import com.github.zafarkhaja.semver.Version;
 import java.util.Set;
+import java.util.function.Supplier;
 import org.thymeleaf.context.IExpressionContext;
 import org.thymeleaf.expression.IExpressionObjectFactory;
 import run.halo.app.theme.dialect.expression.Annotations;
+import run.halo.app.theme.dialect.expression.HaloExpressionObject;
 
 /**
  * Builds the expression objects to be used by Halo dialects.
@@ -14,11 +17,23 @@ import run.halo.app.theme.dialect.expression.Annotations;
 public class HaloExpressionObjectFactory implements IExpressionObjectFactory {
 
     public static final String ANNOTATIONS_EXPRESSION_OBJECT_NAME = "annotations";
+    public static final String HALO_EXPRESSION_OBJECT_NAME = "halo";
 
     protected static final Set<String> ALL_EXPRESSION_OBJECT_NAMES = Set.of(
-        ANNOTATIONS_EXPRESSION_OBJECT_NAME);
+        ANNOTATIONS_EXPRESSION_OBJECT_NAME,
+        HALO_EXPRESSION_OBJECT_NAME);
 
     private static final Annotations ANNOTATIONS = new Annotations();
+
+    private final Supplier<Version> versionSupplier;
+
+    public HaloExpressionObjectFactory() {
+        this(null);
+    }
+
+    public HaloExpressionObjectFactory(Supplier<Version> versionSupplier) {
+        this.versionSupplier = versionSupplier;
+    }
 
     @Override
     public Set<String> getAllExpressionObjectNames() {
@@ -29,6 +44,9 @@ public class HaloExpressionObjectFactory implements IExpressionObjectFactory {
     public Object buildObject(IExpressionContext context, String expressionObjectName) {
         if (ANNOTATIONS_EXPRESSION_OBJECT_NAME.equals(expressionObjectName)) {
             return ANNOTATIONS;
+        }
+        if (HALO_EXPRESSION_OBJECT_NAME.equals(expressionObjectName)) {
+            return new HaloExpressionObject(versionSupplier);
         }
         return null;
     }

--- a/application/src/main/java/run/halo/app/theme/dialect/HaloProcessorDialect.java
+++ b/application/src/main/java/run/halo/app/theme/dialect/HaloProcessorDialect.java
@@ -2,10 +2,8 @@ package run.halo.app.theme.dialect;
 
 import static org.thymeleaf.templatemode.TemplateMode.HTML;
 
-import com.github.zafarkhaja.semver.Version;
 import java.util.HashSet;
 import java.util.Set;
-import java.util.function.Supplier;
 import org.thymeleaf.dialect.AbstractProcessorDialect;
 import org.thymeleaf.dialect.IExpressionObjectDialect;
 import org.thymeleaf.dialect.IPostProcessorDialect;

--- a/application/src/main/java/run/halo/app/theme/dialect/HaloProcessorDialect.java
+++ b/application/src/main/java/run/halo/app/theme/dialect/HaloProcessorDialect.java
@@ -2,8 +2,10 @@ package run.halo.app.theme.dialect;
 
 import static org.thymeleaf.templatemode.TemplateMode.HTML;
 
+import com.github.zafarkhaja.semver.Version;
 import java.util.HashSet;
 import java.util.Set;
+import java.util.function.Supplier;
 import org.thymeleaf.dialect.AbstractProcessorDialect;
 import org.thymeleaf.dialect.IExpressionObjectDialect;
 import org.thymeleaf.dialect.IPostProcessorDialect;
@@ -12,6 +14,7 @@ import org.thymeleaf.postprocessor.IPostProcessor;
 import org.thymeleaf.postprocessor.PostProcessor;
 import org.thymeleaf.processor.IProcessor;
 import org.thymeleaf.standard.StandardDialect;
+import run.halo.app.infra.SystemVersionSupplier;
 
 /**
  * Thymeleaf processor dialect for Halo.
@@ -23,13 +26,17 @@ public class HaloProcessorDialect extends AbstractProcessorDialect
     implements IExpressionObjectDialect, IPostProcessorDialect {
     private static final String DIALECT_NAME = "haloThemeProcessorDialect";
 
-    private static final IExpressionObjectFactory HALO_EXPRESSION_OBJECTS_FACTORY =
-        new HaloExpressionObjectFactory();
+    private final IExpressionObjectFactory expressionObjectFactory;
 
     public HaloProcessorDialect() {
+        this(null);
+    }
+
+    public HaloProcessorDialect(SystemVersionSupplier systemVersionSupplier) {
         // We will set this dialect the same "dialect processor" precedence as
         // the Standard Dialect, so that processor executions can interleave.
         super(DIALECT_NAME, "halo", StandardDialect.PROCESSOR_PRECEDENCE);
+        this.expressionObjectFactory = new HaloExpressionObjectFactory(systemVersionSupplier);
     }
 
     @Override
@@ -47,7 +54,7 @@ public class HaloProcessorDialect extends AbstractProcessorDialect
 
     @Override
     public IExpressionObjectFactory getExpressionObjectFactory() {
-        return HALO_EXPRESSION_OBJECTS_FACTORY;
+        return expressionObjectFactory;
     }
 
     @Override

--- a/application/src/main/java/run/halo/app/theme/dialect/expression/HaloExpressionObject.java
+++ b/application/src/main/java/run/halo/app/theme/dialect/expression/HaloExpressionObject.java
@@ -1,0 +1,43 @@
+package run.halo.app.theme.dialect.expression;
+
+import com.github.zafarkhaja.semver.Version;
+import java.util.function.Supplier;
+import run.halo.app.infra.utils.VersionUtils;
+
+/**
+ * Halo expression object for Thymeleaf templates.
+ *
+ * @author ruibaby
+ * @since 2.25.0
+ */
+public class HaloExpressionObject {
+
+    private final Supplier<Version> versionSupplier;
+
+    public HaloExpressionObject(Supplier<Version> versionSupplier) {
+        this.versionSupplier = versionSupplier;
+    }
+
+    /**
+     * Checks if the current Halo version matches the specified SemVer constraint.
+     * <p>Examples:</p>
+     * <ul>
+     *   <li>{@code #halo.matchVersion('>=2.24.0')}</li>
+     *   <li>{@code #halo.matchVersion('>2.0.0 & <3.0.0')}</li>
+     * </ul>
+     * <p>Note: development version {@code 0.0.0} always returns {@code true}.</p>
+     *
+     * @param constraint the SemVer expression string to check against
+     * @return {@code true} if the current version satisfies the constraint
+     */
+    public boolean matchVersion(String constraint) {
+        if (versionSupplier == null) {
+            return false;
+        }
+        String version = versionSupplier.get().toString();
+        if ("0.0.0".equals(version)) {
+            return true;
+        }
+        return VersionUtils.checkVersionConstraint(version, constraint);
+    }
+}

--- a/application/src/test/java/run/halo/app/theme/dialect/HaloProcessorDialectTest.java
+++ b/application/src/test/java/run/halo/app/theme/dialect/HaloProcessorDialectTest.java
@@ -39,6 +39,7 @@ import run.halo.app.infra.SystemConfigFetcher;
 import run.halo.app.infra.SystemSetting;
 import run.halo.app.infra.SystemSetting.CodeInjection;
 import run.halo.app.infra.SystemSetting.Seo;
+import run.halo.app.infra.SystemVersionSupplier;
 import run.halo.app.plugin.extensionpoint.ExtensionGetter;
 import run.halo.app.theme.Constant;
 import run.halo.app.theme.DefaultTemplateEnum;
@@ -77,11 +78,14 @@ class HaloProcessorDialectTest {
     @Mock
     ExtensionGetter extensionGetter;
 
+    @Mock
+    SystemVersionSupplier systemVersionSupplier;
+
     private TemplateEngine templateEngine;
 
     @BeforeEach
     void setUp() {
-        HaloProcessorDialect haloProcessorDialect = new HaloProcessorDialect();
+        HaloProcessorDialect haloProcessorDialect = new HaloProcessorDialect(systemVersionSupplier);
         templateEngine = new TemplateEngine();
         templateEngine.setDialects(Set.of(haloProcessorDialect, new SpringStandardDialect()));
         templateEngine.addTemplateResolver(new TestTemplateResolver());
@@ -282,6 +286,50 @@ class HaloProcessorDialectTest {
     }
 
     @Nested
+    class HaloExpressionObjectTest {
+
+        @Test
+        void matchVersionWhenSatisfied() {
+            when(systemVersionSupplier.get())
+                .thenReturn(com.github.zafarkhaja.semver.Version.parse("2.24.2"));
+
+            Context context = getContext();
+            String result = templateEngine.process("matchVersionSatisfied", context);
+            assertThat(result).contains("<p>true</p>");
+        }
+
+        @Test
+        void matchVersionWhenNotSatisfied() {
+            when(systemVersionSupplier.get())
+                .thenReturn(com.github.zafarkhaja.semver.Version.parse("2.23.0"));
+
+            Context context = getContext();
+            String result = templateEngine.process("matchVersionNotSatisfied", context);
+            assertThat(result).contains("<p>false</p>");
+        }
+
+        @Test
+        void matchVersionWithRange() {
+            when(systemVersionSupplier.get())
+                .thenReturn(com.github.zafarkhaja.semver.Version.parse("2.24.2"));
+
+            Context context = getContext();
+            String result = templateEngine.process("matchVersionRange", context);
+            assertThat(result).contains("<p>true</p>");
+        }
+
+        @Test
+        void matchVersionWithDevVersion() {
+            when(systemVersionSupplier.get())
+                .thenReturn(com.github.zafarkhaja.semver.Version.parse("0.0.0"));
+
+            Context context = getContext();
+            String result = templateEngine.process("matchVersionNotSatisfied", context);
+            assertThat(result).contains("<p>true</p>");
+        }
+    }
+
+    @Nested
     class AnnotationExpressionObjectFactoryTest {
 
         @Test
@@ -387,6 +435,15 @@ class HaloProcessorDialectTest {
             if (template.equals("annotationsContainsExpression")) {
                 return new StringTemplateResource(annotationsContainsExpression());
             }
+            if (template.equals("matchVersionSatisfied")) {
+                return new StringTemplateResource(matchVersionSatisfied());
+            }
+            if (template.equals("matchVersionNotSatisfied")) {
+                return new StringTemplateResource(matchVersionNotSatisfied());
+            }
+            if (template.equals("matchVersionRange")) {
+                return new StringTemplateResource(matchVersionRange());
+            }
             return null;
         }
 
@@ -453,6 +510,24 @@ class HaloProcessorDialectTest {
         private String annotationsContainsExpression() {
             return """
                 <p th:text="${#annotations.contains(user, 'background')}"></p>
+                """;
+        }
+
+        private String matchVersionSatisfied() {
+            return """
+                <p th:text="${#halo.matchVersion('>=2.24.0')}"></p>
+                """;
+        }
+
+        private String matchVersionNotSatisfied() {
+            return """
+                <p th:text="${#halo.matchVersion('>=2.24.0')}"></p>
+                """;
+        }
+
+        private String matchVersionRange() {
+            return """
+                <p th:text="${#halo.matchVersion('>=2.24.0 & <2.26.0')}"></p>
                 """;
         }
     }


### PR DESCRIPTION
<!--
1. If this is your first time, please read our contributor guidelines: <https://github.com/halo-dev/halo/blob/main/CONTRIBUTING.md>.
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request.
3. Ensure you have added or ran the appropriate tests for your PR.
4. If your PR uses LLM generated code, please add a corresponding description in the PR, we do not oppose using LLM to assist development, but we hope you can review the generated code first.
-->

#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

Currently, if a theme wants to adapt a new feature that depends on a newer Halo version, the theme author has to raise the minimum required Halo version globally in `theme.yaml`. However, some features are only used in isolated template fragments. This forces users on older Halo versions to upgrade even when they only want unrelated improvements in the theme.

This PR exposes a version-matching capability to theme templates via the new `#halo` Thymeleaf expression object. Theme developers can now declare version requirements per fragment/module, improving backward compatibility and adoption range.

Example usage in a theme template:

```html
<div th:fragment="random-post" th:if="${#halo.matchVersion('>=2.24.0')}">
    <!-- New feature only available in Halo 2.24.0+ -->
</div>
```

Key behaviors:
- Uses the existing `VersionUtils.checkVersionConstraint` based on jsemver, supporting full SemVer expressions such as `>=2.24.0`, `>2.0.0 & <3.0.0`, etc.
- Development version `0.0.0` always returns `true` to facilitate local theme development.

#### Which issue(s) this PR fixes:

Fixes https://github.com/halo-dev/halo/issues/9937

#### Special notes for your reviewer:

- The `#halo` expression object is registered alongside the existing `#annotations` object in `HaloExpressionObjectFactory`.
- `HaloProcessorDialect` now accepts an optional `SystemVersionSupplier` constructor argument. A no-arg constructor is preserved for backward compatibility in tests.
- `TemplateEngineManager` injects the `SystemVersionSupplier` bean and passes it to the dialect.

#### Does this PR introduce a user-facing change?

```release-note
主题支持通过 `#halo.matchVersion('<version>')` 判断 Halo 版本范围
```

by kimi code
