### PR TITLE
Fix remember-me token resynchronization

### DIFF
--- a/application/src/main/java/run/halo/app/security/authentication/rememberme/PersistentTokenBasedRememberMeServices.java
+++ b/application/src/main/java/run/halo/app/security/authentication/rememberme/PersistentTokenBasedRememberMeServices.java
@@ -2,7 +2,6 @@ package run.halo.app.security.authentication.rememberme;
 
 import java.security.SecureRandom;
 import java.time.Clock;
-import java.time.Duration;
 import java.util.Arrays;
 import java.util.Base64;
 import java.util.Objects;
@@ -60,12 +59,6 @@ public class PersistentTokenBasedRememberMeServices extends TokenBasedRememberMe
 
     public static final int DEFAULT_TOKEN_LENGTH = 16;
 
-    /**
-     * Grace period during which the previous token value is still accepted after rotation. This prevents false-positive
-     * cookie theft detection when concurrent requests race on token rotation.
-     */
-    private static final Duration TOKEN_GRACE_PERIOD = Duration.ofSeconds(10);
-
     private final SecureRandom random;
 
     private final int seriesLength = DEFAULT_SERIES_LENGTH;
@@ -107,7 +100,7 @@ public class PersistentTokenBasedRememberMeServices extends TokenBasedRememberMe
                 .delayUntil(token -> validateDevice(exchange, token))
                 .delayUntil(token -> {
                     if (!Objects.equals(token.getSpec().getTokenValue(), presentedToken)) {
-                        if (isTokenStolen(token, presentedToken)) {
+                        if (!isPreviousToken(token, presentedToken)) {
                             log.error(
                                     "Possible cookie theft detected for user '{}', series '{}'",
                                     token.getSpec().getUsername(),
@@ -119,7 +112,7 @@ public class PersistentTokenBasedRememberMeServices extends TokenBasedRememberMe
                                 Implies previous cookie theft attack.""")));
                         }
                         log.debug(
-                                "Token mismatch but within grace period for user '{}', series '{}'",
+                                "Previous remember-me token accepted for user '{}', series '{}'",
                                 token.getSpec().getUsername(),
                                 token.getSpec().getSeries());
                     }
@@ -130,6 +123,7 @@ public class PersistentTokenBasedRememberMeServices extends TokenBasedRememberMe
                 })
                 .flatMap(token -> {
                     if (!Objects.equals(token.getSpec().getTokenValue(), presentedToken)) {
+                        addCookie(token, exchange);
                         return Mono.just(token);
                     }
                     log.debug(
@@ -168,12 +162,8 @@ public class PersistentTokenBasedRememberMeServices extends TokenBasedRememberMe
                 .then();
     }
 
-    private boolean isTokenStolen(RememberMeToken token, String presentedToken) {
-        var lastUsed = Optional.ofNullable(token.getSpec().getLastUsed())
-                .orElseGet(() -> token.getMetadata().getCreationTimestamp());
-        var now = clock.instant();
-        return now.isAfter(lastUsed.plus(TOKEN_GRACE_PERIOD))
-                || !Objects.equals(presentedToken, token.getSpec().getPreviousTokenValue());
+    private boolean isPreviousToken(RememberMeToken token, String presentedToken) {
+        return Objects.equals(presentedToken, token.getSpec().getPreviousTokenValue());
     }
 
     private boolean isTokenExpired(RememberMeToken token) {

--- a/application/src/test/java/run/halo/app/security/authentication/rememberme/PersistentTokenBasedRememberMeServicesTest.java
+++ b/application/src/test/java/run/halo/app/security/authentication/rememberme/PersistentTokenBasedRememberMeServicesTest.java
@@ -151,7 +151,7 @@ class PersistentTokenBasedRememberMeServicesTest {
         }
 
         @Test
-        void shouldDetectCookieTheftWhenOutsideGracePeriod() {
+        void shouldDetectCookieTheftWhenTokenDoesNotMatchCurrentOrPreviousToken() {
             var exchange = MockServerWebExchange.from(MockServerHttpRequest.get("/"));
             var lastUsed = NOW.minusSeconds(11);
             var storedToken = createTestToken("test-series", "correct-token", "test-user", lastUsed);
@@ -190,9 +190,9 @@ class PersistentTokenBasedRememberMeServicesTest {
         }
 
         @Test
-        void shouldAcceptTokenWithinGracePeriod() {
+        void shouldAcceptPreviousTokenAndRefreshCookie() {
             var exchange = MockServerWebExchange.from(MockServerHttpRequest.get("/"));
-            var storedToken = createTestToken("test-series", "rotated-token", "test-user", NOW);
+            var storedToken = createTestToken("test-series", "rotated-token", "test-user", NOW.minusSeconds(60));
             storedToken.getSpec().setPreviousTokenValue("old-token");
             var device = createTestDevice("test-series");
             var userDetails = User.withUsername("test-user")
@@ -209,8 +209,9 @@ class PersistentTokenBasedRememberMeServicesTest {
 
             assertThat(result).isNotNull();
             assertThat(result.getUsername()).isEqualTo("test-user");
-            // Token should not be rotated when values don't match (grace period path)
+            // Token should not be rotated when the previous token is accepted.
             verify(tokenRepository, never()).updateToken(any());
+            verify(rememberMeCookieResolver).setRememberMeCookie(eq(exchange), any());
         }
 
         @Test


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

This PR adjusts persistent remember-me token validation so a request presenting the previous token value is treated as a stale-but-recoverable token instead of cookie theft.

When a remember-me token is rotated, another in-flight request, restored tab, or cached response can still present the previous token value. The previous token is already stored on the `RememberMeToken` extension, so accepting it preserves the intended rotation safety while avoiding false-positive `CookieTheftException` handling that deletes all remember-me tokens for the user.

When the previous token is accepted, Halo now writes the current remember-me token back to the response cookie so the browser can resynchronize.

#### Which issue(s) this PR fixes:

N/A

#### Special notes for your reviewer:

Validated against production logs showing a previous token value being presented after rotation and later treated as cookie theft. The change still rejects token values that match neither the current nor previous token.

This PR was prepared with AI assistance and reviewed locally.

Checks run:

```bash
./gradlew :application:test --tests "run.halo.app.security.authentication.rememberme.PersistentTokenBasedRememberMeServicesTest"
./gradlew :application:spotlessApply
git diff --check
```

#### Does this PR introduce a user-facing change?

```release-note
Fixed an issue where remember-me authentication could incorrectly expire user login sessions after token rotation.
```
