### PR TITLE
fix: revoking multiple images may cause duplicate upload issues

### DIFF
--- a/ui/packages/editor/src/extensions/image/ImageView.vue
+++ b/ui/packages/editor/src/extensions/image/ImageView.vue
@@ -17,6 +17,19 @@ import { ExtensionImage } from "./index";
 
 const props = defineProps<NodeViewProps>();
 
+const updateAttrsSilently = (attrs: Record<string, unknown>) => {
+  const pos = props.getPos();
+  if (typeof pos !== "number") {
+    return;
+  }
+  const tr = props.editor.state.tr.setNodeMarkup(pos, undefined, {
+    ...props.node.attrs,
+    ...attrs,
+  });
+  tr.setMeta("addToHistory", false);
+  props.editor.view.dispatch(tr);
+};
+
 const src = computed({
   get: () => {
     return props.node?.attrs.src;
@@ -85,7 +98,7 @@ const handleUploadReady = async (file: File) => {
 
 const handleSetExternalLink = (attachment?: AttachmentSimple) => {
   if (!attachment) return;
-  props.updateAttributes({
+  updateAttrsSilently({
     src: attachment.url,
     alt: attachment.alt,
   });
@@ -109,7 +122,7 @@ const resetUpload = () => {
 
   const { file } = props.node.attrs;
   if (file) {
-    props.updateAttributes({
+    updateAttrsSilently({
       width: undefined,
       file: undefined,
     });
@@ -133,6 +146,10 @@ function onImageLoaded(event: Event) {
   if (target instanceof HTMLImageElement) {
     props.editor
       .chain()
+      .command(({ tr }) => {
+        tr.setMeta("addToHistory", false);
+        return true;
+      })
       .updateAttributes(ExtensionImage.name, {
         width: `${target.naturalWidth}px`,
       })


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/area ui
/area editor

#### What this PR does / why we need it:

解决上传多张图片后撤销，会导致图片重复上传且无法撤销的问题。

#### How to test it?

1. 复制多张本地图片。
2. 打开编辑器并粘贴。
3. 使用 `Ctrl + Z` 撤销。查看图片是否被成功撤销且没有重复上传的问题。

#### Which issue(s) this PR fixes:

Fixes #8334

#### Does this PR introduce a user-facing change?
```release-note
解决编辑器中无法一次撤销多张图片且会导致图片重复上传的问题。
```
