### PR TITLE
fix: update remember-me cookie on concurrent rotation failure

### DIFF
--- a/application/src/main/java/run/halo/app/security/authentication/rememberme/PersistentTokenBasedRememberMeServices.java
+++ b/application/src/main/java/run/halo/app/security/authentication/rememberme/PersistentTokenBasedRememberMeServices.java
@@ -146,7 +146,12 @@ public class PersistentTokenBasedRememberMeServices extends TokenBasedRememberMe
                                         updated.getSpec().getSeries());
                                 addCookie(updated, exchange);
                             })
-                            .onErrorReturn(OptimisticLockingFailureException.class, token);
+                            .onErrorResume(
+                                    OptimisticLockingFailureException.class,
+                                    e -> tokenRepository
+                                            .getTokenForSeries(presentedSeries)
+                                            .doOnNext(fresh -> addCookie(fresh, exchange))
+                                            .defaultIfEmpty(token));
                 })
                 .flatMap(t -> getUserDetailsService().findByUsername(t.getSpec().getUsername()));
     }

--- a/application/src/test/java/run/halo/app/security/authentication/rememberme/PersistentTokenBasedRememberMeServicesTest.java
+++ b/application/src/test/java/run/halo/app/security/authentication/rememberme/PersistentTokenBasedRememberMeServicesTest.java
@@ -261,12 +261,15 @@ class PersistentTokenBasedRememberMeServicesTest {
         void shouldFallbackToExistingTokenWhenRotationFailsWithOptimisticLock() {
             var exchange = MockServerWebExchange.from(MockServerHttpRequest.get("/"));
             var storedToken = createTestToken("test-series", "test-token", "test-user", NOW);
+            var updatedToken = createTestToken("test-series", "new-token", "test-user", NOW);
             var device = createTestDevice("test-series");
             var userDetails = User.withUsername("test-user")
                     .password("password")
                     .roles("USER")
                     .build();
-            when(tokenRepository.getTokenForSeries(eq("test-series"))).thenReturn(Mono.just(storedToken));
+            when(tokenRepository.getTokenForSeries(eq("test-series")))
+                    .thenReturn(Mono.just(storedToken))
+                    .thenReturn(Mono.just(updatedToken));
             when(deviceService.resolveCurrentDevice(exchange)).thenReturn(Mono.just(device));
             when(tokenRepository.updateToken(any(RememberMeToken.class)))
                     .thenReturn(Mono.error(new OptimisticLockingFailureException("concurrent update")));
@@ -279,8 +282,8 @@ class PersistentTokenBasedRememberMeServicesTest {
             assertThat(result).isNotNull();
             assertThat(result.getUsername()).isEqualTo("test-user");
             verify(tokenRepository).updateToken(any(RememberMeToken.class));
-            // Cookie should NOT be set because rotation failed
-            verify(rememberMeCookieResolver, never()).setRememberMeCookie(any(), any());
+            verify(tokenRepository, times(2)).getTokenForSeries(eq("test-series"));
+            verify(rememberMeCookieResolver).setRememberMeCookie(eq(exchange), any());
         }
     }
 


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

This PR re-reads the current remember-me token from the database on optimistic lock failure and sets the correct cookie via `addCookie`, ensuring the client always receives the latest token value.

When multiple concurrent requests race to rotate the same remember-me token, only the winning request sets the updated cookie via `addCookie`. Losing requests that get `OptimisticLockingFailureException` previously fell back with `onErrorReturn`, leaving the client with a stale cookie. Once the grace period expires, subsequent requests with the stale cookie trigger `CookieTheftException` and delete all user tokens.

#### Which issue(s) this PR fixes:

Fixes https://github.com/halo-dev/halo/issues/9953

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
修复“记住我”功能在并发请求场景下可能抛出 CookieTheftException 导致所有 Token 被删除的问题
```