### PR TITLE
Restore thumbnail API client compatibility exports

### DIFF
--- a/ui/packages/api-client/entry/index.ts
+++ b/ui/packages/api-client/entry/index.ts
@@ -1,3 +1,9 @@
 export * from "../src";
 export * from "./api-client";
 export * from "./utils";
+
+/**
+ * Note: This export is for compatibility with older versions, it will be removed in the future, please do not use it.
+ * See：https://github.com/halo-dev/halo/issues/10012
+ */
+export * from "./patch/thumbnail";

--- a/ui/packages/api-client/entry/patch/thumbnail.ts
+++ b/ui/packages/api-client/entry/patch/thumbnail.ts
@@ -1,18 +1,6 @@
 /**
  * Note: This export is for compatibility with older versions, it will be removed in the future, please do not use it.
  * See：https://github.com/halo-dev/halo/issues/10012
- * @deprecated
- */
-export interface ThumbnailSpec {
-  imageSignature: string;
-  imageUri: string;
-  size: ThumbnailSpecSizeEnum;
-  thumbnailUri: string;
-}
-
-/**
- * Note: This export is for compatibility with older versions, it will be removed in the future, please do not use it.
- * See：https://github.com/halo-dev/halo/issues/10012
  * @deprecated use GetThumbnailByUriSizeEnum instead
  */
 export const ThumbnailSpecSizeEnum = {

--- a/ui/packages/api-client/entry/patch/thumbnail.ts
+++ b/ui/packages/api-client/entry/patch/thumbnail.ts
@@ -1,0 +1,31 @@
+/**
+ * Note: This export is for compatibility with older versions, it will be removed in the future, please do not use it.
+ * See：https://github.com/halo-dev/halo/issues/10012
+ * @deprecated
+ */
+export interface ThumbnailSpec {
+  imageSignature: string;
+  imageUri: string;
+  size: ThumbnailSpecSizeEnum;
+  thumbnailUri: string;
+}
+
+/**
+ * Note: This export is for compatibility with older versions, it will be removed in the future, please do not use it.
+ * See：https://github.com/halo-dev/halo/issues/10012
+ * @deprecated use GetThumbnailByUriSizeEnum instead
+ */
+export const ThumbnailSpecSizeEnum = {
+  S: "S",
+  M: "M",
+  L: "L",
+  Xl: "XL",
+} as const;
+
+/**
+ * Note: This export is for compatibility with older versions, it will be removed in the future, please do not use it.
+ * See：https://github.com/halo-dev/halo/issues/10012
+ * @deprecated use GetThumbnailByUriSizeEnum instead
+ */
+export type ThumbnailSpecSizeEnum =
+  (typeof ThumbnailSpecSizeEnum)[keyof typeof ThumbnailSpecSizeEnum];


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/area core

#### What this PR does / why we need it:

This PR restores deprecated thumbnail type exports from `@halo-dev/api-client` through the package entry patch layer.

After #9934 removed the deprecated `Thumbnail` and `LocalThumbnail` extension models, `ThumbnailSpecSizeEnum` disappeared from the generated API client exports. Existing App Store plugin versions still import this symbol, so upgrading Halo can cause the App Store UI to fail during module loading.

The restored export is marked as deprecated and points callers to `GetThumbnailByUriSizeEnum` for new code.

#### Which issue(s) this PR fixes:

Fixes #10012

#### Special notes for your reviewer:

This is a compatibility-only patch for older plugin versions. New code should not depend on `ThumbnailSpec` or `ThumbnailSpecSizeEnum`.

AI assistance was used to inspect and package this change.

#### Does this PR introduce a user-facing change?

```release-note
None
```
