### PR TITLE
Improve refresh button semantics

### DIFF
--- a/ui/console-src/modules/contents/attachments/AttachmentList.vue
+++ b/ui/console-src/modules/contents/attachments/AttachmentList.vue
@@ -437,16 +437,17 @@ watch(
                     </div>
                   </div>
                   <div class="flex flex-row gap-2">
-                    <div
+                    <button
+                      v-tooltip="$t('core.common.buttons.refresh')"
+                      type="button"
                       class="group cursor-pointer rounded p-1 hover:bg-gray-200"
                       @click="handleFetchAttachments()"
                     >
                       <IconRefreshLine
-                        v-tooltip="$t('core.common.buttons.refresh')"
                         :class="{ 'animate-spin text-gray-900': isFetching }"
                         class="h-4 w-4 text-gray-600 group-hover:text-gray-900"
                       />
-                    </div>
+                    </button>
                   </div>
                 </VSpace>
               </div>

--- a/ui/console-src/modules/contents/attachments/components/selector-providers/CoreSelectorProvider.vue
+++ b/ui/console-src/modules/contents/attachments/components/selector-providers/CoreSelectorProvider.vue
@@ -269,16 +269,17 @@ function handleToggleUploadView() {
           </div>
 
           <div class="flex flex-row gap-2">
-            <div
+            <button
+              v-tooltip="$t('core.common.buttons.refresh')"
+              type="button"
               class="group cursor-pointer rounded p-1 hover:bg-gray-200"
               @click="handleFetchAttachments()"
             >
               <IconRefreshLine
-                v-tooltip="$t('core.common.buttons.refresh')"
                 :class="{ 'animate-spin text-gray-900': isFetching }"
                 class="h-4 w-4 text-gray-600 group-hover:text-gray-900"
               />
-            </div>
+            </button>
           </div>
         </VSpace>
       </div>

--- a/ui/console-src/modules/contents/comments/CommentList.vue
+++ b/ui/console-src/modules/contents/comments/CommentList.vue
@@ -310,16 +310,17 @@ const handleApproveInBatch = async () => {
                 ]"
               />
               <div class="flex flex-row gap-2">
-                <div
+                <button
+                  v-tooltip="$t('core.common.buttons.refresh')"
+                  type="button"
                   class="group cursor-pointer rounded p-1 hover:bg-gray-200"
                   @click="refetch()"
                 >
                   <IconRefreshLine
-                    v-tooltip="$t('core.common.buttons.refresh')"
                     :class="{ 'animate-spin text-gray-900': isFetching }"
                     class="h-4 w-4 text-gray-600 group-hover:text-gray-900"
                   />
-                </div>
+                </button>
               </div>
             </VSpace>
           </div>

--- a/ui/console-src/modules/contents/comments/components/SubjectQueryCommentList.vue
+++ b/ui/console-src/modules/contents/comments/components/SubjectQueryCommentList.vue
@@ -131,16 +131,17 @@ function handleClearFilters() {
           ]"
         />
         <div class="flex flex-row gap-2">
-          <div
+          <button
+            v-tooltip="$t('core.common.buttons.refresh')"
+            type="button"
             class="group cursor-pointer rounded p-1 hover:bg-gray-200"
             @click="refetch()"
           >
             <IconRefreshLine
-              v-tooltip="$t('core.common.buttons.refresh')"
               :class="{ 'animate-spin text-gray-900': isFetching }"
               class="h-4 w-4 text-gray-600 group-hover:text-gray-900"
             />
-          </div>
+          </button>
         </div>
       </VSpace>
     </div>

--- a/ui/console-src/modules/contents/pages/DeletedSinglePageList.vue
+++ b/ui/console-src/modules/contents/pages/DeletedSinglePageList.vue
@@ -252,19 +252,17 @@ watch(
                 </VButton>
               </VSpace>
             </div>
-            <VSpace spacing="lg" class="flex-wrap">
-              <div class="flex flex-row gap-2">
-                <div
-                  class="group cursor-pointer rounded p-1 hover:bg-gray-200"
-                  @click="refetch()"
-                >
-                  <IconRefreshLine
-                    :class="{ 'animate-spin text-gray-900': isFetching }"
-                    class="h-4 w-4 text-gray-600 group-hover:text-gray-900"
-                  />
-                </div>
-              </div>
-            </VSpace>
+            <button
+              v-tooltip="$t('core.common.buttons.refresh')"
+              type="button"
+              class="group cursor-pointer rounded p-1 hover:bg-gray-200"
+              @click="refetch()"
+            >
+              <IconRefreshLine
+                :class="{ 'animate-spin text-gray-900': isFetching }"
+                class="h-4 w-4 text-gray-600 group-hover:text-gray-900"
+              />
+            </button>
           </div>
         </div>
       </template>

--- a/ui/console-src/modules/contents/pages/SinglePageList.vue
+++ b/ui/console-src/modules/contents/pages/SinglePageList.vue
@@ -402,16 +402,17 @@ watch(selectedPageNames, (newValue) => {
                 ]"
               />
               <div class="flex flex-row gap-2">
-                <div
+                <button
+                  v-tooltip="$t('core.common.buttons.refresh')"
+                  type="button"
                   class="group cursor-pointer rounded p-1 hover:bg-gray-200"
                   @click="refetch()"
                 >
                   <IconRefreshLine
-                    v-tooltip="$t('core.common.buttons.refresh')"
                     :class="{ 'animate-spin text-gray-900': isFetching }"
                     class="h-4 w-4 text-gray-600 group-hover:text-gray-900"
                   />
-                </div>
+                </button>
               </div>
             </VSpace>
           </div>

--- a/ui/console-src/modules/contents/posts/DeletedPostList.vue
+++ b/ui/console-src/modules/contents/posts/DeletedPostList.vue
@@ -263,19 +263,17 @@ watch(
                 </VButton>
               </VSpace>
             </div>
-            <VSpace spacing="lg" class="flex-wrap">
-              <div class="flex flex-row gap-2">
-                <div
-                  class="group cursor-pointer rounded p-1 hover:bg-gray-200"
-                  @click="refetch()"
-                >
-                  <IconRefreshLine
-                    :class="{ 'animate-spin text-gray-900': isFetching }"
-                    class="h-4 w-4 text-gray-600 group-hover:text-gray-900"
-                  />
-                </div>
-              </div>
-            </VSpace>
+            <button
+              v-tooltip="$t('core.common.buttons.refresh')"
+              type="button"
+              class="group cursor-pointer rounded p-1 hover:bg-gray-200"
+              @click="refetch()"
+            >
+              <IconRefreshLine
+                :class="{ 'animate-spin text-gray-900': isFetching }"
+                class="h-4 w-4 text-gray-600 group-hover:text-gray-900"
+              />
+            </button>
           </div>
         </div>
       </template>

--- a/ui/console-src/modules/contents/posts/PostList.vue
+++ b/ui/console-src/modules/contents/posts/PostList.vue
@@ -549,16 +549,17 @@ watch(
                 ]"
               />
               <div class="flex flex-row gap-2">
-                <div
+                <button
+                  v-tooltip="$t('core.common.buttons.refresh')"
+                  type="button"
                   class="group cursor-pointer rounded p-1 hover:bg-gray-200"
                   @click="refetch()"
                 >
                   <IconRefreshLine
-                    v-tooltip="$t('core.common.buttons.refresh')"
                     :class="{ 'animate-spin text-gray-900': isFetching }"
                     class="h-4 w-4 text-gray-600 group-hover:text-gray-900"
                   />
-                </div>
+                </button>
               </div>
             </VSpace>
           </div>

--- a/ui/console-src/modules/contents/posts/tags/TagList.vue
+++ b/ui/console-src/modules/contents/posts/tags/TagList.vue
@@ -243,16 +243,17 @@ watch(selectedTagNames, (newVal) => {
                 ]"
               />
               <div class="flex flex-row gap-2">
-                <div
+                <button
+                  v-tooltip="$t('core.common.buttons.refresh')"
+                  type="button"
                   class="group cursor-pointer rounded p-1 hover:bg-gray-200"
                   @click="handleFetchTags()"
                 >
                   <IconRefreshLine
-                    v-tooltip="$t('core.common.buttons.refresh')"
                     :class="{ 'animate-spin text-gray-900': isFetching }"
                     class="h-4 w-4 text-gray-600 group-hover:text-gray-900"
                   />
-                </div>
+                </button>
               </div>
             </VSpace>
           </div>

--- a/ui/console-src/modules/system/plugins/PluginList.vue
+++ b/ui/console-src/modules/system/plugins/PluginList.vue
@@ -270,16 +270,17 @@ onMounted(() => {
                 ]"
               />
               <div class="flex flex-row gap-2">
-                <div
+                <button
+                  v-tooltip="$t('core.common.buttons.refresh')"
+                  type="button"
                   class="group cursor-pointer rounded p-1 hover:bg-gray-200"
                   @click="refetch()"
                 >
                   <IconRefreshLine
-                    v-tooltip="$t('core.common.buttons.refresh')"
                     :class="{ 'animate-spin text-gray-900': isFetching }"
                     class="h-4 w-4 text-gray-600 group-hover:text-gray-900"
                   />
-                </div>
+                </button>
               </div>
             </VSpace>
           </div>

--- a/ui/console-src/modules/system/users/UserList.vue
+++ b/ui/console-src/modules/system/users/UserList.vue
@@ -342,18 +342,19 @@ function onCreationModalClose() {
                 ]"
               />
               <div class="flex flex-row gap-2">
-                <div
+                <button
+                  v-tooltip="$t('core.common.buttons.refresh')"
+                  type="button"
                   class="group cursor-pointer rounded p-1 hover:bg-gray-200"
                   @click="refetch()"
                 >
                   <IconRefreshLine
-                    v-tooltip="$t('core.common.buttons.refresh')"
                     :class="{
                       'animate-spin text-gray-900': isFetching,
                     }"
                     class="h-4 w-4 text-gray-600 group-hover:text-gray-900"
                   />
-                </div>
+                </button>
               </div>
             </VSpace>
           </div>

--- a/ui/uc-src/modules/contents/attachments/components/selector-providers/CoreSelectorProvider.vue
+++ b/ui/uc-src/modules/contents/attachments/components/selector-providers/CoreSelectorProvider.vue
@@ -312,16 +312,17 @@ function onUploaded(response: SuccessResponse) {
           </div>
 
           <div class="flex flex-row gap-2">
-            <div
+            <button
+              v-tooltip="$t('core.common.buttons.refresh')"
+              type="button"
               class="group cursor-pointer rounded p-1 hover:bg-gray-200"
               @click="handleFetchAttachments()"
             >
               <IconRefreshLine
-                v-tooltip="$t('core.common.buttons.refresh')"
                 :class="{ 'animate-spin text-gray-900': isFetching }"
                 class="h-4 w-4 text-gray-600 group-hover:text-gray-900"
               />
-            </div>
+            </button>
           </div>
         </VSpace>
       </div>

--- a/ui/uc-src/modules/contents/posts/PostList.vue
+++ b/ui/uc-src/modules/contents/posts/PostList.vue
@@ -148,16 +148,17 @@ const {
                   },
                 ]"
               />
-              <div
+              <button
+                v-tooltip="$t('core.common.buttons.refresh')"
+                type="button"
                 class="group cursor-pointer rounded p-1 hover:bg-gray-200"
                 @click="refetch()"
               >
                 <IconRefreshLine
-                  v-tooltip="$t('core.common.buttons.refresh')"
                   :class="{ 'animate-spin text-gray-900': isFetching }"
                   class="h-4 w-4 text-gray-600 group-hover:text-gray-900"
                 />
-              </div>
+              </button>
             </VSpace>
           </div>
         </div>


### PR DESCRIPTION
#### What type of PR is this?

/kind improvement

#### What this PR does / why we need it:

This PR converts the icon-only refresh controls in Console and User Center list toolbars from clickable `div` wrappers to semantic `button` elements.

This keeps the existing visual styling and tooltip behavior while improving keyboard and accessibility semantics. The buttons also use `type="button"` so they do not accidentally submit a parent form if these toolbars are reused in form contexts.

#### Which issue(s) this PR fixes:

None.

#### Special notes for your reviewer:

Assisted by OpenAI Codex and reviewed before submission.

Validation:

- `pnpm -C ui typecheck && pnpm -C ui lint`

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
