### PR TITLE
fix: prevent 500 error when search keyword contains Lucene special characters

### DIFF
--- a/application/src/main/java/run/halo/app/search/lucene/LuceneSearchEngine.java
+++ b/application/src/main/java/run/halo/app/search/lucene/LuceneSearchEngine.java
@@ -20,6 +20,7 @@ import org.apache.lucene.analysis.custom.CustomAnalyzer;
 import org.apache.lucene.analysis.standard.StandardTokenizerFactory;
 import org.apache.lucene.document.*;
 import org.apache.lucene.index.*;
+import org.apache.lucene.queryparser.classic.QueryParserBase;
 import org.apache.lucene.queryparser.flexible.core.QueryNodeException;
 import org.apache.lucene.queryparser.flexible.standard.StandardQueryParser;
 import org.apache.lucene.search.*;
@@ -142,7 +143,8 @@ public class LuceneSearchEngine implements SearchEngine, InitializingBean, Dispo
             queryParser.setFuzzyPrefixLength(FuzzyQuery.defaultPrefixLength);
 
             var keyword = option.getKeyword();
-            var query = queryParser.parse(keyword, null);
+            var escapedKeyword = QueryParserBase.escape(keyword);
+            var query = queryParser.parse(escapedKeyword, null);
             var queryBuilder = new BooleanQuery.Builder().add(query, MUST);
 
             var filterExposed = option.getFilterExposed();

--- a/application/src/test/java/run/halo/app/search/lucene/LuceneSearchEngineTest.java
+++ b/application/src/test/java/run/halo/app/search/lucene/LuceneSearchEngineTest.java
@@ -144,6 +144,20 @@ class LuceneSearchEngineTest {
         assertEquals("<fake-tag>fake</fake-tag>-content", gotHaloDoc.getContent());
     }
 
+    @Test
+    void shouldNotThrowExceptionWhenKeywordContainsLeadingWildcard() {
+        this.searchEngine.addOrUpdate(List.of(createFakeHaloDoc()));
+
+        var option = new SearchOption();
+        option.setLimit(10);
+
+        option.setKeyword("*");
+        assertDoesNotThrow(() -> this.searchEngine.search(option));
+
+        option.setKeyword("*fake");
+        assertDoesNotThrow(() -> this.searchEngine.search(option));
+    }
+
     void runConcurrently(Runnable runnable) throws ExecutionException, InterruptedException, TimeoutException {
         var executorService = Executors.newFixedThreadPool(10);
         var futures = IntStream.of(0, 10)


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Escape user input keywords using `QueryParserBase.escape()` before parsing with Lucene's `StandardQueryParser`. This prevents `QueryNodeException` from being thrown when search keywords contain Lucene query syntax special characters (e.g., leading wildcards `*`).

Before this fix, searching with keywords starting with `*` would cause a 500 error because Lucene's `AllowLeadingWildcardProcessor` rejects leading wildcards by default.

#### Which issue(s) this PR fixes:

Fixes #6339

#### Special notes for your reviewer:

This change treats all user input as plain text during query parsing. Advanced Lucene query syntax (e.g., `title:keyword`, `keyword~`) will no longer work for end-user search, which is the expected behavior for a CMS site search.

#### Does this PR introduce a user-facing change?

```release-note
优化默认搜索引擎的关键词兼容性
```