### PR TITLE
Add AGENTS.md for AI coding agents

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,55 +1,86 @@
-# AGENTS.md — Halo Project Conventions
+# AGENTS.md — Halo
 
-## Project Overview
+Open-source website builder — Java 21, Spring Boot WebFlux + R2DBC, Vue 3 + TailwindCSS. Versions: `gradle/libs.versions.toml`, `gradle.properties`, `ui/package.json`.
 
-Halo is an open-source website building tool — Java 21, Spring Boot WebFlux + R2DBC backend, Vue 3 + TailwindCSS frontend. 5 Gradle submodules: `api`, `application`, `platform:application`, `platform:plugin`, `ui`. Key source: `application/src/main/java/run/halo/app/`. Versions: see `gradle/libs.versions.toml`, `gradle.properties`, `ui/package.json`.
+## Commands
 
-## Build & Formatting
+### File-scoped (preferred — fast feedback)
 
-- **Spotless** is the sole formatter. Java uses `palantirJavaFormat("2.90.0")` (4-space indent, 120-char line limit).
+```bash
+./gradlew :api:compileJava                        # Compile API module
+./gradlew :application:compileJava                # Compile application module
+./gradlew :application:test --tests "*PostService*"    # Run specific test class
+./gradlew spotlessCheck                           # Check formatting only
+./gradlew spotlessApply                           # Auto-fix formatting
+cd ui && pnpm build                               # Build frontend only
+```
+
+### Full build (before pushing)
+
+```bash
+./gradlew spotlessCheck build -x test             # Format + compile (no tests)
+./gradlew build                                   # Everything: format + compile + test + UI
+```
+
+## Project Structure
+
+5 Gradle submodules: `api`, `application`, `platform:application`, `platform:plugin`, `ui`. Key source: `application/src/main/java/run/halo/app/`.
+
+## Code Formatting
+
+- **Spotless** is the sole formatter (Checkstyle removed in #9963).
+- Java: `palantirJavaFormat("2.90.0")` — 4-space indent, 120-char line limit.
 - The `format 'misc'` block (XML, properties, gitignore, editorconfig) MUST live in root `build.gradle` — putting it in a submodule alongside `java` causes a Gradle classloader conflict.
-- Use `leadingTabsToSpaces()` in misc format — `indentWithSpaces()` is deprecated in Spotless 8.x.
-- Pre-push check: `./gradlew spotlessCheck build -x test`
-- Apply formatting: `./gradlew spotlessApply`
+- Use `leadingTabsToSpaces()` — `indentWithSpaces()` is deprecated in Spotless 8.x.
+
+### ✅ Good patterns
+
+- `application/src/main/java/run/halo/app/security/authentication/oauth2/MapOAuth2AuthenticationFilter.java` — reactive filter with proper null-safety
+- `application/src/main/java/run/halo/app/core/user/service/impl/UserServiceImpl.java` — service pattern with extension hooks, duplicate checking
+- `application/src/main/resources/extensions/role-template-authenticated.yaml` — extension resource registration
 
 ## Critical Pitfalls
 
-1. **Never `git add -A` or `git add .`** — H2 database artifacts in `application/` will pollute your commit. Stage specific files only.
+1. **Never `git add -A` or `git add .`** — H2 database artifacts in `application/`. Stage specific files only.
 
-2. **H2 database paths must be absolute.** Use `r2dbc:h2:file:///tmp/halo-db`, not relative paths like `file:./tmp/...`. The latter resolves relative to the working directory and creates stray `application/tmp/` directories.
+2. **H2 database paths must be absolute.** Use `r2dbc:h2:file:///tmp/halo-db`. Relative paths (`file:./tmp/...`) create stray `application/tmp/` directories.
 
-3. **`@Schema(pattern=...)` must be inline.** The OpenAPI generator reads annotations at compile time — extracting the regex to a `static final String` constant results in the literal constant name in the generated spec, not the actual regex.
+3. **`@Schema(pattern=...)` must be inline.** Extracting the regex to a `static final String` constant puts the literal constant name (not the regex) into the generated OpenAPI spec.
 
-4. **Resilience4j rate limiter keys must NOT include user-controlled values.** Each unique key creates an independent limiter instance — if the key includes email, phone, or any request field, the rate limit can be bypassed by varying that input. Use only authenticated identity (username) or client IP.
+4. **Resilience4j rate limiter keys must NOT include user-controlled values.** Each unique key creates an independent limiter — including email, phone, or request body fields allows bypass by varying those values. Use only authenticated identity or client IP.
 
 5. **Gradle wrapper upgrade requires TWO commands:**
    ```bash
    ./gradlew wrapper --gradle-version=X.Y.Z
    ./gradlew wrapper
    ```
-   The first updates `gradle-wrapper.properties`; the second regenerates the wrapper JAR and scripts using the new Gradle version. Skipping the second step leaves the old wrapper JAR in place.
+   First updates `gradle-wrapper.properties`; second regenerates the wrapper JAR and scripts.
 
-6. **Stale worktrees can lock `main`.** If `git checkout main` fails with "already used by worktree", run `git worktree list` and `git worktree remove --force <path>` to clean up.
+6. **Stale worktrees lock `main`.** If `git checkout main` fails with "already used by worktree":
+   ```bash
+   git worktree list
+   git worktree remove --force <path>
+   ```
 
 ## Git Workflow
 
+```bash
+# Always start from upstream/main — never checkout local main
+git fetch upstream && git checkout upstream/main && git checkout -b feat/xxx
+```
+
 - **Branch naming:** `upgrade/gradle-X`, `feat/name`, `fix/name`, `improvement/name`
-- **Always start from upstream/main:**
-  ```bash
-  git fetch upstream && git checkout upstream/main && git checkout -b feat/xxx
-  ```
-  Never `git checkout main && git pull` — avoids stale local main and worktree lock issues.
-- **PR template:** see `.github/pull_request_template.md` (do not duplicate here).
-- **CI:** see `.github/workflows/halo.yaml` and adjacent workflow files.
+- **PR template:** `.github/pull_request_template.md`
+- **CI:** `.github/workflows/halo.yaml`
 
 ## Key Files
 
 | Purpose | Path |
 |---|---|
 | Dependency catalog | `gradle/libs.versions.toml` |
-| Gradle properties (version, etc.) | `gradle.properties` |
+| Gradle properties (version) | `gradle.properties` |
 | Root build config | `build.gradle`, `settings.gradle` |
-| Java module build configs | `api/build.gradle`, `application/build.gradle` |
-| App entry & config | `application/src/main/resources/application.yaml` |
-| Frontend | `ui/` (pnpm, see `ui/package.json`) |
-| PR template | `.github/pull_request_template.md` |
+| Module build configs | `api/build.gradle`, `application/build.gradle` |
+| App config | `application/src/main/resources/application.yaml` |
+| Frontend | `ui/package.json` (pnpm, Vue 3, TailwindCSS) |
+| Extension points | `application/src/main/resources/extensions/` |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,9 +35,43 @@ cd ui && pnpm build                               # Build frontend only
 
 ### ✅ Good patterns
 
-- `application/src/main/java/run/halo/app/security/authentication/oauth2/MapOAuth2AuthenticationFilter.java` — reactive filter with proper null-safety
-- `application/src/main/java/run/halo/app/core/user/service/impl/UserServiceImpl.java` — service pattern with extension hooks, duplicate checking
+- `application/.../security/authentication/oauth2/MapOAuth2AuthenticationFilter.java` — reactive filter with proper null-safety
+- `application/.../core/user/service/impl/UserServiceImpl.java` — service pattern with extension hooks, duplicate checking
 - `application/src/main/resources/extensions/role-template-authenticated.yaml` — extension resource registration
+
+## UI (Frontend)
+
+pnpm workspace at `ui/`. Build tool: **vite-plus** (`vp`). Vue 3 + TypeScript + TailwindCSS 3.4 + Vitest.
+
+### Key directories
+
+| Directory | Purpose |
+|---|---|
+| `ui/console-src/` | Admin console (main application) |
+| `ui/packages/` | Shared packages: api-client, components, editor, console-shared |
+
+### Commands
+
+```bash
+cd ui
+pnpm install                # Install dependencies (required before any other command)
+pnpm dev                    # Dev server with HMR
+pnpm build                  # Full build: typecheck + bundle
+pnpm build:packages         # Build workspace packages only (faster)
+pnpm test:unit              # Run unit tests (Vitest)
+pnpm lint                   # ESLint
+pnpm format                 # Format code (vp fmt)
+pnpm format:check           # Check formatting
+pnpm api-client:gen         # Generate API client from OpenAPI spec
+pnpm typecheck              # vue-tsc type checking
+```
+
+The `Makefile` wraps common workflows: `make -C ui dev`, `make -C ui build`, `make -C ui test`, `make -C ui api-client-gen`.
+
+### Pitfalls
+
+- **Pre-commit hooks run lint-staged on UI files.** If `node_modules/@halo-dev/components` is missing (no `pnpm install`), `git commit` fails on Java-only changes. Use `git commit --no-verify` or `cd ui && pnpm install` first.
+- **API client regeneration needs two commands in order:** `./gradlew generateOpenApiDocs` (slow, ~28s, boots Spring), then `cd ui && pnpm api-client:gen`.
 
 ## Critical Pitfalls
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,55 @@
+# AGENTS.md — Halo Project Conventions
+
+## Project Overview
+
+Halo is an open-source website building tool — Java 21, Spring Boot WebFlux + R2DBC backend, Vue 3 + TailwindCSS frontend. 5 Gradle submodules: `api`, `application`, `platform:application`, `platform:plugin`, `ui`. Key source: `application/src/main/java/run/halo/app/`. Versions: see `gradle/libs.versions.toml`, `gradle.properties`, `ui/package.json`.
+
+## Build & Formatting
+
+- **Spotless** is the sole formatter. Java uses `palantirJavaFormat("2.90.0")` (4-space indent, 120-char line limit).
+- The `format 'misc'` block (XML, properties, gitignore, editorconfig) MUST live in root `build.gradle` — putting it in a submodule alongside `java` causes a Gradle classloader conflict.
+- Use `leadingTabsToSpaces()` in misc format — `indentWithSpaces()` is deprecated in Spotless 8.x.
+- Pre-push check: `./gradlew spotlessCheck build -x test`
+- Apply formatting: `./gradlew spotlessApply`
+
+## Critical Pitfalls
+
+1. **Never `git add -A` or `git add .`** — H2 database artifacts in `application/` will pollute your commit. Stage specific files only.
+
+2. **H2 database paths must be absolute.** Use `r2dbc:h2:file:///tmp/halo-db`, not relative paths like `file:./tmp/...`. The latter resolves relative to the working directory and creates stray `application/tmp/` directories.
+
+3. **`@Schema(pattern=...)` must be inline.** The OpenAPI generator reads annotations at compile time — extracting the regex to a `static final String` constant results in the literal constant name in the generated spec, not the actual regex.
+
+4. **Resilience4j rate limiter keys must NOT include user-controlled values.** Each unique key creates an independent limiter instance — if the key includes email, phone, or any request field, the rate limit can be bypassed by varying that input. Use only authenticated identity (username) or client IP.
+
+5. **Gradle wrapper upgrade requires TWO commands:**
+   ```bash
+   ./gradlew wrapper --gradle-version=X.Y.Z
+   ./gradlew wrapper
+   ```
+   The first updates `gradle-wrapper.properties`; the second regenerates the wrapper JAR and scripts using the new Gradle version. Skipping the second step leaves the old wrapper JAR in place.
+
+6. **Stale worktrees can lock `main`.** If `git checkout main` fails with "already used by worktree", run `git worktree list` and `git worktree remove --force <path>` to clean up.
+
+## Git Workflow
+
+- **Branch naming:** `upgrade/gradle-X`, `feat/name`, `fix/name`, `improvement/name`
+- **Always start from upstream/main:**
+  ```bash
+  git fetch upstream && git checkout upstream/main && git checkout -b feat/xxx
+  ```
+  Never `git checkout main && git pull` — avoids stale local main and worktree lock issues.
+- **PR template:** see `.github/pull_request_template.md` (do not duplicate here).
+- **CI:** see `.github/workflows/halo.yaml` and adjacent workflow files.
+
+## Key Files
+
+| Purpose | Path |
+|---|---|
+| Dependency catalog | `gradle/libs.versions.toml` |
+| Gradle properties (version, etc.) | `gradle.properties` |
+| Root build config | `build.gradle`, `settings.gradle` |
+| Java module build configs | `api/build.gradle`, `application/build.gradle` |
+| App entry & config | `application/src/main/resources/application.yaml` |
+| Frontend | `ui/` (pnpm, see `ui/package.json`) |
+| PR template | `.github/pull_request_template.md` |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,124 +1,47 @@
-# AGENTS.md — Halo
+# Halo — AGENTS.md
 
-Open-source website builder — Java 21, Spring Boot WebFlux + R2DBC, Vue 3 + TailwindCSS. Versions: `gradle/libs.versions.toml`, `gradle.properties`, `ui/package.json`.
+Open-source website builder. Java 21 / Spring Boot WebFlux + R2DBC / Vue 3 + TailwindCSS.
 
-## Commands
+Versions live in `gradle/libs.versions.toml`, `gradle.properties`, `ui/package.json`. Do not hard-code them.
 
-### File-scoped (preferred — fast feedback)
+## Subproject AGENTS.md files
+
+This is a multi-module Gradle project. Each subproject has its own `AGENTS.md` with specialized
+conventions. Load them when working in that area:
+
+| Subproject | Path | What it is |
+|---|---|---|
+| API library | [`api/AGENTS.md`](api/AGENTS.md) | Extension model, reactive interfaces, security abstractions |
+| Application | [`application/AGENTS.md`](application/AGENTS.md) | Spring Boot app, service implementations, routers |
+| Frontend | [`ui/AGENTS.md`](ui/AGENTS.md) | pnpm workspace, Vue 3, TailwindCSS, packages |
+| Platform BOMs | [`platform/application/AGENTS.md`](platform/application/AGENTS.md) | Dependency version constraints |
+| Plugin BOM | [`platform/plugin/AGENTS.md`](platform/plugin/AGENTS.md) | Plugin development dependency platform |
+
+## Build Commands (Quick Reference)
 
 ```bash
-./gradlew :api:compileJava                        # Compile API module
-./gradlew :application:compileJava                # Compile application module
-./gradlew :application:test --tests "*PostService*"    # Run specific test class
-./gradlew spotlessCheck                           # Check formatting only
-./gradlew spotlessApply                           # Auto-fix formatting
-cd ui && pnpm build                               # Build frontend only
+# File-scoped (fast feedback — preferred during development)
+./gradlew :api:compileJava                         # Compile API module only
+./gradlew :application:compileJava                 # Compile application module only
+./gradlew :application:test --tests "*ClassName*"  # Run specific test class
+./gradlew spotlessCheck                            # Check formatting (all modules)
+./gradlew spotlessApply                            # Auto-fix formatting
+
+# Full verification (before pushing)
+./gradlew spotlessCheck build -x test              # Format + compile (skip tests)
+./gradlew build                                    # Everything: format + compile + test + UI
+
+# Frontend
+cd ui && pnpm build                                # Build frontend only
 ```
-
-### Full build (before pushing)
-
-```bash
-./gradlew spotlessCheck build -x test             # Format + compile (no tests)
-./gradlew build                                   # Everything: format + compile + test + UI
-```
-
-## Project Structure
-
-5 Gradle submodules: `api`, `application`, `platform:application`, `platform:plugin`, `ui`. Key source: `application/src/main/java/run/halo/app/`.
 
 ## Code Formatting
 
-- **Spotless** is the sole formatter (Checkstyle removed in #9963).
-- Java: `palantirJavaFormat("2.90.0")` — 4-space indent, 120-char line limit.
-- The `format 'misc'` block (XML, properties, gitignore, editorconfig) MUST live in root `build.gradle` — putting it in a submodule alongside `java` causes a Gradle classloader conflict.
-- Use `leadingTabsToSpaces()` — `indentWithSpaces()` is deprecated in Spotless 8.x.
+**Spotless** is the sole formatter (Checkstyle removed in #9963).
+Java: `palantirJavaFormat("2.90.0")` — 4-space indent, 120-char line limit.
 
-### ✅ Good patterns
-
-- `application/.../security/authentication/oauth2/MapOAuth2AuthenticationFilter.java` — reactive filter with proper null-safety
-- `application/.../core/user/service/impl/UserServiceImpl.java` — service pattern with extension hooks, duplicate checking
-- `application/src/main/resources/extensions/role-template-authenticated.yaml` — extension resource registration
-
-## UI (Frontend)
-
-pnpm workspace at `ui/`. Build tool: **vite-plus** (`vp`). Vue 3 + TypeScript + TailwindCSS 3.4 + Vitest.
-
-### Key directories
-
-| Directory | Purpose |
-|---|---|
-| `ui/console-src/` | Admin console (main application) — modules, stores, layouts, router |
-| `ui/src/` | Shared code: components, composables, stores, i18n locales, FormKit, styles, setup |
-| `ui/packages/` | Workspace packages (see below) |
-
-### Commands
-
-```bash
-cd ui
-pnpm install                # Install dependencies (required before any other command)
-pnpm dev                    # Dev server with HMR
-pnpm build                  # Full build: typecheck + bundle
-pnpm build:packages         # Build workspace packages only (faster)
-pnpm test:unit              # Run unit tests (Vitest)
-pnpm lint                   # ESLint
-pnpm format                 # Format code (vp fmt)
-pnpm format:check           # Check formatting
-pnpm api-client:gen         # Generate API client from OpenAPI spec
-pnpm typecheck              # vue-tsc type checking
-```
-
-The `Makefile` wraps common workflows: `make -C ui dev`, `make -C ui build`, `make -C ui test`, `make -C ui api-client-gen`.
-
-### Packages (`ui/packages/`)
-
-| Package | Purpose |
-|---|---|
-| `api-client` | Generated Axios-based API client from OpenAPI spec |
-| `components` | Shared UI component library (Vue) + icons (Iconify) |
-| `editor` | Rich-text editor (Tiptap-based) |
-| `console-shared` | Console-specific shared code (stores, events, utils) |
-| `shared` | Cross-platform shared code (plugin system, types, stores) |
-| `ui-plugin-bundler-kit` | Build tooling for Halo UI plugins |
-
-### Conventions
-
-- **Module pattern:** Each feature in `ui/console-src/modules/<feature>/module.ts` uses `definePlugin()` to register routes, menus, and permissions. Modules are auto-discovered via `import.meta.glob("./**/module.ts")`.
-- **Main.ts setup chain:** components → i18n → vue-query → api-client → pinia → core modules → user → permissions → plugin modules → router → mount.
-- **Path aliases:** `@/*` → `src/*`, `@console/*` → `console-src/*`, `@uc/*` → `uc-src/*` (see `tsconfig.app.json`).
-- **State:** Pinia stores in `console-src/stores/` (console-specific) and `src/stores/` (shared: `plugin.ts`, `role.ts`).
-- **i18n:** vue-i18n with JSON locale files in `src/locales/` (en, zh-CN, zh-TW, es). Translation keys in `meta.title` on routes.
-- **Forms:** FormKit with custom inputs/plugins in `src/formkit/`. Theme config: `src/formkit/theme.ts`.
-- **Icons:** Iconify via `@iconify/vue`. Icon sets: lucide, mdi, ri, fluent, material-symbols, etc. (installed as `@iconify-json/*` devDeps).
-- **Shared composables:** `src/composables/` (e.g. `use-auto-save-content`, `use-role`, `use-title`).
-- **Tailwind theming:** `tailwindcss-themer` plugin with default theme (primary `#4CCBA0`, secondary `#0E1731`, danger `#D71D1D`). FormKit theme integrated.
-
-### Pitfalls
-
-- **Pre-commit hooks run lint-staged on UI files.** If `node_modules/@halo-dev/components` is missing (no `pnpm install`), `git commit` fails on Java-only changes. Use `git commit --no-verify` or `cd ui && pnpm install` first.
-- **API client regeneration needs two commands in order:** `./gradlew generateOpenApiDocs` (slow, ~28s, boots Spring), then `cd ui && pnpm api-client:gen`.
-
-## Critical Pitfalls
-
-1. **Never `git add -A` or `git add .`** — H2 database artifacts in `application/`. Stage specific files only.
-
-2. **H2 database paths must be absolute.** Use `r2dbc:h2:file:///tmp/halo-db`. Relative paths (`file:./tmp/...`) create stray `application/tmp/` directories.
-
-3. **`@Schema(pattern=...)` must be inline.** Extracting the regex to a `static final String` constant puts the literal constant name (not the regex) into the generated OpenAPI spec.
-
-4. **Resilience4j rate limiter keys must NOT include user-controlled values.** Each unique key creates an independent limiter — including email, phone, or request body fields allows bypass by varying those values. Use only authenticated identity or client IP.
-
-5. **Gradle wrapper upgrade requires TWO commands:**
-   ```bash
-   ./gradlew wrapper --gradle-version=X.Y.Z
-   ./gradlew wrapper
-   ```
-   First updates `gradle-wrapper.properties`; second regenerates the wrapper JAR and scripts.
-
-6. **Stale worktrees lock `main`.** If `git checkout main` fails with "already used by worktree":
-   ```bash
-   git worktree list
-   git worktree remove --force <path>
-   ```
+The `format 'misc'` block (XML, properties, gitignore, editorconfig) MUST live in root
+`build.gradle`. Putting it in a submodule alongside `java` causes a Gradle classloader conflict.
 
 ## Git Workflow
 
@@ -130,15 +53,46 @@ git fetch upstream && git checkout upstream/main && git checkout -b feat/xxx
 - **Branch naming:** `upgrade/gradle-X`, `feat/name`, `fix/name`, `improvement/name`
 - **PR template:** `.github/pull_request_template.md`
 - **CI:** `.github/workflows/halo.yaml`
+- **Never `git add -A` or `git add .`** — H2 database artifacts live in `application/`. Stage specific files only.
+- **Stale worktrees lock `main`.** If `git checkout main` fails: `git worktree list && git worktree remove --force <path>`
 
-## Key Files
+## Critical Pitfalls (Project-Wide)
 
-| Purpose | Path |
+### 1. H2 database paths must be absolute
+Use `r2dbc:h2:file:///tmp/halo-db`. Relative paths (`file:./tmp/...`) create stray `application/tmp/` directories.
+
+### 2. `@Schema(pattern=...)` must be inline
+Extracting the regex to a `static final String` puts the literal constant name into the generated
+OpenAPI spec, not the regex. Keep it inline even if it exceeds the 120-char line limit.
+
+### 3. Resilience4j rate limiter keys MUST NOT include user-controlled values
+Each unique key creates an independent limiter. Including email, phone, or request body fields
+allows bypass by varying those values. Use only authenticated identity or client IP.
+
+### 4. Gradle wrapper upgrade requires TWO commands
+```bash
+./gradlew wrapper --gradle-version=X.Y.Z   # Updates gradle-wrapper.properties
+./gradlew wrapper                           # Regenerates wrapper JAR + scripts
+```
+
+### 5. `format 'misc'` placement
+Must be in root `build.gradle`, never in `application/build.gradle`. Co-locating `java` and `misc`
+in the same submodule causes a Gradle 9.x implicit dependency validation error.
+
+### 6. API client regeneration needs two commands in order
+```bash
+./gradlew generateOpenApiDocs    # Boots Spring, extracts OpenAPI JSON (~28s)
+cd ui && pnpm api-client:gen     # Runs openapi-generator
+```
+
+## Config & Version Files
+
+| What | Where |
 |---|---|
-| Dependency catalog | `gradle/libs.versions.toml` |
-| Gradle properties (version) | `gradle.properties` |
-| Root build config | `build.gradle`, `settings.gradle` |
-| Module build configs | `api/build.gradle`, `application/build.gradle` |
-| App config | `application/src/main/resources/application.yaml` |
-| Frontend | `ui/package.json` (pnpm, Vue 3, TailwindCSS) |
+| Dependency versions | `gradle/libs.versions.toml` |
+| Project version | `gradle.properties` → `version=` |
+| Spring Boot version | `gradle/libs.versions.toml` → `[plugins] spring-boot` |
+| JDK version | `api/build.gradle` / `application/build.gradle` → `options.release = 21` |
+| Frontend deps | `ui/package.json` |
+| App configuration | `application/src/main/resources/application.yaml` |
 | Extension points | `application/src/main/resources/extensions/` |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,8 +47,9 @@ pnpm workspace at `ui/`. Build tool: **vite-plus** (`vp`). Vue 3 + TypeScript + 
 
 | Directory | Purpose |
 |---|---|
-| `ui/console-src/` | Admin console (main application) |
-| `ui/packages/` | Shared packages: api-client, components, editor, console-shared |
+| `ui/console-src/` | Admin console (main application) — modules, stores, layouts, router |
+| `ui/src/` | Shared code: components, composables, stores, i18n locales, FormKit, styles, setup |
+| `ui/packages/` | Workspace packages (see below) |
 
 ### Commands
 
@@ -67,6 +68,29 @@ pnpm typecheck              # vue-tsc type checking
 ```
 
 The `Makefile` wraps common workflows: `make -C ui dev`, `make -C ui build`, `make -C ui test`, `make -C ui api-client-gen`.
+
+### Packages (`ui/packages/`)
+
+| Package | Purpose |
+|---|---|
+| `api-client` | Generated Axios-based API client from OpenAPI spec |
+| `components` | Shared UI component library (Vue) + icons (Iconify) |
+| `editor` | Rich-text editor (Tiptap-based) |
+| `console-shared` | Console-specific shared code (stores, events, utils) |
+| `shared` | Cross-platform shared code (plugin system, types, stores) |
+| `ui-plugin-bundler-kit` | Build tooling for Halo UI plugins |
+
+### Conventions
+
+- **Module pattern:** Each feature in `ui/console-src/modules/<feature>/module.ts` uses `definePlugin()` to register routes, menus, and permissions. Modules are auto-discovered via `import.meta.glob("./**/module.ts")`.
+- **Main.ts setup chain:** components → i18n → vue-query → api-client → pinia → core modules → user → permissions → plugin modules → router → mount.
+- **Path aliases:** `@/*` → `src/*`, `@console/*` → `console-src/*`, `@uc/*` → `uc-src/*` (see `tsconfig.app.json`).
+- **State:** Pinia stores in `console-src/stores/` (console-specific) and `src/stores/` (shared: `plugin.ts`, `role.ts`).
+- **i18n:** vue-i18n with JSON locale files in `src/locales/` (en, zh-CN, zh-TW, es). Translation keys in `meta.title` on routes.
+- **Forms:** FormKit with custom inputs/plugins in `src/formkit/`. Theme config: `src/formkit/theme.ts`.
+- **Icons:** Iconify via `@iconify/vue`. Icon sets: lucide, mdi, ri, fluent, material-symbols, etc. (installed as `@iconify-json/*` devDeps).
+- **Shared composables:** `src/composables/` (e.g. `use-auto-save-content`, `use-role`, `use-title`).
+- **Tailwind theming:** `tailwindcss-themer` plugin with default theme (primary `#4CCBA0`, secondary `#0E1731`, danger `#D71D1D`). FormKit theme integrated.
 
 ### Pitfalls
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,98 +1,199 @@
 # Halo — AGENTS.md
 
-Open-source website builder. Java 21 / Spring Boot WebFlux + R2DBC / Vue 3 + TailwindCSS.
+Open-source CMS/blogging platform. Java 21 / Spring Boot WebFlux + R2DBC + Vue 3 + TypeScript + TailwindCSS.
 
-Versions live in `gradle/libs.versions.toml`, `gradle.properties`, `ui/package.json`. Do not hard-code them.
+Versions live in `gradle/libs.versions.toml`, `gradle.properties`, and `ui/package.json`. Do not hard-code them.
 
-## Subproject AGENTS.md files
+## Start here
 
-This is a multi-module Gradle project. Each subproject has its own `AGENTS.md` with specialized
-conventions. Load them when working in that area:
+- This repository is usually opened and worked from the **repo root**, even for frontend-only changes. Prefer root-scoped commands such as `./gradlew :application:test` and `pnpm -C ui lint`.
+- Backend and frontend changes are often part of the same task. Treat this as a **full-stack repo**, not two isolated projects.
+- This root file is the **repo-wide baseline**. Nested `AGENTS.md` files add local rules. When a task touches multiple areas, load **every relevant nested file**, not just the one closest to the first edited file.
 
-| Subproject | Path | What it is |
-|---|---|---|
-| API library | [`api/AGENTS.md`](api/AGENTS.md) | Extension model, reactive interfaces, security abstractions |
-| Application | [`application/AGENTS.md`](application/AGENTS.md) | Spring Boot app, service implementations, routers |
-| Frontend | [`ui/AGENTS.md`](ui/AGENTS.md) | pnpm workspace, Vue 3, TailwindCSS, packages |
-| Platform BOMs | [`platform/application/AGENTS.md`](platform/application/AGENTS.md) | Dependency version constraints |
-| Plugin BOM | [`platform/plugin/AGENTS.md`](platform/plugin/AGENTS.md) | Plugin development dependency platform |
-
-## Build Commands (Quick Reference)
+## Quick commands (run from repo root)
 
 ```bash
-# File-scoped (fast feedback — preferred during development)
-./gradlew :api:compileJava                         # Compile API module only
-./gradlew :application:compileJava                 # Compile application module only
-./gradlew :application:test --tests "*ClassName*"  # Run specific test class
-./gradlew spotlessCheck                            # Check formatting (all modules)
-./gradlew spotlessApply                            # Auto-fix formatting
-
-# Full verification (before pushing)
-./gradlew spotlessCheck build -x test              # Format + compile (skip tests)
-./gradlew build                                    # Everything: format + compile + test + UI
-
-# Frontend
-cd ui && pnpm build                                # Build frontend only
+./gradlew build                                # full repo build: backend + UI packaging + tests
+./gradlew spotlessApply                        # format Java and repo-level markdown/json/properties
+./gradlew :api:test                            # API module tests
+./gradlew :application:test                    # backend tests
+./gradlew :application:bootRun                 # backend dev server
+pnpm -C ui install                             # install frontend deps
+pnpm -C ui build                               # frontend build
+pnpm -C ui typecheck && pnpm -C ui lint        # frontend validation
+pnpm -C ui test:unit                           # frontend unit tests
+./gradlew generateOpenApiDocs && pnpm -C ui api-client:gen   # refresh OpenAPI-generated UI client
 ```
 
-## Code Formatting
+## How work is split in this repo
 
-**Spotless** is the sole formatter (Checkstyle removed in #9963).
-Java: `palantirJavaFormat("2.90.0")` — 4-space indent, 120-char line limit.
+|         Area         |          Path           |                           Use it for                           |                        Also load                         |
+|----------------------|-------------------------|----------------------------------------------------------------|----------------------------------------------------------|
+| Public API contracts | `api/`                  | Extension model, service interfaces, security abstractions     | `application/AGENTS.md` when implementations also change |
+| Backend application  | `application/`          | WebFlux services, routers, security, migrations, packaging     | `ui/AGENTS.md` when payloads or UX also change           |
+| Frontend             | `ui/`                   | Console, user center, workspace packages, generated API client | `application/AGENTS.md` for API or OpenAPI work          |
+| Application BOM      | `platform/application/` | Shared dependency constraints                                  | root only unless API/application also change             |
+| Plugin BOM           | `platform/plugin/`      | Plugin-facing dependency constraints                           | `api/AGENTS.md` when plugin API changes                  |
 
-The `format 'misc'` block (XML, properties, gitignore, editorconfig) MUST live in root
-`build.gradle`. Putting it in a submodule alongside `java` causes a Gradle classloader conflict.
+## Nested AGENTS.md files
 
-## Git Workflow
+Use the root file plus the relevant nested file(s):
+
+|  Subproject  |                                Path                                |                           What it adds                            |
+|--------------|--------------------------------------------------------------------|-------------------------------------------------------------------|
+| API library  | [`api/AGENTS.md`](api/AGENTS.md)                                   | Public API boundaries, extension model, service contract pitfalls |
+| Application  | [`application/AGENTS.md`](application/AGENTS.md)                   | WebFlux implementation patterns, routers, security, tests         |
+| Frontend     | [`ui/AGENTS.md`](ui/AGENTS.md)                                     | pnpm workspace commands, module layout, UI conventions            |
+| Platform BOM | [`platform/application/AGENTS.md`](platform/application/AGENTS.md) | Dependency constraint rules                                       |
+| Plugin BOM   | [`platform/plugin/AGENTS.md`](platform/plugin/AGENTS.md)           | Plugin BOM rules and downstream compatibility notes               |
+
+## Cross-module workflows
+
+### Full-stack feature work
+
+1. Start at the repo root.
+2. Load the nested `AGENTS.md` for **every** touched module.
+3. Keep API contracts, backend handlers, and UI usage in sync in the same change.
+
+### Backend contract or OpenAPI changes
+
+If you change any of these, also consider UI impact:
+
+- public request/response DTOs
+- REST routes or router contracts
+- OpenAPI annotations or generated schema
+- auth/session behavior consumed by console or user center
+
+Then regenerate the client:
 
 ```bash
-# Always start from upstream/main — never checkout local main
+./gradlew generateOpenApiDocs
+pnpm -C ui api-client:gen
+```
+
+Do not edit generated files in `ui/packages/api-client/src/` directly.
+
+### UI packaging
+
+The UI is embedded into the backend JAR. `application:copyUiDist` copies `ui/build/dist` into the application resources during the backend build. If the UI output changes, assume the backend packaging path matters too.
+
+## Repository structure
+
+- **`api/`** — Public API library published as `run.halo.app`; changes here affect external plugins.
+- **`application/`** — Main Spring Boot application; all business logic lives here.
+- **`platform/application/`** — Application BOM for dependency versions.
+- **`platform/plugin/`** — Plugin BOM for downstream plugin development.
+- **`ui/`** — pnpm workspace for admin console (`/console`) and user center (`/uc`).
+- **`docs/`** — Human-facing developer documentation.
+
+## Code style and examples
+
+**Java:** Spotless + Palantir Java Format (`2.90.0`) with 4-space indentation and 120-character lines. Spotless is the source of truth.
+
+**Frontend:** `vp fmt` (`pnpm -C ui format`) + ESLint. See [`ui/AGENTS.md`](ui/AGENTS.md) for module conventions.
+
+Example validation paths:
+
+```bash
+# backend-only change
+./gradlew spotlessApply
+./gradlew :application:test
+
+# frontend-only change
+pnpm -C ui format
+pnpm -C ui typecheck && pnpm -C ui lint
+
+# cross-stack contract change
+./gradlew generateOpenApiDocs
+pnpm -C ui api-client:gen
+pnpm -C ui typecheck && pnpm -C ui lint
+./gradlew :application:test
+```
+
+## Key development notes
+
+- Preset plugins are downloaded at build time via `downloadPluginPresets`.
+- Database migrations use `r2dbc-migrate`, not Flyway/Liquibase.
+- Migration scripts live in `application/src/main/resources/db/migration/{h2,mariadb,mysql,postgresql}/`.
+- Extension type schemas live in `application/src/main/resources/extensions/`; runtime data is stored as JSON in the database.
+- Profile-specific configs include `application-local.yaml`, `application-dev.yaml`, and `application-postgresql.yaml`.
+- Default work directory is `~/.halo2` unless overridden by `halo.work-dir`.
+- Virtual threads are enabled. Do not introduce blocking I/O in reactive paths.
+- AI-assisted contributions are allowed, but material usage should be disclosed in PR descriptions.
+
+## Repository & upstream context
+
+This AGENTS.md is shared by two repositories:
+
+|      Repository       |         Purpose         |
+|-----------------------|-------------------------|
+| `halo-dev/halo`       | Open-source edition     |
+| `lxware-dev/halo-pro` | Pro/proprietary edition |
+
+Always identify the current upstream before pushing or opening a PR:
+
+```bash
+git remote -v
+```
+
+PRs must target the `upstream` remote of the current repo. Opening against the wrong upstream is costly to unwind.
+
+## Git workflow
+
+```bash
 git fetch upstream && git checkout upstream/main && git checkout -b feat/xxx
 ```
 
 - **Branch naming:** `upgrade/gradle-X`, `feat/name`, `fix/name`, `improvement/name`
 - **PR template:** `.github/pull_request_template.md`
 - **CI:** `.github/workflows/halo.yaml`
-- **Never `git add -A` or `git add .`** — H2 database artifacts live in `application/`. Stage specific files only.
-- **Stale worktrees lock `main`.** If `git checkout main` fails: `git worktree list && git worktree remove --force <path>`
+- **Never `git add -A` or `git add .`** — H2 artifacts and build outputs can appear under `application/`; stage specific files only.
+- **Stale worktrees can lock `main`.** If `git checkout main` fails, inspect with `git worktree list` and remove the stale worktree explicitly.
 
-## Critical Pitfalls (Project-Wide)
+## Before you submit
+
+Run the checks that match the touched area, and do not leave red CI behind:
+
+```bash
+./gradlew spotlessApply
+./gradlew :application:test
+pnpm -C ui typecheck && pnpm -C ui lint
+```
+
+Add or update tests for the code you change.
+
+## Boundaries
+
+- ✅ **Always:** Work from the repo root for command orchestration; load all touched nested `AGENTS.md` files; stage files explicitly; regenerate the UI API client after OpenAPI contract changes; add or update tests for changed behavior.
+- ⚠️ **Ask first:** Public API changes in `api/`; new Gradle or npm dependencies; database migration scripts; security configuration; CI workflow changes; destructive changes to generated client output.
+- 🚫 **Never:** Commit secrets or credentials; hard-code versions; introduce blocking I/O into reactive flows; edit generated API client files directly; open a PR without verifying the correct upstream.
+
+## Critical pitfalls
 
 ### 1. H2 database paths must be absolute
-Use `r2dbc:h2:file:///tmp/halo-db`. Relative paths (`file:./tmp/...`) create stray `application/tmp/` directories.
 
-### 2. `@Schema(pattern=...)` must be inline
-Extracting the regex to a `static final String` puts the literal constant name into the generated
-OpenAPI spec, not the regex. Keep it inline even if it exceeds the 120-char line limit.
+Use `r2dbc:h2:file:///tmp/halo-db`. Relative paths such as `file:./tmp/...` create stray `application/tmp/` directories.
 
-### 3. Resilience4j rate limiter keys MUST NOT include user-controlled values
-Each unique key creates an independent limiter. Including email, phone, or request body fields
-allows bypass by varying those values. Use only authenticated identity or client IP.
+### 2. Gradle wrapper upgrades require two commands
 
-### 4. Gradle wrapper upgrade requires TWO commands
 ```bash
-./gradlew wrapper --gradle-version=X.Y.Z   # Updates gradle-wrapper.properties
-./gradlew wrapper                           # Regenerates wrapper JAR + scripts
+./gradlew wrapper --gradle-version=X.Y.Z
+./gradlew wrapper
 ```
 
-### 5. `format 'misc'` placement
-Must be in root `build.gradle`, never in `application/build.gradle`. Co-locating `java` and `misc`
-in the same submodule causes a Gradle 9.x implicit dependency validation error.
+### 3. `format 'misc'` must stay in the root `build.gradle`
 
-### 6. API client regeneration needs two commands in order
-```bash
-./gradlew generateOpenApiDocs    # Boots Spring, extracts OpenAPI JSON (~28s)
-cd ui && pnpm api-client:gen     # Runs openapi-generator
-```
+Do not move it into `application/build.gradle`. Putting `java` and `misc` formatting in the same submodule triggers a Gradle 9.x implicit dependency validation error.
 
-## Config & Version Files
+## Config and version files
 
-| What | Where |
-|---|---|
-| Dependency versions | `gradle/libs.versions.toml` |
-| Project version | `gradle.properties` → `version=` |
-| Spring Boot version | `gradle/libs.versions.toml` → `[plugins] spring-boot` |
-| JDK version | `api/build.gradle` / `application/build.gradle` → `options.release = 21` |
-| Frontend deps | `ui/package.json` |
-| App configuration | `application/src/main/resources/application.yaml` |
-| Extension points | `application/src/main/resources/extensions/` |
+|            What            |                                  Where                                  |
+|----------------------------|-------------------------------------------------------------------------|
+| Dependency versions        | `gradle/libs.versions.toml`                                             |
+| Project version            | `gradle.properties`                                                     |
+| Spring Boot plugin version | `gradle/libs.versions.toml` → `[plugins] spring-boot`                   |
+| JDK release                | `api/build.gradle`, `application/build.gradle` → `options.release = 21` |
+| Frontend dependencies      | `ui/package.json`                                                       |
+| App configuration          | `application/src/main/resources/application.yaml`                       |
+| Extension schemas          | `application/src/main/resources/extensions/`                            |
+

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/api/AGENTS.md
+++ b/api/AGENTS.md
@@ -1,68 +1,101 @@
 # API Module — AGENTS.md
 
-`java-library` module at `api/`. Defines the extension model, reactive interfaces, security
-abstractions, and service contracts used by the `application` module and plugins.
+`java-library` module at `api/`. It defines the extension model, reactive interfaces, security abstractions, and service contracts used by `application` and external plugins.
 
-## Build
+Read this file together with the root [`AGENTS.md`](../AGENTS.md). If a task changes both contracts and implementations, also load [`application/AGENTS.md`](../application/AGENTS.md). If API or OpenAPI-visible DTOs affect the console or user center, also load [`ui/AGENTS.md`](../ui/AGENTS.md).
+
+## Quick commands
 
 ```bash
-./gradlew :api:compileJava              # Compile only
-./gradlew :api:test                     # Run all tests
-./gradlew :api:test --tests "*Xxx*"     # Run specific test
-./gradlew :api:spotlessApply            # Format only API module
+./gradlew :api:compileJava
+./gradlew :api:test
+./gradlew :api:test --tests "*Xxx*"
+./gradlew :api:spotlessApply
 ```
 
-## Key Packages
+## When to work here
 
-| Package | Purpose |
-|---|---|
-| `run.halo.app.extension` | Kubernetes-style extension model: `Extension`, `Metadata`, `Scheme`, `ReactiveExtensionClient`, `Unstructured` |
-| `run.halo.app.extension.router` | REST router framework for extensions: `IListRequest`, `SortableRequest`, `QueryParamBuildUtil` |
-| `run.halo.app.extension.controller` | Controller pattern for reconciling extensions |
-| `run.halo.app.core.extension` | Core extensions: `Post`, `Category`, `Tag`, `Comment`, `User`, `Role`, `Plugin`, `Theme`, `Setting` |
-| `run.halo.app.core.extension.service` | Core service interfaces: `UserService`, `RoleService`, `PostService`, etc. |
-| `run.halo.app.infra` | Infrastructure: `SystemSetting`, `SystemConfigurableEnvironmentFetcher` |
-| `run.halo.app.security` | Security abstractions: `HaloOAuth2AuthenticationToken`, authorization interfaces |
-| `run.halo.app.plugin` | Plugin API: `PluginApplicationContext`, extension points |
-| `run.halo.app.theme` | Theme API: `ThemeSetting`, template interfaces |
-| `run.halo.app.content` | Content abstractions: `Snapshot`, `ContentWrapper`, `Contributor` |
-| `run.halo.app.event` | Event types (Spring `ApplicationEvent` subclasses) |
-| `run.halo.app.search` | Search abstractions |
-| `run.halo.app.migration` | Migration framework |
-| `run.halo.app.notification` | Notification abstractions: `Reason`, `ReasonType`, `NotificationCenter` |
+- service interfaces implemented in `application`
+- extension model types and metadata contracts
+- public security abstractions
+- plugin-facing APIs and extension points
+- shared DTOs or annotations that affect generated OpenAPI
 
-## Extension Model
+Because plugins depend on this module, changes here are higher risk than ordinary backend refactors.
+
+## Key packages
+
+|                Package                |                                                    Purpose                                                     |
+|---------------------------------------|----------------------------------------------------------------------------------------------------------------|
+| `run.halo.app.extension`              | Kubernetes-style extension model: `Extension`, `Metadata`, `Scheme`, `ReactiveExtensionClient`, `Unstructured` |
+| `run.halo.app.extension.router`       | REST router framework for extensions: `IListRequest`, `SortableRequest`, `QueryParamBuildUtil`                 |
+| `run.halo.app.extension.controller`   | Controller pattern for reconciling extensions                                                                  |
+| `run.halo.app.core.extension`         | Core extensions: `Post`, `Category`, `Tag`, `Comment`, `User`, `Role`, `Plugin`, `Theme`, `Setting`            |
+| `run.halo.app.core.extension.service` | Core service interfaces such as `UserService`, `RoleService`, `PostService`                                    |
+| `run.halo.app.infra`                  | Infrastructure abstractions                                                                                    |
+| `run.halo.app.security`               | Security abstractions including `HaloOAuth2AuthenticationToken`                                                |
+| `run.halo.app.plugin`                 | Plugin API and extension points                                                                                |
+| `run.halo.app.theme`                  | Theme API                                                                                                      |
+| `run.halo.app.content`                | Content abstractions                                                                                           |
+| `run.halo.app.event`                  | Event types                                                                                                    |
+| `run.halo.app.search`                 | Search abstractions                                                                                            |
+| `run.halo.app.migration`              | Migration framework                                                                                            |
+| `run.halo.app.notification`           | Notification abstractions                                                                                      |
+
+## Extension model
 
 Halo's core data model uses a Kubernetes-style extension system:
 
-- **`Extension`** interface — all domain objects implement this. Provides `getMetadata()`, `getApiVersion()`, `getKind()`.
-- **`Metadata`** — contains `name`, `labels`, `annotations`, `version`, `creationTimestamp`.
-- **`Scheme`** — registers an Extension type with its `GroupVersionKind`, Java type, and JSON schema.
-- **`ReactiveExtensionClient`** — the primary CRUD API: `create()`, `fetch()`, `update()`, `delete()`, `list()`.
-- **`Unstructured`** — generic representation when the concrete type is unknown (e.g., plugin config).
+- **`Extension`** — all domain objects implement this and expose metadata, API version, and kind.
+- **`Metadata`** — holds `name`, labels, annotations, version, and timestamps.
+- **`Scheme`** — registers an extension type with its `GroupVersionKind`, Java type, and JSON schema.
+- **`ReactiveExtensionClient`** — the generic CRUD entry point.
+- **`Unstructured`** — fallback representation when the concrete type is unknown.
 
-### Custom Resource Patterns
+Example:
 
 ```java
-// Most extensions follow this pattern
 @GVK(group = "content.halo.run", version = "v1alpha1", kind = "Post",
-     singular = "post", plural = "posts")
+    singular = "post", plural = "posts")
 public class Post extends AbstractExtension { ... }
 ```
 
-## Service Interfaces
+## Service interfaces
 
-Services are defined in `api` as interfaces, implemented in `application`.
-Key ones:
+Interfaces live here; implementations belong in `application`.
 
-- `UserService` — user CRUD, role assignment, password management. Prefer over raw `ReactiveExtensionClient` for user operations (handles duplicate checking, extensions hooks).
+- `UserService` — prefer this over raw `ReactiveExtensionClient` for user creation and role wiring.
 - `RoleService` — role CRUD and dependency resolution.
 - `PostService` / `SinglePageService` — content publishing pipeline.
 - `NotificationCenter` — notification dispatch.
-- `ThemeService` / `PluginService` — theme/plugin lifecycle.
+- `ThemeService` / `PluginService` — theme and plugin lifecycle.
+
+If an interface signature changes, expect follow-on changes in `application` and often in `ui`.
+
+## OpenAPI and downstream impact
+
+Changes in `api` can surface in generated docs and the UI API client. If you touch OpenAPI-visible DTOs, schema annotations, or route-facing types, regenerate the client from the repo root:
+
+```bash
+./gradlew generateOpenApiDocs
+pnpm -C ui api-client:gen
+```
+
+## Test patterns
+
+- Run focused tests with `./gradlew :api:test --tests "*NamePattern*"`.
+- Add or update tests for any changed contract behavior.
+- Prefer contract-level assertions that make downstream breakage obvious.
 
 ## Pitfalls
 
-- **`@Schema(pattern=...)` must be inline** in DTOs/extensions. Extracting the regex to a `static final String` puts the literal constant name (not the regex) into the generated OpenAPI spec.
-- **Rate limiter keys** in `api` module abstractions must not include user-controlled parameters. Each unique key is an independent limiter. Use authenticated identity or client IP only.
-- **`Extension` metadata name convention:** use `setName("prefix-" + UUID)` not `setGenerateName()`. Service implementations like `UserServiceImpl` call `grantRoles(user.getMetadata().getName())` on the original reference — `generateName` returns null until persisted.
+- **`@Schema(pattern = ...)` must stay inline.** Extracting the regex into a constant makes the generated OpenAPI contain the constant name instead of the pattern.
+- **Rate limiter keys must not include user-controlled input.** Each unique key becomes its own limiter; use authenticated identity or client IP only.
+- **Use `setName("prefix-" + UUID)`, not `setGenerateName()`.** Service implementations often read `metadata.name` before persistence; `generateName` is still null at that point.
+
+## Boundaries
+
+- ✅ **Always:** Keep API contracts minimal and stable; update downstream implementations and tests together; think about plugin compatibility before changing signatures.
+- ⚠️ **Ask first:** Breaking changes to public APIs, plugin extension points, public annotations, or serialization shape.
+- 🚫 **Never:** Hide a breaking API change behind silent defaults; change public contracts without updating `application`; edit generated UI client files instead of regenerating them.
+

--- a/api/AGENTS.md
+++ b/api/AGENTS.md
@@ -1,0 +1,68 @@
+# API Module — AGENTS.md
+
+`java-library` module at `api/`. Defines the extension model, reactive interfaces, security
+abstractions, and service contracts used by the `application` module and plugins.
+
+## Build
+
+```bash
+./gradlew :api:compileJava              # Compile only
+./gradlew :api:test                     # Run all tests
+./gradlew :api:test --tests "*Xxx*"     # Run specific test
+./gradlew :api:spotlessApply            # Format only API module
+```
+
+## Key Packages
+
+| Package | Purpose |
+|---|---|
+| `run.halo.app.extension` | Kubernetes-style extension model: `Extension`, `Metadata`, `Scheme`, `ReactiveExtensionClient`, `Unstructured` |
+| `run.halo.app.extension.router` | REST router framework for extensions: `IListRequest`, `SortableRequest`, `QueryParamBuildUtil` |
+| `run.halo.app.extension.controller` | Controller pattern for reconciling extensions |
+| `run.halo.app.core.extension` | Core extensions: `Post`, `Category`, `Tag`, `Comment`, `User`, `Role`, `Plugin`, `Theme`, `Setting` |
+| `run.halo.app.core.extension.service` | Core service interfaces: `UserService`, `RoleService`, `PostService`, etc. |
+| `run.halo.app.infra` | Infrastructure: `SystemSetting`, `SystemConfigurableEnvironmentFetcher` |
+| `run.halo.app.security` | Security abstractions: `HaloOAuth2AuthenticationToken`, authorization interfaces |
+| `run.halo.app.plugin` | Plugin API: `PluginApplicationContext`, extension points |
+| `run.halo.app.theme` | Theme API: `ThemeSetting`, template interfaces |
+| `run.halo.app.content` | Content abstractions: `Snapshot`, `ContentWrapper`, `Contributor` |
+| `run.halo.app.event` | Event types (Spring `ApplicationEvent` subclasses) |
+| `run.halo.app.search` | Search abstractions |
+| `run.halo.app.migration` | Migration framework |
+| `run.halo.app.notification` | Notification abstractions: `Reason`, `ReasonType`, `NotificationCenter` |
+
+## Extension Model
+
+Halo's core data model uses a Kubernetes-style extension system:
+
+- **`Extension`** interface — all domain objects implement this. Provides `getMetadata()`, `getApiVersion()`, `getKind()`.
+- **`Metadata`** — contains `name`, `labels`, `annotations`, `version`, `creationTimestamp`.
+- **`Scheme`** — registers an Extension type with its `GroupVersionKind`, Java type, and JSON schema.
+- **`ReactiveExtensionClient`** — the primary CRUD API: `create()`, `fetch()`, `update()`, `delete()`, `list()`.
+- **`Unstructured`** — generic representation when the concrete type is unknown (e.g., plugin config).
+
+### Custom Resource Patterns
+
+```java
+// Most extensions follow this pattern
+@GVK(group = "content.halo.run", version = "v1alpha1", kind = "Post",
+     singular = "post", plural = "posts")
+public class Post extends AbstractExtension { ... }
+```
+
+## Service Interfaces
+
+Services are defined in `api` as interfaces, implemented in `application`.
+Key ones:
+
+- `UserService` — user CRUD, role assignment, password management. Prefer over raw `ReactiveExtensionClient` for user operations (handles duplicate checking, extensions hooks).
+- `RoleService` — role CRUD and dependency resolution.
+- `PostService` / `SinglePageService` — content publishing pipeline.
+- `NotificationCenter` — notification dispatch.
+- `ThemeService` / `PluginService` — theme/plugin lifecycle.
+
+## Pitfalls
+
+- **`@Schema(pattern=...)` must be inline** in DTOs/extensions. Extracting the regex to a `static final String` puts the literal constant name (not the regex) into the generated OpenAPI spec.
+- **Rate limiter keys** in `api` module abstractions must not include user-controlled parameters. Each unique key is an independent limiter. Use authenticated identity or client IP only.
+- **`Extension` metadata name convention:** use `setName("prefix-" + UUID)` not `setGenerateName()`. Service implementations like `UserServiceImpl` call `grantRoles(user.getMetadata().getName())` on the original reference — `generateName` returns null until persisted.

--- a/application/AGENTS.md
+++ b/application/AGENTS.md
@@ -1,0 +1,126 @@
+# Application Module — AGENTS.md
+
+Executable Spring Boot WebFlux application at `application/`. Implements all service interfaces
+from `api`, REST routers, security filters, and extension controllers.
+
+## Build
+
+```bash
+./gradlew :application:compileJava                      # Compile only
+./gradlew :application:test --tests "*PostService*"     # Run specific test class
+./gradlew :application:test                             # Run all tests
+./gradlew :application:spotlessApply                    # Format only application module
+./gradlew :application:bootRun                          # Start dev server (port 8090)
+```
+
+## Key Packages
+
+| Package | Purpose |
+|---|---|
+| `run.halo.app.core.extension.service.impl` | Service implementations: `UserServiceImpl`, `PostServiceImpl`, `RoleServiceImpl` |
+| `run.halo.app.content` | Content management: post/page publishing, snapshots, contributors |
+| `run.halo.app.security` | Security: authentication filters, OAuth2, authorization |
+| `run.halo.app.security.authentication.oauth2` | OAuth2 login: `MapOAuth2AuthenticationFilter`, login handlers |
+| `run.halo.app.extension.controller` | Extension controllers (reconcilers) |
+| `run.halo.app.infra` | Infrastructure: system config, theme/plugin management |
+| `run.halo.app.notification` | Notification implementation: `DefaultNotificationCenter` |
+| `run.halo.app.plugin` | Plugin lifecycle: `PluginApplicationContextFactory`, extension point registration |
+| `run.halo.app.theme` | Theme engine: template resolution, theme routes |
+| `run.halo.app.search` | Search implementation (Lucene) |
+| `run.halo.app.migration` | Database migration (r2dbc-migrate) |
+
+## Service Implementation Pattern
+
+All service implementations follow the same reactive pattern:
+
+```java
+@Component
+public class XxxServiceImpl implements XxxService {
+    private final ReactiveExtensionClient client;
+
+    @Override
+    public Mono<Xxx> doSomething(String name) {
+        return client.fetch(Xxx.class, name)
+            .switchIfEmpty(Mono.error(new ExtensionNotFoundException(name, Xxx.class)))
+            .flatMap(xxx -> {
+                // mutate
+                return client.update(xxx);
+            });
+    }
+}
+```
+
+### Key service classes:
+- `UserServiceImpl` — handles duplicate checking, `UserPreCreatingHandler`/`UserPostCreatingHandler` extension hooks, `grantRoles()`. Always use this for user creation, not raw `ReactiveExtensionClient`.
+- `UserConnectionServiceImpl` — OAuth2 connection management: `createUserConnection()`.
+- `DefaultNotificationCenter` — notification dispatch via `ReasonType` resolution.
+
+## Security
+
+### OAuth2 Authentication Flow
+
+1. `MapOAuth2AuthenticationFilter` maps OAuth2 `OAuth2User` to Halo `UserDetails`
+2. Auto-registration creates a new Halo user from OAuth2 attributes
+3. `DefaultOAuth2LoginHandlerEnhancer` creates/updates `UserConnection`
+
+### OAuth2 key classes:
+- `MapOAuth2AuthenticationFilter.java` — central filter, maps OAuth2 to Halo user
+- `OAuth2SecurityConfigurer.java` — registers filter in Spring Security chain
+- `HaloOAuth2AuthenticationToken.java` (in `api`) — wraps OAuth2 token + UserDetails
+
+### Pitfalls:
+- Pre-auth check in `MapOAuth2AuthenticationFilter` MUST exclude `OAuth2AuthenticationToken` instances. Without `!(preAuth instanceof OAuth2AuthenticationToken)`, the OAuth2-only flow tries to bind to the OAuth2 user's "name" attribute as a Halo username.
+- Use `UserService.createUser()`, not `ReactiveExtensionClient.create()` followed by manual `RoleBinding.create()`.
+- Do NOT use `setGenerateName()` with `createUser()` — it returns null from `getName()`.
+
+## REST Router Pattern
+
+Routers use Spring WebFlux functional endpoints:
+
+```java
+@Component
+public class PostRouter implements RouterFunction<ServerResponse> {
+    @Override
+    public RouterFunction<ServerResponse> route() {
+        return RouterFunctions.route()
+            .GET("/posts", this::list)
+            .POST("/posts", this::create)
+            .build();
+    }
+}
+```
+
+Router packages:
+- `run.halo.app.core.extension.router` — core extension CRUD routes
+- `run.halo.app.content.router` — content management endpoints
+- `run.halo.app.security.router` — auth endpoints (login, token refresh)
+
+## Config & Resources
+
+| What | Path |
+|---|---|
+| Application YAML | `application/src/main/resources/application.yaml` |
+| Extension point files | `application/src/main/resources/extensions/` |
+| Role templates | `application/src/main/resources/extensions/role-template-*.yaml` |
+| i18n resources | `application/src/main/resources/i18n/` |
+
+## Test Patterns
+
+```bash
+# Run specific test class
+./gradlew :application:test --tests "*ClassName*"
+
+# Run tests matching a pattern (e.g., all OAuth2 tests)
+./gradlew :application:test --tests "*oauth2*"
+
+# Run multiple patterns
+./gradlew :application:test --tests "*PostService*" --tests "*ContentService*"
+```
+
+Tests use JUnit 5 + Spring Boot Test + Mockito + `StepVerifier` for reactive chains.
+Lombok available in test scope.
+
+When testing OAuth2 auto-registration:
+- Mock `UserService` with `when(userService.createUser(any(User.class), anySet()))`
+- Use `ArgumentCaptor` to inspect created User fields
+- Use `@MockitoSettings(strictness = Strictness.LENIENT)` to handle reactive chain stubbing

--- a/application/AGENTS.md
+++ b/application/AGENTS.md
@@ -1,37 +1,45 @@
 # Application Module — AGENTS.md
 
-Executable Spring Boot WebFlux application at `application/`. Implements all service interfaces
-from `api`, REST routers, security filters, and extension controllers.
+Executable Spring Boot WebFlux application at `application/`. This module implements the contracts from `api`, owns routers, security, migrations, plugin/theme runtime behavior, and packages the UI into the backend artifact.
 
-## Build
+Read this file together with the root [`AGENTS.md`](../AGENTS.md). If a change affects public contracts, also load [`api/AGENTS.md`](../api/AGENTS.md). If a change affects console or user-center payloads, auth flows, or generated OpenAPI, also load [`ui/AGENTS.md`](../ui/AGENTS.md).
+
+## Quick commands
 
 ```bash
-./gradlew :application:compileJava                      # Compile only
-./gradlew :application:test --tests "*PostService*"     # Run specific test class
-./gradlew :application:test                             # Run all tests
-./gradlew :application:spotlessApply                    # Format only application module
-./gradlew :application:bootRun                          # Start dev server (port 8090)
+./gradlew :application:compileJava
+./gradlew :application:test
+./gradlew :application:test --tests "*PostService*"
+./gradlew :application:spotlessApply
+./gradlew :application:bootRun
+./gradlew generateOpenApiDocs
 ```
 
-## Key Packages
+## Cross-stack touchpoints
 
-| Package | Purpose |
-|---|---|
-| `run.halo.app.core.extension.service.impl` | Service implementations: `UserServiceImpl`, `PostServiceImpl`, `RoleServiceImpl` |
-| `run.halo.app.content` | Content management: post/page publishing, snapshots, contributors |
-| `run.halo.app.security` | Security: authentication filters, OAuth2, authorization |
-| `run.halo.app.security.authentication.oauth2` | OAuth2 login: `MapOAuth2AuthenticationFilter`, login handlers |
-| `run.halo.app.extension.controller` | Extension controllers (reconcilers) |
-| `run.halo.app.infra` | Infrastructure: system config, theme/plugin management |
-| `run.halo.app.notification` | Notification implementation: `DefaultNotificationCenter` |
-| `run.halo.app.plugin` | Plugin lifecycle: `PluginApplicationContextFactory`, extension point registration |
-| `run.halo.app.theme` | Theme engine: template resolution, theme routes |
-| `run.halo.app.search` | Search implementation (Lucene) |
-| `run.halo.app.migration` | Database migration (r2dbc-migrate) |
+- `generateOpenApiDocs` is driven from this module and feeds the generated UI API client.
+- `copyUiDist` pulls `ui/build/dist` into the backend resources during packaging.
+- If request/response shape, auth behavior, or route semantics change here, assume the UI may need changes too.
 
-## Service Implementation Pattern
+## Key packages
 
-All service implementations follow the same reactive pattern:
+|                    Package                    |                                         Purpose                                         |
+|-----------------------------------------------|-----------------------------------------------------------------------------------------|
+| `run.halo.app.core.extension.service.impl`    | Service implementations such as `UserServiceImpl`, `PostServiceImpl`, `RoleServiceImpl` |
+| `run.halo.app.content`                        | Content management: publishing, snapshots, contributors                                 |
+| `run.halo.app.security`                       | Security filters, OAuth2, authorization                                                 |
+| `run.halo.app.security.authentication.oauth2` | OAuth2 login flow                                                                       |
+| `run.halo.app.extension.controller`           | Extension reconcilers and controllers                                                   |
+| `run.halo.app.infra`                          | System config, theme/plugin management                                                  |
+| `run.halo.app.notification`                   | `DefaultNotificationCenter` and related behavior                                        |
+| `run.halo.app.plugin`                         | Plugin lifecycle and extension registration                                             |
+| `run.halo.app.theme`                          | Theme engine and route integration                                                      |
+| `run.halo.app.search`                         | Lucene-backed search                                                                    |
+| `run.halo.app.migration`                      | `r2dbc-migrate` integration                                                             |
+
+## Service implementation pattern
+
+Most services follow the same reactive shape:
 
 ```java
 @Component
@@ -50,30 +58,33 @@ public class XxxServiceImpl implements XxxService {
 }
 ```
 
-### Key service classes:
-- `UserServiceImpl` — handles duplicate checking, `UserPreCreatingHandler`/`UserPostCreatingHandler` extension hooks, `grantRoles()`. Always use this for user creation, not raw `ReactiveExtensionClient`.
-- `UserConnectionServiceImpl` — OAuth2 connection management: `createUserConnection()`.
-- `DefaultNotificationCenter` — notification dispatch via `ReasonType` resolution.
+Key service reminders:
+
+- `UserServiceImpl` owns duplicate checks, create hooks, and role grants. Use it instead of raw `ReactiveExtensionClient` for user creation.
+- `UserConnectionServiceImpl` owns OAuth2 connection persistence.
+- `DefaultNotificationCenter` resolves `ReasonType` and dispatches notifications.
 
 ## Security
 
-### OAuth2 Authentication Flow
+### OAuth2 authentication flow
 
-1. `MapOAuth2AuthenticationFilter` maps OAuth2 `OAuth2User` to Halo `UserDetails`
-2. Auto-registration creates a new Halo user from OAuth2 attributes
-3. `DefaultOAuth2LoginHandlerEnhancer` creates/updates `UserConnection`
+1. `MapOAuth2AuthenticationFilter` maps `OAuth2User` to Halo `UserDetails`.
+2. Auto-registration creates the Halo user from OAuth2 attributes.
+3. `DefaultOAuth2LoginHandlerEnhancer` creates or updates `UserConnection`.
 
-### OAuth2 key classes:
-- `MapOAuth2AuthenticationFilter.java` — central filter, maps OAuth2 to Halo user
-- `OAuth2SecurityConfigurer.java` — registers filter in Spring Security chain
-- `HaloOAuth2AuthenticationToken.java` (in `api`) — wraps OAuth2 token + UserDetails
+Key classes:
 
-### Pitfalls:
-- Pre-auth check in `MapOAuth2AuthenticationFilter` MUST exclude `OAuth2AuthenticationToken` instances. Without `!(preAuth instanceof OAuth2AuthenticationToken)`, the OAuth2-only flow tries to bind to the OAuth2 user's "name" attribute as a Halo username.
-- Use `UserService.createUser()`, not `ReactiveExtensionClient.create()` followed by manual `RoleBinding.create()`.
-- Do NOT use `setGenerateName()` with `createUser()` — it returns null from `getName()`.
+- `MapOAuth2AuthenticationFilter.java`
+- `OAuth2SecurityConfigurer.java`
+- `HaloOAuth2AuthenticationToken.java` in `api`
 
-## REST Router Pattern
+Pitfalls:
+
+- The pre-auth check in `MapOAuth2AuthenticationFilter` must exclude `OAuth2AuthenticationToken` instances.
+- Use `UserService.createUser()`, not raw extension creation plus manual role binding.
+- Do not use `setGenerateName()` with `createUser()` because the name is still null when downstream code reads it.
+
+## REST router pattern
 
 Routers use Spring WebFlux functional endpoints:
 
@@ -91,36 +102,40 @@ public class PostRouter implements RouterFunction<ServerResponse> {
 ```
 
 Router packages:
-- `run.halo.app.core.extension.router` — core extension CRUD routes
-- `run.halo.app.content.router` — content management endpoints
-- `run.halo.app.security.router` — auth endpoints (login, token refresh)
 
-## Config & Resources
+- `run.halo.app.core.extension.router`
+- `run.halo.app.content.router`
+- `run.halo.app.security.router`
 
-| What | Path |
-|---|---|
-| Application YAML | `application/src/main/resources/application.yaml` |
-| Extension point files | `application/src/main/resources/extensions/` |
-| Role templates | `application/src/main/resources/extensions/role-template-*.yaml` |
-| i18n resources | `application/src/main/resources/i18n/` |
+## Config and resources
 
-## Test Patterns
+|       What        |                               Path                               |
+|-------------------|------------------------------------------------------------------|
+| Application YAML  | `application/src/main/resources/application.yaml`                |
+| Extension schemas | `application/src/main/resources/extensions/`                     |
+| Role templates    | `application/src/main/resources/extensions/role-template-*.yaml` |
+| i18n resources    | `application/src/main/resources/i18n/`                           |
+| DB migrations     | `application/src/main/resources/db/migration/`                   |
+
+## Test patterns
 
 ```bash
-# Run specific test class
 ./gradlew :application:test --tests "*ClassName*"
-
-# Run tests matching a pattern (e.g., all OAuth2 tests)
 ./gradlew :application:test --tests "*oauth2*"
-
-# Run multiple patterns
 ./gradlew :application:test --tests "*PostService*" --tests "*ContentService*"
 ```
 
-Tests use JUnit 5 + Spring Boot Test + Mockito + `StepVerifier` for reactive chains.
-Lombok available in test scope.
+Tests use JUnit 5, Spring Boot Test, Mockito, and `StepVerifier`.
 
 When testing OAuth2 auto-registration:
-- Mock `UserService` with `when(userService.createUser(any(User.class), anySet()))`
-- Use `ArgumentCaptor` to inspect created User fields
-- Use `@MockitoSettings(strictness = Strictness.LENIENT)` to handle reactive chain stubbing
+
+- mock `UserService.createUser(any(User.class), anySet())`
+- inspect created users with `ArgumentCaptor`
+- use lenient Mockito settings only when the reactive setup truly requires it
+
+## Boundaries
+
+- ✅ **Always:** Preserve reactive, non-blocking behavior; update API contracts and UI consumers together when backend behavior changes; run focused backend tests for the touched area.
+- ⚠️ **Ask first:** Security model changes, migration scripts, plugin preset behavior, or anything that breaks public API assumptions.
+- 🚫 **Never:** Add blocking I/O in the request path; bypass `UserService` for user creation flows; change generated OpenAPI behavior without considering UI regeneration.
+

--- a/platform/application/AGENTS.md
+++ b/platform/application/AGENTS.md
@@ -1,43 +1,49 @@
 # Platform Application BOM — AGENTS.md
 
-`java-platform` module at `platform/application/`. Bill of Materials that declares version
-constraints for all application dependencies. Published as `run.halo.tools.platform:platform-application`.
+`java-platform` module at `platform/application/`. This BOM declares shared dependency constraints for the application-side modules and is published as `run.halo.tools.platform:platform-application`.
 
-## Build
+Read this file together with the root [`AGENTS.md`](../../AGENTS.md). If the dependency change affects code in `api` or `application`, also load the corresponding nested `AGENTS.md`.
+
+## Quick commands
 
 ```bash
-./gradlew :platform:application:compileJava    # Compile only
+./gradlew :platform:application:compileJava
 ```
 
-This module has no source code — it's purely dependency constraint declarations.
+This module has no source code; changes here are dependency-constraint changes only.
 
 ## Purpose
 
-Centralizes dependency versions so `api` and `application` modules don't need to repeat
-version numbers. Applies the Spring Boot BOM via `SpringBootPlugin.BOM_COORDINATES`.
+- centralize dependency versions used by `api` and `application`
+- import the Spring Boot BOM baseline
+- keep downstream build files versionless wherever possible
 
-## Key Dependencies
+## Key dependencies
 
-See `platform/application/build.gradle` for the full constraint list. Key ones:
+See `platform/application/build.gradle` for the full constraint list. Important families include:
 
-| Dependency | Purpose |
-|---|---|
-| Spring Boot BOM | Framework baseline (`org.springframework.boot:spring-boot-dependencies`) |
-| Lucene bundles | Search engine |
-| Resilience4j | Rate limiting / circuit breaker |
-| PF4J | Plugin framework |
-| Guava | Utility library |
+|    Dependency     |           Purpose            |
+|-------------------|------------------------------|
+| Spring Boot BOM   | Framework baseline           |
+| Lucene            | Search engine                |
+| Resilience4j      | Rate limiting and resilience |
+| PF4J              | Plugin framework             |
+| Guava             | Shared utilities             |
 | SpringDoc OpenAPI | API documentation generation |
-| Bouncy Castle | Cryptographic operations |
-| jsoup | HTML parsing |
-| Thumbnailator | Image thumbnail generation |
-| UA Parser | User-agent parsing |
+| Bouncy Castle     | Cryptography                 |
+| jsoup             | HTML parsing                 |
+| Thumbnailator     | Thumbnail generation         |
+| UA Parser         | User-agent parsing           |
 
-## Pitfalls
+## Rules
 
-- **Version constraints go here, not in `api/build.gradle` or `application/build.gradle`.**
-  The `api` module uses `api platform(project(':platform:application'))` to import these constraints.
-- **Adding a new dependency?** If it's used by both `api` and `application`, add the version
-  constraint here first, then use the versionless dependency in `api/build.gradle`.
-- **Upgrading a version?** If the version is pinned in `gradle/libs.versions.toml`, update it there.
-  If only in this BOM, update the constraint directly.
+- Put shared versions here instead of repeating them in `api/build.gradle` or `application/build.gradle`.
+- If a version is already managed in `gradle/libs.versions.toml`, update it there instead of duplicating it here.
+- If a dependency is shared by `api` and `application`, add the constraint here first, then use the dependency without an inline version downstream.
+
+## Boundaries
+
+- ✅ **Always:** Keep version management centralized and consistent with `gradle/libs.versions.toml`.
+- ⚠️ **Ask first:** New shared libraries, major upgrades with compatibility risk, or BOM changes that affect plugin consumers indirectly.
+- 🚫 **Never:** Scatter shared versions back into module build files; add implementation-style logic to this `java-platform` module.
+

--- a/platform/application/AGENTS.md
+++ b/platform/application/AGENTS.md
@@ -1,0 +1,43 @@
+# Platform Application BOM — AGENTS.md
+
+`java-platform` module at `platform/application/`. Bill of Materials that declares version
+constraints for all application dependencies. Published as `run.halo.tools.platform:platform-application`.
+
+## Build
+
+```bash
+./gradlew :platform:application:compileJava    # Compile only
+```
+
+This module has no source code — it's purely dependency constraint declarations.
+
+## Purpose
+
+Centralizes dependency versions so `api` and `application` modules don't need to repeat
+version numbers. Applies the Spring Boot BOM via `SpringBootPlugin.BOM_COORDINATES`.
+
+## Key Dependencies
+
+See `platform/application/build.gradle` for the full constraint list. Key ones:
+
+| Dependency | Purpose |
+|---|---|
+| Spring Boot BOM | Framework baseline (`org.springframework.boot:spring-boot-dependencies`) |
+| Lucene bundles | Search engine |
+| Resilience4j | Rate limiting / circuit breaker |
+| PF4J | Plugin framework |
+| Guava | Utility library |
+| SpringDoc OpenAPI | API documentation generation |
+| Bouncy Castle | Cryptographic operations |
+| jsoup | HTML parsing |
+| Thumbnailator | Image thumbnail generation |
+| UA Parser | User-agent parsing |
+
+## Pitfalls
+
+- **Version constraints go here, not in `api/build.gradle` or `application/build.gradle`.**
+  The `api` module uses `api platform(project(':platform:application'))` to import these constraints.
+- **Adding a new dependency?** If it's used by both `api` and `application`, add the version
+  constraint here first, then use the versionless dependency in `api/build.gradle`.
+- **Upgrading a version?** If the version is pinned in `gradle/libs.versions.toml`, update it there.
+  If only in this BOM, update the constraint directly.

--- a/platform/plugin/AGENTS.md
+++ b/platform/plugin/AGENTS.md
@@ -1,20 +1,20 @@
 # Platform Plugin BOM — AGENTS.md
 
-`java-platform` module at `platform/plugin/`. Bill of Materials for plugin development.
-Published as `run.halo.tools.platform:platform-plugin`. Plugins import this BOM to get
-compatible versions of the Halo API and other plugin dependencies.
+`java-platform` module at `platform/plugin/`. This BOM is published as `run.halo.tools.platform:platform-plugin` and defines the dependency baseline that external Halo plugins consume.
 
-## Build
+Read this file together with the root [`AGENTS.md`](../../AGENTS.md). If a change affects the public API surface that plugin authors use, also load [`api/AGENTS.md`](../../api/AGENTS.md).
+
+## Quick commands
 
 ```bash
-./gradlew :platform:plugin:compileJava    # Compile only
+./gradlew :platform:plugin:compileJava
 ```
 
-This module has no source code — it's purely dependency constraint declarations.
+This module has no source code; it only declares dependency constraints.
 
 ## Purpose
 
-Plugin developers import this BOM in their `build.gradle`:
+Plugin developers import this BOM so they get compatible versions automatically:
 
 ```groovy
 dependencies {
@@ -23,19 +23,23 @@ dependencies {
 }
 ```
 
-## Key Dependencies
+## Key dependencies
 
-| Dependency | Purpose |
-|---|---|
-| `platform:application` BOM | Inherits all application dependency versions |
-| `project(':api')` | The Halo API library — core dependency for all plugins |
-| (future) Plugin APIs | Reserved for other plugin-specific API dependencies |
+|         Dependency         |                    Purpose                     |
+|----------------------------|------------------------------------------------|
+| `platform:application` BOM | Inherits the application-side version baseline |
+| `project(':api')`          | Core Halo API consumed by plugins              |
+| future plugin API modules  | Reserved for additional plugin-facing APIs     |
 
-## Pitfalls
+## Rules
 
-- **Extends `platform:application`.** This BOM inherits from `:platform:application`, so any version
-  change in the parent automatically applies to plugin builds.
-- **New plugin APIs go here.** When adding a new plugin-related API module (e.g., `links-api`),
-  add the version constraint here so plugin developers don't need to specify versions.
-- **This is a `javaPlatform`, not a library.** It declares constraints, not implementations.
-  Do not add `implementation`-style dependencies.
+- This BOM extends `:platform:application`, so upstream version changes flow into plugin builds.
+- New plugin-facing API modules should be constrained here so downstream plugin builds stay versionless.
+- Treat changes here as ecosystem changes, not local build tweaks.
+
+## Boundaries
+
+- ✅ **Always:** Preserve plugin compatibility and keep dependency declarations centralized.
+- ⚠️ **Ask first:** Version or dependency changes that alter the plugin development contract.
+- 🚫 **Never:** Add implementation-style dependencies or source logic to this `java-platform` module.
+

--- a/platform/plugin/AGENTS.md
+++ b/platform/plugin/AGENTS.md
@@ -1,0 +1,41 @@
+# Platform Plugin BOM — AGENTS.md
+
+`java-platform` module at `platform/plugin/`. Bill of Materials for plugin development.
+Published as `run.halo.tools.platform:platform-plugin`. Plugins import this BOM to get
+compatible versions of the Halo API and other plugin dependencies.
+
+## Build
+
+```bash
+./gradlew :platform:plugin:compileJava    # Compile only
+```
+
+This module has no source code — it's purely dependency constraint declarations.
+
+## Purpose
+
+Plugin developers import this BOM in their `build.gradle`:
+
+```groovy
+dependencies {
+    implementation platform('run.halo.tools.platform:platform-plugin:<version>')
+    implementation 'run.halo.app:api'
+}
+```
+
+## Key Dependencies
+
+| Dependency | Purpose |
+|---|---|
+| `platform:application` BOM | Inherits all application dependency versions |
+| `project(':api')` | The Halo API library — core dependency for all plugins |
+| (future) Plugin APIs | Reserved for other plugin-specific API dependencies |
+
+## Pitfalls
+
+- **Extends `platform:application`.** This BOM inherits from `:platform:application`, so any version
+  change in the parent automatically applies to plugin builds.
+- **New plugin APIs go here.** When adding a new plugin-related API module (e.g., `links-api`),
+  add the version constraint here so plugin developers don't need to specify versions.
+- **This is a `javaPlatform`, not a library.** It declares constraints, not implementations.
+  Do not add `implementation`-style dependencies.

--- a/ui/AGENTS.md
+++ b/ui/AGENTS.md
@@ -1,65 +1,81 @@
 # UI (Frontend) — AGENTS.md
 
-pnpm monorepo at `ui/`. Admin console + user center. Vue 3 + TypeScript + TailwindCSS 3.4.
+pnpm workspace at `ui/`. It contains the admin console, user center, shared packages, and the generated API client used by the frontend.
 
-## Quick Commands
+Read this file together with the root [`AGENTS.md`](../AGENTS.md). If a change touches backend contracts, auth flows, or generated OpenAPI, also load [`application/AGENTS.md`](../application/AGENTS.md). If a shared public type or extension contract changes, also load [`api/AGENTS.md`](../api/AGENTS.md).
+
+## Quick commands
+
+Prefer root-scoped commands:
 
 ```bash
-cd ui
-pnpm install                # Required before any other command
-pnpm dev                    # Dev server with HMR (port varies by route)
-pnpm build                  # Full: typecheck + bundle (console + UC)
-pnpm build:packages         # Build workspace packages only (faster)
-pnpm test:unit              # Vitest unit tests
-pnpm lint                   # ESLint
-pnpm format                 # Format code (vp fmt)
-pnpm format:check           # Check formatting
-pnpm api-client:gen         # Generate API client from OpenAPI spec
-pnpm typecheck              # vue-tsc type checking
+pnpm -C ui install
+pnpm -C ui dev
+pnpm -C ui build
+pnpm -C ui build:packages
+pnpm -C ui test:unit
+pnpm -C ui lint
+pnpm -C ui format
+pnpm -C ui format:check
+pnpm -C ui typecheck
+pnpm -C ui api-client:gen
 ```
 
-Or use Makefile wrappers: `make -C ui dev`, `make -C ui build`, `make -C ui test`, `make -C ui api-client-gen`.
+Local wrappers also exist:
 
-## Directory Layout
-
+```bash
+make -C ui dev
+make -C ui build
+make -C ui test
+make -C ui api-client-gen
 ```
+
+## Cross-stack touchpoints
+
+- `packages/api-client` is generated from backend OpenAPI docs. Do not hand-edit generated files.
+- Backend route, DTO, auth, or schema changes often require `./gradlew generateOpenApiDocs && pnpm -C ui api-client:gen`.
+- The frontend build output is bundled into the backend JAR during the application build.
+
+## Directory layout
+
+```text
 ui/
-├── console-src/            # Admin console (main application)
-│   ├── modules/            # Feature modules — auto-discovered via import.meta.glob
-│   ├── stores/             # Pinia stores (console-specific)
-│   ├── router/             # Vue Router config
-│   ├── layouts/            # Layout components
-│   └── styles/             # Console-specific styles
-├── src/                    # Shared code
+├── console-src/            # Admin console
+│   ├── modules/            # Feature modules, auto-discovered via import.meta.glob
+│   ├── stores/             # Console-specific Pinia stores
+│   ├── router/             # Console router config
+│   ├── layouts/            # Console layouts
+│   └── styles/             # Console styles
+├── src/                    # Shared frontend code
 │   ├── components/         # Shared Vue components
-│   ├── composables/        # Shared composables (use-auto-save-content, use-role, etc.)
-│   ├── stores/             # Shared Pinia stores (plugin.ts, role.ts)
-│   ├── formkit/            # FormKit config + custom inputs/plugins
-│   ├── locales/            # i18n JSON files (en, zh-CN, zh-TW, es)
-│   └── styles/             # Shared TailwindCSS + theme config
-├── uc-src/                 # User center (public-facing)
-│   ├── modules/            # Feature modules — auto-discovered
-│   └── router/             # Router with auth guards
-├── packages/               # Workspace packages (see below)
+│   ├── composables/        # Shared composables
+│   ├── stores/             # Shared Pinia stores
+│   ├── formkit/            # FormKit setup and theme
+│   ├── locales/            # i18n JSON files
+│   └── styles/             # Shared Tailwind/theme files
+├── uc-src/                 # User center
+├── packages/               # Workspace packages
 ├── public/                 # Static assets
 └── scripts/                # Build scripts
 ```
 
-## Workspace Packages (`ui/packages/`)
+## Workspace packages
 
-| Package | Purpose |
-|---|---|
-| `api-client` | Generated Axios-based API client from OpenAPI spec |
-| `components` | Shared UI component library + icons (Iconify) |
-| `editor` | Rich-text editor (Tiptap-based) |
-| `console-shared` | Console-specific shared code (stores, events, utils) |
-| `shared` | Cross-platform shared code (plugin system, types, stores) |
-| `ui-plugin-bundler-kit` | Build tooling for Halo UI plugins |
+| Package                 | Purpose                                           |
+| ----------------------- | ------------------------------------------------- |
+| `api-client`            | Generated Axios-based API client from OpenAPI     |
+| `components`            | Shared UI components and icons                    |
+| `editor`                | Tiptap-based rich-text editor                     |
+| `console-shared`        | Console-specific shared stores, events, and utils |
+| `shared`                | Cross-platform shared types and utilities         |
+| `ui-plugin-bundler-kit` | Build tooling for Halo UI plugins                 |
 
 ## Conventions
 
-### Module Pattern
+### Module pattern
+
 Each feature in `console-src/modules/<feature>/module.ts` uses `definePlugin()`:
+
 ```ts
 export default definePlugin({
   name: 'posts',
@@ -68,54 +84,75 @@ export default definePlugin({
   permissions: [...],
 })
 ```
+
 Modules are auto-discovered via `import.meta.glob("./**/module.ts")`.
 
-### Startup Order (main.ts)
-components → i18n → vue-query → api-client → pinia → core modules → user → permissions → plugin modules → router → mount
+### Startup order
 
-### Path Aliases
+`components -> i18n -> vue-query -> api-client -> pinia -> core modules -> user -> permissions -> plugin modules -> router -> mount`
+
+### Path aliases
+
 - `@/*` → `src/*`
 - `@console/*` → `console-src/*`
 - `@uc/*` → `uc-src/*`
+
 Defined in `tsconfig.app.json`.
 
-### Tech Stack
-- **State:** Pinia stores
-- **i18n:** vue-i18n with JSON locale files in `src/locales/`
-- **Forms:** FormKit (`src/formkit/theme.ts`)
-- **Icons:** Iconify via `@iconify/vue`. Icon sets: lucide, mdi, ri, fluent (installed as `@iconify-json/*` devDeps)
-- **CSS:** TailwindCSS 3.4 with `tailwindcss-themer` plugin
+### Tech stack
+
+- **State:** Pinia
+- **i18n:** `vue-i18n` with JSON locale files in `src/locales/`
+- **Forms:** FormKit
+- **Icons:** Iconify via `@iconify/vue`
+- **CSS:** TailwindCSS 3.4 + `tailwindcss-themer`
 - **Build tool:** `vite-plus` (`vp`)
 - **Testing:** Vitest
-- **API:** vue-query (TanStack Query)
+- **Data fetching:** TanStack Query (`@tanstack/vue-query`)
 
 ### Theme
-Default theme via `tailwindcss-themer`:
+
+Default theme tokens:
+
 - Primary: `#4CCBA0`
 - Secondary: `#0E1731`
 - Danger: `#D71D1D`
-FormKit theme integrated with TailwindCSS theme tokens.
+
+Prefer theme tokens over hard-coded colors in features.
 
 ### Formatting
-Uses `vp fmt` (vite-plus format wrapper) and ESLint.
-Pre-commit hooks run lint-staged on staged UI files.
+
+Use `vp fmt` via `pnpm -C ui format`. Pre-commit hooks run `lint-staged` for staged UI files.
+
+## Testing
+
+- **Framework:** Vitest with jsdom
+- **Location:** colocated `.spec.ts` files
+- **Single file:** `pnpm -C ui test:unit -- src/utils/foo.spec.ts`
+- **Pattern:** `pnpm -C ui test:unit -- -t "test name pattern"`
+- **Watch:** `pnpm -C ui test:unit:watch`
+
+Add or update tests for changed UI behavior, especially utilities, composables, and package exports.
+
+## Validation flow
+
+- Run `pnpm -C ui build:packages` before `pnpm -C ui build` when workspace packages changed.
+- Use `pnpm -C ui typecheck && pnpm -C ui lint` as the normal validation path.
+- Regenerate the API client after backend contract changes:
+
+```bash
+./gradlew generateOpenApiDocs
+pnpm -C ui api-client:gen
+```
+
+## Boundaries
+
+- ✅ **Always:** Work from the repo root for command orchestration; run `pnpm -C ui format`; run `pnpm -C ui build:packages` when package code changes; keep frontend behavior in sync with backend contract changes.
+- ⚠️ **Ask first:** Public exports from `packages/*`; new npm dependencies; `vite.config.ts` or `tsconfig*.json` changes; global FormKit or theme token changes.
+- 🚫 **Never:** Commit `node_modules/`; hand-edit `packages/api-client/src/`; hard-code theme colors in feature code when a token exists; treat `--no-verify` as a normal fix for broken hooks.
 
 ## Pitfalls
 
-1. **Pre-commit hooks run lint-staged on UI files.** If `node_modules/@halo-dev/components` is missing
-   (no `pnpm install` after fresh clone), `git commit` fails even on Java-only changes.
-   Fix: `git commit --no-verify` or `cd ui && pnpm install`.
-
-2. **API client regeneration requires two commands in order:**
-   ```bash
-   ./gradlew generateOpenApiDocs    # from project root (~28s, boots Spring)
-   cd ui && pnpm api-client:gen     # runs openapi-generator
-   ```
-   The Gradle task must complete before the pnpm script can run.
-
-3. **Build order matters.** Run `pnpm build:packages` before `pnpm build` when packages changed.
-   The full `pnpm build` includes typecheck, which can be slow. For package-only changes,
-   `pnpm build:packages` then `pnpm dev` is the fast path.
-
-4. **`pnpm install` required after `git pull`.** The `node_modules` may include workspace
-   protocol links that break after upstream dependency changes.
+1. **`pnpm install` is required after dependency changes or fresh clones.** Missing workspace links can break lint-staged and local package resolution.
+2. **API client generation is a two-step flow.** `generateOpenApiDocs` must finish before `pnpm -C ui api-client:gen`.
+3. **Package build order matters.** Run `pnpm -C ui build:packages` first when `packages/*` changed.

--- a/ui/AGENTS.md
+++ b/ui/AGENTS.md
@@ -1,0 +1,121 @@
+# UI (Frontend) — AGENTS.md
+
+pnpm monorepo at `ui/`. Admin console + user center. Vue 3 + TypeScript + TailwindCSS 3.4.
+
+## Quick Commands
+
+```bash
+cd ui
+pnpm install                # Required before any other command
+pnpm dev                    # Dev server with HMR (port varies by route)
+pnpm build                  # Full: typecheck + bundle (console + UC)
+pnpm build:packages         # Build workspace packages only (faster)
+pnpm test:unit              # Vitest unit tests
+pnpm lint                   # ESLint
+pnpm format                 # Format code (vp fmt)
+pnpm format:check           # Check formatting
+pnpm api-client:gen         # Generate API client from OpenAPI spec
+pnpm typecheck              # vue-tsc type checking
+```
+
+Or use Makefile wrappers: `make -C ui dev`, `make -C ui build`, `make -C ui test`, `make -C ui api-client-gen`.
+
+## Directory Layout
+
+```
+ui/
+├── console-src/            # Admin console (main application)
+│   ├── modules/            # Feature modules — auto-discovered via import.meta.glob
+│   ├── stores/             # Pinia stores (console-specific)
+│   ├── router/             # Vue Router config
+│   ├── layouts/            # Layout components
+│   └── styles/             # Console-specific styles
+├── src/                    # Shared code
+│   ├── components/         # Shared Vue components
+│   ├── composables/        # Shared composables (use-auto-save-content, use-role, etc.)
+│   ├── stores/             # Shared Pinia stores (plugin.ts, role.ts)
+│   ├── formkit/            # FormKit config + custom inputs/plugins
+│   ├── locales/            # i18n JSON files (en, zh-CN, zh-TW, es)
+│   └── styles/             # Shared TailwindCSS + theme config
+├── uc-src/                 # User center (public-facing)
+│   ├── modules/            # Feature modules — auto-discovered
+│   └── router/             # Router with auth guards
+├── packages/               # Workspace packages (see below)
+├── public/                 # Static assets
+└── scripts/                # Build scripts
+```
+
+## Workspace Packages (`ui/packages/`)
+
+| Package | Purpose |
+|---|---|
+| `api-client` | Generated Axios-based API client from OpenAPI spec |
+| `components` | Shared UI component library + icons (Iconify) |
+| `editor` | Rich-text editor (Tiptap-based) |
+| `console-shared` | Console-specific shared code (stores, events, utils) |
+| `shared` | Cross-platform shared code (plugin system, types, stores) |
+| `ui-plugin-bundler-kit` | Build tooling for Halo UI plugins |
+
+## Conventions
+
+### Module Pattern
+Each feature in `console-src/modules/<feature>/module.ts` uses `definePlugin()`:
+```ts
+export default definePlugin({
+  name: 'posts',
+  routes: [...],
+  menus: [...],
+  permissions: [...],
+})
+```
+Modules are auto-discovered via `import.meta.glob("./**/module.ts")`.
+
+### Startup Order (main.ts)
+components → i18n → vue-query → api-client → pinia → core modules → user → permissions → plugin modules → router → mount
+
+### Path Aliases
+- `@/*` → `src/*`
+- `@console/*` → `console-src/*`
+- `@uc/*` → `uc-src/*`
+Defined in `tsconfig.app.json`.
+
+### Tech Stack
+- **State:** Pinia stores
+- **i18n:** vue-i18n with JSON locale files in `src/locales/`
+- **Forms:** FormKit (`src/formkit/theme.ts`)
+- **Icons:** Iconify via `@iconify/vue`. Icon sets: lucide, mdi, ri, fluent (installed as `@iconify-json/*` devDeps)
+- **CSS:** TailwindCSS 3.4 with `tailwindcss-themer` plugin
+- **Build tool:** `vite-plus` (`vp`)
+- **Testing:** Vitest
+- **API:** vue-query (TanStack Query)
+
+### Theme
+Default theme via `tailwindcss-themer`:
+- Primary: `#4CCBA0`
+- Secondary: `#0E1731`
+- Danger: `#D71D1D`
+FormKit theme integrated with TailwindCSS theme tokens.
+
+### Formatting
+Uses `vp fmt` (vite-plus format wrapper) and ESLint.
+Pre-commit hooks run lint-staged on staged UI files.
+
+## Pitfalls
+
+1. **Pre-commit hooks run lint-staged on UI files.** If `node_modules/@halo-dev/components` is missing
+   (no `pnpm install` after fresh clone), `git commit` fails even on Java-only changes.
+   Fix: `git commit --no-verify` or `cd ui && pnpm install`.
+
+2. **API client regeneration requires two commands in order:**
+   ```bash
+   ./gradlew generateOpenApiDocs    # from project root (~28s, boots Spring)
+   cd ui && pnpm api-client:gen     # runs openapi-generator
+   ```
+   The Gradle task must complete before the pnpm script can run.
+
+3. **Build order matters.** Run `pnpm build:packages` before `pnpm build` when packages changed.
+   The full `pnpm build` includes typecheck, which can be slow. For package-only changes,
+   `pnpm build:packages` then `pnpm dev` is the fast path.
+
+4. **`pnpm install` required after `git pull`.** The `node_modules` may include workspace
+   protocol links that break after upstream dependency changes.


### PR DESCRIPTION
#### What type of PR is this?

/kind improvement

#### What this PR does / why we need it:

Add nested AGENTS.md files following the [agents.md](https://agents.md/) spec to help AI coding agents (Claude Code, Cursor, Copilot, OpenCode, etc.) understand Halo project conventions, build systems, coding standards, and critical pitfalls.

**Structure:**

- **Root AGENTS.md** — project overview, global conventions, 6 critical pitfalls, subproject index table with links
- **api/AGENTS.md** — extension model (ReactiveExtensionClient, Scheme, GVK), service interfaces, package map
- **application/AGENTS.md** — Spring Boot app, service implementation patterns, OAuth2 auth flow, router patterns, test patterns
- **ui/AGENTS.md** — pnpm workspace layout, 6 packages, module pattern, conventions, pitfalls
- **platform/application/AGENTS.md** — dependency version BOM constraints
- **platform/plugin/AGENTS.md** — plugin development BOM

Each subproject AGENTS.md is focused on information specific to that module. An agent working in `application/` only loads `application/AGENTS.md` — not the entire project.

**Key principles:**
- Reference source of truth, don't duplicate (point to libs.versions.toml, pull_request_template.md)
- No personal info or hard-coded versions
- Pitfalls section covers non-obvious issues: H2 paths, @Schema pattern, rate limiter key safety, Gradle two-step upgrade, misc format placement, API client regeneration order

#### Which issue(s) this PR fixes:

Fixes #

#### Special notes for your reviewer:

Generated based on the agents.md spec format. Each subproject AGENTS.md can be loaded independently — agents working in a specific subproject don't need to scan the entire project. All files use markdown with clear headings suitable for agent parsing.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```