### PR TITLE
improvement: specify node engine version requirement in package.json

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -174,6 +174,9 @@
   "browserslist": [
     "defaults"
   ],
+  "engines": {
+    "node": "^24.0.0"
+  },
   "packageManager": "pnpm@10.30.3+sha512.c961d1e0a2d8e354ecaa5166b822516668b7f44cb5bd95122d590dd81922f606f5473b6d23ec4a5be05e7fcd18e8488d47d978bbe981872f1145d06e9a740017",
   "pnpm": {
     "overrides": {


### PR DESCRIPTION
/kind improvement

#### What this PR does / why we need it:

Add an `engines` field to `ui/package.json` to explicitly require Node.js `^24.0.0`. This ensures that developers and CI environments use the correct Node.js version, providing a clear error message when the wrong version is used instead of silently failing.

#### Which issue(s) this PR fixes:

Fixes #

#### Special notes for your reviewer:

This is a metadata-only change to `ui/package.json`. No runtime behavior is affected.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```