### PR TITLE
Fix repeatable meta tag rendering

### DIFF
--- a/application/src/main/java/run/halo/app/theme/dialect/DuplicateMetaTagProcessor.java
+++ b/application/src/main/java/run/halo/app/theme/dialect/DuplicateMetaTagProcessor.java
@@ -27,6 +27,11 @@ import reactor.core.publisher.Mono;
 @AllArgsConstructor
 public class DuplicateMetaTagProcessor implements TemplateHeadProcessor {
     static final Pattern META_PATTERN = Pattern.compile("<meta[^>]+?name=\"([^\"]+)\"[^>]*>\\n*");
+    /**
+     * These meta tags have well-known multiple-tag semantics. theme-color uses multiple candidates, often selected by
+     * media queries, and robots can express combined crawler directives across separate meta tags.
+     */
+    private static final Set<String> REPEATABLE_META_NAMES = Set.of("theme-color", "robots");
 
     @Override
     public Mono<Void> process(ITemplateContext context, IModel model, IElementModelStructureHandler structureHandler) {
@@ -44,6 +49,9 @@ public class DuplicateMetaTagProcessor implements TemplateHeadProcessor {
                 while (matcher.find()) {
                     String tagLine = matcher.group(0);
                     String nameAttribute = matcher.group(1);
+                    if (shouldKeepRepeatedMeta(nameAttribute)) {
+                        continue;
+                    }
                     // create a new text node to replace the original text node
                     // replace multiple line breaks with one line break
                     IText metaTagNode = context.getModelFactory().createText(tagLine.replaceAll("\\n+", "\n"));
@@ -60,6 +68,10 @@ public class DuplicateMetaTagProcessor implements TemplateHeadProcessor {
                 if ("meta".equals(tag.getElementCompleteName())) {
                     var attribute = tag.getAttribute("name");
                     if (attribute != null) {
+                        if (shouldKeepRepeatedMeta(attribute.getValue())) {
+                            otherModel.add(indexedModel);
+                            continue;
+                        }
                         uniqueMetaTags.put(attribute.getValue(), indexedModel);
                         continue;
                     }
@@ -77,6 +89,10 @@ public class DuplicateMetaTagProcessor implements TemplateHeadProcessor {
         model.reset();
         model.addModel(newModel);
         return Mono.empty();
+    }
+
+    private static boolean shouldKeepRepeatedMeta(String name) {
+        return REPEATABLE_META_NAMES.contains(name.toLowerCase(Locale.ROOT));
     }
 
     record IndexedModel(int index, ITemplateEvent templateEvent) {}

--- a/application/src/test/java/run/halo/app/theme/dialect/ContentTemplateHeadProcessorIntegrationTest.java
+++ b/application/src/test/java/run/halo/app/theme/dialect/ContentTemplateHeadProcessorIntegrationTest.java
@@ -159,6 +159,32 @@ class ContentTemplateHeadProcessorIntegrationTest {
         assertThat(actual).isEqualTo(expected);
     }
 
+    @Test
+    void shouldKeepThemeColorMetasWithDifferentMedia() {
+        SystemSetting.CodeInjection codeInjection = new SystemSetting.CodeInjection();
+        codeInjection.setGlobalHead(null);
+        codeInjection.setContentHead(null);
+        when(fetcher.fetch(eq(SystemSetting.CodeInjection.GROUP), eq(SystemSetting.CodeInjection.class)))
+                .thenReturn(Mono.just(codeInjection));
+
+        String result = templateEngine.process("themeColor", getContext());
+
+        var actual = Jsoup.parse(result);
+        var themeColorMetas = actual.select("meta[name=theme-color]");
+        assertThat(themeColorMetas).hasSize(2);
+        assertThat(themeColorMetas.get(0).attr("content")).isEqualTo("cyan");
+        assertThat(themeColorMetas.get(0).attr("media")).isEqualTo("(prefers-color-scheme: light)");
+        assertThat(themeColorMetas.get(1).attr("content")).isEqualTo("black");
+        assertThat(themeColorMetas.get(1).attr("media")).isEqualTo("(prefers-color-scheme: dark)");
+        assertThat(actual.select("meta[name=robots]")).hasSize(2);
+        assertThat(actual.select("meta[name=custom-meta]")).singleElement().satisfies(meta -> {
+            assertThat(meta.attr("content")).isEqualTo("new custom");
+        });
+        assertThat(actual.select("meta[name=description]")).singleElement().satisfies(meta -> {
+            assertThat(meta.attr("content")).isEqualTo("new description");
+        });
+    }
+
     Map<String, String> mutableMetaMap(String nameValue, String contentValue) {
         Map<String, String> map = new HashMap<>();
         map.put("name", nameValue);
@@ -184,6 +210,9 @@ class ContentTemplateHeadProcessorIntegrationTest {
             if (template.equals("post")) {
                 return new StringTemplateResource(postTemplate());
             }
+            if (template.equals("themeColor")) {
+                return new StringTemplateResource(themeColorTemplate());
+            }
             return null;
         }
 
@@ -194,6 +223,30 @@ class ContentTemplateHeadProcessorIntegrationTest {
                   <head>
                     <meta charset="UTF-8" />
                     <title>Post detail</title>
+                  </head>
+                  <body>
+                    this is body
+                  </body>
+                </html>
+                """;
+        }
+
+        private String themeColorTemplate() {
+            return """
+                <!DOCTYPE html>
+                <html lang="en" xmlns:th="http://www.thymeleaf.org">
+                  <head>
+                    <meta charset="UTF-8" />
+                    <title>Theme color</title>
+                    <meta name="theme-color" th:if="true" content="cyan" media="(prefers-color-scheme: light)">
+                    <meta name="theme-color" th:if="true" content="black" media="(prefers-color-scheme: dark)">
+                    <meta name="theme-color" th:if="false" content="blue" media="(prefers-color-scheme: dark)">
+                    <meta name="robots" content="noindex">
+                    <meta name="robots" content="nofollow">
+                    <meta name="custom-meta" content="old custom">
+                    <meta name="custom-meta" content="new custom">
+                    <meta name="description" content="old description">
+                    <meta name="description" content="new description">
                   </head>
                   <body>
                     this is body


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

This PR preserves repeatable meta tags that have well-known multiple-tag semantics while keeping the existing duplicate-meta behavior for other `meta name` values.

`DuplicateMetaTagProcessor` still removes duplicate meta tags by name and keeps the last one by default, but now skips deduplication for:

- `theme-color`, which can define multiple candidates selected by media queries.
- `robots`, which can express combined crawler directives across separate meta tags.

The integration test covers preserving light/dark `theme-color` tags, preserving multiple `robots` tags, and keeping the previous last-one-wins behavior for ordinary duplicate meta tags.

This change was implemented with AI assistance and reviewed locally.

#### Which issue(s) this PR fixes:

Fixes #8420

#### Special notes for your reviewer:

The allow-list is intentionally narrow to avoid changing the historical behavior for arbitrary duplicate meta tags.

#### Does this PR introduce a user-facing change?

```release-note
None
```