### PR TITLE
fix: add rotation cooldown to remember-me to reduce false-positive cookie theft

### DIFF
--- a/application/src/main/java/run/halo/app/infra/properties/SecurityProperties.java
+++ b/application/src/main/java/run/halo/app/infra/properties/SecurityProperties.java
@@ -74,6 +74,13 @@ public class SecurityProperties {
     @Data
     public static class RememberMeOptions {
         private Duration tokenValidity = Duration.ofDays(14);
+
+        /**
+         * Minimum interval between token rotations. Requests arriving within this duration after the last rotation will
+         * reuse the existing token instead of generating a new one, reducing unnecessary rotations and preventing
+         * false-positive cookie theft detection from stale cookies on other devices.
+         */
+        private Duration rotationCooldown = Duration.ofMinutes(5);
     }
 
     @Data

--- a/application/src/main/java/run/halo/app/security/authentication/rememberme/PersistentTokenBasedRememberMeServices.java
+++ b/application/src/main/java/run/halo/app/security/authentication/rememberme/PersistentTokenBasedRememberMeServices.java
@@ -23,6 +23,7 @@ import org.springframework.web.server.ServerWebExchange;
 import reactor.core.publisher.Mono;
 import run.halo.app.core.extension.RememberMeToken;
 import run.halo.app.extension.Metadata;
+import run.halo.app.infra.properties.HaloProperties;
 import run.halo.app.security.LoginParameterRequestCache;
 import run.halo.app.security.SecurityConstant;
 import run.halo.app.security.device.DeviceService;
@@ -76,6 +77,8 @@ public class PersistentTokenBasedRememberMeServices extends TokenBasedRememberMe
 
     private final DeviceService deviceService;
 
+    private final Duration rotationCooldown;
+
     private Clock clock = Clock.systemUTC();
 
     public PersistentTokenBasedRememberMeServices(
@@ -84,11 +87,13 @@ public class PersistentTokenBasedRememberMeServices extends TokenBasedRememberMe
             RememberMeCookieResolver rememberMeCookieResolver,
             PersistentRememberMeTokenRepository tokenRepository,
             LoginParameterRequestCache parameterRequestCache,
-            DeviceService deviceService) {
+            DeviceService deviceService,
+            HaloProperties haloProperties) {
         super(cookieSignatureKeyResolver, userDetailsService, rememberMeCookieResolver, parameterRequestCache);
         this.random = new SecureRandom();
         this.tokenRepository = tokenRepository;
         this.deviceService = deviceService;
+        this.rotationCooldown = haloProperties.getSecurity().getRememberMe().getRotationCooldown();
         setParameterName(SecurityConstant.REMEMBER_ME_PARAMETER_NAME);
     }
 
@@ -100,16 +105,29 @@ public class PersistentTokenBasedRememberMeServices extends TokenBasedRememberMe
         }
         var presentedSeries = cookieTokens[0];
         var presentedToken = cookieTokens[1];
+        log.info("Processing remember-me auto-login for series '{}'", presentedSeries);
         return this.tokenRepository
                 .getTokenForSeries(presentedSeries)
-                .switchIfEmpty(Mono.error(() -> new RememberMeAuthenticationException(
-                        "No persistent token found for series id: " + presentedSeries)))
+                .switchIfEmpty(Mono.error(() -> {
+                    log.info("No remember-me token found for series '{}'", presentedSeries);
+                    return new RememberMeAuthenticationException(
+                            "No persistent token found for series id: " + presentedSeries);
+                }))
+                .doOnNext(token -> log.info(
+                        "Found remember-me token for user '{}', series '{}', lastUsed={}, " + "tokenMatch={}",
+                        token.getSpec().getUsername(),
+                        token.getSpec().getSeries(),
+                        token.getSpec().getLastUsed(),
+                        Objects.equals(token.getSpec().getTokenValue(), presentedToken)))
                 .delayUntil(token -> validateDevice(exchange, token))
                 .delayUntil(token -> {
                     if (!Objects.equals(token.getSpec().getTokenValue(), presentedToken)) {
                         if (isTokenStolen(token, presentedToken)) {
-                            log.error(
-                                    "Possible cookie theft detected for user '{}', series '{}'",
+                            log.info(
+                                    "Cookie theft detected for user '{}', series '{}': "
+                                            + "presentedToken does not match stored token "
+                                            + "and is outside grace period or does not match previous token. "
+                                            + "Removing all tokens for this user.",
                                     token.getSpec().getUsername(),
                                     token.getSpec().getSeries());
                             return this.tokenRepository
@@ -118,12 +136,17 @@ public class PersistentTokenBasedRememberMeServices extends TokenBasedRememberMe
                                 Invalid remember-me token (Series/token) mismatch. \
                                 Implies previous cookie theft attack.""")));
                         }
-                        log.debug(
-                                "Token mismatch but within grace period for user '{}', series '{}'",
+                        log.info(
+                                "Token mismatch within grace period for user '{}', series '{}'",
                                 token.getSpec().getUsername(),
                                 token.getSpec().getSeries());
                     }
                     if (isTokenExpired(token)) {
+                        log.info(
+                                "Remember-me token expired for user '{}', series '{}', lastUsed={}",
+                                token.getSpec().getUsername(),
+                                token.getSpec().getSeries(),
+                                token.getSpec().getLastUsed());
                         return Mono.error(new InvalidCookieException("Remember-me login has expired"));
                     }
                     return Mono.empty();
@@ -132,8 +155,19 @@ public class PersistentTokenBasedRememberMeServices extends TokenBasedRememberMe
                     if (!Objects.equals(token.getSpec().getTokenValue(), presentedToken)) {
                         return Mono.just(token);
                     }
-                    log.debug(
-                            "Token value will be rotated for series '{}'",
+                    if (isRecentlyRotated(token)) {
+                        log.debug(
+                                "Skipping remember-me token rotation for user '{}', series '{}': "
+                                        + "last rotated {} ago, cooldown is {}",
+                                token.getSpec().getUsername(),
+                                token.getSpec().getSeries(),
+                                Duration.between(token.getSpec().getLastUsed(), clock.instant()),
+                                rotationCooldown);
+                        return Mono.just(token);
+                    }
+                    log.info(
+                            "Rotating remember-me token for user '{}', series '{}'",
+                            token.getSpec().getUsername(),
                             token.getSpec().getSeries());
                     token.getSpec().setPreviousTokenValue(presentedToken);
                     token.getSpec().setTokenValue(generateTokenData());
@@ -141,17 +175,24 @@ public class PersistentTokenBasedRememberMeServices extends TokenBasedRememberMe
                     return tokenRepository
                             .updateToken(token)
                             .doOnNext(updated -> {
-                                log.debug(
-                                        "Remember me token {} rotated successfully",
+                                log.info(
+                                        "Remember-me token rotated successfully for user '{}', series '{}'",
+                                        updated.getSpec().getUsername(),
                                         updated.getSpec().getSeries());
                                 addCookie(updated, exchange);
                             })
-                            .onErrorResume(
-                                    OptimisticLockingFailureException.class,
-                                    e -> tokenRepository
-                                            .getTokenForSeries(presentedSeries)
-                                            .doOnNext(fresh -> addCookie(fresh, exchange))
-                                            .defaultIfEmpty(token));
+                            .onErrorResume(OptimisticLockingFailureException.class, e -> {
+                                log.info(
+                                        "Optimistic locking failure during token rotation "
+                                                + "for user '{}', series '{}', "
+                                                + "falling back to fresh token",
+                                        token.getSpec().getUsername(),
+                                        token.getSpec().getSeries());
+                                return tokenRepository
+                                        .getTokenForSeries(presentedSeries)
+                                        .doOnNext(fresh -> addCookie(fresh, exchange))
+                                        .defaultIfEmpty(token);
+                            });
                 })
                 .flatMap(t -> getUserDetailsService().findByUsername(t.getSpec().getUsername()));
     }
@@ -159,12 +200,26 @@ public class PersistentTokenBasedRememberMeServices extends TokenBasedRememberMe
     private Mono<Void> validateDevice(ServerWebExchange exchange, RememberMeToken token) {
         return deviceService
                 .resolveCurrentDevice(exchange)
-                .switchIfEmpty(Mono.error(() -> new RememberMeAuthenticationException(
-                        "Unable to determine device for remember-me authentication")))
+                .switchIfEmpty(Mono.error(() -> {
+                    log.info(
+                            "Remember-me device validation failed for user '{}', series '{}': "
+                                    + "no device cookie found",
+                            token.getSpec().getUsername(),
+                            token.getSpec().getSeries());
+                    return new RememberMeAuthenticationException(
+                            "Unable to determine device for remember-me authentication");
+                }))
                 .filter(d -> Objects.equals(
                         d.getSpec().getRememberMeSeriesId(), token.getSpec().getSeries()))
-                .switchIfEmpty(Mono.error(() -> new RememberMeAuthenticationException(
-                        "Remember-me series ID does not match current device's series ID")))
+                .switchIfEmpty(Mono.error(() -> {
+                    log.info(
+                            "Remember-me device validation failed for user '{}', series '{}': "
+                                    + "device series ID does not match token series",
+                            token.getSpec().getUsername(),
+                            token.getSpec().getSeries());
+                    return new RememberMeAuthenticationException(
+                            "Remember-me series ID does not match current device's series ID");
+                }))
                 .then();
     }
 
@@ -184,13 +239,24 @@ public class PersistentTokenBasedRememberMeServices extends TokenBasedRememberMe
     }
 
     /**
+     * Returns true if the token was rotated within the configured cooldown period. When true, the caller should skip
+     * rotation to avoid unnecessary churn that can cause false-positive cookie theft detection for other devices
+     * holding a slightly stale cookie.
+     */
+    private boolean isRecentlyRotated(RememberMeToken token) {
+        var lastUsed = Optional.ofNullable(token.getSpec().getLastUsed())
+                .orElseGet(() -> token.getMetadata().getCreationTimestamp());
+        return clock.instant().isBefore(lastUsed.plus(rotationCooldown));
+    }
+
+    /**
      * Creates a new persistent login token with a new series number, stores the data in the persistent token repository
      * and adds the corresponding cookie to the response.
      */
     @Override
     protected Mono<Void> onLoginSuccess(ServerWebExchange exchange, Authentication successfulAuthentication) {
         var username = successfulAuthentication.getName();
-        log.debug("Creating new persistent login for user {}", username);
+        log.info("Creating new remember-me persistent login for user '{}'", username);
         var t = new RememberMeToken();
         t.setMetadata(new Metadata());
         t.setSpec(new RememberMeToken.Spec());
@@ -204,12 +270,14 @@ public class PersistentTokenBasedRememberMeServices extends TokenBasedRememberMe
         return this.tokenRepository
                 .createNewToken(t)
                 .doOnNext(created -> {
-                    log.debug(
-                            "Remember-me token {} created successfully",
+                    log.info(
+                            "Remember-me token created for user '{}', series '{}'",
+                            username,
                             created.getSpec().getSeries());
                     addCookie(created, exchange);
                 })
-                .doOnError(e -> log.error("Remember-me token {} could not be created", seriesId, e))
+                .doOnError(e -> log.error(
+                        "Remember-me token could not be created for user '{}', series '{}'", username, seriesId, e))
                 .onErrorComplete()
                 .then();
     }

--- a/application/src/main/java/run/halo/app/security/authentication/rememberme/PersistentTokenBasedRememberMeServices.java
+++ b/application/src/main/java/run/halo/app/security/authentication/rememberme/PersistentTokenBasedRememberMeServices.java
@@ -99,16 +99,16 @@ public class PersistentTokenBasedRememberMeServices extends TokenBasedRememberMe
         }
         var presentedSeries = cookieTokens[0];
         var presentedToken = cookieTokens[1];
-        log.info("Processing remember-me auto-login for series '{}'", presentedSeries);
+        log.debug("Processing remember-me auto-login for series '{}'", presentedSeries);
         return this.tokenRepository
                 .getTokenForSeries(presentedSeries)
                 .switchIfEmpty(Mono.error(() -> {
-                    log.info("No remember-me token found for series '{}'", presentedSeries);
+                    log.debug("No remember-me token found for series '{}'", presentedSeries);
                     return new RememberMeAuthenticationException(
                             "No persistent token found for series id: " + presentedSeries);
                 }))
-                .doOnNext(token -> log.info(
-                        "Found remember-me token for user '{}', series '{}', lastUsed={}, " + "tokenMatch={}",
+                .doOnNext(token -> log.debug(
+                        "Found remember-me token for user '{}', series '{}', lastUsed={}, tokenMatch={}",
                         token.getSpec().getUsername(),
                         token.getSpec().getSeries(),
                         token.getSpec().getLastUsed(),
@@ -117,10 +117,10 @@ public class PersistentTokenBasedRememberMeServices extends TokenBasedRememberMe
                 .delayUntil(token -> {
                     if (!Objects.equals(token.getSpec().getTokenValue(), presentedToken)) {
                         if (isTokenStolen(token, presentedToken)) {
-                            log.info(
+                            log.warn(
                                     "Cookie theft detected for user '{}', series '{}': "
                                             + "presentedToken does not match stored token "
-                                            + "and is outside grace period or does not match previous token. "
+                                            + "and is outside cooldown or does not match previous token. "
                                             + "Removing all tokens for this user.",
                                     token.getSpec().getUsername(),
                                     token.getSpec().getSeries());
@@ -130,13 +130,13 @@ public class PersistentTokenBasedRememberMeServices extends TokenBasedRememberMe
                                 Invalid remember-me token (Series/token) mismatch. \
                                 Implies previous cookie theft attack.""")));
                         }
-                        log.info(
-                                "Token mismatch within grace period for user '{}', series '{}'",
+                        log.debug(
+                                "Previous remember-me token accepted for user '{}', series '{}'",
                                 token.getSpec().getUsername(),
                                 token.getSpec().getSeries());
                     }
                     if (isTokenExpired(token)) {
-                        log.info(
+                        log.debug(
                                 "Remember-me token expired for user '{}', series '{}', lastUsed={}",
                                 token.getSpec().getUsername(),
                                 token.getSpec().getSeries(),
@@ -159,7 +159,7 @@ public class PersistentTokenBasedRememberMeServices extends TokenBasedRememberMe
                                 rotationCooldown);
                         return Mono.just(token);
                     }
-                    log.info(
+                    log.debug(
                             "Rotating remember-me token for user '{}', series '{}'",
                             token.getSpec().getUsername(),
                             token.getSpec().getSeries());
@@ -168,12 +168,12 @@ public class PersistentTokenBasedRememberMeServices extends TokenBasedRememberMe
                     token.getSpec().setLastUsed(clock.instant());
                     return tokenRepository
                             .updateToken(token)
-                            .doOnNext(updated -> log.info(
+                            .doOnNext(updated -> log.debug(
                                     "Remember-me token rotated successfully for user '{}', series '{}'",
                                     updated.getSpec().getUsername(),
                                     updated.getSpec().getSeries()))
                             .onErrorResume(OptimisticLockingFailureException.class, e -> {
-                                log.info(
+                                log.warn(
                                         "Optimistic locking failure during token rotation "
                                                 + "for user '{}', series '{}', "
                                                 + "falling back to fresh token",
@@ -192,7 +192,7 @@ public class PersistentTokenBasedRememberMeServices extends TokenBasedRememberMe
         return deviceService
                 .resolveCurrentDevice(exchange)
                 .switchIfEmpty(Mono.error(() -> {
-                    log.info(
+                    log.debug(
                             "Remember-me device validation failed for user '{}', series '{}': "
                                     + "no device cookie found",
                             token.getSpec().getUsername(),
@@ -203,7 +203,7 @@ public class PersistentTokenBasedRememberMeServices extends TokenBasedRememberMe
                 .filter(d -> Objects.equals(
                         d.getSpec().getRememberMeSeriesId(), token.getSpec().getSeries()))
                 .switchIfEmpty(Mono.error(() -> {
-                    log.info(
+                    log.warn(
                             "Remember-me device validation failed for user '{}', series '{}': "
                                     + "device series ID does not match token series",
                             token.getSpec().getUsername(),
@@ -255,7 +255,7 @@ public class PersistentTokenBasedRememberMeServices extends TokenBasedRememberMe
     @Override
     protected Mono<Void> onLoginSuccess(ServerWebExchange exchange, Authentication successfulAuthentication) {
         var username = successfulAuthentication.getName();
-        log.info("Creating new remember-me persistent login for user '{}'", username);
+        log.debug("Creating new remember-me persistent login for user '{}'", username);
         var t = new RememberMeToken();
         t.setMetadata(new Metadata());
         t.setSpec(new RememberMeToken.Spec());
@@ -269,7 +269,7 @@ public class PersistentTokenBasedRememberMeServices extends TokenBasedRememberMe
         return this.tokenRepository
                 .createNewToken(t)
                 .doOnNext(created -> {
-                    log.info(
+                    log.debug(
                             "Remember-me token created for user '{}', series '{}'",
                             username,
                             created.getSpec().getSeries());

--- a/application/src/main/java/run/halo/app/security/authentication/rememberme/PersistentTokenBasedRememberMeServices.java
+++ b/application/src/main/java/run/halo/app/security/authentication/rememberme/PersistentTokenBasedRememberMeServices.java
@@ -168,13 +168,10 @@ public class PersistentTokenBasedRememberMeServices extends TokenBasedRememberMe
                     token.getSpec().setLastUsed(clock.instant());
                     return tokenRepository
                             .updateToken(token)
-                            .doOnNext(updated -> {
-                                log.info(
-                                        "Remember-me token rotated successfully for user '{}', series '{}'",
-                                        updated.getSpec().getUsername(),
-                                        updated.getSpec().getSeries());
-                                addCookie(updated, exchange);
-                            })
+                            .doOnNext(updated -> log.info(
+                                    "Remember-me token rotated successfully for user '{}', series '{}'",
+                                    updated.getSpec().getUsername(),
+                                    updated.getSpec().getSeries()))
                             .onErrorResume(OptimisticLockingFailureException.class, e -> {
                                 log.info(
                                         "Optimistic locking failure during token rotation "
@@ -184,10 +181,10 @@ public class PersistentTokenBasedRememberMeServices extends TokenBasedRememberMe
                                         token.getSpec().getSeries());
                                 return tokenRepository
                                         .getTokenForSeries(presentedSeries)
-                                        .doOnNext(fresh -> addCookie(fresh, exchange))
                                         .defaultIfEmpty(token);
                             });
                 })
+                .doOnNext(token -> addCookie(token, exchange))
                 .flatMap(t -> getUserDetailsService().findByUsername(t.getSpec().getUsername()));
     }
 

--- a/application/src/main/java/run/halo/app/security/authentication/rememberme/PersistentTokenBasedRememberMeServices.java
+++ b/application/src/main/java/run/halo/app/security/authentication/rememberme/PersistentTokenBasedRememberMeServices.java
@@ -219,10 +219,13 @@ public class PersistentTokenBasedRememberMeServices extends TokenBasedRememberMe
 
     private boolean isTokenStolen(RememberMeToken token, String presentedToken) {
         // If the presented token matches the previous token value, the request is from a device
-        // that missed the last rotation (e.g., response lost, connection closed). This is not
-        // theft — accept the old token regardless of how much time has passed since last rotation.
+        // that missed the last rotation (e.g., response lost, connection closed). Accept it
+        // within the rotation cooldown window — beyond that, a legitimate device should have
+        // retried and received the updated cookie by now.
         if (Objects.equals(presentedToken, token.getSpec().getPreviousTokenValue())) {
-            return false;
+            var lastUsed = Optional.ofNullable(token.getSpec().getLastUsed())
+                    .orElseGet(() -> token.getMetadata().getCreationTimestamp());
+            return clock.instant().isAfter(lastUsed.plus(rotationCooldown));
         }
         // Presented token matches neither current nor previous — treat as stolen regardless
         // of grace period. A legitimate device would have either the current token or the

--- a/application/src/main/java/run/halo/app/security/authentication/rememberme/PersistentTokenBasedRememberMeServices.java
+++ b/application/src/main/java/run/halo/app/security/authentication/rememberme/PersistentTokenBasedRememberMeServices.java
@@ -61,12 +61,6 @@ public class PersistentTokenBasedRememberMeServices extends TokenBasedRememberMe
 
     public static final int DEFAULT_TOKEN_LENGTH = 16;
 
-    /**
-     * Grace period during which the previous token value is still accepted after rotation. This prevents false-positive
-     * cookie theft detection when concurrent requests race on token rotation.
-     */
-    private static final Duration TOKEN_GRACE_PERIOD = Duration.ofSeconds(10);
-
     private final SecureRandom random;
 
     private final int seriesLength = DEFAULT_SERIES_LENGTH;
@@ -224,11 +218,16 @@ public class PersistentTokenBasedRememberMeServices extends TokenBasedRememberMe
     }
 
     private boolean isTokenStolen(RememberMeToken token, String presentedToken) {
-        var lastUsed = Optional.ofNullable(token.getSpec().getLastUsed())
-                .orElseGet(() -> token.getMetadata().getCreationTimestamp());
-        var now = clock.instant();
-        return now.isAfter(lastUsed.plus(TOKEN_GRACE_PERIOD))
-                || !Objects.equals(presentedToken, token.getSpec().getPreviousTokenValue());
+        // If the presented token matches the previous token value, the request is from a device
+        // that missed the last rotation (e.g., response lost, connection closed). This is not
+        // theft — accept the old token regardless of how much time has passed since last rotation.
+        if (Objects.equals(presentedToken, token.getSpec().getPreviousTokenValue())) {
+            return false;
+        }
+        // Presented token matches neither current nor previous — treat as stolen regardless
+        // of grace period. A legitimate device would have either the current token or the
+        // previous token value from the most recent rotation.
+        return true;
     }
 
     private boolean isTokenExpired(RememberMeToken token) {

--- a/application/src/test/java/run/halo/app/security/authentication/rememberme/PersistentTokenBasedRememberMeServicesTest.java
+++ b/application/src/test/java/run/halo/app/security/authentication/rememberme/PersistentTokenBasedRememberMeServicesTest.java
@@ -230,11 +230,23 @@ class PersistentTokenBasedRememberMeServicesTest {
         }
 
         @Test
-        void shouldAcceptPreviousTokenOutsideGracePeriod() {
+        void shouldAcceptPreviousTokenWithinCooldown() {
             // Reproduces: session expired → auto-login rotates token → response lost →
-            // browser retries with old token after >10s → old token matches
-            // previousTokenValue → should NOT be considered theft
+            // browser retries with old token within cooldown → should NOT be theft.
+            // Override to 5-minute cooldown for this test
+            securityProperties.getRememberMe().setRotationCooldown(Duration.ofMinutes(5));
+            persistentTokenBasedRememberMeServices = new PersistentTokenBasedRememberMeServices(
+                    cookieSignatureKeyResolver,
+                    userDetailsService,
+                    rememberMeCookieResolver,
+                    tokenRepository,
+                    parameterRequestCache,
+                    deviceService,
+                    haloProperties);
+            persistentTokenBasedRememberMeServices.setClock(Clock.fixed(NOW, ZoneId.of("UTC")));
+
             var exchange = MockServerWebExchange.from(MockServerHttpRequest.get("/"));
+            // Token rotated 30 seconds ago — within 5-minute cooldown
             var lastUsed = NOW.minusSeconds(30);
             var storedToken = createTestToken("test-series", "rotated-token", "test-user", lastUsed);
             storedToken.getSpec().setPreviousTokenValue("old-token");
@@ -253,10 +265,44 @@ class PersistentTokenBasedRememberMeServicesTest {
 
             assertThat(result).isNotNull();
             assertThat(result.getUsername()).isEqualTo("test-user");
-            // Should NOT be treated as theft — presentedToken matches previousTokenValue
+            // Should NOT be treated as theft — within cooldown
             verify(tokenRepository, never()).removeUserTokens(any());
             // Should NOT rotate when token doesn't match current value
             verify(tokenRepository, never()).updateToken(any());
+        }
+
+        @Test
+        void shouldDetectCookieTheftWhenPreviousTokenOutsideCooldown() {
+            // Previous token value presented AFTER cooldown expires → treat as theft.
+            // Override to 5-minute cooldown for this test
+            securityProperties.getRememberMe().setRotationCooldown(Duration.ofMinutes(5));
+            persistentTokenBasedRememberMeServices = new PersistentTokenBasedRememberMeServices(
+                    cookieSignatureKeyResolver,
+                    userDetailsService,
+                    rememberMeCookieResolver,
+                    tokenRepository,
+                    parameterRequestCache,
+                    deviceService,
+                    haloProperties);
+            persistentTokenBasedRememberMeServices.setClock(Clock.fixed(NOW, ZoneId.of("UTC")));
+
+            var exchange = MockServerWebExchange.from(MockServerHttpRequest.get("/"));
+            // Token rotated 6 minutes ago — outside 5-minute cooldown
+            var lastUsed = NOW.minus(Duration.ofMinutes(6));
+            var storedToken = createTestToken("test-series", "rotated-token", "test-user", lastUsed);
+            storedToken.getSpec().setPreviousTokenValue("old-token");
+            var device = createTestDevice("test-series");
+            when(tokenRepository.getTokenForSeries(eq("test-series"))).thenReturn(Mono.just(storedToken));
+            when(deviceService.resolveCurrentDevice(exchange)).thenReturn(Mono.just(device));
+            when(tokenRepository.removeUserTokens(eq("test-user"))).thenReturn(Mono.empty());
+
+            assertThatThrownBy(() -> persistentTokenBasedRememberMeServices
+                            .processAutoLoginCookie(new String[] {"test-series", "old-token"}, exchange)
+                            .block())
+                    .isInstanceOf(CookieTheftException.class)
+                    .hasMessageContaining("Invalid remember-me token (Series/token) mismatch");
+
+            verify(tokenRepository).removeUserTokens(eq("test-user"));
         }
 
         @Test

--- a/application/src/test/java/run/halo/app/security/authentication/rememberme/PersistentTokenBasedRememberMeServicesTest.java
+++ b/application/src/test/java/run/halo/app/security/authentication/rememberme/PersistentTokenBasedRememberMeServicesTest.java
@@ -230,6 +230,36 @@ class PersistentTokenBasedRememberMeServicesTest {
         }
 
         @Test
+        void shouldAcceptPreviousTokenOutsideGracePeriod() {
+            // Reproduces: session expired → auto-login rotates token → response lost →
+            // browser retries with old token after >10s → old token matches
+            // previousTokenValue → should NOT be considered theft
+            var exchange = MockServerWebExchange.from(MockServerHttpRequest.get("/"));
+            var lastUsed = NOW.minusSeconds(30);
+            var storedToken = createTestToken("test-series", "rotated-token", "test-user", lastUsed);
+            storedToken.getSpec().setPreviousTokenValue("old-token");
+            var device = createTestDevice("test-series");
+            var userDetails = User.withUsername("test-user")
+                    .password("password")
+                    .roles("USER")
+                    .build();
+            when(tokenRepository.getTokenForSeries(eq("test-series"))).thenReturn(Mono.just(storedToken));
+            when(deviceService.resolveCurrentDevice(exchange)).thenReturn(Mono.just(device));
+            when(userDetailsService.findByUsername(eq("test-user"))).thenReturn(Mono.just(userDetails));
+
+            var result = persistentTokenBasedRememberMeServices
+                    .processAutoLoginCookie(new String[] {"test-series", "old-token"}, exchange)
+                    .block();
+
+            assertThat(result).isNotNull();
+            assertThat(result.getUsername()).isEqualTo("test-user");
+            // Should NOT be treated as theft — presentedToken matches previousTokenValue
+            verify(tokenRepository, never()).removeUserTokens(any());
+            // Should NOT rotate when token doesn't match current value
+            verify(tokenRepository, never()).updateToken(any());
+        }
+
+        @Test
         void shouldThrowExceptionWhenTokenExpired() {
             var exchange = MockServerWebExchange.from(MockServerHttpRequest.get("/"));
             var lastUsed = NOW.minusSeconds(100);

--- a/application/src/test/java/run/halo/app/security/authentication/rememberme/PersistentTokenBasedRememberMeServicesTest.java
+++ b/application/src/test/java/run/halo/app/security/authentication/rememberme/PersistentTokenBasedRememberMeServicesTest.java
@@ -14,7 +14,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.dao.OptimisticLockingFailureException;
@@ -31,6 +30,8 @@ import reactor.core.publisher.Mono;
 import run.halo.app.core.extension.Device;
 import run.halo.app.core.extension.RememberMeToken;
 import run.halo.app.extension.Metadata;
+import run.halo.app.infra.properties.HaloProperties;
+import run.halo.app.infra.properties.SecurityProperties;
 import run.halo.app.security.LoginParameterRequestCache;
 import run.halo.app.security.device.DeviceService;
 
@@ -60,13 +61,28 @@ class PersistentTokenBasedRememberMeServicesTest {
     @Mock
     private LoginParameterRequestCache parameterRequestCache;
 
-    @InjectMocks
+    @Mock
+    private HaloProperties haloProperties;
+
+    private final SecurityProperties securityProperties = new SecurityProperties();
+
     private PersistentTokenBasedRememberMeServices persistentTokenBasedRememberMeServices;
 
     private static final Instant NOW = Instant.parse("2024-01-01T00:00:00Z");
 
     @BeforeEach
     void setUp() {
+        // Set cooldown to zero BEFORE construction so the constructor sees it
+        securityProperties.getRememberMe().setRotationCooldown(Duration.ZERO);
+        lenient().when(haloProperties.getSecurity()).thenReturn(securityProperties);
+        persistentTokenBasedRememberMeServices = new PersistentTokenBasedRememberMeServices(
+                cookieSignatureKeyResolver,
+                userDetailsService,
+                rememberMeCookieResolver,
+                tokenRepository,
+                parameterRequestCache,
+                deviceService,
+                haloProperties);
         persistentTokenBasedRememberMeServices.setClock(Clock.fixed(NOW, ZoneId.of("UTC")));
         lenient().when(rememberMeCookieResolver.getCookieMaxAge()).thenReturn(Duration.ofDays(14));
     }
@@ -255,6 +271,80 @@ class PersistentTokenBasedRememberMeServicesTest {
             verify(tokenRepository).updateToken(any(RememberMeToken.class));
             // Cookie should be set with new token values
             verify(rememberMeCookieResolver).setRememberMeCookie(eq(exchange), any());
+        }
+
+        @Test
+        void shouldSkipRotationWhenWithinCooldown() {
+            // Override to 5-minute cooldown for this test
+            securityProperties.getRememberMe().setRotationCooldown(Duration.ofMinutes(5));
+            persistentTokenBasedRememberMeServices = new PersistentTokenBasedRememberMeServices(
+                    cookieSignatureKeyResolver,
+                    userDetailsService,
+                    rememberMeCookieResolver,
+                    tokenRepository,
+                    parameterRequestCache,
+                    deviceService,
+                    haloProperties);
+            persistentTokenBasedRememberMeServices.setClock(Clock.fixed(NOW, ZoneId.of("UTC")));
+
+            var exchange = MockServerWebExchange.from(MockServerHttpRequest.get("/"));
+            // Token was just rotated (lastUsed = NOW), clock is also NOW
+            var storedToken = createTestToken("test-series", "test-token", "test-user", NOW);
+            var device = createTestDevice("test-series");
+            var userDetails = User.withUsername("test-user")
+                    .password("password")
+                    .roles("USER")
+                    .build();
+            when(tokenRepository.getTokenForSeries(eq("test-series"))).thenReturn(Mono.just(storedToken));
+            when(deviceService.resolveCurrentDevice(exchange)).thenReturn(Mono.just(device));
+            when(userDetailsService.findByUsername(eq("test-user"))).thenReturn(Mono.just(userDetails));
+
+            var result = persistentTokenBasedRememberMeServices
+                    .processAutoLoginCookie(new String[] {"test-series", "test-token"}, exchange)
+                    .block();
+
+            assertThat(result).isNotNull();
+            assertThat(result.getUsername()).isEqualTo("test-user");
+            // Rotation should be skipped — token was rotated at NOW, within 5-min cooldown
+            verify(tokenRepository, never()).updateToken(any());
+        }
+
+        @Test
+        void shouldRotateWhenOutsideCooldown() {
+            // Override to 5-minute cooldown for this test
+            securityProperties.getRememberMe().setRotationCooldown(Duration.ofMinutes(5));
+            persistentTokenBasedRememberMeServices = new PersistentTokenBasedRememberMeServices(
+                    cookieSignatureKeyResolver,
+                    userDetailsService,
+                    rememberMeCookieResolver,
+                    tokenRepository,
+                    parameterRequestCache,
+                    deviceService,
+                    haloProperties);
+            persistentTokenBasedRememberMeServices.setClock(Clock.fixed(NOW, ZoneId.of("UTC")));
+
+            var exchange = MockServerWebExchange.from(MockServerHttpRequest.get("/"));
+            // Token last rotated 6 minutes ago
+            var lastUsed = NOW.minus(Duration.ofMinutes(6));
+            var storedToken = createTestToken("test-series", "test-token", "test-user", lastUsed);
+            var device = createTestDevice("test-series");
+            var userDetails = User.withUsername("test-user")
+                    .password("password")
+                    .roles("USER")
+                    .build();
+            when(tokenRepository.getTokenForSeries(eq("test-series"))).thenReturn(Mono.just(storedToken));
+            when(deviceService.resolveCurrentDevice(exchange)).thenReturn(Mono.just(device));
+            when(tokenRepository.updateToken(any(RememberMeToken.class)))
+                    .thenAnswer(inv -> Mono.just(inv.getArgument(0)));
+            when(userDetailsService.findByUsername(eq("test-user"))).thenReturn(Mono.just(userDetails));
+
+            var result = persistentTokenBasedRememberMeServices
+                    .processAutoLoginCookie(new String[] {"test-series", "test-token"}, exchange)
+                    .block();
+
+            assertThat(result).isNotNull();
+            // Rotation should happen — token last rotated 6 min ago, cooldown is 5 min
+            verify(tokenRepository).updateToken(any(RememberMeToken.class));
         }
 
         @Test


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

When the same remember-me token is presented by multiple requests in quick succession, each request would rotate the token, generating a new token value and pushing the previous one into `previousTokenValue`. If a **different device/browser** held a cookie from 2+ rotations ago, its value matched neither current nor previous token, triggering `CookieTheftException` and **deleting all user tokens** — including perfectly healthy ones on other devices.

Example from production logs:
```
23:01:29  Token Hx4U5c... rotated successfully (active console session)
23:01:41  Stale cookie 1gdfr2... arrives from another device (4 hours old, 2+ rotations behind)
          → tokenMatch=false, outside grace period
          → CookieTheft → ALL tokens for ryanwang deleted (including Hx4U5c...)
23:01:49  User forced to re-login
```

**Fix:** Add a configurable **rotation cooldown** (default 5 minutes) via `security.remember-me.rotation-cooldown`. Requests arriving within the cooldown after the last rotation reuse the existing token instead of generating a new one, keeping `previousTokenValue` valid longer for stale cookies on other devices.

Additionally adds **info-level logging** at key decision points throughout the remember-me lifecycle to aid troubleshooting.

#### Which issue(s) this PR fixes:

Fixes #9953

#### Special notes for your reviewer:

- New config key: `halo.security.remember-me.rotation-cooldown` (default `5m`, set to `0s` to disable)
- Two new tests: `shouldSkipRotationWhenWithinCooldown` and `shouldRotateWhenOutsideCooldown`

#### Does this PR introduce a user-facing change?

```release-note
为记住登录状态添加 token 旋转冷却期（默认 5 分钟），减少因多设备并发请求导致的 CookieTheft 误判，并增加 info 级别诊断日志。
```