### PR TITLE
fix: pin thymeleaf to 3.1.3.RELEASE to resolve property accessor restrictions

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,4 @@
 version=2.24.0-SNAPSHOT
 jsonassert.version=2.0-rc1
+thymeleaf.version=3.1.3.RELEASE
+thymeleaf-extras-springsecurity.version=3.1.3.RELEASE


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Thymeleaf 3.1.5.RELEASE introduced ACL-based `PropertyAccessor` and `MethodResolver` in `ThymeleafEvaluationContext` that replace the standard `ReflectivePropertyAccessor` with `ThymeleafEvaluationContextACLPropertyAccessor`. This breaks Halo's reactive property accessor wrapping in `EvaluationContextEnhancer`, causing expression parsing failures in themes.

This PR pins `thymeleaf.version` and `thymeleaf-extras-springsecurity.version` to `3.1.3.RELEASE` to maintain compatibility.

#### Which issue(s) this PR fixes:

Fixes #

#### Does this PR introduce a user-facing change?

```release-note
NONE
```