### PR TITLE
Format application web resources with Spotless

### DIFF
--- a/application/build.gradle
+++ b/application/build.gradle
@@ -262,4 +262,10 @@ spotless {
         target 'src/**/*.sql'
         dbeaver()
     }
+    format 'webResources', {
+        target 'src/main/resources/templates/**/*.html',
+            'src/main/resources/static/styles/**/*.css',
+            'src/main/resources/static/js/**/*.js'
+        prettier().config(['tabWidth': 2, 'printWidth': 120])
+    }
 }

--- a/application/src/main/resources/static/js/main.js
+++ b/application/src/main/resources/static/js/main.js
@@ -1,11 +1,11 @@
 const Toast = (function () {
-    let container;
+  let container;
 
-    function getContainer() {
-        if (container) return container;
+  function getContainer() {
+    if (container) return container;
 
-        container = document.createElement("div");
-        container.style.cssText = `
+    container = document.createElement("div");
+    container.style.cssText = `
       position: fixed;
       top: 20px;
       left: 50%;
@@ -13,29 +13,29 @@ const Toast = (function () {
       z-index: 9999;
     `;
 
-        if (document.body) {
-            document.body.appendChild(container);
-        } else {
-            document.addEventListener("DOMContentLoaded", () => {
-                document.body.appendChild(container);
-            });
-        }
-
-        return container;
+    if (document.body) {
+      document.body.appendChild(container);
+    } else {
+      document.addEventListener("DOMContentLoaded", () => {
+        document.body.appendChild(container);
+      });
     }
 
-    class ToastMessage {
-        constructor(message, type) {
-            this.message = message;
-            this.type = type;
-            this.element = null;
-            this.create();
-        }
+    return container;
+  }
 
-        create() {
-            this.element = document.createElement("div");
-            this.element.textContent = this.message;
-            this.element.style.cssText = `
+  class ToastMessage {
+    constructor(message, type) {
+      this.message = message;
+      this.type = type;
+      this.element = null;
+      this.create();
+    }
+
+    create() {
+      this.element = document.createElement("div");
+      this.element.textContent = this.message;
+      this.element.style.cssText = `
         background-color: ${this.type === "success" ? "#4CAF50" : "#F44336"};
         color: white;
         padding: 12px 24px;
@@ -45,128 +45,128 @@ const Toast = (function () {
         opacity: 0;
         transition: opacity 0.3s ease-in-out;
       `;
-            getContainer().appendChild(this.element);
+      getContainer().appendChild(this.element);
 
-            setTimeout(() => {
-                this.element.style.opacity = "1";
-            }, 10);
+      setTimeout(() => {
+        this.element.style.opacity = "1";
+      }, 10);
 
-            setTimeout(() => {
-                this.remove();
-            }, 3000);
-        }
-
-        remove() {
-            this.element.style.opacity = "0";
-            setTimeout(() => {
-                const parent = this.element.parentNode;
-                if (parent) {
-                    parent.removeChild(this.element);
-                }
-            }, 300);
-        }
+      setTimeout(() => {
+        this.remove();
+      }, 3000);
     }
 
-    function showToast(message, type) {
-        if (document.readyState === "loading") {
-            document.addEventListener("DOMContentLoaded", () => {
-                new ToastMessage(message, type);
-            });
-        } else {
-            new ToastMessage(message, type);
+    remove() {
+      this.element.style.opacity = "0";
+      setTimeout(() => {
+        const parent = this.element.parentNode;
+        if (parent) {
+          parent.removeChild(this.element);
         }
+      }, 300);
     }
+  }
 
-    return {
-        success: function (message) {
-            showToast(message, "success");
-        },
-        error: function (message) {
-            showToast(message, "error");
-        },
-    };
+  function showToast(message, type) {
+    if (document.readyState === "loading") {
+      document.addEventListener("DOMContentLoaded", () => {
+        new ToastMessage(message, type);
+      });
+    } else {
+      new ToastMessage(message, type);
+    }
+  }
+
+  return {
+    success: function (message) {
+      showToast(message, "success");
+    },
+    error: function (message) {
+      showToast(message, "error");
+    },
+  };
 })();
 
 function sendVerificationCode(button, sendRequest) {
-    let timer;
-    const countdown = 60;
-    const originalButtonText = button.textContent;
+  let timer;
+  const countdown = 60;
+  const originalButtonText = button.textContent;
 
-    button.addEventListener("click", () => {
-        button.disabled = true;
-        button.textContent = i18nResources.sendVerificationCodeSending;
-        sendRequest()
-            .then(() => {
-                startCountdown();
-                Toast.success(i18nResources.sendVerificationCodeSuccess);
-            })
-            .catch((e) => {
-                button.disabled = false;
-                button.textContent = originalButtonText;
-                if (e instanceof Error) {
-                    Toast.error(e.message);
-                } else {
-                    Toast.error(i18nResources.sendVerificationCodeFailed);
-                }
-            });
-    });
+  button.addEventListener("click", () => {
+    button.disabled = true;
+    button.textContent = i18nResources.sendVerificationCodeSending;
+    sendRequest()
+      .then(() => {
+        startCountdown();
+        Toast.success(i18nResources.sendVerificationCodeSuccess);
+      })
+      .catch((e) => {
+        button.disabled = false;
+        button.textContent = originalButtonText;
+        if (e instanceof Error) {
+          Toast.error(e.message);
+        } else {
+          Toast.error(i18nResources.sendVerificationCodeFailed);
+        }
+      });
+  });
 
-    function startCountdown() {
-        let remainingTime = countdown;
-        button.disabled = true;
-        button.classList.add("disabled");
+  function startCountdown() {
+    let remainingTime = countdown;
+    button.disabled = true;
+    button.classList.add("disabled");
 
-        timer = setInterval(() => {
-            if (remainingTime > 0) {
-                button.textContent = `${remainingTime}s`;
-                remainingTime--;
-            } else {
-                clearInterval(timer);
-                button.textContent = originalButtonText;
-                button.disabled = false;
-                button.classList.remove("disabled");
-            }
-        }, 1000);
-    }
+    timer = setInterval(() => {
+      if (remainingTime > 0) {
+        button.textContent = `${remainingTime}s`;
+        remainingTime--;
+      } else {
+        clearInterval(timer);
+        button.textContent = originalButtonText;
+        button.disabled = false;
+        button.classList.remove("disabled");
+      }
+    }, 1000);
+  }
 }
 
 document.addEventListener("DOMContentLoaded", () => {
-    const passwordContainers = document.querySelectorAll(".toggle-password-display-flag");
+  const passwordContainers = document.querySelectorAll(".toggle-password-display-flag");
 
-    passwordContainers.forEach((container) => {
-        const passwordInput = container.querySelector('input[type="password"]');
-        const toggleButton = container.querySelector(".toggle-password-button");
-        const displayIcon = container.querySelector(".password-display-icon");
-        const hiddenIcon = container.querySelector(".password-hidden-icon");
+  passwordContainers.forEach((container) => {
+    const passwordInput = container.querySelector('input[type="password"]');
+    const toggleButton = container.querySelector(".toggle-password-button");
+    const displayIcon = container.querySelector(".password-display-icon");
+    const hiddenIcon = container.querySelector(".password-hidden-icon");
 
-        if (passwordInput && toggleButton && displayIcon && hiddenIcon) {
-            toggleButton.addEventListener("click", () => {
-                if (passwordInput.type === "password") {
-                    passwordInput.type = "text";
-                    displayIcon.style.display = "none";
-                    hiddenIcon.style.display = "block";
-                } else {
-                    passwordInput.type = "password";
-                    displayIcon.style.display = "block";
-                    hiddenIcon.style.display = "none";
-                }
-            });
+    if (passwordInput && toggleButton && displayIcon && hiddenIcon) {
+      toggleButton.addEventListener("click", () => {
+        if (passwordInput.type === "password") {
+          passwordInput.type = "text";
+          displayIcon.style.display = "none";
+          hiddenIcon.style.display = "block";
+        } else {
+          passwordInput.type = "password";
+          displayIcon.style.display = "block";
+          hiddenIcon.style.display = "none";
         }
-    });
+      });
+    }
+  });
 });
 
 function setupPasswordConfirmation(passwordId, confirmPasswordId) {
-    const password = document.getElementById(passwordId);
-    const confirmPassword = document.getElementById(confirmPasswordId);
+  const password = document.getElementById(passwordId);
+  const confirmPassword = document.getElementById(confirmPasswordId);
 
-    function validatePasswordMatch() {
-        if (password.value !== confirmPassword.value) {
-            confirmPassword.setCustomValidity(i18nResources.passwordConfirmationFailed);
-        } else {
-            confirmPassword.setCustomValidity("");
-        }
+  function validatePasswordMatch() {
+    if (password.value !== confirmPassword.value) {
+      confirmPassword.setCustomValidity(i18nResources.passwordConfirmationFailed);
+    } else {
+      confirmPassword.setCustomValidity("");
     }
+  }
 
-    password.addEventListener("change", validatePasswordMatch);
-    confirmPassword.addEventListener("input", validatePasswordMatch);
+  password.addEventListener("change", validatePasswordMatch);
+  confirmPassword.addEventListener("input", validatePasswordMatch);
 }

--- a/application/src/main/resources/static/styles/main.css
+++ b/application/src/main/resources/static/styles/main.css
@@ -1,7 +1,7 @@
 .gateway-page {
-    width: 100%;
-    height: 100vh;
-    overflow: auto;
+  width: 100%;
+  height: 100vh;
+  overflow: auto;
 }
 
 .gateway-wrapper,
@@ -10,418 +10,418 @@
 .gateway-wrapper *,
 .gateway-wrapper :before,
 .gateway-wrapper :after {
-    box-sizing: border-box;
-    border-style: solid;
-    border-width: 0;
+  box-sizing: border-box;
+  border-style: solid;
+  border-width: 0;
 }
 
 .gateway-wrapper {
-    --color-primary: #4ccba0;
-    --color-secondary: #0e1731;
-    --color-link: #1f75cb;
-    --color-text: #374151;
-    --color-border: #d1d5db;
-    --rounded-sm: 0.125em;
-    --rounded-base: 0.25em;
-    --rounded-lg: 0.5em;
-    --spacing-2xl: 1.5em;
-    --spacing-xl: 1.25em;
-    --spacing-lg: 1em;
-    --spacing-md: 0.875em;
-    --spacing-sm: 0.625em;
-    --spacing-xs: 0.5em;
-    --text-xl: 1.25em;
-    --text-2xl: 1.5em;
-    --text-lg: 1.125em;
-    --text-base: 1em;
-    --text-sm: 0.875em;
-    --font-size-base: 16px;
-    --font-size-md: 14px;
-    padding: 5% var(--spacing-lg);
-    font-size: var(--font-size-base);
-    max-width: 28em;
-    margin: 0 auto;
-    font-family: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, Segoe UI, Roboto, Helvetica Neue, Arial,
-        Noto Sans, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol, Noto Color Emoji;
-    line-height: 1.5;
+  --color-primary: #4ccba0;
+  --color-secondary: #0e1731;
+  --color-link: #1f75cb;
+  --color-text: #374151;
+  --color-border: #d1d5db;
+  --rounded-sm: 0.125em;
+  --rounded-base: 0.25em;
+  --rounded-lg: 0.5em;
+  --spacing-2xl: 1.5em;
+  --spacing-xl: 1.25em;
+  --spacing-lg: 1em;
+  --spacing-md: 0.875em;
+  --spacing-sm: 0.625em;
+  --spacing-xs: 0.5em;
+  --text-xl: 1.25em;
+  --text-2xl: 1.5em;
+  --text-lg: 1.125em;
+  --text-base: 1em;
+  --text-sm: 0.875em;
+  --font-size-base: 16px;
+  --font-size-md: 14px;
+  padding: 5% var(--spacing-lg);
+  font-size: var(--font-size-base);
+  max-width: 28em;
+  margin: 0 auto;
+  font-family: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, Segoe UI, Roboto, Helvetica Neue, Arial,
+    Noto Sans, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol, Noto Color Emoji;
+  line-height: 1.5;
 }
 
 .halo-form-wrapper {
-    border-radius: var(--rounded-lg);
-    padding: var(--spacing-2xl);
-    background: #fff;
-    border: 1px solid #dfe6ecb3;
+  border-radius: var(--rounded-lg);
+  padding: var(--spacing-2xl);
+  background: #fff;
+  border: 1px solid #dfe6ecb3;
 }
 
 .form-title {
-    all: unset;
-    font-size: var(--text-2xl);
-    margin-bottom: var(--spacing-lg);
-    font-weight: 500;
-    display: block;
+  all: unset;
+  font-size: var(--text-2xl);
+  margin-bottom: var(--spacing-lg);
+  font-weight: 500;
+  display: block;
 }
 
 .halo-form .form-item {
-    margin-bottom: var(--spacing-2xl);
-    flex-direction: column;
-    width: 100%;
-    display: flex;
+  margin-bottom: var(--spacing-2xl);
+  flex-direction: column;
+  width: 100%;
+  display: flex;
 }
 
 .halo-form .form-item:last-of-type {
-    margin-bottom: 0;
+  margin-bottom: 0;
 }
 
 .halo-form .form-item-group {
-    gap: var(--spacing-lg);
-    margin-bottom: var(--spacing-2xl);
-    align-items: flex-start;
-    display: flex;
+  gap: var(--spacing-lg);
+  margin-bottom: var(--spacing-2xl);
+  align-items: flex-start;
+  display: flex;
 }
 
 .halo-form .form-item-group .form-item {
-    margin-bottom: 0;
+  margin-bottom: 0;
 }
 
 .halo-form .form-input {
-    border-radius: var(--rounded-base);
-    border: 1px solid var(--color-border);
-    background: #fff;
-    height: 2.5em;
-    padding: 0 0.75rem;
+  border-radius: var(--rounded-base);
+  border: 1px solid var(--color-border);
+  background: #fff;
+  height: 2.5em;
+  padding: 0 0.75rem;
 }
 
 .halo-form .form-input:focus-within {
-    border-color: var(--color-primary);
-    outline-offset: "2px";
-    outline: 2px solid #0000;
+  border-color: var(--color-primary);
+  outline-offset: "2px";
+  outline: 2px solid #0000;
 }
 
 .halo-form .form-item input {
-    appearance: none;
-    font-size: var(--text-base);
-    box-shadow: none;
-    background: none;
-    width: 100%;
-    height: 100%;
-    display: block;
+  appearance: none;
+  font-size: var(--text-base);
+  box-shadow: none;
+  background: none;
+  width: 100%;
+  height: 100%;
+  display: block;
 }
 
 .halo-form .form-item select {
-    appearance: none;
-    font-size: var(--text-base);
-    box-shadow: none;
-    width: 100%;
-    height: 100%;
-    display: block;
-    outline: none;
-    border: none;
-    background: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='1em' height='1em' viewBox='0 0 24 24'%3E%3Cpath fill='%23000' d='m12 13.171l4.95-4.95l1.414 1.415L12 16L5.636 9.636L7.05 8.222z'/%3E%3C/svg%3E")
-        right 0em center no-repeat;
+  appearance: none;
+  font-size: var(--text-base);
+  box-shadow: none;
+  width: 100%;
+  height: 100%;
+  display: block;
+  outline: none;
+  border: none;
+  background: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='1em' height='1em' viewBox='0 0 24 24'%3E%3Cpath fill='%23000' d='m12 13.171l4.95-4.95l1.414 1.415L12 16L5.636 9.636L7.05 8.222z'/%3E%3C/svg%3E")
+    right 0em center no-repeat;
 }
 
 .halo-form .form-item input:focus {
-    outline: none;
+  outline: none;
 }
 
 .halo-form .form-input-stack {
-    align-items: center;
-    gap: 0.5em;
-    display: flex;
+  align-items: center;
+  gap: 0.5em;
+  display: flex;
 }
 
 .halo-form .form-input-stack-icon {
-    color: var(--color-text);
-    cursor: pointer;
-    align-items: center;
-    display: inline-flex;
+  color: var(--color-text);
+  cursor: pointer;
+  align-items: center;
+  display: inline-flex;
 }
 
 .halo-form .form-input-stack-select {
-    all: unset;
-    color: var(--color-text);
-    font-size: var(--text-sm);
-    background: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='1em' height='1em' viewBox='0 0 24 24'%3E%3Cpath fill='%23000' d='m12 13.171l4.95-4.95l1.414 1.415L12 16L5.636 9.636L7.05 8.222z'/%3E%3C/svg%3E")
-        right 0.3em center no-repeat;
-    align-items: center;
-    padding-right: 1.85em;
-    display: inline-flex;
+  all: unset;
+  color: var(--color-text);
+  font-size: var(--text-sm);
+  background: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='1em' height='1em' viewBox='0 0 24 24'%3E%3Cpath fill='%23000' d='m12 13.171l4.95-4.95l1.414 1.415L12 16L5.636 9.636L7.05 8.222z'/%3E%3C/svg%3E")
+    right 0.3em center no-repeat;
+  align-items: center;
+  padding-right: 1.85em;
+  display: inline-flex;
 }
 
 .halo-form .form-input-stack-text {
-    color: var(--color-text);
-    font-size: var(--text-sm);
+  color: var(--color-text);
+  font-size: var(--text-sm);
 }
 
 .halo-form .form-item label {
-    color: var(--color-text);
-    font-size: var(--text-base);
-    margin-bottom: 0.75rem;
-    font-weight: 500;
+  color: var(--color-text);
+  font-size: var(--text-base);
+  margin-bottom: 0.75rem;
+  font-weight: 500;
 }
 
 .halo-form .form-item .form-label-group {
-    justify-content: space-between;
-    align-items: center;
-    margin-bottom: 0.75em;
-    display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 0.75em;
+  display: flex;
 }
 
 .halo-form .form-item .form-label-group label {
-    margin-bottom: 0;
+  margin-bottom: 0;
 }
 
 .halo-form .form-item-extra-link {
-    color: var(--color-link);
-    font-size: var(--text-sm);
-    text-decoration: none;
+  color: var(--color-link);
+  font-size: var(--text-sm);
+  text-decoration: none;
 }
 
 .halo-form .form-item-compact {
-    gap: var(--spacing-sm);
-    margin-bottom: var(--spacing-2xl);
-    align-items: center;
-    display: flex;
+  gap: var(--spacing-sm);
+  margin-bottom: var(--spacing-2xl);
+  align-items: center;
+  display: flex;
 }
 
 .halo-form .form-item-compact label {
-    color: var(--color-text);
-    font-size: var(--text-sm);
+  color: var(--color-text);
+  font-size: var(--text-sm);
 }
 
 .halo-form button[type="submit"] {
-    background: var(--color-secondary);
-    border-radius: var(--rounded-base);
-    color: #fff;
-    cursor: pointer;
-    border: none;
-    height: 2.5em;
+  background: var(--color-secondary);
+  border-radius: var(--rounded-base);
+  color: #fff;
+  cursor: pointer;
+  border: none;
+  height: 2.5em;
 }
 
 .halo-form button[type="submit"]:hover {
-    opacity: 0.8;
+  opacity: 0.8;
 }
 
 .halo-form button[type="submit"]:active {
-    opacity: 0.9;
+  opacity: 0.9;
 }
 
 .halo-form button[disabled] {
-    cursor: not-allowed !important;
+  cursor: not-allowed !important;
 }
 
 .halo-form input[type="checkbox"] {
-    border: 1px solid var(--color-border);
-    border-radius: var(--rounded-sm);
-    appearance: none;
-    print-color-adjust: exact;
-    vertical-align: middle;
-    user-select: none;
-    color: #2563eb;
-    background-color: #fff;
-    background-origin: border-box;
-    flex-shrink: 0;
-    width: 1em;
-    height: 1em;
-    padding: 0;
-    display: inline-block;
+  border: 1px solid var(--color-border);
+  border-radius: var(--rounded-sm);
+  appearance: none;
+  print-color-adjust: exact;
+  vertical-align: middle;
+  user-select: none;
+  color: #2563eb;
+  background-color: #fff;
+  background-origin: border-box;
+  flex-shrink: 0;
+  width: 1em;
+  height: 1em;
+  padding: 0;
+  display: inline-block;
 }
 
 .halo-form input[type="checkbox"]:focus {
-    outline-offset: 2px;
-    outline: 2px solid #0000;
-    box-shadow: 0 0 0 2px #fff, 0 0 0 4px #2563eb, 0 0 #0000;
+  outline-offset: 2px;
+  outline: 2px solid #0000;
+  box-shadow: 0 0 0 2px #fff, 0 0 0 4px #2563eb, 0 0 #0000;
 }
 
 .halo-form input[type="checkbox"]:checked {
-    background-color: currentColor;
-    background-image: url("data:image/svg+xml,%3csvg viewBox='0 0 16 16' fill='white' xmlns='http://www.w3.org/2000/svg'%3e%3cpath d='M12.207 4.793a1 1 0 010 1.414l-5 5a1 1 0 01-1.414 0l-2-2a1 1 0 011.414-1.414L6.5 9.086l4.293-4.293a1 1 0 011.414 0z'/%3e%3c/svg%3e");
-    background-position: center;
-    background-repeat: no-repeat;
-    background-size: 100% 100%;
-    border-color: #0000;
+  background-color: currentColor;
+  background-image: url("data:image/svg+xml,%3csvg viewBox='0 0 16 16' fill='white' xmlns='http://www.w3.org/2000/svg'%3e%3cpath d='M12.207 4.793a1 1 0 010 1.414l-5 5a1 1 0 01-1.414 0l-2-2a1 1 0 011.414-1.414L6.5 9.086l4.293-4.293a1 1 0 011.414 0z'/%3e%3c/svg%3e");
+  background-position: center;
+  background-repeat: no-repeat;
+  background-size: 100% 100%;
+  border-color: #0000;
 }
 
 .halo-form .form-input-group {
-    gap: var(--spacing-sm);
-    grid-template-columns: repeat(3, minmax(0, 1fr));
-    align-items: center;
-    display: grid;
-    height: 2.5em;
+  gap: var(--spacing-sm);
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  align-items: center;
+  display: grid;
+  height: 2.5em;
 }
 
 .halo-form .form-input {
-    grid-column: span 2 / span 2;
+  grid-column: span 2 / span 2;
 }
 
 .halo-form .form-input-group button {
-    border-radius: var(--rounded-base);
-    border: 1px solid var(--color-border);
-    color: var(--color-text);
-    font-size: var(--text-sm);
-    cursor: pointer;
-    background: #fff;
-    grid-column: span 1 / span 1;
-    height: 100%;
+  border-radius: var(--rounded-base);
+  border: 1px solid var(--color-border);
+  color: var(--color-text);
+  font-size: var(--text-sm);
+  cursor: pointer;
+  background: #fff;
+  grid-column: span 1 / span 1;
+  height: 100%;
 }
 
 .halo-form .form-input-group button:hover {
-    color: #333;
-    background: #f3f4f6;
+  color: #333;
+  background: #f3f4f6;
 }
 
 .halo-form .form-input-group button:active {
-    background: #f9fafb;
+  background: #f9fafb;
 }
 
 .pill-items {
-    all: unset;
-    gap: var(--spacing-sm);
-    flex-wrap: wrap;
-    justify-content: center;
-    margin: 0;
-    display: flex;
+  all: unset;
+  gap: var(--spacing-sm);
+  flex-wrap: wrap;
+  justify-content: center;
+  margin: 0;
+  display: flex;
 }
 
 .pill-items li {
-    all: unset;
-    border-radius: var(--rounded-lg);
-    border: 1px solid #e5e7eb;
-    transition-property: all;
-    transition-duration: 0.15s;
-    transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
-    overflow: hidden;
+  all: unset;
+  border-radius: var(--rounded-lg);
+  border: 1px solid #e5e7eb;
+  transition-property: all;
+  transition-duration: 0.15s;
+  transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
+  overflow: hidden;
 }
 
 .pill-items li button {
-    all: unset;
-    cursor: pointer;
-    width: 100%;
-    height: 100%;
+  all: unset;
+  cursor: pointer;
+  width: 100%;
+  height: 100%;
 }
 
 .pill-items li a,
 .pill-items li button {
-    gap: var(--spacing-sm);
-    font-size: var(--text-sm);
-    color: #1f2937;
-    align-items: center;
-    padding: 0.6em 0.9em;
-    text-decoration: none;
-    display: flex;
+  gap: var(--spacing-sm);
+  font-size: var(--text-sm);
+  color: #1f2937;
+  align-items: center;
+  padding: 0.6em 0.9em;
+  text-decoration: none;
+  display: flex;
 }
 
 .pill-items li img {
-    width: 1.5em;
-    height: 1.5em;
+  width: 1.5em;
+  height: 1.5em;
 }
 
 .pill-items li:hover {
-    border-color: var(--color-primary);
-    background: #f3f4f6;
+  border-color: var(--color-primary);
+  background: #f3f4f6;
 }
 
 .pill-items li:hover {
-    color: #111827;
+  color: #111827;
 }
 
 .pill-items li:focus-within {
-    border-color: var(--color-primary);
+  border-color: var(--color-primary);
 }
 
 .divider-wrapper {
-    color: var(--color-text);
-    font-size: var(--text-sm);
-    gap: var(--spacing-lg);
-    align-items: center;
-    margin: 1.5em 0;
-    display: flex;
+  color: var(--color-text);
+  font-size: var(--text-sm);
+  gap: var(--spacing-lg);
+  align-items: center;
+  margin: 1.5em 0;
+  display: flex;
 }
 
 .divider-wrapper hr {
-    border: 0;
-    border-top: 1px solid #f3f4f6;
-    flex-grow: 1;
-    overflow: hidden;
+  border: 0;
+  border-top: 1px solid #f3f4f6;
+  flex-grow: 1;
+  overflow: hidden;
 }
 
 .alert {
-    border-radius: var(--rounded-base);
-    margin-bottom: var(--spacing-xl);
-    padding: var(--spacing-md) var(--spacing-xl);
-    font-size: var(--text-sm);
-    color: var(--color-text);
-    border: 1px solid #e5e7eb;
-    position: relative;
-    overflow: hidden;
+  border-radius: var(--rounded-base);
+  margin-bottom: var(--spacing-xl);
+  padding: var(--spacing-md) var(--spacing-xl);
+  font-size: var(--text-sm);
+  color: var(--color-text);
+  border: 1px solid #e5e7eb;
+  position: relative;
+  overflow: hidden;
 }
 
 .alert:before {
-    content: "";
-    background: #d1d5db;
-    width: 0.25em;
-    height: 100%;
-    position: absolute;
-    top: 0;
-    left: 0;
+  content: "";
+  background: #d1d5db;
+  width: 0.25em;
+  height: 100%;
+  position: absolute;
+  top: 0;
+  left: 0;
 }
 
 .alert-warning {
-    border-color: #fde047;
+  border-color: #fde047;
 }
 
 .alert-warning:before {
-    background: #ea580c;
+  background: #ea580c;
 }
 
 .alert-error {
-    border-color: #fca5a5;
+  border-color: #fca5a5;
 }
 
 .alert-error:before {
-    background: #dc2626;
+  background: #dc2626;
 }
 
 .alert-success {
-    border-color: #86efac;
+  border-color: #86efac;
 }
 
 .alert-success:before {
-    background: #16a34a;
+  background: #16a34a;
 }
 
 .alert-info {
-    border-color: #7dd3fc;
+  border-color: #7dd3fc;
 }
 
 .alert-info:before {
-    background: #0284c7;
+  background: #0284c7;
 }
 
 @media (forced-colors: active) {
-    .halo-form input[type="checkbox"]:checked {
-        appearance: auto;
-    }
+  .halo-form input[type="checkbox"]:checked {
+    appearance: auto;
+  }
 }
 
 @media only screen and (max-width: 768px) {
-    .halo-form .form-item-group {
-        flex-direction: column;
-    }
+  .halo-form .form-item-group {
+    flex-direction: column;
+  }
 }
 
 @media screen and (min-width: 1201px) and (max-width: 1600px) {
-    .gateway-wrapper {
-        font-size: var(--font-size-md);
-    }
+  .gateway-wrapper {
+    font-size: var(--font-size-md);
+  }
 }
 
 @media screen and (min-width: 1601px) {
-    .gateway-wrapper {
-        font-size: var(--font-size-base);
-    }
+  .gateway-wrapper {
+    font-size: var(--font-size-base);
+  }
 }
 
 ::-ms-reveal {
-    display: none;
+  display: none;
 }

--- a/application/src/main/resources/templates/challenges/two-factor/totp.html
+++ b/application/src/main/resources/templates/challenges/two-factor/totp.html
@@ -1,26 +1,26 @@
-<!doctype html>
+<!DOCTYPE html>
 <html
-    xmlns:th="https://www.thymeleaf.org"
-    th:replace="~{gateway_fragments/layout :: layout(title = |#{title} - ${site.title}|, head = ~{::head}, body = ~{::body})}"
+  xmlns:th="https://www.thymeleaf.org"
+  th:replace="~{gateway_fragments/layout :: layout(title = |#{title} - ${site.title}|, head = ~{::head}, body = ~{::body})}"
 >
-    <th:block th:fragment="body">
-        <div class="gateway-wrapper totp-page-wrapper">
-            <div th:replace="~{gateway_fragments/common::haloLogo}"></div>
-            <div class="halo-form-wrapper">
-                <h1 class="form-title" th:text="#{title}"></h1>
-                <form th:replace="~{gateway_fragments/totp::form}"></form>
-            </div>
-        </div>
-    </th:block>
+  <th:block th:fragment="body">
+    <div class="gateway-wrapper totp-page-wrapper">
+      <div th:replace="~{gateway_fragments/common::haloLogo}"></div>
+      <div class="halo-form-wrapper">
+        <h1 class="form-title" th:text="#{title}"></h1>
+        <form th:replace="~{gateway_fragments/totp::form}"></form>
+      </div>
+    </div>
+  </th:block>
 
-    <th:block th:fragment="head">
-        <style>
-            .totp-page-wrapper .cancel-link {
-                color: var(--color-link);
-                font-size: var(--text-sm);
-                text-decoration: none;
-                text-align: center;
-            }
-        </style>
-    </th:block>
+  <th:block th:fragment="head">
+    <style>
+      .totp-page-wrapper .cancel-link {
+        color: var(--color-link);
+        font-size: var(--text-sm);
+        text-decoration: none;
+        text-align: center;
+      }
+    </style>
+  </th:block>
 </html>

--- a/application/src/main/resources/templates/error/error.html
+++ b/application/src/main/resources/templates/error/error.html
@@ -1,130 +1,128 @@
 <!DOCTYPE html>
 <html lang="zh" xmlns:th="https://www.thymeleaf.org">
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width,initial-scale=1">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width,initial-scale=1" />
     <title th:text="${error.status} + ' | ' + ${#strings.defaultString(error.title, 'Internal server error')}"></title>
     <style>
+      body {
+        padding: 30px 20px;
+        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell",
+          "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
+        color: #727272;
+        line-height: 1.6;
+      }
+
+      .container {
+        max-width: 500px;
+        margin: 0 auto;
+      }
+
+      h1 {
+        margin: 0;
+        font-size: 60px;
+        line-height: 1;
+        color: #252427;
+        font-weight: 700;
+        display: inline-block;
+      }
+
+      h2 {
+        margin: 100px 0 0;
+        font-weight: 600;
+        letter-spacing: 0.1em;
+        color: #a299ac;
+        text-transform: uppercase;
+      }
+
+      p {
+        font-size: 16px;
+        margin: 1em 0;
+      }
+
+      @media screen and (min-width: 768px) {
         body {
-            padding: 30px 20px;
-            font-family: -apple-system, BlinkMacSystemFont,
-            "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell",
-            "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
-            color: #727272;
-            line-height: 1.6;
+          padding: 50px;
         }
+      }
 
-        .container {
-            max-width: 500px;
-            margin: 0 auto;
-        }
-
+      @media screen and (max-width: 480px) {
         h1 {
-            margin: 0;
-            font-size: 60px;
-            line-height: 1;
-            color: #252427;
-            font-weight: 700;
-            display: inline-block;
+          font-size: 48px;
         }
+      }
 
-        h2 {
-            margin: 100px 0 0;
-            font-weight: 600;
-            letter-spacing: 0.1em;
-            color: #A299AC;
-            text-transform: uppercase;
-        }
+      .title {
+        position: relative;
+      }
 
-        p {
-            font-size: 16px;
-            margin: 1em 0;
-        }
+      .title::before {
+        content: "";
+        position: absolute;
+        bottom: 0;
+        left: 0;
+        right: 0;
+        height: 2px;
+        background-color: #000;
+        transform-origin: bottom right;
+        transform: scaleX(0);
+        transition: transform 0.5s ease;
+      }
 
-        @media screen and (min-width: 768px) {
-            body {
-                padding: 50px;
-            }
-        }
+      .title:hover::before {
+        transform-origin: bottom left;
+        transform: scaleX(1);
+      }
 
-        @media screen and (max-width: 480px) {
-            h1 {
-                font-size: 48px;
-            }
-        }
+      .back-home button {
+        z-index: 1;
+        position: relative;
+        font-size: inherit;
+        font-family: inherit;
+        color: white;
+        padding: 0.5em 1em;
+        outline: none;
+        border: none;
+        background-color: hsl(0, 0%, 0%);
+        overflow: hidden;
+        transition: color 0.4s ease-in-out;
+      }
 
-        .title {
-            position: relative;
-        }
+      .back-home button::before {
+        content: "";
+        z-index: -1;
+        position: absolute;
+        top: 100%;
+        left: 100%;
+        width: 1em;
+        height: 1em;
+        border-radius: 50%;
+        background-color: #fff;
+        transform-origin: center;
+        transform: translate3d(-50%, -50%, 0) scale3d(0, 0, 0);
+        transition: transform 0.45s ease-in-out;
+      }
 
-        .title::before {
-            content: '';
-            position: absolute;
-            bottom: 0;
-            left: 0;
-            right: 0;
-            height: 2px;
-            background-color: #000;
-            transform-origin: bottom right;
-            transform: scaleX(0);
-            transition: transform 0.5s ease;
-        }
+      .back-home button:hover {
+        cursor: pointer;
+        color: #000;
+      }
 
-        .title:hover::before {
-            transform-origin: bottom left;
-            transform: scaleX(1);
-        }
-
-        .back-home button {
-            z-index: 1;
-            position: relative;
-            font-size: inherit;
-            font-family: inherit;
-            color: white;
-            padding: 0.5em 1em;
-            outline: none;
-            border: none;
-            background-color: hsl(0, 0%, 0%);
-            overflow: hidden;
-            transition: color 0.4s ease-in-out;
-        }
-
-        .back-home button::before {
-            content: '';
-            z-index: -1;
-            position: absolute;
-            top: 100%;
-            left: 100%;
-            width: 1em;
-            height: 1em;
-            border-radius: 50%;
-            background-color: #fff;
-            transform-origin: center;
-            transform: translate3d(-50%, -50%, 0) scale3d(0, 0, 0);
-            transition: transform 0.45s ease-in-out;
-        }
-
-        .back-home button:hover {
-            cursor: pointer;
-            color: #000;
-        }
-
-        .back-home button:hover::before {
-            transform: translate3d(-50%, -50%, 0) scale3d(15, 15, 15);
-        }
+      .back-home button:hover::before {
+        transform: translate3d(-50%, -50%, 0) scale3d(15, 15, 15);
+      }
     </style>
-</head>
-<body>
-
-<div class="container">
-    <h2 th:text="${error.status}"></h2>
-    <h1 class="title" th:text="${#strings.defaultString(error.title, 'Internal server error')}"></h1>
-    <p th:text="${#strings.defaultString(error.detail, '未知错误！可能存在的原因：未正确设置主题或主题文件缺失。')}"></p>
-    <div class="back-home">
-        <button th:onclick="window.location.href='[(${site.url})]'"
-                th:text="首页">
-        </button>
+  </head>
+  <body>
+    <div class="container">
+      <h2 th:text="${error.status}"></h2>
+      <h1 class="title" th:text="${#strings.defaultString(error.title, 'Internal server error')}"></h1>
+      <p
+        th:text="${#strings.defaultString(error.detail, '未知错误！可能存在的原因：未正确设置主题或主题文件缺失。')}"
+      ></p>
+      <div class="back-home">
+        <button th:onclick="window.location.href='[(${site.url})]'" th:text="首页"></button>
+      </div>
     </div>
-</div>
-</body>
+  </body>
 </html>

--- a/application/src/main/resources/templates/gateway_fragments/common.html
+++ b/application/src/main/resources/templates/gateway_fragments/common.html
@@ -1,258 +1,258 @@
 <th:block th:fragment="basicStaticResources">
-    <th:block th:replace="~{gateway_fragments/common::basicStyleResources}"></th:block>
-    <th:block th:replace="~{gateway_fragments/common::basicScriptResources}"></th:block>
+  <th:block th:replace="~{gateway_fragments/common::basicStyleResources}"></th:block>
+  <th:block th:replace="~{gateway_fragments/common::basicScriptResources}"></th:block>
 </th:block>
 
 <th:block th:fragment="basicScriptResources">
-    <th:block th:if="${not #strings.isEmpty(publicKey)} and ${fragmentTemplateName} == 'login_local'">
-        <script src="/webjars/jsencrypt/3.5.4/bin/jsencrypt.min.js" defer></script>
-        <script th:inline="javascript" type="text/javascript">
-            const publicKey = /*[[${publicKey}]]*/ "";
+  <th:block th:if="${not #strings.isEmpty(publicKey)} and ${fragmentTemplateName} == 'login_local'">
+    <script src="/webjars/jsencrypt/3.5.4/bin/jsencrypt.min.js" defer></script>
+    <script th:inline="javascript" type="text/javascript">
+      const publicKey = /*[[${publicKey}]]*/ "";
 
-            // Encrypt function
-            function encryptPassword(password) {
-                const encrypt = new JSEncrypt();
-                encrypt.setPublicKey(publicKey);
-                return encrypt.encrypt(password);
-            }
+      // Encrypt function
+      function encryptPassword(password) {
+        const encrypt = new JSEncrypt();
+        encrypt.setPublicKey(publicKey);
+        return encrypt.encrypt(password);
+      }
 
-            document.addEventListener("DOMContentLoaded", function () {
-                const loginForm = document.getElementById("login-form");
-                loginForm.addEventListener("submit", function (event) {
-                    const plainPasswordInput = document.getElementById("plainPassword");
-                    const passwordInput = document.getElementById("password");
-                    passwordInput.value = encryptPassword(plainPasswordInput.value);
-                });
-            });
-        </script>
-    </th:block>
-
-    <script th:inline="javascript">
-        const i18nResources = {
-            sendVerificationCodeSuccess: `[(#{js.sendVerificationCode.success})]`,
-            sendVerificationCodeFailed: `[(#{js.sendVerificationCode.failed})]`,
-            sendVerificationCodeSending: `[(#{js.sendVerificationCode.sending})]`,
-            passwordConfirmationFailed: `[(#{js.passwordConfirmation.failed})]`,
-        };
+      document.addEventListener("DOMContentLoaded", function () {
+        const loginForm = document.getElementById("login-form");
+        loginForm.addEventListener("submit", function (event) {
+          const plainPasswordInput = document.getElementById("plainPassword");
+          const passwordInput = document.getElementById("password");
+          passwordInput.value = encryptPassword(plainPasswordInput.value);
+        });
+      });
     </script>
+  </th:block>
 
-    <script src="/js/main.js"></script>
+  <script th:inline="javascript">
+    const i18nResources = {
+      sendVerificationCodeSuccess: `[(#{js.sendVerificationCode.success})]`,
+      sendVerificationCodeFailed: `[(#{js.sendVerificationCode.failed})]`,
+      sendVerificationCodeSending: `[(#{js.sendVerificationCode.sending})]`,
+      passwordConfirmationFailed: `[(#{js.passwordConfirmation.failed})]`,
+    };
+  </script>
+
+  <script src="/js/main.js"></script>
 </th:block>
 
 <th:block th:fragment="basicStyleResources">
-    <link rel="stylesheet" href="/webjars/normalize.css/8.0.1/normalize.css" />
-    <link rel="stylesheet" th:href="|/styles/main.css?v=${site.version}|" />
+  <link rel="stylesheet" href="/webjars/normalize.css/8.0.1/normalize.css" />
+  <link rel="stylesheet" th:href="|/styles/main.css?v=${site.version}|" />
 </th:block>
 
 <div th:remove="tag" th:fragment="languageSwitcher">
-    <style>
-        .language-switcher {
-            display: flex;
-            align-items: center;
-            justify-content: center;
-            margin: 2em 0;
-            gap: 0.625rem;
-        }
+  <style>
+    .language-switcher {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      margin: 2em 0;
+      gap: 0.625rem;
+    }
 
-        .language-switcher label {
-            color: var(--color-text);
-            display: inline-flex;
-        }
+    .language-switcher label {
+      color: var(--color-text);
+      display: inline-flex;
+    }
 
-        .language-switcher select {
-            all: unset;
-            border: 1px solid var(--color-border);
-            font-size: var(--text-sm);
-            height: 2em;
-            border-radius: var(--rounded-lg);
-            outline: none;
-            padding: 0 2em 0 0.5em;
-            display: inline-flex;
-            align-items: center;
-            color: var(--color-text);
-            background-color: var(--color-text);
-            background: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='1em' height='1em' viewBox='0 0 24 24'%3E%3Cpath fill='%23000' d='m12 13.171l4.95-4.95l1.414 1.415L12 16L5.636 9.636L7.05 8.222z'/%3E%3C/svg%3E");
-            background-repeat: no-repeat;
-            background-position: right 0.45rem center;
-        }
+    .language-switcher select {
+      all: unset;
+      border: 1px solid var(--color-border);
+      font-size: var(--text-sm);
+      height: 2em;
+      border-radius: var(--rounded-lg);
+      outline: none;
+      padding: 0 2em 0 0.5em;
+      display: inline-flex;
+      align-items: center;
+      color: var(--color-text);
+      background-color: var(--color-text);
+      background: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='1em' height='1em' viewBox='0 0 24 24'%3E%3Cpath fill='%23000' d='m12 13.171l4.95-4.95l1.414 1.415L12 16L5.636 9.636L7.05 8.222z'/%3E%3C/svg%3E");
+      background-repeat: no-repeat;
+      background-position: right 0.45rem center;
+    }
 
-        .language-switcher select:focus {
-            border-color: var(--color-primary);
-        }
-    </style>
-    <div class="language-switcher">
-        <label for="language-select">
-            <svg viewBox="0 0 24 24" width="1.2em" height="1.2em">
-                <path
-                    fill="currentColor"
-                    d="m12.87 15.07l-2.54-2.51l.03-.03A17.5 17.5 0 0 0 14.07 6H17V4h-7V2H8v2H1v2h11.17C11.5 7.92 10.44 9.75 9 11.35C8.07 10.32 7.3 9.19 6.69 8h-2c.73 1.63 1.73 3.17 2.98 4.56l-5.09 5.02L4 19l5-5l3.11 3.11zM18.5 10h-2L12 22h2l1.12-3h4.75L21 22h2zm-2.62 7l1.62-4.33L19.12 17z"
-                ></path>
-            </svg>
-        </label>
-        <select id="language-select" onchange="changeLanguage()">
-            <option value="en" th:selected="${#locale.toLanguageTag} == 'en'">English</option>
-            <option value="es" th:selected="${#locale.toLanguageTag} == 'es'">Español</option>
-            <option value="zh-CN" th:selected="${#locale.toLanguageTag} == 'zh-CN'">简体中文</option>
-            <option value="zh-TW" th:selected="${#locale.toLanguageTag} == 'zh-TW'">繁体中文</option>
-        </select>
-        <script type="text/javascript">
-            function changeLanguage() {
-                const selectedLanguage = document.getElementById("language-select").value;
-                const currentURL = new URL(window.location.href);
-                currentURL.searchParams.set("language", selectedLanguage);
+    .language-switcher select:focus {
+      border-color: var(--color-primary);
+    }
+  </style>
+  <div class="language-switcher">
+    <label for="language-select">
+      <svg viewBox="0 0 24 24" width="1.2em" height="1.2em">
+        <path
+          fill="currentColor"
+          d="m12.87 15.07l-2.54-2.51l.03-.03A17.5 17.5 0 0 0 14.07 6H17V4h-7V2H8v2H1v2h11.17C11.5 7.92 10.44 9.75 9 11.35C8.07 10.32 7.3 9.19 6.69 8h-2c.73 1.63 1.73 3.17 2.98 4.56l-5.09 5.02L4 19l5-5l3.11 3.11zM18.5 10h-2L12 22h2l1.12-3h4.75L21 22h2zm-2.62 7l1.62-4.33L19.12 17z"
+        ></path>
+      </svg>
+    </label>
+    <select id="language-select" onchange="changeLanguage()">
+      <option value="en" th:selected="${#locale.toLanguageTag} == 'en'">English</option>
+      <option value="es" th:selected="${#locale.toLanguageTag} == 'es'">Español</option>
+      <option value="zh-CN" th:selected="${#locale.toLanguageTag} == 'zh-CN'">简体中文</option>
+      <option value="zh-TW" th:selected="${#locale.toLanguageTag} == 'zh-TW'">繁体中文</option>
+    </select>
+    <script type="text/javascript">
+      function changeLanguage() {
+        const selectedLanguage = document.getElementById("language-select").value;
+        const currentURL = new URL(window.location.href);
+        currentURL.searchParams.set("language", selectedLanguage);
 
-                history.replaceState(null, "", currentURL.toString());
+        history.replaceState(null, "", currentURL.toString());
 
-                window.location.reload();
-            }
-        </script>
-    </div>
+        window.location.reload();
+      }
+    </script>
+  </div>
 </div>
 
 <div th:remove="tag" th:fragment="haloLogo">
-    <style>
-        .halo-logo {
-            width: 100%;
-            display: flex;
-            justify-content: center;
-            margin-bottom: 2em;
-        }
+  <style>
+    .halo-logo {
+      width: 100%;
+      display: flex;
+      justify-content: center;
+      margin-bottom: 2em;
+    }
 
-        .halo-logo img {
-            width: 6em;
-        }
-    </style>
-    <div class="halo-logo">
-        <img src="/images/wordmark.svg" alt="Halo" />
-    </div>
+    .halo-logo img {
+      width: 6em;
+    }
+  </style>
+  <div class="halo-logo">
+    <img src="/images/wordmark.svg" alt="Halo" />
+  </div>
 </div>
 
 <div th:remove="tag" th:fragment="socialAuthProviders">
-    <th:block th:unless="${#lists.isEmpty(socialAuthProviders)}">
-        <div class="divider-wrapper">
-            <hr />
-            <th:block th:text="#{socialLogin.label}"></th:block>
-            <hr />
-        </div>
-        <ul class="pill-items">
-            <li th:each="provider : ${socialAuthProviders}">
-                <form
-                    class="social-auth-provider-form"
-                    th:action="|/login/social/${provider.metadata.name}?remember-me=false|"
-                    method="post"
-                >
-                    <button type="submit">
-                        <img th:src="${provider.spec.logo}" th:alt="|${provider.spec.displayName}'s icon|" />
-                        <span th:text="${provider.spec.displayName}"></span>
-                    </button>
-                </form>
-            </li>
-        </ul>
-    </th:block>
-    <script>
-        document.addEventListener("DOMContentLoaded", function () {
-            const rememberMeCheckbox = document.getElementById("remember-me");
-            const socialAuthProviders = document.querySelectorAll(".social-auth-provider-form");
-            
-            rememberMeCheckbox.addEventListener("change", function (e) {
-                const rememberMe = e.target.checked;
-                
-                socialAuthProviders.forEach((form) => {
-                    const url = new URL(form.action, window.location.origin);
-                    url.searchParams.set("remember-me", rememberMe ? "true" : "false");
-                    form.action = url.pathname + url.search;
-                });
-            });
+  <th:block th:unless="${#lists.isEmpty(socialAuthProviders)}">
+    <div class="divider-wrapper">
+      <hr />
+      <th:block th:text="#{socialLogin.label}"></th:block>
+      <hr />
+    </div>
+    <ul class="pill-items">
+      <li th:each="provider : ${socialAuthProviders}">
+        <form
+          class="social-auth-provider-form"
+          th:action="|/login/social/${provider.metadata.name}?remember-me=false|"
+          method="post"
+        >
+          <button type="submit">
+            <img th:src="${provider.spec.logo}" th:alt="|${provider.spec.displayName}'s icon|" />
+            <span th:text="${provider.spec.displayName}"></span>
+          </button>
+        </form>
+      </li>
+    </ul>
+  </th:block>
+  <script>
+    document.addEventListener("DOMContentLoaded", function () {
+      const rememberMeCheckbox = document.getElementById("remember-me");
+      const socialAuthProviders = document.querySelectorAll(".social-auth-provider-form");
+
+      rememberMeCheckbox.addEventListener("change", function (e) {
+        const rememberMe = e.target.checked;
+
+        socialAuthProviders.forEach((form) => {
+          const url = new URL(form.action, window.location.origin);
+          url.searchParams.set("remember-me", rememberMe ? "true" : "false");
+          form.action = url.pathname + url.search;
         });
-    </script>
+      });
+    });
+  </script>
 </div>
 
 <div th:remove="tag" th:fragment="passwordResetMethods">
-    <th:block th:unless="${#lists.isEmpty(otherMethods)}">
-        <div class="divider-wrapper">
-            <hr />
-            <th:block th:text="#{passwordResetMethods.label}"></th:block>
-            <hr />
-        </div>
-        <ul class="pill-items">
-            <li th:each="method : ${otherMethods}">
-                <a th:href="${method.href}">
-                    <img th:src="${method.icon}" th:alt="|${method.name}'s icon|" />
-                    <span
-                        th:text="${#messages.msgOrNull('passwordResetMethods.' + method.name + '.displayName') ?: method.name}"
-                    ></span>
-                </a>
-            </li>
-        </ul>
-    </th:block>
+  <th:block th:unless="${#lists.isEmpty(otherMethods)}">
+    <div class="divider-wrapper">
+      <hr />
+      <th:block th:text="#{passwordResetMethods.label}"></th:block>
+      <hr />
+    </div>
+    <ul class="pill-items">
+      <li th:each="method : ${otherMethods}">
+        <a th:href="${method.href}">
+          <img th:src="${method.icon}" th:alt="|${method.name}'s icon|" />
+          <span
+            th:text="${#messages.msgOrNull('passwordResetMethods.' + method.name + '.displayName') ?: method.name}"
+          ></span>
+        </a>
+      </li>
+    </ul>
+  </th:block>
 </div>
 
 <div th:remove="tag" th:fragment="signupNoticeContent">
-    <style>
-        .signup-notice-content {
-            font-size: var(--text-sm);
-            color: var(--color-text);
-            text-align: center;
-            margin: 1em 0;
-        }
+  <style>
+    .signup-notice-content {
+      font-size: var(--text-sm);
+      color: var(--color-text);
+      text-align: center;
+      margin: 1em 0;
+    }
 
-        .signup-notice-content a {
-            color: var(--color-link);
-            text-decoration: none;
-        }
-    </style>
-    <div th:if="${globalInfo.allowRegistration}" class="signup-notice-content">
-        <div>
-            <th:block th:text="#{signupNotice.description}"></th:block>
-            <a th:href="@{/signup}" th:text="#{signupNotice.link}"></a>
-        </div>
+    .signup-notice-content a {
+      color: var(--color-link);
+      text-decoration: none;
+    }
+  </style>
+  <div th:if="${globalInfo.allowRegistration}" class="signup-notice-content">
+    <div>
+      <th:block th:text="#{signupNotice.description}"></th:block>
+      <a th:href="@{/signup}" th:text="#{signupNotice.link}"></a>
     </div>
+  </div>
 </div>
 
 <div th:remove="tag" th:fragment="loginNoticeContent">
-    <style>
-        .login-notice-content {
-            font-size: var(--text-sm);
-            color: var(--color-text);
-            text-align: center;
-            margin: 1em 0;
-        }
+  <style>
+    .login-notice-content {
+      font-size: var(--text-sm);
+      color: var(--color-text);
+      text-align: center;
+      margin: 1em 0;
+    }
 
-        .login-notice-content a {
-            color: var(--color-link);
-            text-decoration: none;
-        }
-    </style>
-    <div th:if="${globalInfo.allowRegistration}" class="login-notice-content">
-        <div>
-            <th:block th:text="#{loginNotice.description}"></th:block>
-            <a th:href="@{/login}" th:text="#{loginNotice.link}"></a>
-        </div>
+    .login-notice-content a {
+      color: var(--color-link);
+      text-decoration: none;
+    }
+  </style>
+  <div th:if="${globalInfo.allowRegistration}" class="login-notice-content">
+    <div>
+      <th:block th:text="#{loginNotice.description}"></th:block>
+      <a th:href="@{/login}" th:text="#{loginNotice.link}"></a>
     </div>
+  </div>
 </div>
 
 <div th:remove="tag" th:fragment="returnToSiteContent">
-    <style>
-        .returntosite-content {
-            font-size: var(--text-sm);
-            text-align: center;
-            margin: 1em 0;
-        }
+  <style>
+    .returntosite-content {
+      font-size: var(--text-sm);
+      text-align: center;
+      margin: 1em 0;
+    }
 
-        .returntosite-content a {
-            color: var(--color-text);
-            display: inline-flex;
-            align-items: center;
-            gap: 0.3em;
-            text-decoration: none;
-        }
-    </style>
-    <div class="returntosite-content">
-        <a th:href="@{/}">
-            <svg viewBox="0 0 24 24" width="1.2em" height="1.2em">
-                <path fill="currentColor" d="M21 11H6.83l3.58-3.59L9 6l-6 6l6 6l1.41-1.42L6.83 13H21z"></path>
-            </svg>
-            <span th:text="#{returnToSite}"></span>
-        </a>
-    </div>
+    .returntosite-content a {
+      color: var(--color-text);
+      display: inline-flex;
+      align-items: center;
+      gap: 0.3em;
+      text-decoration: none;
+    }
+  </style>
+  <div class="returntosite-content">
+    <a th:href="@{/}">
+      <svg viewBox="0 0 24 24" width="1.2em" height="1.2em">
+        <path fill="currentColor" d="M21 11H6.83l3.58-3.59L9 6l-6 6l6 6l1.41-1.42L6.83 13H21z"></path>
+      </svg>
+      <span th:text="#{returnToSite}"></span>
+    </a>
+  </div>
 </div>

--- a/application/src/main/resources/templates/gateway_fragments/input.html
+++ b/application/src/main/resources/templates/gateway_fragments/input.html
@@ -1,32 +1,32 @@
 <div th:remove="tag" th:fragment="password(id,name,required,minlength,maxlength,enableToggle)">
-    <div class="form-input" th:classappend="${enableToggle ? 'form-input-stack toggle-password-display-flag' : ''}">
-        <input
-            th:id="${id}"
-            th:name="${name}"
-            type="password"
-            autocomplete="off"
-            spellcheck="false"
-            autocorrect="off"
-            autocapitalize="off"
-            th:required="${required}"
-            th:minlength="${minlength}"
-            th:maxlength="${maxlength}"
-        />
+  <div class="form-input" th:classappend="${enableToggle ? 'form-input-stack toggle-password-display-flag' : ''}">
+    <input
+      th:id="${id}"
+      th:name="${name}"
+      type="password"
+      autocomplete="off"
+      spellcheck="false"
+      autocorrect="off"
+      autocapitalize="off"
+      th:required="${required}"
+      th:minlength="${minlength}"
+      th:maxlength="${maxlength}"
+    />
 
-        <div th:if="${enableToggle}" class="form-input-stack-icon toggle-password-button">
-            <svg class="password-hidden-icon" style="display: none" viewBox="0 0 24 24" width="1em" height="1em">
-                <path
-                    fill="currentColor"
-                    d="M12 3c5.392 0 9.878 3.88 10.819 9c-.94 5.12-5.427 9-10.819 9c-5.392 0-9.878-3.88-10.818-9C2.122 6.88 6.608 3 12 3Zm0 16a9.005 9.005 0 0 0 8.778-7a9.005 9.005 0 0 0-17.555 0A9.005 9.005 0 0 0 12 19Zm0-2.5a4.5 4.5 0 1 1 0-9a4.5 4.5 0 0 1 0 9Zm0-2a2.5 2.5 0 1 0 0-5a2.5 2.5 0 0 0 0 5Z"
-                ></path>
-            </svg>
+    <div th:if="${enableToggle}" class="form-input-stack-icon toggle-password-button">
+      <svg class="password-hidden-icon" style="display: none" viewBox="0 0 24 24" width="1em" height="1em">
+        <path
+          fill="currentColor"
+          d="M12 3c5.392 0 9.878 3.88 10.819 9c-.94 5.12-5.427 9-10.819 9c-5.392 0-9.878-3.88-10.818-9C2.122 6.88 6.608 3 12 3Zm0 16a9.005 9.005 0 0 0 8.778-7a9.005 9.005 0 0 0-17.555 0A9.005 9.005 0 0 0 12 19Zm0-2.5a4.5 4.5 0 1 1 0-9a4.5 4.5 0 0 1 0 9Zm0-2a2.5 2.5 0 1 0 0-5a2.5 2.5 0 0 0 0 5Z"
+        ></path>
+      </svg>
 
-            <svg class="password-display-icon" viewBox="0 0 24 24" width="1em" height="1em">
-                <path
-                    fill="currentColor"
-                    d="M17.883 19.297A10.949 10.949 0 0 1 12 21c-5.392 0-9.878-3.88-10.818-9A10.982 10.982 0 0 1 4.52 5.935L1.394 2.808l1.414-1.414l19.799 19.798l-1.414 1.415l-3.31-3.31ZM5.936 7.35A8.965 8.965 0 0 0 3.223 12a9.005 9.005 0 0 0 13.201 5.838l-2.028-2.028A4.5 4.5 0 0 1 8.19 9.604L5.936 7.35Zm6.978 6.978l-3.242-3.241a2.5 2.5 0 0 0 3.241 3.241Zm7.893 2.265l-1.431-1.431A8.935 8.935 0 0 0 20.778 12A9.005 9.005 0 0 0 9.552 5.338L7.974 3.76C9.221 3.27 10.58 3 12 3c5.392 0 9.878 3.88 10.819 9a10.947 10.947 0 0 1-2.012 4.593Zm-9.084-9.084a4.5 4.5 0 0 1 4.769 4.769l-4.77-4.77Z"
-                ></path>
-            </svg>
-        </div>
+      <svg class="password-display-icon" viewBox="0 0 24 24" width="1em" height="1em">
+        <path
+          fill="currentColor"
+          d="M17.883 19.297A10.949 10.949 0 0 1 12 21c-5.392 0-9.878-3.88-10.818-9A10.982 10.982 0 0 1 4.52 5.935L1.394 2.808l1.414-1.414l19.799 19.798l-1.414 1.415l-3.31-3.31ZM5.936 7.35A8.965 8.965 0 0 0 3.223 12a9.005 9.005 0 0 0 13.201 5.838l-2.028-2.028A4.5 4.5 0 0 1 8.19 9.604L5.936 7.35Zm6.978 6.978l-3.242-3.241a2.5 2.5 0 0 0 3.241 3.241Zm7.893 2.265l-1.431-1.431A8.935 8.935 0 0 0 20.778 12A9.005 9.005 0 0 0 9.552 5.338L7.974 3.76C9.221 3.27 10.58 3 12 3c5.392 0 9.878 3.88 10.819 9a10.947 10.947 0 0 1-2.012 4.593Zm-9.084-9.084a4.5 4.5 0 0 1 4.769 4.769l-4.77-4.77Z"
+        ></path>
+      </svg>
     </div>
+  </div>
 </div>

--- a/application/src/main/resources/templates/gateway_fragments/layout.html
+++ b/application/src/main/resources/templates/gateway_fragments/layout.html
@@ -1,26 +1,26 @@
-<!doctype html>
+<!DOCTYPE html>
 <html th:lang="${#locale.toLanguageTag}" th:fragment="layout (title,head,body)">
-    <head>
-        <meta charset="UTF-8" />
-        <meta content="IE=edge" http-equiv="X-UA-Compatible" />
-        <meta content="webkit" name="renderer" />
-        <meta
-            content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no, viewport-fit=cover"
-            name="viewport"
-        />
-        <meta content="noindex,nofollow" name="robots" />
-        <title th:text="${title}"></title>
-        <link rel="preload" href="/images/wordmark.svg" as="image" type="image/svg+xml" />
-        <link rel="preload" href="/images/logo.png" as="image" type="image/png" />
-        <link th:unless="${#strings.isEmpty(site.favicon)}" rel="icon" th:href="${site.favicon}" />
+  <head>
+    <meta charset="UTF-8" />
+    <meta content="IE=edge" http-equiv="X-UA-Compatible" />
+    <meta content="webkit" name="renderer" />
+    <meta
+      content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no, viewport-fit=cover"
+      name="viewport"
+    />
+    <meta content="noindex,nofollow" name="robots" />
+    <title th:text="${title}"></title>
+    <link rel="preload" href="/images/wordmark.svg" as="image" type="image/svg+xml" />
+    <link rel="preload" href="/images/logo.png" as="image" type="image/png" />
+    <link th:unless="${#strings.isEmpty(site.favicon)}" rel="icon" th:href="${site.favicon}" />
 
-        <th:block th:replace="~{gateway_fragments/common::basicStaticResources}"></th:block>
+    <th:block th:replace="~{gateway_fragments/common::basicStaticResources}"></th:block>
 
-        <th:block th:if="${head != null}">
-            <th:block th:replace="${head}" />
-        </th:block>
-    </head>
-    <body class="gateway-page">
-        <th:block th:replace="${body}" />
-    </body>
+    <th:block th:if="${head != null}">
+      <th:block th:replace="${head}" />
+    </th:block>
+  </head>
+  <body class="gateway-page">
+    <th:block th:replace="${body}" />
+  </body>
 </html>

--- a/application/src/main/resources/templates/gateway_fragments/login.html
+++ b/application/src/main/resources/templates/gateway_fragments/login.html
@@ -1,63 +1,63 @@
 <form
-    th:fragment="form"
-    class="halo-form"
-    name="login-form"
-    id="login-form"
-    th:action="${authProvider.spec.authenticationUrl}"
-    th:method="${authProvider.spec.method}"
+  th:fragment="form"
+  class="halo-form"
+  name="login-form"
+  id="login-form"
+  th:action="${authProvider.spec.authenticationUrl}"
+  th:method="${authProvider.spec.method}"
 >
-    <div class="alert alert-error" role="alert" th:if="${param.error.size() > 0}" th:with="error = ${param.error[0]}">
-        <strong th:if="${error == 'invalid-credential'}">
-            <span th:text="#{form.error.invalidCredential}"></span>
-        </strong>
-        <strong th:if="${error == 'rate-limit-exceeded'}">
-            <span th:text="#{form.error.rateLimitExceeded}"></span>
-        </strong>
-        <strong th:if="${error == 'account-disabled'}">
-            <span th:text="#{form.error.accountDisabled}"></span>
-        </strong>
-    </div>
-    <div class="alert" role="alert" th:if="${param.logout.size() > 0}">
-        <strong th:text="#{form.messages.logoutSuccess}"></strong>
-    </div>
-    <div class="alert" role="alert" th:if="${param.signup.size() > 0}">
-        <strong th:text="#{form.messages.signupSuccess}"></strong>
-    </div>
-    <div class="alert" role="alert" th:if="${param.oauth2_bind.size() > 0}">
-        <strong th:text="#{form.messages.oauth2Bind}"></strong>
-    </div>
-    <div class="alert" role="alert" th:if="${param.password_reset.size() > 0}">
-        <strong th:text="#{form.messages.passwordReset}"></strong>
-    </div>
+  <div class="alert alert-error" role="alert" th:if="${param.error.size() > 0}" th:with="error = ${param.error[0]}">
+    <strong th:if="${error == 'invalid-credential'}">
+      <span th:text="#{form.error.invalidCredential}"></span>
+    </strong>
+    <strong th:if="${error == 'rate-limit-exceeded'}">
+      <span th:text="#{form.error.rateLimitExceeded}"></span>
+    </strong>
+    <strong th:if="${error == 'account-disabled'}">
+      <span th:text="#{form.error.accountDisabled}"></span>
+    </strong>
+  </div>
+  <div class="alert" role="alert" th:if="${param.logout.size() > 0}">
+    <strong th:text="#{form.messages.logoutSuccess}"></strong>
+  </div>
+  <div class="alert" role="alert" th:if="${param.signup.size() > 0}">
+    <strong th:text="#{form.messages.signupSuccess}"></strong>
+  </div>
+  <div class="alert" role="alert" th:if="${param.oauth2_bind.size() > 0}">
+    <strong th:text="#{form.messages.oauth2Bind}"></strong>
+  </div>
+  <div class="alert" role="alert" th:if="${param.password_reset.size() > 0}">
+    <strong th:text="#{form.messages.passwordReset}"></strong>
+  </div>
 
-    <div th:replace="~{__${fragmentTemplateName}__::form}"></div>
+  <div th:replace="~{__${fragmentTemplateName}__::form}"></div>
 
-    <div th:if="${authProvider.spec.rememberMeSupport}" class="form-item-compact">
-        <input type="checkbox" id="remember-me" name="remember-me" value="true" th:checked="${rememberMe}"/>
-        <label for="remember-me" th:text="#{form.rememberMe.label}"></label>
-    </div>
+  <div th:if="${authProvider.spec.rememberMeSupport}" class="form-item-compact">
+    <input type="checkbox" id="remember-me" name="remember-me" value="true" th:checked="${rememberMe}" />
+    <label for="remember-me" th:text="#{form.rememberMe.label}"></label>
+  </div>
 
-    <div class="form-item">
-        <button type="submit" th:text="#{form.submit}"></button>
-    </div>
+  <div class="form-item">
+    <button type="submit" th:text="#{form.submit}"></button>
+  </div>
 </form>
 
 <div th:remove="tag" th:fragment="formAuthProviders">
-    <th:block th:unless="${#lists.isEmpty(formAuthProviders)}">
-        <div class="divider-wrapper">
-            <hr />
-            <th:block th:text="#{otherLogin.label}"></th:block>
-            <hr />
-        </div>
-        <ul class="pill-items">
-            <li th:each="provider : ${formAuthProviders}">
-                <a th:href="'/login?method=' + ${provider.metadata.name}">
-                    <img th:src="${provider.spec.logo}" th:alt="|${provider.spec.displayName}'s icon|" />
-                    <span
-                        th:text="${#messages.msgOrNull('formAuthProviders.' + provider.metadata.name + '.displayName') ?: provider.spec.displayName}"
-                    ></span>
-                </a>
-            </li>
-        </ul>
-    </th:block>
+  <th:block th:unless="${#lists.isEmpty(formAuthProviders)}">
+    <div class="divider-wrapper">
+      <hr />
+      <th:block th:text="#{otherLogin.label}"></th:block>
+      <hr />
+    </div>
+    <ul class="pill-items">
+      <li th:each="provider : ${formAuthProviders}">
+        <a th:href="'/login?method=' + ${provider.metadata.name}">
+          <img th:src="${provider.spec.logo}" th:alt="|${provider.spec.displayName}'s icon|" />
+          <span
+            th:text="${#messages.msgOrNull('formAuthProviders.' + provider.metadata.name + '.displayName') ?: provider.spec.displayName}"
+          ></span>
+        </a>
+      </li>
+    </ul>
+  </th:block>
 </div>

--- a/application/src/main/resources/templates/gateway_fragments/logout.html
+++ b/application/src/main/resources/templates/gateway_fragments/logout.html
@@ -1,16 +1,16 @@
 <form th:fragment="form" class="halo-form" id="logout-form" name="logout-form" th:action="@{/logout}" method="post">
-    <div class="user-info" th:object="${user}">
-        <img th:if="*{spec.avatar}" th:src="*{spec.avatar}" class="user-avatar" />
-        <div class="user-details">
-            <span th:text="#{form.currentUser.label}"></span>
-            <span class="user-name" th:text="|*{spec.displayName}(@*{metadata.name})|"></span>
-        </div>
+  <div class="user-info" th:object="${user}">
+    <img th:if="*{spec.avatar}" th:src="*{spec.avatar}" class="user-avatar" />
+    <div class="user-details">
+      <span th:text="#{form.currentUser.label}"></span>
+      <span class="user-name" th:text="|*{spec.displayName}(@*{metadata.name})|"></span>
     </div>
-    <div class="form-item">
-        <button type="submit" th:text="#{form.submit}"></button>
-    </div>
+  </div>
+  <div class="form-item">
+    <button type="submit" th:text="#{form.submit}"></button>
+  </div>
 
-    <div class="form-item">
-        <a href="javascript:history.back()" class="cancel-link" th:text="#{form.cancel}"> </a>
-    </div>
+  <div class="form-item">
+    <a href="javascript:history.back()" class="cancel-link" th:text="#{form.cancel}"> </a>
+  </div>
 </form>

--- a/application/src/main/resources/templates/gateway_fragments/password_reset_email_reset.html
+++ b/application/src/main/resources/templates/gateway_fragments/password_reset_email_reset.html
@@ -1,37 +1,37 @@
 <form
-        th:fragment="form"
-        class="halo-form"
-        th:action="@{/password-reset/email/{resetToken}(resetToken=${resetToken})}"
-        method="post"
-        th:object="${form}"
+  th:fragment="form"
+  class="halo-form"
+  th:action="@{/password-reset/email/{resetToken}(resetToken=${resetToken})}"
+  method="post"
+  th:object="${form}"
 >
-    <div class="alert alert-error" role="alert" th:if="${error}">
-        <strong th:if="${error == 'rate_limit_exceeded'}" th:text="#{error.rate_limit_exceeded}"></strong>
-    </div>
-    <div class="form-item">
-        <label for="password" th:text="#{form.password.label}">Password</label>
-        <th:block
-                th:replace="~{gateway_fragments/input :: password(id = 'password', name = 'password', required = 'true', minlength = 5, maxlength = 257, enableToggle = true)}"
-        ></th:block>
-        <p class="alert alert-error" th:if="${#fields.hasErrors('password')}" th:errors="*{password}"></p>
-    </div>
-    <div class="form-item">
-        <label for="confirmPassword" th:text="#{form.confirmPassword.label}">Confirm Password</label>
-        <th:block
-                th:replace="~{gateway_fragments/input :: password(id = 'confirmPassword', name = 'confirmPassword', required = 'true', minlength = 5, maxlength = 257, enableToggle = true)}"
-        ></th:block>
-        <p class="alert alert-error" th:if="${#fields.hasErrors('confirmPassword')}" th:errors="*{confirmPassword}"></p>
-    </div>
-    <div class="form-item">
-        <div class="alert" th:text="#{form.password.tips}"></div>
-    </div>
-    <div class="form-item">
-        <button type="submit" th:text="#{form.submit}"></button>
-    </div>
+  <div class="alert alert-error" role="alert" th:if="${error}">
+    <strong th:if="${error == 'rate_limit_exceeded'}" th:text="#{error.rate_limit_exceeded}"></strong>
+  </div>
+  <div class="form-item">
+    <label for="password" th:text="#{form.password.label}">Password</label>
+    <th:block
+      th:replace="~{gateway_fragments/input :: password(id = 'password', name = 'password', required = 'true', minlength = 5, maxlength = 257, enableToggle = true)}"
+    ></th:block>
+    <p class="alert alert-error" th:if="${#fields.hasErrors('password')}" th:errors="*{password}"></p>
+  </div>
+  <div class="form-item">
+    <label for="confirmPassword" th:text="#{form.confirmPassword.label}">Confirm Password</label>
+    <th:block
+      th:replace="~{gateway_fragments/input :: password(id = 'confirmPassword', name = 'confirmPassword', required = 'true', minlength = 5, maxlength = 257, enableToggle = true)}"
+    ></th:block>
+    <p class="alert alert-error" th:if="${#fields.hasErrors('confirmPassword')}" th:errors="*{confirmPassword}"></p>
+  </div>
+  <div class="form-item">
+    <div class="alert" th:text="#{form.password.tips}"></div>
+  </div>
+  <div class="form-item">
+    <button type="submit" th:text="#{form.submit}"></button>
+  </div>
 
-    <script th:inline="javascript">
-        document.addEventListener("DOMContentLoaded", function () {
-            setupPasswordConfirmation("password", "confirmPassword");
-        });
-    </script>
+  <script th:inline="javascript">
+    document.addEventListener("DOMContentLoaded", function () {
+      setupPasswordConfirmation("password", "confirmPassword");
+    });
+  </script>
 </form>

--- a/application/src/main/resources/templates/gateway_fragments/password_reset_email_send.html
+++ b/application/src/main/resources/templates/gateway_fragments/password_reset_email_send.html
@@ -1,28 +1,28 @@
 <th:block th:fragment="form">
-    <form th:if="${sent}" method="get" action="/login" class="halo-form">
-        <div class="form-item">
-            <div class="alert" th:text="#{form.message.success}"></div>
-        </div>
-        <div class="form-item">
-            <button type="submit" th:text="#{form.sent.submit}"></button>
-        </div>
-    </form>
-    <form th:unless="${sent}" class="halo-form" th:action="@{/password-reset/email}" method="post" th:object="${form}">
-        <div class="alert alert-error" th:if="${param.error.size() > 0}">
-            <strong th:if="${param.error[0] == 'invalid_reset_token'}" th:text="#{error.invalid_reset_token}"></strong>
-        </div>
-        <div class="alert alert-error" th:if="${error}">
-            <strong th:if="${error == 'rate_limit_exceeded'}" th:text="#{error.rate_limit_exceeded}"></strong>
-        </div>
-        <div class="form-item">
-            <label for="email" th:text="#{form.email.label}"></label>
-            <div class="form-input">
-                <input type="email" id="email" name="email" autofocus required th:field="*{email}"/>
-            </div>
-            <p class="alert alert-error" role="alert" th:if="${#fields.hasErrors('email')}" th:errors="*{email}"></p>
-        </div>
-        <div class="form-item">
-            <button type="submit" th:text="#{form.submit}"></button>
-        </div>
-    </form>
+  <form th:if="${sent}" method="get" action="/login" class="halo-form">
+    <div class="form-item">
+      <div class="alert" th:text="#{form.message.success}"></div>
+    </div>
+    <div class="form-item">
+      <button type="submit" th:text="#{form.sent.submit}"></button>
+    </div>
+  </form>
+  <form th:unless="${sent}" class="halo-form" th:action="@{/password-reset/email}" method="post" th:object="${form}">
+    <div class="alert alert-error" th:if="${param.error.size() > 0}">
+      <strong th:if="${param.error[0] == 'invalid_reset_token'}" th:text="#{error.invalid_reset_token}"></strong>
+    </div>
+    <div class="alert alert-error" th:if="${error}">
+      <strong th:if="${error == 'rate_limit_exceeded'}" th:text="#{error.rate_limit_exceeded}"></strong>
+    </div>
+    <div class="form-item">
+      <label for="email" th:text="#{form.email.label}"></label>
+      <div class="form-input">
+        <input type="email" id="email" name="email" autofocus required th:field="*{email}" />
+      </div>
+      <p class="alert alert-error" role="alert" th:if="${#fields.hasErrors('email')}" th:errors="*{email}"></p>
+    </div>
+    <div class="form-item">
+      <button type="submit" th:text="#{form.submit}"></button>
+    </div>
+  </form>
 </th:block>

--- a/application/src/main/resources/templates/gateway_fragments/signup.html
+++ b/application/src/main/resources/templates/gateway_fragments/signup.html
@@ -1,188 +1,188 @@
 <form
-    th:fragment="form"
-    class="halo-form"
-    name="signup-form"
-    id="signup-form"
-    th:action="@{/signup}"
-    th:object="${form}"
-    method="post"
+  th:fragment="form"
+  class="halo-form"
+  name="signup-form"
+  id="signup-form"
+  th:action="@{/signup}"
+  th:object="${form}"
+  method="post"
 >
-    <div class="alert alert-error" role="alert" th:if="${error == 'invalid-email-code'}">
-        <strong>
-            <span th:text="#{form.error.invalidEmailCode}"></span>
-        </strong>
-    </div>
-    <div class="alert alert-error" role="alert" th:if="${error == 'rate-limit-exceeded'}">
-        <strong>
-            <span th:text="#{form.error.rateLimitExceeded}"></span>
-        </strong>
-    </div>
-    <div class="alert alert-error" role="alert" th:if="${error == 'duplicate-username'}">
-        <strong>
-            <span th:text="#{form.error.duplicateUsername}"></span>
-        </strong>
-    </div>
-    <div class="alert alert-error" role="alert" th:if="${error == 'restricted-username'}">
-        <strong>
-            <span th:text="#{form.error.protectedUsernames}"></span>
-        </strong>
-    </div>
-    <div class="form-item-group">
-        <div class="form-item">
-            <label for="username" th:text="#{form.username.label}"></label>
-            <div class="form-input">
-                <input
-                    type="text"
-                    id="username"
-                    name="username"
-                    autocomplete="off"
-                    spellcheck="false"
-                    autocorrect="off"
-                    autocapitalize="off"
-                    autofocus
-                    required
-                    minlength="4"
-                    maxlength="63"
-                    th:field="*{username}"
-                />
-            </div>
-            <p class="alert alert-error" th:if="${#fields.hasErrors('username')}" th:errors="*{username}"></p>
-        </div>
-
-        <div class="form-item">
-            <label for="displayName" th:text="#{form.displayName.label}"></label>
-            <div class="form-input">
-                <input
-                    type="text"
-                    id="displayName"
-                    name="displayName"
-                    autocomplete="off"
-                    spellcheck="false"
-                    autocorrect="off"
-                    autocapitalize="off"
-                    required
-                    th:field="*{displayName}"
-                />
-            </div>
-            <p class="alert alert-error" th:if="${#fields.hasErrors('displayName')}" th:errors="*{displayName}"></p>
-        </div>
-    </div>
-
-    <div class="form-item-group">
-        <div class="form-item">
-            <label for="email" th:text="#{form.email.label}"></label>
-            <div class="form-input">
-                <input
-                    type="email"
-                    id="email"
-                    name="email"
-                    autocomplete="off"
-                    spellcheck="false"
-                    autocorrect="off"
-                    autocapitalize="off"
-                    required
-                    th:field="*{email}"
-                />
-            </div>
-            <p class="alert alert-error" th:if="${#fields.hasErrors('email')}" th:errors="*{email}"></p>
-        </div>
-
-        <div class="form-item" th:if="${globalInfo.mustVerifyEmailOnRegistration}">
-            <label for="emailCode" th:text="#{form.emailCode.label}"></label>
-            <div class="form-input-group">
-                <div class="form-input">
-                    <input type="text" inputmode="numeric" pattern="\d*" id="emailCode" name="emailCode" required />
-                </div>
-
-                <button id="emailCodeSendButton" type="button" th:text="#{form.emailCode.sendButton}"></button>
-            </div>
-            <p class="alert alert-error" th:if="${#fields.hasErrors('emailCode')}" th:errors="*{emailCode}"></p>
-        </div>
+  <div class="alert alert-error" role="alert" th:if="${error == 'invalid-email-code'}">
+    <strong>
+      <span th:text="#{form.error.invalidEmailCode}"></span>
+    </strong>
+  </div>
+  <div class="alert alert-error" role="alert" th:if="${error == 'rate-limit-exceeded'}">
+    <strong>
+      <span th:text="#{form.error.rateLimitExceeded}"></span>
+    </strong>
+  </div>
+  <div class="alert alert-error" role="alert" th:if="${error == 'duplicate-username'}">
+    <strong>
+      <span th:text="#{form.error.duplicateUsername}"></span>
+    </strong>
+  </div>
+  <div class="alert alert-error" role="alert" th:if="${error == 'restricted-username'}">
+    <strong>
+      <span th:text="#{form.error.protectedUsernames}"></span>
+    </strong>
+  </div>
+  <div class="form-item-group">
+    <div class="form-item">
+      <label for="username" th:text="#{form.username.label}"></label>
+      <div class="form-input">
+        <input
+          type="text"
+          id="username"
+          name="username"
+          autocomplete="off"
+          spellcheck="false"
+          autocorrect="off"
+          autocapitalize="off"
+          autofocus
+          required
+          minlength="4"
+          maxlength="63"
+          th:field="*{username}"
+        />
+      </div>
+      <p class="alert alert-error" th:if="${#fields.hasErrors('username')}" th:errors="*{username}"></p>
     </div>
 
     <div class="form-item">
-        <label for="password" th:text="#{form.password.label}"></label>
-        <th:block
-            th:replace="~{gateway_fragments/input :: password(id = 'password', name = 'password', required = 'true', minlength = 5, maxlength = 257, enableToggle = true)}"
-        ></th:block>
-        <p class="alert alert-error" th:if="${#fields.hasErrors('password')}" th:errors="*{password}"></p>
+      <label for="displayName" th:text="#{form.displayName.label}"></label>
+      <div class="form-input">
+        <input
+          type="text"
+          id="displayName"
+          name="displayName"
+          autocomplete="off"
+          spellcheck="false"
+          autocorrect="off"
+          autocapitalize="off"
+          required
+          th:field="*{displayName}"
+        />
+      </div>
+      <p class="alert alert-error" th:if="${#fields.hasErrors('displayName')}" th:errors="*{displayName}"></p>
     </div>
+  </div>
 
+  <div class="form-item-group">
     <div class="form-item">
-        <label for="confirmPassword" th:text="#{form.confirmPassword.label}"></label>
-        <th:block
-            th:replace="~{gateway_fragments/input :: password(id = 'confirmPassword', name = 'confirmPassword', required = 'true', minlength = 5, maxlength = 257, enableToggle = true)}"
-        ></th:block>
-        <p class="alert alert-error" th:if="${#fields.hasErrors('confirmPassword')}" th:errors="*{confirmPassword}"></p>
+      <label for="email" th:text="#{form.email.label}"></label>
+      <div class="form-input">
+        <input
+          type="email"
+          id="email"
+          name="email"
+          autocomplete="off"
+          spellcheck="false"
+          autocorrect="off"
+          autocapitalize="off"
+          required
+          th:field="*{email}"
+        />
+      </div>
+      <p class="alert alert-error" th:if="${#fields.hasErrors('email')}" th:errors="*{email}"></p>
     </div>
 
-    <div class="form-item-compact" th:if="${agreementPages != null and !agreementPages.isEmpty()}">
-        <input type="checkbox" id="agreedToTerms" name="agreedToTerms" value="true" required />
-        <label for="agreedToTerms">
-            <span th:text="#{form.agreedToTerms.label}">I have read and agree to</span>
-            <th:block th:each="page, iterStat : ${agreementPages}">
-                <a th:if="${page.permalink != null}" th:href="${page.permalink}" target="_blank" th:text="${page.title}"></a>
-                <span th:if="${page.permalink == null}" th:text="${page.title}"></span>
-                <span th:if="${!iterStat.last}">,</span>
-            </th:block>
-        </label>
+    <div class="form-item" th:if="${globalInfo.mustVerifyEmailOnRegistration}">
+      <label for="emailCode" th:text="#{form.emailCode.label}"></label>
+      <div class="form-input-group">
+        <div class="form-input">
+          <input type="text" inputmode="numeric" pattern="\d*" id="emailCode" name="emailCode" required />
+        </div>
+
+        <button id="emailCodeSendButton" type="button" th:text="#{form.emailCode.sendButton}"></button>
+      </div>
+      <p class="alert alert-error" th:if="${#fields.hasErrors('emailCode')}" th:errors="*{emailCode}"></p>
     </div>
-    <p class="alert alert-error" th:if="${#fields.hasErrors('agreedToTerms')}" th:errors="*{agreedToTerms}"></p>
+  </div>
 
-    <div class="form-item">
-        <button type="submit" th:text="#{form.submit}"></button>
-    </div>
+  <div class="form-item">
+    <label for="password" th:text="#{form.password.label}"></label>
+    <th:block
+      th:replace="~{gateway_fragments/input :: password(id = 'password', name = 'password', required = 'true', minlength = 5, maxlength = 257, enableToggle = true)}"
+    ></th:block>
+    <p class="alert alert-error" th:if="${#fields.hasErrors('password')}" th:errors="*{password}"></p>
+  </div>
 
-    <script th:inline="javascript">
-        document.addEventListener("DOMContentLoaded", function () {
-            setupPasswordConfirmation("password", "confirmPassword");
+  <div class="form-item">
+    <label for="confirmPassword" th:text="#{form.confirmPassword.label}"></label>
+    <th:block
+      th:replace="~{gateway_fragments/input :: password(id = 'confirmPassword', name = 'confirmPassword', required = 'true', minlength = 5, maxlength = 257, enableToggle = true)}"
+    ></th:block>
+    <p class="alert alert-error" th:if="${#fields.hasErrors('confirmPassword')}" th:errors="*{confirmPassword}"></p>
+  </div>
 
-            const form = document.getElementById("signup-form");
-            form.addEventListener("submit", function () {
-                const usernameInput = document.getElementById("username");
-                const displayNameInput = document.getElementById("displayName");
-                if (usernameInput) {
-                    usernameInput.value = usernameInput.value.trim();
-                }
-                if (displayNameInput) {
-                    displayNameInput.value = displayNameInput.value.trim();
-                }
-            });
+  <div class="form-item-compact" th:if="${agreementPages != null and !agreementPages.isEmpty()}">
+    <input type="checkbox" id="agreedToTerms" name="agreedToTerms" value="true" required />
+    <label for="agreedToTerms">
+      <span th:text="#{form.agreedToTerms.label}">I have read and agree to</span>
+      <th:block th:each="page, iterStat : ${agreementPages}">
+        <a th:if="${page.permalink != null}" th:href="${page.permalink}" target="_blank" th:text="${page.title}"></a>
+        <span th:if="${page.permalink == null}" th:text="${page.title}"></span>
+        <span th:if="${!iterStat.last}">,</span>
+      </th:block>
+    </label>
+  </div>
+  <p class="alert alert-error" th:if="${#fields.hasErrors('agreedToTerms')}" th:errors="*{agreedToTerms}"></p>
+
+  <div class="form-item">
+    <button type="submit" th:text="#{form.submit}"></button>
+  </div>
+
+  <script th:inline="javascript">
+    document.addEventListener("DOMContentLoaded", function () {
+      setupPasswordConfirmation("password", "confirmPassword");
+
+      const form = document.getElementById("signup-form");
+      form.addEventListener("submit", function () {
+        const usernameInput = document.getElementById("username");
+        const displayNameInput = document.getElementById("displayName");
+        if (usernameInput) {
+          usernameInput.value = usernameInput.value.trim();
+        }
+        if (displayNameInput) {
+          displayNameInput.value = displayNameInput.value.trim();
+        }
+      });
+    });
+  </script>
+
+  <script th:if="${globalInfo.mustVerifyEmailOnRegistration}" th:inline="javascript">
+    document.addEventListener("DOMContentLoaded", function () {
+      const headerName = /*[[${_csrf.headerName}]]*/ "";
+      const token = /*[[${_csrf.token}]]*/ "";
+      async function sendRequest() {
+        const email = document.getElementById("email").value;
+
+        if (!email) {
+          throw new Error(/*[[#{form.emailCode.send.emptyValidation}]]*/ "");
+        }
+
+        const response = await fetch("/signup/send-email-code", {
+          method: "POST",
+          body: JSON.stringify({ email: email }),
+          headers: {
+            "Content-Type": "application/json",
+            [headerName]: token,
+          },
         });
-    </script>
 
-    <script th:if="${globalInfo.mustVerifyEmailOnRegistration}" th:inline="javascript">
-        document.addEventListener("DOMContentLoaded", function () {
-            const headerName = /*[[${_csrf.headerName}]]*/ "";
-            const token = /*[[${_csrf.token}]]*/ "";
-            async function sendRequest() {
-                const email = document.getElementById("email").value;
+        if (!response.ok) {
+          const json = await response.json();
+          if (json.errors && json.errors.length) {
+            throw new Error(json.errors[0]);
+          }
+        }
 
-                if (!email) {
-                    throw new Error(/*[[#{form.emailCode.send.emptyValidation}]]*/ "");
-                }
+        return response;
+      }
 
-                const response = await fetch("/signup/send-email-code", {
-                    method: "POST",
-                    body: JSON.stringify({ email: email }),
-                    headers: {
-                        "Content-Type": "application/json",
-                        [headerName]: token,
-                    },
-                });
-
-                if (!response.ok) {
-                    const json = await response.json();
-                    if (json.errors && json.errors.length) {
-                        throw new Error(json.errors[0]);
-                    }
-                }
-
-                return response;
-            }
-
-            const emailCodeSendButton = document.getElementById("emailCodeSendButton");
-            sendVerificationCode(emailCodeSendButton, sendRequest);
-        });
-    </script>
+      const emailCodeSendButton = document.getElementById("emailCodeSendButton");
+      sendVerificationCode(emailCodeSendButton, sendRequest);
+    });
+  </script>
 </form>

--- a/application/src/main/resources/templates/gateway_fragments/totp.html
+++ b/application/src/main/resources/templates/gateway_fragments/totp.html
@@ -1,33 +1,33 @@
 <form
-        th:fragment="form"
-        class="halo-form"
-        th:action="@{/challenges/two-factor/totp}"
-        name="two-factor-form"
-        id="two-factor-form"
-        method="post"
+  th:fragment="form"
+  class="halo-form"
+  th:action="@{/challenges/two-factor/totp}"
+  name="two-factor-form"
+  id="two-factor-form"
+  method="post"
 >
-    <div class="alert alert-error" role="alert" th:if="${param.error.size() > 0}">
-        <strong th:text="#{form.messages.invalidError}"></strong>
+  <div class="alert alert-error" role="alert" th:if="${param.error.size() > 0}">
+    <strong th:text="#{form.messages.invalidError}"></strong>
+  </div>
+  <div class="form-item">
+    <label for="code" th:text="#{form.code.label}"></label>
+    <div class="form-input">
+      <input
+        type="text"
+        inputmode="numeric"
+        id="code"
+        name="code"
+        autocomplete="one-time-code"
+        pattern="\d{6}"
+        autofocus
+        required
+      />
     </div>
-    <div class="form-item">
-        <label for="code" th:text="#{form.code.label}"></label>
-        <div class="form-input">
-            <input
-                    type="text"
-                    inputmode="numeric"
-                    id="code"
-                    name="code"
-                    autocomplete="one-time-code"
-                    pattern="\d{6}"
-                    autofocus
-                    required
-            />
-        </div>
-    </div>
-    <div class="form-item">
-        <button type="submit" th:text="#{form.submit}"></button>
-    </div>
-    <div class="form-item">
-        <a th:href="@{/logout}" class="cancel-link" th:text="#{form.cancel}"></a>
-    </div>
+  </div>
+  <div class="form-item">
+    <button type="submit" th:text="#{form.submit}"></button>
+  </div>
+  <div class="form-item">
+    <a th:href="@{/logout}" class="cancel-link" th:text="#{form.cancel}"></a>
+  </div>
 </form>

--- a/application/src/main/resources/templates/login.html
+++ b/application/src/main/resources/templates/login.html
@@ -1,21 +1,21 @@
-<!doctype html>
+<!DOCTYPE html>
 <html
-    xmlns:th="https://www.thymeleaf.org"
-    th:replace="~{gateway_fragments/layout :: layout(title = |#{title} - ${site.title}|, head = null, body = ~{::body})}"
+  xmlns:th="https://www.thymeleaf.org"
+  th:replace="~{gateway_fragments/layout :: layout(title = |#{title} - ${site.title}|, head = null, body = ~{::body})}"
 >
-    <th:block th:fragment="body">
-        <div class="gateway-wrapper">
-            <div th:replace="~{gateway_fragments/common::haloLogo}"></div>
+  <th:block th:fragment="body">
+    <div class="gateway-wrapper">
+      <div th:replace="~{gateway_fragments/common::haloLogo}"></div>
 
-            <div class="halo-form-wrapper">
-                <div th:replace="~{gateway_fragments/login::form}"></div>
-                <div th:replace="~{gateway_fragments/login::formAuthProviders}"></div>
-                <div th:replace="~{gateway_fragments/common::socialAuthProviders}"></div>
-            </div>
+      <div class="halo-form-wrapper">
+        <div th:replace="~{gateway_fragments/login::form}"></div>
+        <div th:replace="~{gateway_fragments/login::formAuthProviders}"></div>
+        <div th:replace="~{gateway_fragments/common::socialAuthProviders}"></div>
+      </div>
 
-            <div th:replace="~{gateway_fragments/common::signupNoticeContent}"></div>
-            <div th:replace="~{gateway_fragments/common::returnToSiteContent}"></div>
-            <div th:replace="~{gateway_fragments/common::languageSwitcher}"></div>
-        </div>
-    </th:block>
+      <div th:replace="~{gateway_fragments/common::signupNoticeContent}"></div>
+      <div th:replace="~{gateway_fragments/common::returnToSiteContent}"></div>
+      <div th:replace="~{gateway_fragments/common::languageSwitcher}"></div>
+    </div>
+  </th:block>
 </html>

--- a/application/src/main/resources/templates/login_local.html
+++ b/application/src/main/resources/templates/login_local.html
@@ -1,38 +1,38 @@
 <div th:remove="tag" th:fragment="form">
-    <input type="hidden" name="password" id="password" />
+  <input type="hidden" name="password" id="password" />
 
-    <div class="form-item">
-        <label for="username" th:text="#{form.username.label}"> </label>
+  <div class="form-item">
+    <label for="username" th:text="#{form.username.label}"> </label>
 
-        <div class="form-input">
-            <input
-                id="username"
-                name="username"
-                type="text"
-                autocomplete="off"
-                spellcheck="false"
-                autocorrect="off"
-                autocapitalize="off"
-                required
-                autofocus
-                th:value="${username}"
-            />
-        </div>
+    <div class="form-input">
+      <input
+        id="username"
+        name="username"
+        type="text"
+        autocomplete="off"
+        spellcheck="false"
+        autocorrect="off"
+        autocapitalize="off"
+        required
+        autofocus
+        th:value="${username}"
+      />
     </div>
-    <div class="form-item">
-        <div class="form-label-group">
-            <label for="plainPassword" th:text="#{form.password.label}"> </label>
-            <a
-                class="form-item-extra-link"
-                tabindex="-1"
-                th:href="@{/password-reset/email}"
-                th:text="#{form.password.forgot}"
-            >
-            </a>
-        </div>
-
-        <th:block
-            th:replace="~{gateway_fragments/input :: password(id = 'plainPassword', name = null, required = 'true', minlength = null, maxlength = 257, enableToggle = true)}"
-        ></th:block>
+  </div>
+  <div class="form-item">
+    <div class="form-label-group">
+      <label for="plainPassword" th:text="#{form.password.label}"> </label>
+      <a
+        class="form-item-extra-link"
+        tabindex="-1"
+        th:href="@{/password-reset/email}"
+        th:text="#{form.password.forgot}"
+      >
+      </a>
     </div>
+
+    <th:block
+      th:replace="~{gateway_fragments/input :: password(id = 'plainPassword', name = null, required = 'true', minlength = null, maxlength = 257, enableToggle = true)}"
+    ></th:block>
+  </div>
 </div>

--- a/application/src/main/resources/templates/logout.html
+++ b/application/src/main/resources/templates/logout.html
@@ -1,55 +1,55 @@
 <!DOCTYPE html>
 <html
-    xmlns:th="https://www.thymeleaf.org"
-    th:replace="~{gateway_fragments/layout:: layout(title = |#{title} - ${site.title}|, head = ~{::head}, body = ~{::body})}"
+  xmlns:th="https://www.thymeleaf.org"
+  th:replace="~{gateway_fragments/layout:: layout(title = |#{title} - ${site.title}|, head = ~{::head}, body = ~{::body})}"
 >
-    <th:block th:fragment="body">
-        <div class="gateway-wrapper logout-page-wrapper">
-            <div th:replace="~{gateway_fragments/common::haloLogo}"></div>
-            <div class="halo-form-wrapper">
-                <h1 class="form-title" th:text="#{form.title}"></h1>
-                <form th:replace="~{gateway_fragments/logout::form}"></form>
-            </div>
-            <div th:replace="~{gateway_fragments/common::languageSwitcher}"></div>
-        </div>
-    </th:block>
+  <th:block th:fragment="body">
+    <div class="gateway-wrapper logout-page-wrapper">
+      <div th:replace="~{gateway_fragments/common::haloLogo}"></div>
+      <div class="halo-form-wrapper">
+        <h1 class="form-title" th:text="#{form.title}"></h1>
+        <form th:replace="~{gateway_fragments/logout::form}"></form>
+      </div>
+      <div th:replace="~{gateway_fragments/common::languageSwitcher}"></div>
+    </div>
+  </th:block>
 
-    <th:block th:fragment="head">
-        <style>
-            .logout-page-wrapper .user-info {
-                border-radius: var(--rounded-lg);
-                padding: var(--spacing-xs);
-                gap: var(--spacing-lg);
-                display: flex;
-                margin-bottom: 2em;
-                align-items: center;
-                border: 1px dashed #dfe6ecb3;
-            }
+  <th:block th:fragment="head">
+    <style>
+      .logout-page-wrapper .user-info {
+        border-radius: var(--rounded-lg);
+        padding: var(--spacing-xs);
+        gap: var(--spacing-lg);
+        display: flex;
+        margin-bottom: 2em;
+        align-items: center;
+        border: 1px dashed #dfe6ecb3;
+      }
 
-            .logout-page-wrapper .user-avatar {
-                width: 4em;
-                border-radius: 100%;
-            }
+      .logout-page-wrapper .user-avatar {
+        width: 4em;
+        border-radius: 100%;
+      }
 
-            .logout-page-wrapper .user-details {
-                color: var(--color-text);
-                font-size: var(--text-sm);
-                gap: var(--spacing-xs);
-                display: flex;
-                flex-direction: column;
-            }
+      .logout-page-wrapper .user-details {
+        color: var(--color-text);
+        font-size: var(--text-sm);
+        gap: var(--spacing-xs);
+        display: flex;
+        flex-direction: column;
+      }
 
-            .logout-page-wrapper .user-name {
-                font-weight: 600;
-                color: #333;
-            }
+      .logout-page-wrapper .user-name {
+        font-weight: 600;
+        color: #333;
+      }
 
-            .logout-page-wrapper .cancel-link {
-                color: var(--color-link);
-                font-size: var(--text-sm);
-                text-decoration: none;
-                text-align: center;
-            }
-        </style>
-    </th:block>
+      .logout-page-wrapper .cancel-link {
+        color: var(--color-link);
+        font-size: var(--text-sm);
+        text-decoration: none;
+        text-align: center;
+      }
+    </style>
+  </th:block>
 </html>

--- a/application/src/main/resources/templates/password-reset/email/reset.html
+++ b/application/src/main/resources/templates/password-reset/email/reset.html
@@ -1,16 +1,16 @@
-<!doctype html>
+<!DOCTYPE html>
 <html
-    xmlns:th="https://www.thymeleaf.org"
-    th:replace="~{gateway_fragments/layout:: layout(title = |#{title(${username})} - ${site.title}|, head = null, body = ~{::body})}"
+  xmlns:th="https://www.thymeleaf.org"
+  th:replace="~{gateway_fragments/layout:: layout(title = |#{title(${username})} - ${site.title}|, head = null, body = ~{::body})}"
 >
-    <th:block th:fragment="body">
-        <div class="gateway-wrapper">
-            <div th:replace="~{gateway_fragments/common::haloLogo}"></div>
-            <div class="halo-form-wrapper">
-                <h1 class="form-title" th:text="#{title(${username})}"></h1>
-                <form th:replace="~{gateway_fragments/password_reset_email_reset::form}"></form>
-            </div>
-            <div th:replace="~{gateway_fragments/common::languageSwitcher}"></div>
-        </div>
-    </th:block>
+  <th:block th:fragment="body">
+    <div class="gateway-wrapper">
+      <div th:replace="~{gateway_fragments/common::haloLogo}"></div>
+      <div class="halo-form-wrapper">
+        <h1 class="form-title" th:text="#{title(${username})}"></h1>
+        <form th:replace="~{gateway_fragments/password_reset_email_reset::form}"></form>
+      </div>
+      <div th:replace="~{gateway_fragments/common::languageSwitcher}"></div>
+    </div>
+  </th:block>
 </html>

--- a/application/src/main/resources/templates/password-reset/email/send.html
+++ b/application/src/main/resources/templates/password-reset/email/send.html
@@ -1,19 +1,19 @@
-<!doctype html>
+<!DOCTYPE html>
 <html
-    xmlns:th="https://www.thymeleaf.org"
-    th:replace="~{gateway_fragments/layout:: layout(title = |#{title} - ${site.title}|, head = null, body = ~{::body})}"
+  xmlns:th="https://www.thymeleaf.org"
+  th:replace="~{gateway_fragments/layout:: layout(title = |#{title} - ${site.title}|, head = null, body = ~{::body})}"
 >
-    <th:block th:fragment="body">
-        <div class="gateway-wrapper">
-            <div th:replace="~{gateway_fragments/common::haloLogo}"></div>
-            <div class="halo-form-wrapper">
-                <h1 class="form-title" th:text="${sent} ? #{sent.title} : #{title}"></h1>
-                <form th:replace="~{gateway_fragments/password_reset_email_send::form}"></form>
+  <th:block th:fragment="body">
+    <div class="gateway-wrapper">
+      <div th:replace="~{gateway_fragments/common::haloLogo}"></div>
+      <div class="halo-form-wrapper">
+        <h1 class="form-title" th:text="${sent} ? #{sent.title} : #{title}"></h1>
+        <form th:replace="~{gateway_fragments/password_reset_email_send::form}"></form>
 
-                <div th:replace="~{gateway_fragments/common::passwordResetMethods}"></div>
-            </div>
+        <div th:replace="~{gateway_fragments/common::passwordResetMethods}"></div>
+      </div>
 
-            <div th:replace="~{gateway_fragments/common::languageSwitcher}"></div>
-        </div>
-    </th:block>
+      <div th:replace="~{gateway_fragments/common::languageSwitcher}"></div>
+    </div>
+  </th:block>
 </html>

--- a/application/src/main/resources/templates/setup.html
+++ b/application/src/main/resources/templates/setup.html
@@ -1,158 +1,147 @@
 <!DOCTYPE html>
 <html
-    xmlns:th="https://www.thymeleaf.org"
-    th:replace="~{gateway_fragments/layout :: layout(title = |#{title} - Halo|, head = ~{::head}, body = ~{::body})}"
+  xmlns:th="https://www.thymeleaf.org"
+  th:replace="~{gateway_fragments/layout :: layout(title = |#{title} - Halo|, head = ~{::head}, body = ~{::body})}"
 >
-    <th:block th:fragment="head">
-        <style>
-            .setup-page-wrapper {
-                max-width: 35em;
-            }
-        </style>
-    </th:block>
-    <th:block th:fragment="body">
-        <div class="gateway-wrapper setup-page-wrapper">
-            <div th:replace="~{gateway_fragments/common::haloLogo}"></div>
+  <th:block th:fragment="head">
+    <style>
+      .setup-page-wrapper {
+        max-width: 35em;
+      }
+    </style>
+  </th:block>
+  <th:block th:fragment="body">
+    <div class="gateway-wrapper setup-page-wrapper">
+      <div th:replace="~{gateway_fragments/common::haloLogo}"></div>
 
-            <div class="halo-form-wrapper">
-                <h1 class="form-title" th:text="#{title}"></h1>
-                <div class="alert alert-error" role="alert" th:if="${usingH2database}">
-                    <strong th:text="#{form.messages.h2.title}"></strong>
-                    <br />
-                    <span th:text="#{form.messages.h2.content}"> </span>
-                </div>
-                <form th:object="${form}" th:action="@{/system/setup}" class="halo-form" method="post">
-
-                    <div class="form-item">
-                        <label for="language" th:text="#{form.language.label}"></label>
-                        <div class="form-input">
-                            <select name="language" id="language">
-                                <option value="en" th:selected="${#locale.toLanguageTag} == 'en'">English</option>
-                                <option value="es" th:selected="${#locale.toLanguageTag} == 'es'">Español</option>
-                                <option value="zh-CN" th:selected="${#locale.toLanguageTag} == 'zh-CN'">简体中文</option>
-                                <option value="zh-TW" th:selected="${#locale.toLanguageTag} == 'zh-TW'">繁体中文</option>
-                            </select>
-                        </div>
-                    </div>
-
-                    <div class="form-item">
-                        <label for="externalUrl" th:text="#{form.externalUrl.label}"></label>
-                        <div class="form-input">
-                            <input name="externalUrl"
-                                   type="url"
-                                   th:field="*{externalUrl}"
-                                   autocomplete="off"
-                                   spellcheck="false"
-                                   autocapitalize="off"
-                                   required/>
-                        </div>
-                        <p class="alert alert-error" th:if="${#fields.hasErrors('externalUrl')}" th:errors="*{externalUrl}"></p>
-                    </div>
-
-                    <div class="form-item">
-                        <label for="siteTitle" th:text="#{form.siteTitle.label}"></label>
-                        <div class="form-input">
-                            <input
-                                name="siteTitle"
-                                id="siteTitle"
-                                type="text"
-                                th:field="*{siteTitle}"
-                                autocomplete="off"
-                                spellcheck="false"
-                                autocorrect="off"
-                                autocapitalize="off"
-                                maxlength="80"
-                                required
-                                autofocus
-                            />
-                        </div>
-                        <p
-                            class="alert alert-error"
-                            th:if="${#fields.hasErrors('siteTitle')}"
-                            th:errors="*{siteTitle}"
-                        ></p>
-                    </div>
-
-                    <div class="form-item">
-                        <label for="username" th:text="#{form.username.label}"></label>
-                        <div class="form-input">
-                            <input
-                                name="username"
-                                id="username"
-                                type="text"
-                                th:field="*{username}"
-                                autocomplete="off"
-                                spellcheck="false"
-                                autocorrect="off"
-                                autocapitalize="off"
-                                maxlength="63"
-                                minlength="4"
-                                required
-                            />
-                        </div>
-                        <p
-                            class="alert alert-error"
-                            th:if="${#fields.hasErrors('username')}"
-                            th:errors="*{username}"
-                        ></p>
-                    </div>
-
-                    <div class="form-item">
-                        <label for="email" th:text="#{form.email.label}"></label>
-                        <div class="form-input">
-                            <input
-                                name="email"
-                                id="email"
-                                type="email"
-                                th:field="*{email}"
-                                autocomplete="off"
-                                spellcheck="false"
-                                autocorrect="off"
-                                autocapitalize="off"
-                                required
-                            />
-                        </div>
-                        <p class="alert alert-error" th:if="${#fields.hasErrors('email')}" th:errors="*{email}"></p>
-                    </div>
-
-                    <div class="form-item">
-                        <label for="password" th:text="#{form.password.label}"></label>
-                        <th:block
-                            th:replace="~{gateway_fragments/input :: password(id = 'password', name = 'password', required = 'true', minlength = 5, maxlength = 257, enableToggle = true)}"
-                        ></th:block>
-                        <p
-                            class="alert alert-error"
-                            th:if="${#fields.hasErrors('password')}"
-                            th:errors="*{password}"
-                        ></p>
-                    </div>
-
-                    <div class="form-item">
-                        <label for="confirmPassword" th:text="#{form.confirmPassword.label}"></label>
-                        <th:block
-                            th:replace="~{gateway_fragments/input :: password(id = 'confirmPassword', name = null, required = 'true', minlength = 5, maxlength = 257, enableToggle = true)}"
-                        ></th:block>
-                    </div>
-
-                    <div class="form-item">
-                        <button type="submit" th:text="#{form.submit}">初始化</button>
-                    </div>
-                </form>
-            </div>
+      <div class="halo-form-wrapper">
+        <h1 class="form-title" th:text="#{title}"></h1>
+        <div class="alert alert-error" role="alert" th:if="${usingH2database}">
+          <strong th:text="#{form.messages.h2.title}"></strong>
+          <br />
+          <span th:text="#{form.messages.h2.content}"> </span>
         </div>
+        <form th:object="${form}" th:action="@{/system/setup}" class="halo-form" method="post">
+          <div class="form-item">
+            <label for="language" th:text="#{form.language.label}"></label>
+            <div class="form-input">
+              <select name="language" id="language">
+                <option value="en" th:selected="${#locale.toLanguageTag} == 'en'">English</option>
+                <option value="es" th:selected="${#locale.toLanguageTag} == 'es'">Español</option>
+                <option value="zh-CN" th:selected="${#locale.toLanguageTag} == 'zh-CN'">简体中文</option>
+                <option value="zh-TW" th:selected="${#locale.toLanguageTag} == 'zh-TW'">繁体中文</option>
+              </select>
+            </div>
+          </div>
 
-        <script th:inline="javascript">
-            document.addEventListener("DOMContentLoaded", function () {
-                setupPasswordConfirmation("password", "confirmPassword");
-            });
+          <div class="form-item">
+            <label for="externalUrl" th:text="#{form.externalUrl.label}"></label>
+            <div class="form-input">
+              <input
+                name="externalUrl"
+                type="url"
+                th:field="*{externalUrl}"
+                autocomplete="off"
+                spellcheck="false"
+                autocapitalize="off"
+                required
+              />
+            </div>
+            <p class="alert alert-error" th:if="${#fields.hasErrors('externalUrl')}" th:errors="*{externalUrl}"></p>
+          </div>
 
-            document.getElementById("language").addEventListener("change", function () {
-                const selectedLanguage = this.value;
-                const currentURL = new URL(window.location.href);
-                currentURL.searchParams.set("language", selectedLanguage);
-                history.replaceState(null, "", currentURL.toString());
-                window.location.reload();
-            });
-        </script>
-    </th:block>
+          <div class="form-item">
+            <label for="siteTitle" th:text="#{form.siteTitle.label}"></label>
+            <div class="form-input">
+              <input
+                name="siteTitle"
+                id="siteTitle"
+                type="text"
+                th:field="*{siteTitle}"
+                autocomplete="off"
+                spellcheck="false"
+                autocorrect="off"
+                autocapitalize="off"
+                maxlength="80"
+                required
+                autofocus
+              />
+            </div>
+            <p class="alert alert-error" th:if="${#fields.hasErrors('siteTitle')}" th:errors="*{siteTitle}"></p>
+          </div>
+
+          <div class="form-item">
+            <label for="username" th:text="#{form.username.label}"></label>
+            <div class="form-input">
+              <input
+                name="username"
+                id="username"
+                type="text"
+                th:field="*{username}"
+                autocomplete="off"
+                spellcheck="false"
+                autocorrect="off"
+                autocapitalize="off"
+                maxlength="63"
+                minlength="4"
+                required
+              />
+            </div>
+            <p class="alert alert-error" th:if="${#fields.hasErrors('username')}" th:errors="*{username}"></p>
+          </div>
+
+          <div class="form-item">
+            <label for="email" th:text="#{form.email.label}"></label>
+            <div class="form-input">
+              <input
+                name="email"
+                id="email"
+                type="email"
+                th:field="*{email}"
+                autocomplete="off"
+                spellcheck="false"
+                autocorrect="off"
+                autocapitalize="off"
+                required
+              />
+            </div>
+            <p class="alert alert-error" th:if="${#fields.hasErrors('email')}" th:errors="*{email}"></p>
+          </div>
+
+          <div class="form-item">
+            <label for="password" th:text="#{form.password.label}"></label>
+            <th:block
+              th:replace="~{gateway_fragments/input :: password(id = 'password', name = 'password', required = 'true', minlength = 5, maxlength = 257, enableToggle = true)}"
+            ></th:block>
+            <p class="alert alert-error" th:if="${#fields.hasErrors('password')}" th:errors="*{password}"></p>
+          </div>
+
+          <div class="form-item">
+            <label for="confirmPassword" th:text="#{form.confirmPassword.label}"></label>
+            <th:block
+              th:replace="~{gateway_fragments/input :: password(id = 'confirmPassword', name = null, required = 'true', minlength = 5, maxlength = 257, enableToggle = true)}"
+            ></th:block>
+          </div>
+
+          <div class="form-item">
+            <button type="submit" th:text="#{form.submit}">初始化</button>
+          </div>
+        </form>
+      </div>
+    </div>
+
+    <script th:inline="javascript">
+      document.addEventListener("DOMContentLoaded", function () {
+        setupPasswordConfirmation("password", "confirmPassword");
+      });
+
+      document.getElementById("language").addEventListener("change", function () {
+        const selectedLanguage = this.value;
+        const currentURL = new URL(window.location.href);
+        currentURL.searchParams.set("language", selectedLanguage);
+        history.replaceState(null, "", currentURL.toString());
+        window.location.reload();
+      });
+    </script>
+  </th:block>
 </html>

--- a/application/src/main/resources/templates/signup.html
+++ b/application/src/main/resources/templates/signup.html
@@ -1,26 +1,26 @@
-<!doctype html>
+<!DOCTYPE html>
 <html
-    xmlns:th="https://www.thymeleaf.org"
-    th:replace="~{gateway_fragments/layout :: layout(title = |#{title} - ${site.title}|, head = ~{::head}, body = ~{::body})}"
+  xmlns:th="https://www.thymeleaf.org"
+  th:replace="~{gateway_fragments/layout :: layout(title = |#{title} - ${site.title}|, head = ~{::head}, body = ~{::body})}"
 >
-    <th:block th:fragment="head">
-        <style>
-            .signup-page-wrapper {
-                max-width: 38em;
-            }
-        </style>
-    </th:block>
-    <th:block th:fragment="body">
-        <div class="gateway-wrapper signup-page-wrapper">
-            <div th:replace="~{gateway_fragments/common::haloLogo}"></div>
-            <div class="halo-form-wrapper">
-                <h1 class="form-title" th:text="#{title}"></h1>
-                <form th:replace="~{gateway_fragments/signup::form}"></form>
-                <div th:replace="~{gateway_fragments/common::socialAuthProviders}"></div>
-            </div>
-            <div th:replace="~{gateway_fragments/common::loginNoticeContent}"></div>
-            <div th:replace="~{gateway_fragments/common::returnToSiteContent}"></div>
-            <div th:replace="~{gateway_fragments/common::languageSwitcher}"></div>
-        </div>
-    </th:block>
+  <th:block th:fragment="head">
+    <style>
+      .signup-page-wrapper {
+        max-width: 38em;
+      }
+    </style>
+  </th:block>
+  <th:block th:fragment="body">
+    <div class="gateway-wrapper signup-page-wrapper">
+      <div th:replace="~{gateway_fragments/common::haloLogo}"></div>
+      <div class="halo-form-wrapper">
+        <h1 class="form-title" th:text="#{title}"></h1>
+        <form th:replace="~{gateway_fragments/signup::form}"></form>
+        <div th:replace="~{gateway_fragments/common::socialAuthProviders}"></div>
+      </div>
+      <div th:replace="~{gateway_fragments/common::loginNoticeContent}"></div>
+      <div th:replace="~{gateway_fragments/common::returnToSiteContent}"></div>
+      <div th:replace="~{gateway_fragments/common::languageSwitcher}"></div>
+    </div>
+  </th:block>
 </html>


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Adds a Spotless `webResources` format in the application module for server-rendered web assets:

- `src/main/resources/templates/**/*.html`
- `src/main/resources/static/styles/**/*.css`
- `src/main/resources/static/js/**/*.js`

The formatter uses Prettier with shared `tabWidth` and `printWidth` settings, letting Prettier infer the parser from each file extension. This keeps template, CSS, and JavaScript formatting checks under the owning application module instead of the repository root.

This PR also applies the formatter to the existing application web resources.

#### Which issue(s) this PR fixes:

N/A

#### Special notes for your reviewer:

Validated with:

```bash
./gradlew :application:spotlessWebResourcesCheck spotlessCheck
```

AI-assisted contribution: OpenAI Codex was used to help inspect the existing Spotless configuration, update the Gradle setup, run validation, and prepare this PR.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
