### PR TITLE
fix: exclude openspec directory from spotless formatting

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,6 +22,7 @@ def excludePatterns = [
     '**/bin/**',
     '**/out/**',
     'api-docs/**',
+    'openspec/**',
     'application/src/main/resources/config/uap/**'
 ]
 


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Adds `'openspec/**'` to the exclude patterns in the root `build.gradle` to prevent spotless from scanning the `openspec` directory. This suppresses unnecessary formatting checks on files that are not part of the main codebase.

#### Which issue(s) this PR fixes:

Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```