### PR TITLE
fix: suppress pnpm cyclic workspace dependency warnings

### DIFF
--- a/ui/pnpm-workspace.yaml
+++ b/ui/pnpm-workspace.yaml
@@ -10,6 +10,8 @@ overrides:
   vite: "catalog:"
   vitest: "catalog:"
 
+ignoreWorkspaceCycles: true
+
 peerDependencyRules:
   allowAny:
     - vite


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Suppresses pnpm cyclic workspace dependency warnings by adding `ignoreWorkspaceCycles: true` to `ui/pnpm-workspace.yaml`.

When running pnpm commands in the `ui/` workspace, the following warning appears:

```
WARN  There are cyclic workspace dependencies:
  /.../ui/packages/editor
  /.../ui/packages/shared
```

These warnings clutter the terminal output and may cause confusion, even though the circular dependency is benign. This is a pnpm-native configuration option (supported since pnpm 9.2.0) that silences cyclic dependency warnings without changing the actual dependency graph.

#### Which issue(s) this PR fixes:

Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```