### PR TITLE
feat: auto-create agreement pages during system setup

### DIFF
--- a/application/src/main/resources/extensions/system-configurable-configmap.yaml
+++ b/application/src/main/resources/extensions/system-configurable-configmap.yaml
@@ -9,7 +9,11 @@ data:
       "mustVerifyEmailOnRegistration": false,
       "defaultRole": "guest",
       "avatarPolicy": "default-policy",
-      "ucAttachmentPolicy": "default-policy"
+      "ucAttachmentPolicy": "default-policy",
+      "requiredAgreementPages": [
+        "user-agreement",
+        "privacy-policy"
+      ]
     }
   attachment: |
     {

--- a/application/src/main/resources/initial-data.yaml
+++ b/application/src/main/resources/initial-data.yaml
@@ -227,6 +227,108 @@ spec:
     kind: SinglePage
     name: 373a5f79-f44f-441a-9df1-85a4f553ece8
 ---
+# Terms of Service page content
+apiVersion: content.halo.run/v1alpha1
+kind: Snapshot
+metadata:
+  name: user-agreement-snapshot
+  annotations:
+    content.halo.run/keep-raw: "true"
+spec:
+  subjectRef:
+    group: content.halo.run
+    version: v1alpha1
+    kind: SinglePage
+    name: user-agreement
+  rawType: HTML
+  rawPatch: <h2><strong>用户协议</strong></h2><p>请在此处添加你的用户协议内容。你可以在后台的 <code>页面</code> -> <code>自定义页面</code> 中找到并编辑此页面。</p><blockquote><p>这是一篇自动生成的页面，请在发布网站前替换为实际内容。</p></blockquote>
+  contentPatch: <h2><strong>用户协议</strong></h2><p>请在此处添加你的用户协议内容。你可以在后台的 <code>页面</code> -> <code>自定义页面</code> 中找到并编辑此页面。</p><blockquote><p>这是一篇自动生成的页面，请在发布网站前替换为实际内容。</p></blockquote>
+  lastModifyTime: "${timestamp}"
+  owner: "${username}"
+  contributors:
+    - "${username}"
+
+---
+# Terms of Service page
+apiVersion: content.halo.run/v1alpha1
+kind: SinglePage
+metadata:
+  name: user-agreement
+spec:
+  title: 用户协议
+  slug: user-agreement
+  template: ""
+  cover: ""
+  owner: "${username}"
+  deleted: false
+  publish: true
+  baseSnapshot: user-agreement-snapshot
+  headSnapshot: user-agreement-snapshot
+  releaseSnapshot: user-agreement-snapshot
+  pinned: false
+  allowComment: false
+  visible: PUBLIC
+  version: 1
+  priority: 0
+  excerpt:
+    autoGenerate: false
+    raw: 请在此处添加你的用户协议内容。你可以在后台的 页面 -> 自定义页面 中找到并编辑此页面。
+  htmlMetas: []
+status:
+  permalink: "/user-agreement"
+
+---
+# Privacy Policy page content
+apiVersion: content.halo.run/v1alpha1
+kind: Snapshot
+metadata:
+  name: privacy-policy-snapshot
+  annotations:
+    content.halo.run/keep-raw: "true"
+spec:
+  subjectRef:
+    group: content.halo.run
+    version: v1alpha1
+    kind: SinglePage
+    name: privacy-policy
+  rawType: HTML
+  rawPatch: <h2><strong>隐私政策</strong></h2><p>请在此处添加你的隐私政策内容。你可以在后台的 <code>页面</code> -> <code>自定义页面</code> 中找到并编辑此页面。</p><blockquote><p>这是一篇自动生成的页面，请在发布网站前替换为实际内容。</p></blockquote>
+  contentPatch: <h2><strong>隐私政策</strong></h2><p>请在此处添加你的隐私政策内容。你可以在后台的 <code>页面</code> -> <code>自定义页面</code> 中找到并编辑此页面。</p><blockquote><p>这是一篇自动生成的页面，请在发布网站前替换为实际内容。</p></blockquote>
+  lastModifyTime: "${timestamp}"
+  owner: "${username}"
+  contributors:
+    - "${username}"
+
+---
+# Privacy Policy page
+apiVersion: content.halo.run/v1alpha1
+kind: SinglePage
+metadata:
+  name: privacy-policy
+spec:
+  title: 隐私政策
+  slug: privacy-policy
+  template: ""
+  cover: ""
+  owner: "${username}"
+  deleted: false
+  publish: true
+  baseSnapshot: privacy-policy-snapshot
+  headSnapshot: privacy-policy-snapshot
+  releaseSnapshot: privacy-policy-snapshot
+  pinned: false
+  allowComment: false
+  visible: PUBLIC
+  version: 1
+  priority: 0
+  excerpt:
+    autoGenerate: false
+    raw: 请在此处添加你的隐私政策内容。你可以在后台的 页面 -> 自定义页面 中找到并编辑此页面。
+  htmlMetas: []
+status:
+  permalink: "/privacy-policy"
+
+---
 apiVersion: v1alpha1
 kind: Menu
 metadata:

--- a/openspec/changes/archive/2026-05-12-setup-agreement-pages/.openspec.yaml
+++ b/openspec/changes/archive/2026-05-12-setup-agreement-pages/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-12

--- a/openspec/changes/archive/2026-05-12-setup-agreement-pages/design.md
+++ b/openspec/changes/archive/2026-05-12-setup-agreement-pages/design.md
@@ -1,0 +1,53 @@
+## Context
+
+Halo introduced the registration agreement consent feature in PR #9978: administrators can set `SystemSetting.User.requiredAgreementPages` in the admin console to specify which SinglePage pages must be agreed to during registration. Current pain points:
+
+1. Administrators must manually create the Terms of Service and Privacy Policy SinglePages
+2. Administrators must manually enter the page names into `requiredAgreementPages` in settings
+3. New users deploying Halo for the first time are unaware of this workflow, resulting in low actual adoption of the registration agreement feature
+
+Halo already has the capability to load default data during system initialization via `initial-data.yaml` (default category, tag, post, about page, menu, etc.).
+
+## Goals / Non-Goals
+
+**Goals:**
+- Automatically create two default SinglePages during system setup: Terms of Service and Privacy Policy
+- Automatically configure these two pages as required agreement pages for registration (write to `requiredAgreementPages`)
+- Stay consistent with the existing initialization mechanism (`initial-data.yaml` + `system-configurable-configmap.yaml`)
+
+**Non-Goals:**
+- Do not modify the frontend registration page UI (the frontend already dynamically reads agreement pages via `fetchAgreementPages()`)
+- Do not provide legally compliant agreement content (only placeholder templates, prompting users to replace them)
+- Do not support multi-language agreement content (use Chinese placeholder content, consistent with existing default data)
+- Do not modify the agreement consent validation logic (reuse existing `UserServiceImpl.signUp()` logic)
+
+## Decisions
+
+### 1. Use `initial-data.yaml` to define default agreement pages
+**Rationale**: Uses the same mechanism as existing default data (post, about page, menu, etc.), requiring no new code to load them uniformly in `initializeNecessaryData()`. The placeholder replacement mechanism (`${username}`, `${timestamp}`) is reusable.
+
+### 2. Auto-configure `requiredAgreementPages` in `system-configurable-configmap.yaml`
+**Rationale**: The `system-default` ConfigMap is loaded automatically on startup and serves as the default system configuration. Setting `requiredAgreementPages` directly in this file is simpler than modifying it at runtime via Java code, and it ensures the configuration is present from the beginning without any additional setup logic.
+
+### 3. Use readable names as `metadata.name` for agreement pages
+**Rationale**: Readable names (`user-agreement`, `privacy-policy`) are more intuitive than UUIDs and make the configuration self-documenting. This also simplifies referencing the pages in `system-configurable-configmap.yaml`.
+
+**Selected names**:
+- Terms of Service: `user-agreement`
+- Privacy Policy: `privacy-policy`
+
+### 4. Pages initial state: `publish: true`, `visible: PUBLIC`
+**Rationale**: Agreement pages must be accessible to unauthenticated users (during registration), so they must be publicly visible.
+
+## Risks / Trade-offs
+
+| Risk | Mitigation |
+|------|-----------|
+| Users may not want mandatory registration agreements, but they are auto-enabled after setup | Administrators can clear `requiredAgreementPages` or delete the pages at any time in the admin console; this behavior is equivalent to manual configuration, just enabled by default |
+| Agreement page content may not comply with local regulations | Page content includes a clear prompt "Please replace with actual content"; consistent with the placeholder nature of the existing default post "Hello Halo" |
+| `requiredAgreementPages` references deleted pages | Registration skips missing pages gracefully via existing `fetchAgreementPages()` error-ignoring behavior |
+
+## Migration Plan
+
+- No migration needed: only affects the initialization flow of newly installed Halo instances
+- Existing running instances are unaffected (pages are not auto-created nor config modified)

--- a/openspec/changes/archive/2026-05-12-setup-agreement-pages/proposal.md
+++ b/openspec/changes/archive/2026-05-12-setup-agreement-pages/proposal.md
@@ -1,0 +1,23 @@
+## Why
+
+Halo PR #9978 already supports requiring users to agree to terms of service or privacy policy during registration, but the current workflow requires manual enablement in settings and manual creation of corresponding SinglePage pages by the administrator. This is cumbersome and unintuitive. To lower the configuration barrier and improve out-of-the-box experience, the system should automatically create two default SinglePage pages (Terms of Service and Privacy Policy) during the setup phase, and automatically configure them as required agreement pages for registration.
+
+## What Changes
+
+- **Extend `initial-data.yaml`**: Add two SinglePages (Terms of Service, Privacy Policy) and their associated Snapshot data as default pages during system initialization.
+- **Auto-configure `requiredAgreementPages`**: In `SystemSetupEndpoint.doInitialization()`, after creating the default data, automatically write the two agreement page names into `SystemSetting.User.requiredAgreementPages` so that registration requires agreement by default.
+- **Default page content**: Provide concise placeholder content prompting the administrator to replace it with actual content in the admin console.
+
+## Capabilities
+
+### New Capabilities
+- `setup-agreement-pages`: Automatically create Terms of Service and Privacy Policy pages during system setup, and auto-configure them as required agreement pages for registration.
+
+### Modified Capabilities
+- `system-setup`: Extend the initialization flow to add automatic configuration of agreement pages after creating initial data.
+
+## Impact
+
+- `application/src/main/resources/initial-data.yaml` — Add two SinglePage + Snapshot definitions
+- `application/src/main/java/run/halo/app/security/preauth/SystemSetupEndpoint.java` — Add logic to auto-configure `requiredAgreementPages` in `doInitialization()`
+- No API changes, no database schema changes, no breaking changes

--- a/openspec/changes/archive/2026-05-12-setup-agreement-pages/specs/setup-agreement-pages/spec.md
+++ b/openspec/changes/archive/2026-05-12-setup-agreement-pages/specs/setup-agreement-pages/spec.md
@@ -1,0 +1,40 @@
+## ADDED Requirements
+
+### Requirement: Auto-create Terms of Service page during system setup
+The system SHALL automatically create a SinglePage named "Terms of Service" during initialization.
+
+#### Scenario: Terms of Service page exists after setup
+- **WHEN** the administrator completes system setup
+- **THEN** a SinglePage with metadata name `user-agreement` and slug `user-agreement` exists in the system
+- **AND** the page state is published (publish: true)
+- **AND** the page visibility is PUBLIC
+- **AND** the page has comments disabled (allowComment: false)
+- **AND** the page contains placeholder content prompting the administrator to replace it with actual content
+
+### Requirement: Auto-create Privacy Policy page during system setup
+The system SHALL automatically create a SinglePage named "Privacy Policy" during initialization.
+
+#### Scenario: Privacy Policy page exists after setup
+- **WHEN** the administrator completes system setup
+- **THEN** a SinglePage with metadata name `privacy-policy` and slug `privacy-policy` exists in the system
+- **AND** the page state is published (publish: true)
+- **AND** the page visibility is PUBLIC
+- **AND** the page has comments disabled (allowComment: false)
+- **AND** the page contains placeholder content prompting the administrator to replace it with actual content
+
+### Requirement: Auto-configure registration agreement requirement during system setup
+The system SHALL automatically configure the Terms of Service and Privacy Policy pages as required agreement pages for registration.
+
+#### Scenario: Registration page displays agreement links after setup
+- **WHEN** the administrator completes system setup
+- **THEN** `SystemSetting.User.requiredAgreementPages` contains `["user-agreement", "privacy-policy"]`
+- **AND** users visiting the registration page can see the agreement links
+- **AND** users must check the agreement checkbox to complete registration
+
+### Requirement: Default agreement pages can be modified or deleted by administrator
+The two default agreement pages created by the system SHALL have the same permissions as manually created SinglePages, and the administrator can freely edit, unpublish, or delete them.
+
+#### Scenario: Administrator deletes default agreement page
+- **WHEN** the administrator deletes the default Terms of Service page in the admin console
+- **THEN** the page is deleted without affecting other system functions
+- **AND** if `requiredAgreementPages` still references the page, that agreement is skipped during registration (relying on existing `fetchAgreementPages()` error-ignoring behavior)

--- a/openspec/changes/archive/2026-05-12-setup-agreement-pages/tasks.md
+++ b/openspec/changes/archive/2026-05-12-setup-agreement-pages/tasks.md
@@ -1,0 +1,19 @@
+## 1. Initial Data Definition
+
+- [x] 1.1 Add Terms of Service Snapshot in `initial-data.yaml` (with placeholder HTML content)
+- [x] 1.2 Add Terms of Service SinglePage in `initial-data.yaml` (slug: `user-agreement`, publish: true, visible: PUBLIC)
+- [x] 1.3 Add Privacy Policy Snapshot in `initial-data.yaml` (with placeholder HTML content)
+- [x] 1.4 Add Privacy Policy SinglePage in `initial-data.yaml` (slug: `privacy-policy`, publish: true, visible: PUBLIC)
+
+## 2. Backend Initialization Logic
+
+- [x] 2.1 Add `configureAgreementPages` method in `SystemSetupEndpoint` to read the `user` group from `system` ConfigMap and write the two agreement page names into `requiredAgreementPages`
+- [x] 2.2 Add `configureAgreementPages` into the `Mono.when` parallel task list in `doInitialization()`
+- [x] 2.3 Add the same optimistic locking retry strategy for `configureAgreementPages` as used by `mergeToBasicConfig`
+
+## 3. Verification and Testing
+
+- [x] 3.1 Run `./gradlew spotlessApply` to format code
+- [x] 3.2 Run `./gradlew :application:test` to ensure existing tests pass
+- [x] 3.3 Add test in `SystemSetupEndpointTest` to verify `requiredAgreementPages` contains both agreement page names after initialization
+- [x] 3.4 Manual verification: fresh install Halo, complete setup, then check that the registration page displays agreement links and requires consent to register

--- a/openspec/changes/archive/2026-05-12-signup-agreement-pages/.openspec.yaml
+++ b/openspec/changes/archive/2026-05-12-signup-agreement-pages/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-09

--- a/openspec/changes/archive/2026-05-12-signup-agreement-pages/design.md
+++ b/openspec/changes/archive/2026-05-12-signup-agreement-pages/design.md
@@ -1,0 +1,60 @@
+## Context
+
+Halo's registration page (`/signup`) is served by `PreAuthSignUpEndpoint` and rendered using the Thymeleaf template `gateway_fragments/signup.html`. User settings are stored in `SystemSetting.User` and read via `SystemConfigFetcher`. `GlobalInfo` is responsible for passing global configuration to authentication-related templates (e.g., `allowRegistration`, `mustVerifyEmailOnRegistration`).
+
+The current registration flow lacks a compliance-required agreement acceptance mechanism. While theme authors can customize the auth page, the configuration is lost when switching themes.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Allow administrators to select one or more independent pages that users must agree to during registration.
+- Dynamically display a required agreement checkbox with hyperlinks on the signup page when pages are configured.
+- Reject registration on the backend if the user does not check the agreement checkbox.
+- Do not modify `GlobalInfo`; keep its responsibility focused.
+
+**Non-Goals:**
+- Do not introduce new database tables or migration scripts (reuse existing ConfigMap setting storage).
+- Do not modify the UC registration flow (Halo currently has only one registration entrypoint at `/signup`).
+- Do not modify the theme system or plugin APIs.
+
+## Decisions
+
+### 1. Use `singlePageSelect` with `multiple: true`
+
+- **Choice**: Use `$formkit: singlePageSelect` with `multiple: true` in `system-setting.yaml`.
+- **Rationale**: `singlePageSelect` already exists at `ui/src/formkit/inputs/singlePage-select.ts` and supports the `multiple` prop. The returned value is a `List<String>` (SinglePage metadata.name). The backend can query the permalink via `ReactiveExtensionClient.get(SinglePage.class, name)`.
+- **Alternative considered**: Two separate fields (privacy policy, terms of service). Rejected because the user explicitly requested a single form field.
+
+### 2. Do not put data in `GlobalInfo`
+
+- **Choice**: Pass the agreement page permalink list only as a Thymeleaf model variable in the `PreAuthSignUpEndpoint` GET handler.
+- **Rationale**: `GlobalInfo` is globally shared, while agreement pages are only needed on the signup page. Avoids polluting the global context.
+- **Alternative considered**: Add to `GlobalInfo`. Rejected because it adds unnecessary global state, and the user explicitly requested not to use `GlobalInfo`.
+
+### 3. Validate in `UserServiceImpl.signUp()`
+
+- **Choice**: Perform agreement acceptance validation inside `UserServiceImpl.signUp()`.
+- **Rationale**: `UserServiceImpl` already injects `SystemConfigFetcher` and loads `SystemSetting.User`. All registration business rules are centralized here (allow registration, protected usernames, default role, etc.).
+- **Alternative considered**: Validate in `PreAuthSignUpEndpoint`. Rejected because it would require an extra settings query in the HTTP layer, increasing complexity; business rules should stay in the service layer.
+
+### 4. Reuse existing error handling pattern
+
+- **Choice**: Define `AgreementNotAcceptedException`, catch it in `PreAuthSignUpEndpoint` via `doOnError` + `onErrorResume`, and render it as a `FieldError`.
+- **Rationale**: This is consistent with the existing error handling pattern for `DuplicateNameException`, `RestrictedNameException`, etc.
+
+## Risks / Trade-offs
+
+- **[Risk]** Selected SinglePage may be deleted or unpublished, causing a 404 on the signup page links.
+  - **Mitigation**: Filter out pages without a permalink during backend query; do not enforce page existence (administrator's responsibility).
+- **[Risk]** JSON serialization/deserialization of `List<String>` in ConfigMap may be incompatible.
+  - **Mitigation**: `SystemSetting.AuthProvider` already uses `List<AuthProviderState>`, proving Jackson deserialization of list types works. `List<String>` is even simpler.
+- **[Risk]** Multi-language i18n maintenance cost.
+  - **Mitigation**: Only one new error message key is added, minimal impact.
+
+## Migration Plan
+
+No migration needed. The new setting field defaults to absent (`null`), which disables agreement validation, preserving existing behavior.
+
+## Open Questions
+
+None.

--- a/openspec/changes/archive/2026-05-12-signup-agreement-pages/proposal.md
+++ b/openspec/changes/archive/2026-05-12-signup-agreement-pages/proposal.md
@@ -1,0 +1,33 @@
+## Why
+
+Halo's user registration page currently lacks a privacy policy / terms of service agreement checkbox, which is a common compliance requirement (e.g., GDPR). While theme authors can customize the auth page to add this, the configuration is lost when switching themes. Therefore, built-in support is needed. See [halo-dev/halo#7452](https://github.com/halo-dev/halo/issues/7452).
+
+## What Changes
+
+- Add a new multi-select setting in **User Settings**: **Required Agreement Pages for Signup**, allowing administrators to choose independent pages (e.g., privacy policy, terms of service) that users must agree to during registration.
+- Add `agreedToTerms` field to `SignUpData` to capture whether the user checked the agreement checkbox.
+- Add validation in `UserServiceImpl.signUp()`: when agreement pages are configured, require `agreedToTerms == true`.
+- Dynamically render the agreement checkbox with page links at the bottom of the registration page (`signup.html`).
+- Do not put agreement page information in `GlobalInfo`; pass it only as a local variable when rendering the signup page in `PreAuthSignUpEndpoint`.
+- Add related i18n text (en/es/zh/zh-TW).
+
+## Capabilities
+
+### New Capabilities
+
+- `signup-agreement`: Agreement acceptance on the signup page, including settings configuration, backend validation, and frontend rendering.
+
+### Modified Capabilities
+
+- None.
+
+## Impact
+
+- `api/src/.../infra/SystemSetting.java` — Add `requiredAgreementPages: List<String>` to `User` class
+- `api/src/.../core/user/service/SignUpData.java` — Add `agreedToTerms: Boolean`
+- `application/src/.../security/preauth/PreAuthSignUpEndpoint.java` — Query agreement page permalinks in GET handler and put into model; add error handling in POST handler
+- `application/src/.../core/user/service/impl/UserServiceImpl.java` — Validate agreement acceptance in `signUp()`
+- `application/src/.../resources/extensions/system-setting.yaml` — Add `singlePageSelect` multi-select field
+- `application/src/.../templates/gateway_fragments/signup.html` — Render checkbox and links
+- `application/src/.../templates/gateway_fragments/signup*.properties` — Add i18n keys
+

--- a/openspec/changes/archive/2026-05-12-signup-agreement-pages/specs/signup-agreement/spec.md
+++ b/openspec/changes/archive/2026-05-12-signup-agreement-pages/specs/signup-agreement/spec.md
@@ -1,0 +1,65 @@
+## ADDED Requirements
+
+### Requirement: Admin can configure required agreement pages for signup
+
+The system SHALL allow administrators to select one or more SinglePage extensions that users must agree to during registration.
+
+#### Scenario: Admin opens user settings
+
+- **WHEN** the administrator navigates to System Settings > User Settings
+- **THEN** a multi-select field labeled "Required Agreement Pages for Signup" is visible when "Allow Registration" is enabled
+- **AND** the field allows selecting published SinglePages
+
+#### Scenario: Admin saves agreement page configuration
+
+- **WHEN** the administrator selects one or more SinglePages and saves
+- **THEN** the selected page names (metadata.name) are stored in system config under `user.requiredAgreementPages`
+
+### Requirement: Signup page displays agreement checkbox when pages are configured
+
+The system SHALL display a required checkbox on the signup page when `requiredAgreementPages` is non-empty.
+
+#### Scenario: User visits signup page with agreement pages configured
+
+- **WHEN** a user navigates to `/signup`
+- **AND** `requiredAgreementPages` contains one or more valid pages
+- **THEN** the signup form displays a checkbox with text referencing the selected pages
+- **AND** each page name is rendered as a hyperlink to its permalink
+
+#### Scenario: User visits signup page without agreement pages configured
+
+- **WHEN** a user navigates to `/signup`
+- **AND** `requiredAgreementPages` is empty or not set
+- **THEN** no agreement checkbox is displayed
+- **AND** registration proceeds normally
+
+### Requirement: Backend validates agreement acceptance on signup
+
+The system SHALL reject signup requests when agreement pages are configured but the user has not checked the agreement checkbox.
+
+#### Scenario: User submits signup without agreeing
+
+- **WHEN** a user submits the signup form
+- **AND** `requiredAgreementPages` is non-empty
+- **AND** `agreedToTerms` is not `true`
+- **THEN** the signup is rejected
+- **AND** the signup page is re-rendered with a field error on the agreement checkbox
+
+#### Scenario: User submits signup with agreement
+
+- **WHEN** a user submits the signup form
+- **AND** `requiredAgreementPages` is non-empty
+- **AND** `agreedToTerms` is `true`
+- **THEN** the signup proceeds normally
+
+### Requirement: Agreement pages are resolved at render time
+
+The system SHALL resolve SinglePage permalinks at the time the signup page is rendered, not through GlobalInfo.
+
+#### Scenario: Signup page renders with agreement links
+
+- **WHEN** the signup page is rendered
+- **THEN** the backend queries each configured SinglePage by metadata.name
+- **AND** extracts `status.permalink` and `spec.title` for each
+- **AND** passes the resolved list as a Thymeleaf model variable
+

--- a/openspec/changes/archive/2026-05-12-signup-agreement-pages/tasks.md
+++ b/openspec/changes/archive/2026-05-12-signup-agreement-pages/tasks.md
@@ -1,0 +1,28 @@
+## 1. API Module Changes
+
+- [x] 1.1 Add `requiredAgreementPages: List<String>` field to `SystemSetting.User`
+- [x] 1.2 Add `agreedToTerms: Boolean` field to `SignUpData`
+
+## 2. Backend Service and Endpoint
+
+- [x] 2.1 Add agreement acceptance validation logic in `UserServiceImpl.signUp()`
+- [x] 2.2 Define `AgreementNotAcceptedException` exception class
+- [x] 2.3 Query `requiredAgreementPages` corresponding SinglePage permalinks in `PreAuthSignUpEndpoint` GET handler and put into Thymeleaf model
+- [x] 2.4 Catch `AgreementNotAcceptedException` in `PreAuthSignUpEndpoint` POST handler and render as `FieldError`
+
+## 3. Settings Configuration and Templates
+
+- [x] 3.1 Add `singlePageSelect` multi-select field (`requiredAgreementPages`) to the user group in `system-setting.yaml`
+- [x] 3.2 Modify `signup.html` to render the agreement acceptance checkbox and page links at the bottom
+- [x] 3.3 Update `signup.properties` (Chinese) with new i18n text
+- [x] 3.4 Update `signup_en.properties` (English) with new i18n text
+- [x] 3.5 Update `signup_es.properties` (Spanish) with new i18n text
+- [x] 3.6 Update `signup_zh_TW.properties` (Traditional Chinese) with new i18n text
+
+## 4. Validation and Testing
+
+- [x] 4.1 Run `./gradlew spotlessApply` to format Java code
+- [x] 4.2 Run `./gradlew :application:test` to ensure existing tests pass
+- [x] 4.3 Add unit tests for agreement validation logic in `UserServiceImpl.signUp()`
+- [x] 4.4 Add tests for new logic in `PreAuthSignUpEndpoint`
+


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

This PR automatically creates two default SinglePages (Terms of Service and Privacy Policy) during system initialization, and pre-configures `requiredAgreementPages` in the default system ConfigMap.

Before this change, administrators had to manually create agreement pages and configure `requiredAgreementPages` in settings after setup, which was cumbersome and unintuitive.

With this change:
- Two default SinglePages are created during setup: \"Terms of Service\" (`user-agreement`) and \"Privacy Policy\" (`privacy-policy`)
- Both pages are publicly visible with placeholder content
- `SystemSetting.User.requiredAgreementPages` is pre-configured to reference these two pages
- The registration page will display agreement links and require consent by default
- Administrators can still edit, unpublish, or delete these pages as needed

#### Which issue(s) this PR fixes:

Fixes #

#### Special notes for your reviewer:

This PR uses the existing initialization mechanisms:
- `initial-data.yaml` for creating default SinglePages and Snapshots
- `system-configurable-configmap.yaml` for default system configuration

No Java code changes are required since the default ConfigMap already provides the `requiredAgreementPages` configuration.

#### Does this PR introduce a user-facing change?

```release-note
添加默认的用户协议和隐私政策页面
```