### PR TITLE
Mark generateOpenApiDocs as not compatible with configuration cache

### DIFF
--- a/application/build.gradle
+++ b/application/build.gradle
@@ -184,6 +184,9 @@ tasks.named('forkedSpringBootRun') {
 }
 
 tasks.named('generateOpenApiDocs') {
+    notCompatibleWithConfigurationCache(
+        'Task generates OpenAPI docs from a running server and is not compatible with configuration cache'
+    )
     outputs.upToDateWhen {
         false
     }


### PR DESCRIPTION
#### What type of PR is this?

/kind improvement

#### What this PR does / why we need it:

Add `notCompatibleWithConfigurationCache` to the `generateOpenApiDocs` task. This task depends on a running server instance (`forkedSpringBootRun`) to generate OpenAPI documentation, which is inherently incompatible with Gradle's configuration cache. The existing `outputs.upToDateWhen { false }` only prevents task output caching, but does not prevent the configuration cache from attempting to cache the task configuration itself.

#### Special notes for your reviewer:

None.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)