### PR TITLE
fix: suppress stacktrace logging for WebExchangeBindException

### DIFF
--- a/application/src/main/java/run/halo/app/infra/exception/handlers/HaloErrorWebExceptionHandler.java
+++ b/application/src/main/java/run/halo/app/infra/exception/handlers/HaloErrorWebExceptionHandler.java
@@ -2,6 +2,8 @@ package run.halo.app.infra.exception.handlers;
 
 import java.util.Map;
 import java.util.Optional;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.boot.autoconfigure.web.ErrorProperties;
 import org.springframework.boot.autoconfigure.web.WebProperties;
 import org.springframework.boot.webflux.autoconfigure.error.DefaultErrorWebExceptionHandler;
@@ -9,6 +11,7 @@ import org.springframework.boot.webflux.error.ErrorAttributes;
 import org.springframework.context.ApplicationContext;
 import org.springframework.http.MediaType;
 import org.springframework.http.ProblemDetail;
+import org.springframework.web.bind.support.WebExchangeBindException;
 import org.springframework.web.reactive.function.server.ServerRequest;
 import org.springframework.web.reactive.function.server.ServerResponse;
 import reactor.core.publisher.Mono;
@@ -18,6 +21,8 @@ import run.halo.app.theme.ThemeResolver;
 import run.halo.app.theme.engine.ThemeTemplateAvailabilityProvider;
 
 public class HaloErrorWebExceptionHandler extends DefaultErrorWebExceptionHandler {
+
+    private static final Logger logger = LoggerFactory.getLogger(HaloErrorWebExceptionHandler.class);
 
     private final ThemeTemplateAvailabilityProvider templateAvailabilityProvider;
 
@@ -46,6 +51,21 @@ public class HaloErrorWebExceptionHandler extends DefaultErrorWebExceptionHandle
     protected int getHttpStatus(Map<String, Object> errorAttributes) {
         var problemDetail = (ProblemDetail) errorAttributes.get("error");
         return problemDetail.getStatus();
+    }
+
+    @Override
+    protected void logError(ServerRequest request, ServerResponse response, Throwable throwable) {
+        if (throwable instanceof WebExchangeBindException) {
+            if (logger.isDebugEnabled()) {
+                logger.debug(
+                        "Resolved [{}] for HTTP {} {}",
+                        throwable.getClass().getSimpleName(),
+                        request.method(),
+                        request.path());
+            }
+            return;
+        }
+        super.logError(request, response, throwable);
     }
 
     @Override


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Override `logError()` in `HaloErrorWebExceptionHandler` to suppress full stacktrace logging for `WebExchangeBindException` (caused by type conversion failures like integer overflow on form fields).

Each request with a form field exceeding `Integer.MAX_VALUE` would generate 1000+ lines of WARN log output with full Reactor stack traces. An attacker could automate these requests to rapidly exhaust disk space (DoS via log flooding).

This fix logs `WebExchangeBindException` at DEBUG level only, with a single-line message and no stack trace.

#### Which issue(s) this PR fixes:

N/A (security report, no public issue)

#### Special notes for your reviewer:

The `logError` signature changed in Spring Boot 4.1.0-RC1 to include `ServerResponse` and `Throwable` parameters. This fix uses the updated API.

#### Does this PR introduce a user-facing change?

```release-note
抑制表单绑定异常（WebExchangeBindException）的完整堆栈日志输出，防止日志泛洪 DoS 攻击。
```