### PR TITLE
Improve extension model OpenAPI documentation

### DIFF
--- a/api-docs/openapi/v3_0/aggregated.json
+++ b/api-docs/openapi/v3_0/aggregated.json
@@ -15196,7 +15196,8 @@
           "spec": {
             "$ref": "#/components/schemas/AnnotationSettingSpec"
           }
-        }
+        },
+        "description": "Annotation setting extension that defines dynamic annotation forms for a target extension kind."
       },
       "AnnotationSettingList": {
         "required": [
@@ -15267,6 +15268,7 @@
           "formSchema": {
             "minLength": 1,
             "type": "array",
+            "description": "FormKit-compatible schema used to render annotation fields.",
             "items": {
               "minLength": 1,
               "type": "object"
@@ -15275,7 +15277,8 @@
           "targetRef": {
             "$ref": "#/components/schemas/GroupKind"
           }
-        }
+        },
+        "description": "Desired annotation form configuration for a target resource kind."
       },
       "Attachment": {
         "required": [
@@ -15301,7 +15304,8 @@
           "status": {
             "$ref": "#/components/schemas/AttachmentStatus"
           }
-        }
+        },
+        "description": "Attachment extension that describes an uploaded file and its resolved access URLs."
       },
       "AttachmentList": {
         "required": [
@@ -15367,55 +15371,57 @@
         "properties": {
           "displayName": {
             "type": "string",
-            "description": "Display name of attachment"
+            "description": "Display name shown for the attachment."
           },
           "groupName": {
             "type": "string",
-            "description": "Group name"
+            "description": "Attachment group metadata.name this attachment belongs to."
           },
           "mediaType": {
             "type": "string",
-            "description": "Media type of attachment"
+            "description": "Media type detected or supplied for the attachment, such as image/png."
           },
           "ownerName": {
             "type": "string",
-            "description": "Name of User who uploads the attachment"
+            "description": "User metadata.name of the uploader."
           },
           "policyName": {
             "type": "string",
-            "description": "Policy name"
+            "description": "Storage policy metadata.name used to store this attachment."
           },
           "size": {
             "minimum": 0,
             "type": "integer",
-            "description": "Size of attachment. Unit is Byte",
+            "description": "Size of the attachment in bytes.",
             "format": "int64"
           },
           "tags": {
             "uniqueItems": true,
             "type": "array",
-            "description": "Tags of attachment",
+            "description": "Free-form tags assigned to the attachment.",
             "items": {
-              "type": "string",
-              "description": "Tag name"
+              "type": "string"
             }
           }
-        }
+        },
+        "description": "Desired attachment metadata and storage placement."
       },
       "AttachmentStatus": {
         "type": "object",
         "properties": {
           "permalink": {
             "type": "string",
-            "description": "Permalink of attachment.\nIf it is in local storage, the public URL will be set.\nIf it is in s3 storage, the Object URL will be set.\n"
+            "description": "Public permalink for the attachment. Local storage usually exposes a public URL, while object storage may\n expose the object URL."
           },
           "thumbnails": {
             "type": "object",
             "additionalProperties": {
               "type": "string"
-            }
+            },
+            "description": "Generated thumbnail URLs keyed by thumbnail size name."
           }
-        }
+        },
+        "description": "Observed attachment access state."
       },
       "AuthProvider": {
         "required": [
@@ -15439,7 +15445,7 @@
             "$ref": "#/components/schemas/AuthProviderSpec"
           }
         },
-        "description": "Auth provider extension."
+        "description": "Authentication provider extension that describes an external or form-based sign-in integration."
       },
       "AuthProviderList": {
         "required": [
@@ -15518,43 +15524,52 @@
           },
           "authenticationUrl": {
             "type": "string",
-            "description": "Authentication url of the auth provider"
+            "description": "URL that starts the authentication flow."
           },
           "bindingUrl": {
-            "type": "string"
+            "type": "string",
+            "description": "URL that starts account binding for an already signed-in user."
           },
           "configMapRef": {
             "$ref": "#/components/schemas/ConfigMapRef"
           },
           "description": {
-            "type": "string"
+            "type": "string",
+            "description": "Human-readable description of the provider."
           },
           "displayName": {
             "type": "string",
-            "description": "Display name of the auth provider"
+            "description": "Display name shown on sign-in and account binding screens."
           },
           "helpPage": {
-            "type": "string"
+            "type": "string",
+            "description": "Help page URL for users who need sign-in assistance."
           },
           "logo": {
-            "type": "string"
+            "type": "string",
+            "description": "Logo URL or attachment URI for the provider."
           },
           "method": {
-            "type": "string"
+            "type": "string",
+            "description": "HTTP method used when starting the authentication flow."
           },
           "rememberMeSupport": {
-            "type": "boolean"
+            "type": "boolean",
+            "description": "Whether the provider supports remember-me during sign-in."
           },
           "settingRef": {
             "$ref": "#/components/schemas/SettingRef"
           },
           "unbindUrl": {
-            "type": "string"
+            "type": "string",
+            "description": "URL that unbinds the external account from the current user."
           },
           "website": {
-            "type": "string"
+            "type": "string",
+            "description": "Provider website URL."
           }
-        }
+        },
+        "description": "Authentication provider metadata and endpoint configuration."
       },
       "Author": {
         "required": [
@@ -15564,12 +15579,15 @@
         "properties": {
           "name": {
             "minLength": 1,
-            "type": "string"
+            "type": "string",
+            "description": "Author display name."
           },
           "website": {
-            "type": "string"
+            "type": "string",
+            "description": "Author website URL."
           }
-        }
+        },
+        "description": "Theme author metadata."
       },
       "Backup": {
         "required": [
@@ -15594,7 +15612,8 @@
           "status": {
             "$ref": "#/components/schemas/BackupStatus"
           }
-        }
+        },
+        "description": "Backup metadata and runtime state for an exported Halo data package."
       },
       "BackupFile": {
         "type": "object",
@@ -15680,33 +15699,39 @@
         "properties": {
           "expiresAt": {
             "type": "string",
+            "description": "Time after which the generated backup should be considered expired.",
             "format": "date-time"
           },
           "format": {
             "type": "string",
-            "description": "Backup file format. Currently, only zip format is supported."
+            "description": "Backup file format. Currently, only zip is supported."
           }
-        }
+        },
+        "description": "Desired backup options."
       },
       "BackupStatus": {
         "type": "object",
         "properties": {
           "completionTimestamp": {
             "type": "string",
+            "description": "Time when backup execution finished, regardless of success or failure.",
             "format": "date-time"
           },
           "failureMessage": {
-            "type": "string"
+            "type": "string",
+            "description": "Human-readable failure message for a failed backup."
           },
           "failureReason": {
-            "type": "string"
+            "type": "string",
+            "description": "Stable failure reason code for a failed backup."
           },
           "filename": {
             "type": "string",
-            "description": "Name of backup file."
+            "description": "Name of the generated backup file."
           },
           "phase": {
             "type": "string",
+            "description": "Current backup execution phase.",
             "enum": [
               "PENDING",
               "RUNNING",
@@ -15716,14 +15741,16 @@
           },
           "size": {
             "type": "integer",
-            "description": "Size of backup file. Data unit: byte",
+            "description": "Size of the generated backup file in bytes.",
             "format": "int64"
           },
           "startTimestamp": {
             "type": "string",
+            "description": "Time when backup execution started.",
             "format": "date-time"
           }
-        }
+        },
+        "description": "Observed backup execution state."
       },
       "Category": {
         "required": [
@@ -15869,7 +15896,7 @@
             "description": "Theme template used to render the category archive page."
           }
         },
-        "description": "Desired display, hierarchy, and rendering configuration of a category."
+        "description": "Desired category display, hierarchy, and rendering configuration."
       },
       "CategoryStatus": {
         "type": "object",
@@ -15889,7 +15916,7 @@
             "format": "int32"
           }
         },
-        "description": "Observed state of a category."
+        "description": "Observed category state derived by content reconcilers."
       },
       "CategoryVo": {
         "required": [
@@ -16318,7 +16345,7 @@
             "format": "int32"
           }
         },
-        "description": "Observed state of a comment."
+        "description": "Observed state of a top-level comment."
       },
       "CommentVo": {
         "required": [
@@ -16552,7 +16579,8 @@
             "type": "object",
             "additionalProperties": {
               "type": "string"
-            }
+            },
+            "description": "String key-value configuration entries consumed by Halo or plugins."
           },
           "kind": {
             "type": "string"
@@ -16630,9 +16658,11 @@
         "properties": {
           "name": {
             "minLength": 1,
-            "type": "string"
+            "type": "string",
+            "description": "ConfigMap metadata.name."
           }
-        }
+        },
+        "description": "Reference to a ConfigMap used by this provider."
       },
       "Content": {
         "required": [
@@ -16805,10 +16835,12 @@
           },
           "approvedComment": {
             "type": "integer",
+            "description": "Number of approved comments recorded for the resource.",
             "format": "int32"
           },
           "downvote": {
             "type": "integer",
+            "description": "Number of downvotes recorded for the resource.",
             "format": "int32"
           },
           "kind": {
@@ -16819,18 +16851,21 @@
           },
           "totalComment": {
             "type": "integer",
+            "description": "Total number of comments recorded for the resource.",
             "format": "int32"
           },
           "upvote": {
             "type": "integer",
+            "description": "Number of upvotes recorded for the resource.",
             "format": "int32"
           },
           "visit": {
             "type": "integer",
+            "description": "Number of visits recorded for the resource.",
             "format": "int32"
           }
         },
-        "description": "A counter for number of requests by extension resource name."
+        "description": "Counter extension that stores aggregate interaction counts for a resource."
       },
       "CounterList": {
         "required": [
@@ -16965,23 +17000,27 @@
         "properties": {
           "category": {
             "type": "array",
+            "description": "Custom templates available for categories.",
             "items": {
               "$ref": "#/components/schemas/TemplateDescriptor"
             }
           },
           "page": {
             "type": "array",
+            "description": "Custom templates available for single pages.",
             "items": {
               "$ref": "#/components/schemas/TemplateDescriptor"
             }
           },
           "post": {
             "type": "array",
+            "description": "Custom templates available for posts.",
             "items": {
               "$ref": "#/components/schemas/TemplateDescriptor"
             }
           }
-        }
+        },
+        "description": "Custom template descriptors grouped by the content type they render."
       },
       "DashboardStats": {
         "type": "object",
@@ -17055,7 +17094,8 @@
           "status": {
             "$ref": "#/components/schemas/DeviceStatus"
           }
-        }
+        },
+        "description": "Device extension that records an authenticated browser session for account security visibility."
       },
       "DeviceList": {
         "required": [
@@ -17126,43 +17166,54 @@
         "properties": {
           "ipAddress": {
             "maxLength": 129,
-            "type": "string"
+            "type": "string",
+            "description": "Client IP address observed for the session."
           },
           "lastAccessedTime": {
             "type": "string",
+            "description": "Last time this session accessed Halo.",
             "format": "date-time"
           },
           "lastAuthenticatedTime": {
             "type": "string",
+            "description": "Last time the user authenticated for this session.",
             "format": "date-time"
           },
           "principalName": {
             "minLength": 1,
-            "type": "string"
+            "type": "string",
+            "description": "Principal name of the authenticated user."
           },
           "rememberMeSeriesId": {
-            "type": "string"
+            "type": "string",
+            "description": "Remember-me series id associated with the session, if any."
           },
           "sessionId": {
             "minLength": 1,
-            "type": "string"
+            "type": "string",
+            "description": "Web session identifier associated with the device."
           },
           "userAgent": {
             "maxLength": 500,
-            "type": "string"
+            "type": "string",
+            "description": "Client user-agent header captured for the session."
           }
-        }
+        },
+        "description": "Session identity and request metadata captured for a device."
       },
       "DeviceStatus": {
         "type": "object",
         "properties": {
           "browser": {
-            "type": "string"
+            "type": "string",
+            "description": "Browser name parsed from the user agent."
           },
           "os": {
-            "type": "string"
+            "type": "string",
+            "description": "Operating system name parsed from the user agent."
           }
-        }
+        },
+        "description": "Parsed browser and operating system details for display."
       },
       "EmailConfigValidationRequest": {
         "type": "object",
@@ -17224,7 +17275,7 @@
             "description": "Manual excerpt text used when autoGenerate is false."
           }
         },
-        "description": "Excerpt generation configuration."
+        "description": "Excerpt generation configuration for a post or single page."
       },
       "Extension": {
         "required": [
@@ -17268,7 +17319,7 @@
             "$ref": "#/components/schemas/ExtensionSpec"
           }
         },
-        "description": "Extension definition. An {@link ExtensionDefinition ExtensionDefinition} is a type of metadata that provides additional information about\n an extension. An extension is a way to add new functionality to an existing class, structure, enumeration, or\n protocol type without needing to subclass it."
+        "description": "Extension definition that describes one plugin-provided implementation of an extension point."
       },
       "ExtensionDefinitionList": {
         "required": [
@@ -17351,7 +17402,7 @@
             "$ref": "#/components/schemas/ExtensionPointSpec"
           }
         },
-        "description": "Extension point definition. An {@link ExtensionPointDefinition ExtensionPointDefinition} is a concept used in \u003ccode\u003eHalo\u003c/code\u003e to allow for\n the dynamic extension of system. It defines a location within \u003ccode\u003eHalo\u003c/code\u003e where additional functionality can be\n added through the use of plugins or extensions."
+        "description": "Extension point definition that advertises where plugins can contribute implementations."
       },
       "ExtensionPointDefinitionList": {
         "required": [
@@ -17421,25 +17472,31 @@
         "type": "object",
         "properties": {
           "className": {
-            "type": "string"
+            "type": "string",
+            "description": "Fully qualified Java class name of the extension point interface."
           },
           "description": {
-            "type": "string"
+            "type": "string",
+            "description": "Human-readable description of what this extension point allows plugins to provide."
           },
           "displayName": {
-            "type": "string"
+            "type": "string",
+            "description": "Display name shown for the extension point."
           },
           "icon": {
-            "type": "string"
+            "type": "string",
+            "description": "Icon URL, class, or identifier shown for the extension point."
           },
           "type": {
             "type": "string",
+            "description": "Registration mode used when loading implementations for this extension point.",
             "enum": [
               "SINGLETON",
               "MULTI_INSTANCE"
             ]
           }
-        }
+        },
+        "description": "Desired extension point metadata."
       },
       "ExtensionSpec": {
         "required": [
@@ -17450,21 +17507,27 @@
         "type": "object",
         "properties": {
           "className": {
-            "type": "string"
+            "type": "string",
+            "description": "Fully qualified Java class name of the implementation."
           },
           "description": {
-            "type": "string"
+            "type": "string",
+            "description": "Human-readable description of what this implementation does."
           },
           "displayName": {
-            "type": "string"
+            "type": "string",
+            "description": "Display name shown for the implementation."
           },
           "extensionPointName": {
-            "type": "string"
+            "type": "string",
+            "description": "ExtensionPointDefinition metadata.name this implementation contributes to."
           },
           "icon": {
-            "type": "string"
+            "type": "string",
+            "description": "Icon URL, class, or identifier shown for the implementation."
           }
-        }
+        },
+        "description": "Desired plugin-provided extension implementation metadata."
       },
       "FileReverseProxyProvider": {
         "type": "object",
@@ -17475,7 +17538,8 @@
           "filename": {
             "type": "string"
           }
-        }
+        },
+        "description": "File provider that resolves a request to a plugin or theme file location."
       },
       "GrantRequest": {
         "type": "object",
@@ -17513,7 +17577,8 @@
           "status": {
             "$ref": "#/components/schemas/GroupStatus"
           }
-        }
+        },
+        "description": "Attachment group extension used to organize attachments and expose aggregate counts."
       },
       "GroupKind": {
         "type": "object",
@@ -17596,9 +17661,10 @@
         "properties": {
           "displayName": {
             "type": "string",
-            "description": "Display name of group"
+            "description": "Display name shown for the attachment group."
           }
-        }
+        },
+        "description": "Desired attachment group metadata."
       },
       "GroupStatus": {
         "type": "object",
@@ -17606,15 +17672,16 @@
           "totalAttachments": {
             "minimum": 0,
             "type": "integer",
-            "description": "Total of attachments under the current group",
+            "description": "Total number of attachments under the group.",
             "format": "int64"
           },
           "updateTimestamp": {
             "type": "string",
-            "description": "Update timestamp of the group",
+            "description": "Last time the group aggregate state was updated.",
             "format": "date-time"
           }
-        }
+        },
+        "description": "Observed attachment group aggregate state."
       },
       "HaloDocument": {
         "required": [
@@ -17767,17 +17834,17 @@
         "properties": {
           "expression": {
             "type": "string",
-            "description": "The expression to be interested in"
+            "description": "Optional expression used to match reasons more flexibly than subject matching."
           },
           "reasonType": {
             "type": "string",
-            "description": "The name of the reason definition to be interested in"
+            "description": "ReasonType metadata.name this subscription is interested in."
           },
           "subject": {
             "$ref": "#/components/schemas/InterestReasonSubject"
           }
         },
-        "description": "The reason to be interested in"
+        "description": "Reason selector that decides which notifications match this subscription."
       },
       "InterestReasonSubject": {
         "required": [
@@ -17788,18 +17855,20 @@
         "properties": {
           "apiVersion": {
             "minLength": 1,
-            "type": "string"
+            "type": "string",
+            "description": "Subject API version."
           },
           "kind": {
             "minLength": 1,
-            "type": "string"
+            "type": "string",
+            "description": "Subject kind."
           },
           "name": {
             "type": "string",
-            "description": "if name is not specified, it presents all subjects of the specified reason type and custom resources"
+            "description": "Subject metadata.name. If omitted, all subjects of the selected kind and API version are matched."
           }
         },
-        "description": "The subject name of reason type to be interested in"
+        "description": "Subject selector used by a subscription interest reason."
       },
       "JsonPatch": {
         "minItems": 1,
@@ -18586,7 +18655,8 @@
           "spec": {
             "$ref": "#/components/schemas/MenuSpec"
           }
-        }
+        },
+        "description": "Menu extension that groups ordered menu items for theme navigation."
       },
       "MenuItem": {
         "required": [
@@ -18612,7 +18682,8 @@
           "status": {
             "$ref": "#/components/schemas/MenuItemStatus"
           }
-        }
+        },
+        "description": "Menu item extension that describes a navigable item and its resolved rendering state."
       },
       "MenuItemList": {
         "required": [
@@ -18679,28 +18750,27 @@
           "children": {
             "uniqueItems": true,
             "type": "array",
-            "description": "Children of this menu item",
+            "description": "Child MenuItem metadata.name values shown under this item.",
             "items": {
-              "type": "string",
-              "description": "The name of menu item child"
+              "type": "string"
             }
           },
           "displayName": {
             "type": "string",
-            "description": "The display name of menu item."
+            "description": "Display name shown for the menu item."
           },
           "href": {
             "type": "string",
-            "description": "The href of this menu item."
+            "description": "Direct URL used by the menu item."
           },
           "priority": {
             "type": "integer",
-            "description": "The priority is for ordering.",
+            "description": "Sorting priority. Higher values sort before lower values where priority ordering is applied.",
             "format": "int32"
           },
           "target": {
             "type": "string",
-            "description": "The \u003ca\u003e target attribute of this menu item.",
+            "description": "HTML anchor target used by the menu item.",
             "enum": [
               "_blank",
               "_self",
@@ -18711,20 +18781,22 @@
           "targetRef": {
             "$ref": "#/components/schemas/Ref"
           }
-        }
+        },
+        "description": "Desired menu item configuration."
       },
       "MenuItemStatus": {
         "type": "object",
         "properties": {
           "displayName": {
             "type": "string",
-            "description": "Calculated Display name of menu item."
+            "description": "Calculated display name after resolving targetRef, falling back to spec.displayName."
           },
           "href": {
             "type": "string",
-            "description": "Calculated href of manu item."
+            "description": "Calculated href after resolving targetRef, falling back to spec.href."
           }
-        }
+        },
+        "description": "Resolved menu item values used for rendering."
       },
       "MenuItemVo": {
         "required": [
@@ -18824,18 +18896,18 @@
         "properties": {
           "displayName": {
             "type": "string",
-            "description": "The display name of the menu."
+            "description": "Display name shown for the menu."
           },
           "menuItems": {
             "uniqueItems": true,
             "type": "array",
-            "description": "Menu items of this menu.",
+            "description": "Ordered MenuItem metadata.name values included in this menu.",
             "items": {
-              "type": "string",
-              "description": "Name of menu item."
+              "type": "string"
             }
           }
-        }
+        },
+        "description": "Desired menu configuration."
       },
       "MenuVo": {
         "required": [
@@ -18977,7 +19049,7 @@
             "$ref": "#/components/schemas/NotificationSpec"
           }
         },
-        "description": "{@link Notification Notification} is a custom extension that used to store notification information for inner use, it\u0027s on-site\n notification.\n\n \u003cp\u003eSupports the following operations:\n\n \u003cul\u003e\n   \u003cli\u003eMarked as read: {@link NotificationSpec#setUnread(boolean) NotificationSpec#setUnread(boolean)}\n   \u003cli\u003eGet the last read time: {@link NotificationSpec#getLastReadAt NotificationSpec#getLastReadAt()}\n   \u003cli\u003eFilter by recipient: {@link NotificationSpec#getRecipient NotificationSpec#getRecipient()}\n \u003c/ul\u003e"
+        "description": "Notification extension that stores an on-site notification delivered to a Halo user.\n\n \u003cp\u003eSupports the following operations:\n\n \u003cul\u003e\n   \u003cli\u003eMarked as read: {@link NotificationSpec#setUnread(boolean) NotificationSpec#setUnread(boolean)}\n   \u003cli\u003eGet the last read time: {@link NotificationSpec#getLastReadAt NotificationSpec#getLastReadAt()}\n   \u003cli\u003eFilter by recipient: {@link NotificationSpec#getRecipient NotificationSpec#getRecipient()}\n \u003c/ul\u003e"
       },
       "NotificationList": {
         "required": [
@@ -19049,33 +19121,39 @@
         "type": "object",
         "properties": {
           "htmlContent": {
-            "type": "string"
+            "type": "string",
+            "description": "HTML notification content."
           },
           "lastReadAt": {
             "type": "string",
+            "description": "Last time the recipient marked this notification as read.",
             "format": "date-time"
           },
           "rawContent": {
-            "type": "string"
+            "type": "string",
+            "description": "Plain text or source notification content."
           },
           "reason": {
             "minLength": 1,
             "type": "string",
-            "description": "The name of reason"
+            "description": "Reason metadata.name that generated this notification."
           },
           "recipient": {
             "minLength": 1,
             "type": "string",
-            "description": "The name of user"
+            "description": "User metadata.name that receives the notification."
           },
           "title": {
             "minLength": 1,
-            "type": "string"
+            "type": "string",
+            "description": "Notification title shown in the notification center."
           },
           "unread": {
-            "type": "boolean"
+            "type": "boolean",
+            "description": "Whether the recipient has not read the notification yet."
           }
-        }
+        },
+        "description": "Notification content and read state for one recipient."
       },
       "NotificationTemplate": {
         "required": [
@@ -19098,7 +19176,7 @@
             "$ref": "#/components/schemas/NotificationTemplateSpec"
           }
         },
-        "description": "{@link NotificationTemplate NotificationTemplate} is a custom extension that defines a notification template.\n\n \u003cp\u003eIt describes the notification template\u0027s name, description, and the template content.\n\n \u003cp\u003e{@link Spec#getReasonSelector Spec#getReasonSelector()} is used to select the template by reasonType and language, if multiple templates\n are matched, the best match will be selected. This is useful when you want to override the default template."
+        "description": "Notification template extension that defines localized message content for matching reason types.\n\n \u003cp\u003eIt describes the notification template\u0027s name, description, and the template content.\n\n \u003cp\u003e{@link Spec#getReasonSelector Spec#getReasonSelector()} is used to select the template by reasonType and language, if multiple templates\n are matched, the best match will be selected. This is useful when you want to override the default template."
       },
       "NotificationTemplateList": {
         "required": [
@@ -19168,7 +19246,8 @@
           "template": {
             "$ref": "#/components/schemas/TemplateContent"
           }
-        }
+        },
+        "description": "Desired notification template selector and content."
       },
       "NotifierDescriptor": {
         "required": [
@@ -19191,7 +19270,7 @@
             "$ref": "#/components/schemas/NotifierDescriptorSpec"
           }
         },
-        "description": "{@link NotifierDescriptor NotifierDescriptor} is a custom extension that defines a notifier.\n\n \u003cp\u003eIt describes the notifier\u0027s name, description, and the extension name of the notifier to let the user know what\n the notifier is and what it can do in the UI and also let the \u003ccode\u003eNotificationCenter\u003c/code\u003e know how to load the\n notifier and prepare the notifier\u0027s settings."
+        "description": "Notifier descriptor extension that advertises a notification delivery implementation and its settings.\n\n \u003cp\u003eIt describes the notifier\u0027s name, description, and the extension name of the notifier to let the user know what\n the notifier is and what it can do in the UI and also let the \u003ccode\u003eNotificationCenter\u003c/code\u003e know how to load the\n notifier and prepare the notifier\u0027s settings."
       },
       "NotifierDescriptorList": {
         "required": [
@@ -19260,15 +19339,18 @@
         "type": "object",
         "properties": {
           "description": {
-            "type": "string"
+            "type": "string",
+            "description": "Human-readable description of what the notifier sends."
           },
           "displayName": {
             "minLength": 1,
-            "type": "string"
+            "type": "string",
+            "description": "Display name shown for the notifier."
           },
           "notifierExtName": {
             "minLength": 1,
-            "type": "string"
+            "type": "string",
+            "description": "Extension name of the notifier implementation."
           },
           "receiverSettingRef": {
             "$ref": "#/components/schemas/NotifierSettingRef"
@@ -19276,7 +19358,8 @@
           "senderSettingRef": {
             "$ref": "#/components/schemas/NotifierSettingRef"
           }
-        }
+        },
+        "description": "Desired notifier descriptor metadata and configuration references."
       },
       "NotifierInfo": {
         "type": "object",
@@ -19300,12 +19383,15 @@
         "type": "object",
         "properties": {
           "group": {
-            "type": "string"
+            "type": "string",
+            "description": "Setting form group name."
           },
           "name": {
-            "type": "string"
+            "type": "string",
+            "description": "Setting metadata.name."
           }
-        }
+        },
+        "description": "Reference to a notifier setting form group."
       },
       "OwnerInfo": {
         "type": "object",
@@ -19357,45 +19443,56 @@
         "type": "object",
         "properties": {
           "description": {
-            "type": "string"
+            "type": "string",
+            "description": "Optional human-readable description of how the token is used."
           },
           "expiresAt": {
             "type": "string",
+            "description": "Time when the token expires. A null value means the token does not expire by time.",
             "format": "date-time"
           },
           "lastUsed": {
             "type": "string",
+            "description": "Last time the token was used successfully.",
             "format": "date-time"
           },
           "name": {
-            "type": "string"
+            "type": "string",
+            "description": "Display name chosen by the token owner."
           },
           "revoked": {
-            "type": "boolean"
+            "type": "boolean",
+            "description": "Whether the token has been manually revoked."
           },
           "revokesAt": {
             "type": "string",
+            "description": "Time when the token was revoked.",
             "format": "date-time"
           },
           "roles": {
             "type": "array",
+            "description": "Role names granted to this token.",
             "items": {
               "type": "string"
             }
           },
           "scopes": {
             "type": "array",
+            "description": "Scope strings granted to this token.",
             "items": {
               "type": "string"
             }
           },
           "tokenId": {
-            "type": "string"
+            "type": "string",
+            "description": "Stable token identifier stored separately from the secret token value."
           },
           "username": {
-            "type": "string"
+            "type": "string",
+            "description": "User metadata.name that owns this token."
           }
-        }
+        },
+        "description": "Desired personal access token settings and lifecycle flags."
       },
       "PersonalAccessToken": {
         "required": [
@@ -19417,7 +19514,8 @@
           "spec": {
             "$ref": "#/components/schemas/PatSpec"
           }
-        }
+        },
+        "description": "Personal access token extension used for non-interactive API authentication on behalf of a Halo user."
       },
       "PersonalAccessTokenList": {
         "required": [
@@ -19503,7 +19601,7 @@
             "$ref": "#/components/schemas/PluginStatus"
           }
         },
-        "description": "A custom resource for Plugin."
+        "description": "Plugin extension that describes an installed plugin and its runtime lifecycle state."
       },
       "PluginAuthor": {
         "required": [
@@ -19513,12 +19611,15 @@
         "properties": {
           "name": {
             "minLength": 1,
-            "type": "string"
+            "type": "string",
+            "description": "Author display name."
           },
           "website": {
-            "type": "string"
+            "type": "string",
+            "description": "Author website URL."
           }
-        }
+        },
+        "description": "Plugin author metadata."
       },
       "PluginInstallRequest": {
         "type": "object",
@@ -19622,54 +19723,66 @@
             "$ref": "#/components/schemas/PluginAuthor"
           },
           "configMapName": {
-            "type": "string"
+            "type": "string",
+            "description": "ConfigMap metadata.name storing plugin configuration values."
           },
           "description": {
-            "type": "string"
+            "type": "string",
+            "description": "Human-readable plugin description."
           },
           "displayName": {
-            "type": "string"
+            "type": "string",
+            "description": "Display name shown for the plugin."
           },
           "enabled": {
-            "type": "boolean"
+            "type": "boolean",
+            "description": "Whether the plugin should be enabled."
           },
           "homepage": {
-            "type": "string"
+            "type": "string",
+            "description": "Plugin homepage URL."
           },
           "issues": {
-            "type": "string"
+            "type": "string",
+            "description": "Issue tracker URL."
           },
           "license": {
             "type": "array",
+            "description": "Licenses declared by the plugin.",
             "items": {
               "$ref": "#/components/schemas/License"
             }
           },
           "logo": {
-            "type": "string"
+            "type": "string",
+            "description": "Logo URL or attachment URI for the plugin."
           },
           "pluginDependencies": {
             "type": "object",
             "additionalProperties": {
               "type": "string"
-            }
+            },
+            "description": "Required plugin dependencies keyed by plugin name with version constraints as values."
           },
           "repo": {
-            "type": "string"
+            "type": "string",
+            "description": "Source repository URL."
           },
           "requires": {
             "type": "string",
             "description": "SemVer format."
           },
           "settingName": {
-            "type": "string"
+            "type": "string",
+            "description": "Setting metadata.name used to render the plugin configuration form."
           },
           "version": {
             "pattern": "^(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)(?:-((?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\\.(?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?$",
             "type": "string",
             "description": "plugin version."
           }
-        }
+        },
+        "description": "Desired plugin metadata and configuration references."
       },
       "PluginStatus": {
         "type": "object",
@@ -19681,15 +19794,18 @@
                 "type": "boolean"
               }
             },
+            "description": "Reconciliation conditions for the plugin.",
             "items": {
               "$ref": "#/components/schemas/Condition"
             }
           },
           "entry": {
-            "type": "string"
+            "type": "string",
+            "description": "JavaScript bundle entry path served for the plugin UI."
           },
           "lastProbeState": {
             "type": "string",
+            "description": "Last PF4J probe state observed for the plugin.",
             "enum": [
               "CREATED",
               "DISABLED",
@@ -19702,18 +19818,21 @@
           },
           "lastStartTime": {
             "type": "string",
+            "description": "Last time the plugin started successfully.",
             "format": "date-time"
           },
           "loadLocation": {
             "type": "string",
-            "description": "Load location of the plugin, often a path.",
+            "description": "URI location where the plugin artifact was loaded from.",
             "format": "uri"
           },
           "logo": {
-            "type": "string"
+            "type": "string",
+            "description": "Resolved logo URL or attachment URI for the plugin."
           },
           "phase": {
             "type": "string",
+            "description": "Current plugin lifecycle phase.",
             "enum": [
               "PENDING",
               "STARTING",
@@ -19728,9 +19847,11 @@
             ]
           },
           "stylesheet": {
-            "type": "string"
+            "type": "string",
+            "description": "Stylesheet bundle path served for the plugin UI."
           }
-        }
+        },
+        "description": "Observed plugin lifecycle and runtime asset state."
       },
       "Policy": {
         "required": [
@@ -19753,7 +19874,8 @@
           "spec": {
             "$ref": "#/components/schemas/PolicySpec"
           }
-        }
+        },
+        "description": "Storage policy extension that binds attachment uploads to a policy template and configuration."
       },
       "PolicyList": {
         "required": [
@@ -19847,7 +19969,7 @@
           },
           "verbs": {
             "type": "array",
-            "description": "about who the rule applies to or which namespace the rule applies to.",
+            "description": "Verbs allowed by this rule, such as get, list, create, update, patch, or delete.",
             "items": {
               "type": "string"
             }
@@ -19864,17 +19986,18 @@
         "properties": {
           "configMapName": {
             "type": "string",
-            "description": "Reference name of ConfigMap extension"
+            "description": "ConfigMap metadata.name storing configuration values for this policy."
           },
           "displayName": {
             "type": "string",
-            "description": "Display name of policy"
+            "description": "Display name shown for the storage policy."
           },
           "templateName": {
             "type": "string",
-            "description": "Reference name of PolicyTemplate"
+            "description": "PolicyTemplate metadata.name that provides the storage implementation."
           }
-        }
+        },
+        "description": "Desired storage policy configuration."
       },
       "PolicyTemplate": {
         "required": [
@@ -19896,7 +20019,8 @@
           "spec": {
             "$ref": "#/components/schemas/PolicyTemplateSpec"
           }
-        }
+        },
+        "description": "Storage policy template extension that declares an attachment storage implementation and its settings form."
       },
       "PolicyTemplateList": {
         "required": [
@@ -19964,12 +20088,15 @@
         "type": "object",
         "properties": {
           "displayName": {
-            "type": "string"
+            "type": "string",
+            "description": "Display name shown for the storage policy template."
           },
           "settingName": {
-            "type": "string"
+            "type": "string",
+            "description": "Setting metadata.name used to render configuration fields for policies created from this template."
           }
-        }
+        },
+        "description": "Desired storage policy template metadata."
       },
       "Post": {
         "required": [
@@ -19996,7 +20123,7 @@
             "$ref": "#/components/schemas/PostStatus"
           }
         },
-        "description": "Post extension."
+        "description": "Post extension that stores article metadata, publication settings, taxonomy, and derived status."
       },
       "PostAttachmentRequest": {
         "required": [
@@ -20209,7 +20336,7 @@
             ]
           }
         },
-        "description": "Desired content, publication, taxonomy, and rendering configuration of a post."
+        "description": "Desired post content, publication, taxonomy, and rendering configuration."
       },
       "PostStatus": {
         "type": "object",
@@ -20269,7 +20396,7 @@
             "description": "Current publishing phase, such as DRAFT, PENDING_APPROVAL, PUBLISHED, or FAILED."
           }
         },
-        "description": "Observed state of a content item."
+        "description": "Observed post state derived by content reconcilers."
       },
       "PostVo": {
         "required": [
@@ -20337,7 +20464,7 @@
             "$ref": "#/components/schemas/ReasonSpec"
           }
         },
-        "description": "{@link Reason Reason} is a custom extension that defines a reason for a notification, It represents an instance of a\n {@link ReasonType ReasonType}.\n\n \u003cp\u003eIt can be understood as an event that triggers a notification."
+        "description": "Reason extension that represents one notification event instance of a {@link ReasonType ReasonType}.\n\n \u003cp\u003eIt can be understood as an event that triggers a notification."
       },
       "ReasonAttributes": {
         "type": "object",
@@ -20346,7 +20473,7 @@
             "type": "boolean"
           }
         },
-        "description": "Attributes used to transfer data"
+        "description": "{@link ReasonAttributes ReasonAttributes} is a map that stores the attributes of the reason."
       },
       "ReasonList": {
         "required": [
@@ -20415,21 +20542,26 @@
         "type": "object",
         "properties": {
           "description": {
-            "type": "string"
+            "type": "string",
+            "description": "Human-readable description of the attribute."
           },
           "name": {
             "minLength": 1,
-            "type": "string"
+            "type": "string",
+            "description": "Attribute name."
           },
           "optional": {
             "type": "boolean",
+            "description": "Whether the attribute may be absent from a reason.",
             "default": false
           },
           "type": {
             "minLength": 1,
-            "type": "string"
+            "type": "string",
+            "description": "Attribute value type, such as string, number, boolean, or object."
           }
-        }
+        },
+        "description": "Attribute definition for reasons of a reason type."
       },
       "ReasonSelector": {
         "required": [
@@ -20441,13 +20573,16 @@
           "language": {
             "minLength": 1,
             "type": "string",
+            "description": "Language tag this template applies to, or default for the fallback template.",
             "default": "default"
           },
           "reasonType": {
             "minLength": 1,
-            "type": "string"
+            "type": "string",
+            "description": "ReasonType metadata.name this template applies to."
           }
-        }
+        },
+        "description": "Selector used to match a notification template to a reason type and language."
       },
       "ReasonSpec": {
         "required": [
@@ -20461,15 +20596,18 @@
             "$ref": "#/components/schemas/ReasonAttributes"
           },
           "author": {
-            "type": "string"
+            "type": "string",
+            "description": "User metadata.name or system actor that created the reason."
           },
           "reasonType": {
-            "type": "string"
+            "type": "string",
+            "description": "ReasonType metadata.name that defines this reason."
           },
           "subject": {
             "$ref": "#/components/schemas/ReasonSubject"
           }
-        }
+        },
+        "description": "Notification reason data used to render and dispatch notifications."
       },
       "ReasonSubject": {
         "required": [
@@ -20481,21 +20619,27 @@
         "type": "object",
         "properties": {
           "apiVersion": {
-            "type": "string"
+            "type": "string",
+            "description": "Subject API version."
           },
           "kind": {
-            "type": "string"
+            "type": "string",
+            "description": "Subject kind."
           },
           "name": {
-            "type": "string"
+            "type": "string",
+            "description": "Subject metadata.name."
           },
           "title": {
-            "type": "string"
+            "type": "string",
+            "description": "Human-readable subject title shown in notifications."
           },
           "url": {
-            "type": "string"
+            "type": "string",
+            "description": "URL that opens the subject."
           }
-        }
+        },
+        "description": "Resource subject associated with a notification reason."
       },
       "ReasonType": {
         "required": [
@@ -20518,7 +20662,7 @@
             "$ref": "#/components/schemas/ReasonTypeSpec"
           }
         },
-        "description": "{@link ReasonType ReasonType} is a custom extension that defines a type of reason.\n\n \u003cp\u003eOne {@link ReasonType ReasonType} can have multiple {@link Reason Reason}s to notify."
+        "description": "Reason type extension that defines the schema and display metadata for notification reasons.\n\n \u003cp\u003eOne {@link ReasonType ReasonType} can have multiple {@link Reason Reason}s to notify."
       },
       "ReasonTypeInfo": {
         "type": "object",
@@ -20663,19 +20807,23 @@
         "properties": {
           "description": {
             "minLength": 1,
-            "type": "string"
+            "type": "string",
+            "description": "Human-readable description of when this reason type is triggered."
           },
           "displayName": {
             "minLength": 1,
-            "type": "string"
+            "type": "string",
+            "description": "Display name shown for this reason type."
           },
           "properties": {
             "type": "array",
+            "description": "Attribute definitions available on reasons of this type.",
             "items": {
               "$ref": "#/components/schemas/ReasonProperty"
             }
           }
-        }
+        },
+        "description": "Desired reason type metadata and properties available to templates."
       },
       "Ref": {
         "required": [
@@ -20725,7 +20873,8 @@
           "spec": {
             "$ref": "#/components/schemas/RememberMeTokenSpec"
           }
-        }
+        },
+        "description": "Persistent remember-me token used to keep a user\u0027s browser session signed in across restarts."
       },
       "RememberMeTokenList": {
         "required": [
@@ -20796,6 +20945,7 @@
         "properties": {
           "lastUsed": {
             "type": "string",
+            "description": "Last time this remember-me token was used successfully.",
             "format": "date-time"
           },
           "previousTokenValue": {
@@ -20804,17 +20954,21 @@
           },
           "series": {
             "minLength": 1,
-            "type": "string"
+            "type": "string",
+            "description": "Browser series identifier used by Spring Security remember-me authentication."
           },
           "tokenValue": {
             "minLength": 1,
-            "type": "string"
+            "type": "string",
+            "description": "Current remember-me token value expected from the browser cookie."
           },
           "username": {
             "minLength": 1,
-            "type": "string"
+            "type": "string",
+            "description": "User metadata.name that owns this remember-me token."
           }
-        }
+        },
+        "description": "Persistent remember-me token values for a user and browser series."
       },
       "RemoveOperation": {
         "required": [
@@ -21203,6 +21357,7 @@
           },
           "rules": {
             "type": "array",
+            "description": "Path mapping rules served by this reverse proxy resource.",
             "items": {
               "$ref": "#/components/schemas/ReverseProxyRule"
             }
@@ -21278,7 +21433,8 @@
           "path": {
             "type": "string"
           }
-        }
+        },
+        "description": "A path mapping from a public request path to a file provider."
       },
       "RevertSnapshotForPostParam": {
         "required": [
@@ -21328,11 +21484,13 @@
           },
           "rules": {
             "type": "array",
+            "description": "Policy rules granted by this role.",
             "items": {
               "$ref": "#/components/schemas/PolicyRule"
             }
           }
-        }
+        },
+        "description": "Role extension that defines RBAC policy rules for users and other subjects."
       },
       "RoleBinding": {
         "required": [
@@ -21356,13 +21514,13 @@
           },
           "subjects": {
             "type": "array",
-            "description": "Subjects holds references to the objects the role applies to.",
+            "description": "Subjects that receive the permissions from roleRef.",
             "items": {
               "$ref": "#/components/schemas/Subject"
             }
           }
         },
-        "description": "RoleBinding references a role, but does not contain it. It can reference a Role in the global. It adds who\n information via Subjects."
+        "description": "RoleBinding extension that grants a Role to one or more subjects."
       },
       "RoleBindingList": {
         "required": [
@@ -21487,15 +21645,15 @@
         "properties": {
           "apiGroup": {
             "type": "string",
-            "description": "APIGroup is the group for the resource being referenced."
+            "description": "API group of the role resource being referenced."
           },
           "kind": {
             "type": "string",
-            "description": "Kind is the type of resource being referenced."
+            "description": "Kind of the role resource being referenced."
           },
           "name": {
             "type": "string",
-            "description": "Name is the name of resource being referenced."
+            "description": "Metadata name of the role resource being referenced."
           }
         },
         "description": "RoleRef contains information that points to the role being used."
@@ -21722,7 +21880,7 @@
             "$ref": "#/components/schemas/SettingSpec"
           }
         },
-        "description": "{@link Setting Setting} is a custom extension to generate forms based on configuration."
+        "description": "Setting extension that describes one or more configuration forms and their schema."
       },
       "SettingForm": {
         "minLength": 1,
@@ -21734,17 +21892,21 @@
         "properties": {
           "formSchema": {
             "type": "array",
+            "description": "FormKit-compatible schema used to render the form fields.",
             "items": {
               "type": "object"
             }
           },
           "group": {
-            "type": "string"
+            "type": "string",
+            "description": "Stable form group name used to store submitted values."
           },
           "label": {
-            "type": "string"
+            "type": "string",
+            "description": "Display label shown for this form group."
           }
-        }
+        },
+        "description": "A single form group in a setting definition."
       },
       "SettingList": {
         "required": [
@@ -21814,13 +21976,16 @@
         "properties": {
           "group": {
             "minLength": 1,
-            "type": "string"
+            "type": "string",
+            "description": "Setting form group name."
           },
           "name": {
             "minLength": 1,
-            "type": "string"
+            "type": "string",
+            "description": "Setting metadata.name."
           }
-        }
+        },
+        "description": "Reference to a setting definition used by this provider."
       },
       "SettingSpec": {
         "required": [
@@ -21831,11 +21996,13 @@
           "forms": {
             "minLength": 1,
             "type": "array",
+            "description": "Form groups rendered for this setting definition.",
             "items": {
               "$ref": "#/components/schemas/SettingForm"
             }
           }
-        }
+        },
+        "description": "Collection of form groups that make up this setting definition."
       },
       "SetupRequest": {
         "required": [
@@ -21901,7 +22068,7 @@
             "$ref": "#/components/schemas/SinglePageStatus"
           }
         },
-        "description": "Single page extension."
+        "description": "Single page extension that stores standalone page metadata, publication settings, and derived status."
       },
       "SinglePageList": {
         "required": [
@@ -22080,7 +22247,7 @@
             ]
           }
         },
-        "description": "Desired content, publication, and rendering configuration of a single page."
+        "description": "Desired single page content, publication, and rendering configuration."
       },
       "SinglePageStatus": {
         "type": "object",
@@ -22140,7 +22307,7 @@
             "description": "Current publishing phase, such as DRAFT, PENDING_APPROVAL, PUBLISHED, or FAILED."
           }
         },
-        "description": "Observed state of a single page."
+        "description": "Observed single page state derived by content reconcilers."
       },
       "SinglePageVo": {
         "required": [
@@ -22393,7 +22560,8 @@
             "type": "string",
             "description": "Name of the object being referenced."
           }
-        }
+        },
+        "description": "Subject that receives permissions from a RoleBinding."
       },
       "Subscription": {
         "required": [
@@ -22416,7 +22584,7 @@
             "$ref": "#/components/schemas/SubscriptionSpec"
           }
         },
-        "description": "{@link Subscription Subscription} is a custom extension that defines a subscriber to be notified when a certain {@link Reason Reason} is\n triggered.\n\n \u003cp\u003eIt holds a {@link Subscriber Subscriber} to the user to be notified, a {@link InterestReason InterestReason} to subscribe to."
+        "description": "Subscription extension that records which subscriber should be notified when a matching reason is triggered.\n\n \u003cp\u003eIt holds a {@link Subscriber Subscriber} to the user to be notified, a {@link InterestReason InterestReason} to subscribe to."
       },
       "SubscriptionList": {
         "required": [
@@ -22487,7 +22655,7 @@
         "properties": {
           "disabled": {
             "type": "boolean",
-            "description": "Perhaps users need to unsubscribe and interact without receiving notifications again"
+            "description": "Whether the subscription has been disabled, usually after the subscriber unsubscribes."
           },
           "reason": {
             "$ref": "#/components/schemas/InterestReason"
@@ -22497,9 +22665,10 @@
           },
           "unsubscribeToken": {
             "type": "string",
-            "description": "The token to unsubscribe"
+            "description": "Token used to unsubscribe without authenticating as the subscriber."
           }
-        }
+        },
+        "description": "Desired notification subscription settings."
       },
       "SubscriptionSubscriber": {
         "required": [
@@ -22509,10 +22678,11 @@
         "properties": {
           "name": {
             "minLength": 1,
-            "type": "string"
+            "type": "string",
+            "description": "User metadata.name of the subscriber."
           }
         },
-        "description": "The subscriber to be notified"
+        "description": "Subscriber that receives notifications."
       },
       "Tag": {
         "required": [
@@ -22631,7 +22801,7 @@
             "description": "URL slug used to build the tag permalink."
           }
         },
-        "description": "Desired display and rendering configuration of a tag."
+        "description": "Desired tag display and rendering configuration."
       },
       "TagStatus": {
         "type": "object",
@@ -22656,7 +22826,7 @@
             "format": "int32"
           }
         },
-        "description": "Observed state of a tag."
+        "description": "Observed tag state derived by content reconcilers."
       },
       "TagVo": {
         "required": [
@@ -22746,16 +22916,20 @@
         "type": "object",
         "properties": {
           "htmlBody": {
-            "type": "string"
+            "type": "string",
+            "description": "HTML body rendered for notification channels that support HTML."
           },
           "rawBody": {
-            "type": "string"
+            "type": "string",
+            "description": "Plain text or source body rendered for notification channels that do not use HTML."
           },
           "title": {
             "minLength": 1,
-            "type": "string"
+            "type": "string",
+            "description": "Rendered notification title."
           }
-        }
+        },
+        "description": "Notification template content."
       },
       "TemplateDescriptor": {
         "required": [
@@ -22765,18 +22939,22 @@
         "type": "object",
         "properties": {
           "description": {
-            "type": "string"
+            "type": "string",
+            "description": "Human-readable description of when to use this template."
           },
           "file": {
             "minLength": 1,
-            "type": "string"
+            "type": "string",
+            "description": "Template file path relative to the theme templates directory."
           },
           "name": {
             "minLength": 1,
-            "type": "string"
+            "type": "string",
+            "description": "Template display name shown to users."
           },
           "screenshot": {
-            "type": "string"
+            "type": "string",
+            "description": "Screenshot URL or attachment URI for previewing the template."
           }
         },
         "description": "Type used to describe custom template page."
@@ -22831,7 +23009,7 @@
             "$ref": "#/components/schemas/ThemeStatus"
           }
         },
-        "description": "Theme extension."
+        "description": "Theme extension that describes an installable frontend theme and its runtime state."
       },
       "ThemeInstallRequest": {
         "type": "object"
@@ -22906,46 +23084,58 @@
             "$ref": "#/components/schemas/Author"
           },
           "configMapName": {
-            "type": "string"
+            "type": "string",
+            "description": "ConfigMap metadata.name storing the theme configuration values."
           },
           "customTemplates": {
             "$ref": "#/components/schemas/CustomTemplates"
           },
           "description": {
-            "type": "string"
+            "type": "string",
+            "description": "Human-readable theme description."
           },
           "displayName": {
             "minLength": 1,
-            "type": "string"
+            "type": "string",
+            "description": "Display name shown for the theme."
           },
           "homepage": {
-            "type": "string"
+            "type": "string",
+            "description": "Theme homepage URL."
           },
           "issues": {
-            "type": "string"
+            "type": "string",
+            "description": "Issue tracker URL."
           },
           "license": {
             "type": "array",
+            "description": "Licenses declared by the theme.",
             "items": {
               "$ref": "#/components/schemas/License"
             }
           },
           "logo": {
-            "type": "string"
+            "type": "string",
+            "description": "Logo URL or attachment URI for the theme."
           },
           "repo": {
-            "type": "string"
+            "type": "string",
+            "description": "Source repository URL."
           },
           "requires": {
-            "type": "string"
+            "type": "string",
+            "description": "Required Halo version range. The wildcard value means any Halo version."
           },
           "settingName": {
-            "type": "string"
+            "type": "string",
+            "description": "Setting metadata.name used to render the theme configuration form."
           },
           "version": {
-            "type": "string"
+            "type": "string",
+            "description": "Theme version. The wildcard value means any version."
           }
-        }
+        },
+        "description": "Desired theme metadata and configuration references."
       },
       "ThemeStatus": {
         "type": "object",
@@ -22957,6 +23147,7 @@
                 "type": "boolean"
               }
             },
+            "description": "Reconciliation conditions for the theme.",
             "items": {
               "$ref": "#/components/schemas/Condition"
             }
@@ -22966,17 +23157,20 @@
             "description": "Whether the theme appears to be a local development workspace."
           },
           "location": {
-            "type": "string"
+            "type": "string",
+            "description": "Local filesystem location where the theme is loaded from."
           },
           "phase": {
             "type": "string",
+            "description": "Current theme lifecycle phase.",
             "enum": [
               "READY",
               "FAILED",
               "UNKNOWN"
             ]
           }
-        }
+        },
+        "description": "Observed theme lifecycle and installation state."
       },
       "TotpAuthLinkResponse": {
         "type": "object",
@@ -23142,7 +23336,7 @@
             "$ref": "#/components/schemas/UserStatus"
           }
         },
-        "description": "The extension represents user details of Halo."
+        "description": "User extension that stores profile, authentication, and account state for a Halo user."
       },
       "UserConnection": {
         "required": [
@@ -23166,7 +23360,7 @@
             "$ref": "#/components/schemas/UserConnectionSpec"
           }
         },
-        "description": "User connection extension."
+        "description": "User connection extension that links a Halo user to an external OAuth2 account."
       },
       "UserConnectionList": {
         "required": [
@@ -23252,7 +23446,8 @@
             "type": "string",
             "description": "The {@link Metadata#getName Metadata#getName()} of the user associated with the OAuth connection."
           }
-        }
+        },
+        "description": "External OAuth2 account binding for a Halo user."
       },
       "UserDevice": {
         "required": [
@@ -23427,52 +23622,67 @@
         "type": "object",
         "properties": {
           "avatar": {
-            "type": "string"
+            "type": "string",
+            "description": "Avatar URL or attachment URI for the user."
           },
           "bio": {
-            "type": "string"
+            "type": "string",
+            "description": "User biography shown on profile surfaces."
           },
           "disabled": {
-            "type": "boolean"
+            "type": "boolean",
+            "description": "Whether the user account is disabled."
           },
           "displayName": {
-            "type": "string"
+            "type": "string",
+            "description": "Display name shown for the user."
           },
           "email": {
-            "type": "string"
+            "type": "string",
+            "description": "Email address used for sign-in and notifications."
           },
           "emailVerified": {
-            "type": "boolean"
+            "type": "boolean",
+            "description": "Whether the email address has been verified."
           },
           "loginHistoryLimit": {
             "type": "integer",
+            "description": "Maximum number of login history entries retained for this user.",
             "format": "int32"
           },
           "password": {
-            "type": "string"
+            "type": "string",
+            "description": "Password hash or encoded password value."
           },
           "phone": {
-            "type": "string"
+            "type": "string",
+            "description": "Phone number associated with the user."
           },
           "registeredAt": {
             "type": "string",
+            "description": "Time when the user registered.",
             "format": "date-time"
           },
           "totpEncryptedSecret": {
-            "type": "string"
+            "type": "string",
+            "description": "Encrypted TOTP secret used for two-factor authentication."
           },
           "twoFactorAuthEnabled": {
-            "type": "boolean"
+            "type": "boolean",
+            "description": "Whether two-factor authentication is enabled for this user."
           }
-        }
+        },
+        "description": "Desired user profile and authentication settings."
       },
       "UserStatus": {
         "type": "object",
         "properties": {
           "permalink": {
-            "type": "string"
+            "type": "string",
+            "description": "Public permalink of the user\u0027s profile or author page."
           }
-        }
+        },
+        "description": "Observed user state derived by the application."
       },
       "VerifyCodeRequest": {
         "required": [

--- a/api-docs/openapi/v3_0/apis_console.api_v1alpha1.json
+++ b/api-docs/openapi/v3_0/apis_console.api_v1alpha1.json
@@ -3484,7 +3484,8 @@
           "status": {
             "$ref": "#/components/schemas/AttachmentStatus"
           }
-        }
+        },
+        "description": "Attachment extension that describes an uploaded file and its resolved access URLs."
       },
       "AttachmentList": {
         "required": [
@@ -3550,55 +3551,57 @@
         "properties": {
           "displayName": {
             "type": "string",
-            "description": "Display name of attachment"
+            "description": "Display name shown for the attachment."
           },
           "groupName": {
             "type": "string",
-            "description": "Group name"
+            "description": "Attachment group metadata.name this attachment belongs to."
           },
           "mediaType": {
             "type": "string",
-            "description": "Media type of attachment"
+            "description": "Media type detected or supplied for the attachment, such as image/png."
           },
           "ownerName": {
             "type": "string",
-            "description": "Name of User who uploads the attachment"
+            "description": "User metadata.name of the uploader."
           },
           "policyName": {
             "type": "string",
-            "description": "Policy name"
+            "description": "Storage policy metadata.name used to store this attachment."
           },
           "size": {
             "minimum": 0,
             "type": "integer",
-            "description": "Size of attachment. Unit is Byte",
+            "description": "Size of the attachment in bytes.",
             "format": "int64"
           },
           "tags": {
             "uniqueItems": true,
             "type": "array",
-            "description": "Tags of attachment",
+            "description": "Free-form tags assigned to the attachment.",
             "items": {
-              "type": "string",
-              "description": "Tag name"
+              "type": "string"
             }
           }
-        }
+        },
+        "description": "Desired attachment metadata and storage placement."
       },
       "AttachmentStatus": {
         "type": "object",
         "properties": {
           "permalink": {
             "type": "string",
-            "description": "Permalink of attachment.\nIf it is in local storage, the public URL will be set.\nIf it is in s3 storage, the Object URL will be set.\n"
+            "description": "Public permalink for the attachment. Local storage usually exposes a public URL, while object storage may\n expose the object URL."
           },
           "thumbnails": {
             "type": "object",
             "additionalProperties": {
               "type": "string"
-            }
+            },
+            "description": "Generated thumbnail URLs keyed by thumbnail size name."
           }
-        }
+        },
+        "description": "Observed attachment access state."
       },
       "AuthProvider": {
         "required": [
@@ -3622,7 +3625,7 @@
             "$ref": "#/components/schemas/AuthProviderSpec"
           }
         },
-        "description": "Auth provider extension."
+        "description": "Authentication provider extension that describes an external or form-based sign-in integration."
       },
       "AuthProviderSpec": {
         "required": [
@@ -3642,43 +3645,52 @@
           },
           "authenticationUrl": {
             "type": "string",
-            "description": "Authentication url of the auth provider"
+            "description": "URL that starts the authentication flow."
           },
           "bindingUrl": {
-            "type": "string"
+            "type": "string",
+            "description": "URL that starts account binding for an already signed-in user."
           },
           "configMapRef": {
             "$ref": "#/components/schemas/ConfigMapRef"
           },
           "description": {
-            "type": "string"
+            "type": "string",
+            "description": "Human-readable description of the provider."
           },
           "displayName": {
             "type": "string",
-            "description": "Display name of the auth provider"
+            "description": "Display name shown on sign-in and account binding screens."
           },
           "helpPage": {
-            "type": "string"
+            "type": "string",
+            "description": "Help page URL for users who need sign-in assistance."
           },
           "logo": {
-            "type": "string"
+            "type": "string",
+            "description": "Logo URL or attachment URI for the provider."
           },
           "method": {
-            "type": "string"
+            "type": "string",
+            "description": "HTTP method used when starting the authentication flow."
           },
           "rememberMeSupport": {
-            "type": "boolean"
+            "type": "boolean",
+            "description": "Whether the provider supports remember-me during sign-in."
           },
           "settingRef": {
             "$ref": "#/components/schemas/SettingRef"
           },
           "unbindUrl": {
-            "type": "string"
+            "type": "string",
+            "description": "URL that unbinds the external account from the current user."
           },
           "website": {
-            "type": "string"
+            "type": "string",
+            "description": "Provider website URL."
           }
-        }
+        },
+        "description": "Authentication provider metadata and endpoint configuration."
       },
       "Author": {
         "required": [
@@ -3688,12 +3700,15 @@
         "properties": {
           "name": {
             "minLength": 1,
-            "type": "string"
+            "type": "string",
+            "description": "Author display name."
           },
           "website": {
-            "type": "string"
+            "type": "string",
+            "description": "Author website URL."
           }
-        }
+        },
+        "description": "Theme author metadata."
       },
       "BackupFile": {
         "type": "object",
@@ -3800,7 +3815,7 @@
             "description": "Theme template used to render the category archive page."
           }
         },
-        "description": "Desired display, hierarchy, and rendering configuration of a category."
+        "description": "Desired category display, hierarchy, and rendering configuration."
       },
       "CategoryStatus": {
         "type": "object",
@@ -3820,7 +3835,7 @@
             "format": "int32"
           }
         },
-        "description": "Observed state of a category."
+        "description": "Observed category state derived by content reconcilers."
       },
       "ChangeOwnPasswordRequest": {
         "required": [
@@ -4099,7 +4114,7 @@
             "format": "int32"
           }
         },
-        "description": "Observed state of a comment."
+        "description": "Observed state of a top-level comment."
       },
       "Condition": {
         "required": [
@@ -4158,7 +4173,8 @@
             "type": "object",
             "additionalProperties": {
               "type": "string"
-            }
+            },
+            "description": "String key-value configuration entries consumed by Halo or plugins."
           },
           "kind": {
             "type": "string"
@@ -4177,9 +4193,11 @@
         "properties": {
           "name": {
             "minLength": 1,
-            "type": "string"
+            "type": "string",
+            "description": "ConfigMap metadata.name."
           }
-        }
+        },
+        "description": "Reference to a ConfigMap used by this provider."
       },
       "Content": {
         "required": [
@@ -4348,23 +4366,27 @@
         "properties": {
           "category": {
             "type": "array",
+            "description": "Custom templates available for categories.",
             "items": {
               "$ref": "#/components/schemas/TemplateDescriptor"
             }
           },
           "page": {
             "type": "array",
+            "description": "Custom templates available for single pages.",
             "items": {
               "$ref": "#/components/schemas/TemplateDescriptor"
             }
           },
           "post": {
             "type": "array",
+            "description": "Custom templates available for posts.",
             "items": {
               "$ref": "#/components/schemas/TemplateDescriptor"
             }
           }
-        }
+        },
+        "description": "Custom template descriptors grouped by the content type they render."
       },
       "DashboardStats": {
         "type": "object",
@@ -4473,7 +4495,7 @@
             "description": "Manual excerpt text used when autoGenerate is false."
           }
         },
-        "description": "Excerpt generation configuration."
+        "description": "Excerpt generation configuration for a post or single page."
       },
       "Extension": {
         "required": [
@@ -5193,7 +5215,7 @@
             "$ref": "#/components/schemas/PluginStatus"
           }
         },
-        "description": "A custom resource for Plugin."
+        "description": "Plugin extension that describes an installed plugin and its runtime lifecycle state."
       },
       "PluginAuthor": {
         "required": [
@@ -5203,12 +5225,15 @@
         "properties": {
           "name": {
             "minLength": 1,
-            "type": "string"
+            "type": "string",
+            "description": "Author display name."
           },
           "website": {
-            "type": "string"
+            "type": "string",
+            "description": "Author website URL."
           }
-        }
+        },
+        "description": "Plugin author metadata."
       },
       "PluginInstallRequest": {
         "type": "object",
@@ -5312,54 +5337,66 @@
             "$ref": "#/components/schemas/PluginAuthor"
           },
           "configMapName": {
-            "type": "string"
+            "type": "string",
+            "description": "ConfigMap metadata.name storing plugin configuration values."
           },
           "description": {
-            "type": "string"
+            "type": "string",
+            "description": "Human-readable plugin description."
           },
           "displayName": {
-            "type": "string"
+            "type": "string",
+            "description": "Display name shown for the plugin."
           },
           "enabled": {
-            "type": "boolean"
+            "type": "boolean",
+            "description": "Whether the plugin should be enabled."
           },
           "homepage": {
-            "type": "string"
+            "type": "string",
+            "description": "Plugin homepage URL."
           },
           "issues": {
-            "type": "string"
+            "type": "string",
+            "description": "Issue tracker URL."
           },
           "license": {
             "type": "array",
+            "description": "Licenses declared by the plugin.",
             "items": {
               "$ref": "#/components/schemas/License"
             }
           },
           "logo": {
-            "type": "string"
+            "type": "string",
+            "description": "Logo URL or attachment URI for the plugin."
           },
           "pluginDependencies": {
             "type": "object",
             "additionalProperties": {
               "type": "string"
-            }
+            },
+            "description": "Required plugin dependencies keyed by plugin name with version constraints as values."
           },
           "repo": {
-            "type": "string"
+            "type": "string",
+            "description": "Source repository URL."
           },
           "requires": {
             "type": "string",
             "description": "SemVer format."
           },
           "settingName": {
-            "type": "string"
+            "type": "string",
+            "description": "Setting metadata.name used to render the plugin configuration form."
           },
           "version": {
             "pattern": "^(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)(?:-((?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\\.(?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?$",
             "type": "string",
             "description": "plugin version."
           }
-        }
+        },
+        "description": "Desired plugin metadata and configuration references."
       },
       "PluginStatus": {
         "type": "object",
@@ -5371,15 +5408,18 @@
                 "type": "boolean"
               }
             },
+            "description": "Reconciliation conditions for the plugin.",
             "items": {
               "$ref": "#/components/schemas/Condition"
             }
           },
           "entry": {
-            "type": "string"
+            "type": "string",
+            "description": "JavaScript bundle entry path served for the plugin UI."
           },
           "lastProbeState": {
             "type": "string",
+            "description": "Last PF4J probe state observed for the plugin.",
             "enum": [
               "CREATED",
               "DISABLED",
@@ -5392,18 +5432,21 @@
           },
           "lastStartTime": {
             "type": "string",
+            "description": "Last time the plugin started successfully.",
             "format": "date-time"
           },
           "loadLocation": {
             "type": "string",
-            "description": "Load location of the plugin, often a path.",
+            "description": "URI location where the plugin artifact was loaded from.",
             "format": "uri"
           },
           "logo": {
-            "type": "string"
+            "type": "string",
+            "description": "Resolved logo URL or attachment URI for the plugin."
           },
           "phase": {
             "type": "string",
+            "description": "Current plugin lifecycle phase.",
             "enum": [
               "PENDING",
               "STARTING",
@@ -5418,9 +5461,11 @@
             ]
           },
           "stylesheet": {
-            "type": "string"
+            "type": "string",
+            "description": "Stylesheet bundle path served for the plugin UI."
           }
-        }
+        },
+        "description": "Observed plugin lifecycle and runtime asset state."
       },
       "PolicyRule": {
         "type": "object",
@@ -5455,7 +5500,7 @@
           },
           "verbs": {
             "type": "array",
-            "description": "about who the rule applies to or which namespace the rule applies to.",
+            "description": "Verbs allowed by this rule, such as get, list, create, update, patch, or delete.",
             "items": {
               "type": "string"
             }
@@ -5488,7 +5533,7 @@
             "$ref": "#/components/schemas/PostStatus"
           }
         },
-        "description": "Post extension."
+        "description": "Post extension that stores article metadata, publication settings, taxonomy, and derived status."
       },
       "PostRequest": {
         "required": [
@@ -5622,7 +5667,7 @@
             ]
           }
         },
-        "description": "Desired content, publication, taxonomy, and rendering configuration of a post."
+        "description": "Desired post content, publication, taxonomy, and rendering configuration."
       },
       "PostStatus": {
         "type": "object",
@@ -5682,7 +5727,7 @@
             "description": "Current publishing phase, such as DRAFT, PENDING_APPROVAL, PUBLISHED, or FAILED."
           }
         },
-        "description": "Observed state of a content item."
+        "description": "Observed post state derived by content reconcilers."
       },
       "Ref": {
         "required": [
@@ -5985,11 +6030,13 @@
           },
           "rules": {
             "type": "array",
+            "description": "Policy rules granted by this role.",
             "items": {
               "$ref": "#/components/schemas/PolicyRule"
             }
           }
-        }
+        },
+        "description": "Role extension that defines RBAC policy rules for users and other subjects."
       },
       "Setting": {
         "required": [
@@ -6013,7 +6060,7 @@
             "$ref": "#/components/schemas/SettingSpec"
           }
         },
-        "description": "{@link Setting Setting} is a custom extension to generate forms based on configuration."
+        "description": "Setting extension that describes one or more configuration forms and their schema."
       },
       "SettingForm": {
         "minLength": 1,
@@ -6025,17 +6072,21 @@
         "properties": {
           "formSchema": {
             "type": "array",
+            "description": "FormKit-compatible schema used to render the form fields.",
             "items": {
               "type": "object"
             }
           },
           "group": {
-            "type": "string"
+            "type": "string",
+            "description": "Stable form group name used to store submitted values."
           },
           "label": {
-            "type": "string"
+            "type": "string",
+            "description": "Display label shown for this form group."
           }
-        }
+        },
+        "description": "A single form group in a setting definition."
       },
       "SettingRef": {
         "required": [
@@ -6046,13 +6097,16 @@
         "properties": {
           "group": {
             "minLength": 1,
-            "type": "string"
+            "type": "string",
+            "description": "Setting form group name."
           },
           "name": {
             "minLength": 1,
-            "type": "string"
+            "type": "string",
+            "description": "Setting metadata.name."
           }
-        }
+        },
+        "description": "Reference to a setting definition used by this provider."
       },
       "SettingSpec": {
         "required": [
@@ -6063,11 +6117,13 @@
           "forms": {
             "minLength": 1,
             "type": "array",
+            "description": "Form groups rendered for this setting definition.",
             "items": {
               "$ref": "#/components/schemas/SettingForm"
             }
           }
-        }
+        },
+        "description": "Collection of form groups that make up this setting definition."
       },
       "SinglePage": {
         "required": [
@@ -6094,7 +6150,7 @@
             "$ref": "#/components/schemas/SinglePageStatus"
           }
         },
-        "description": "Single page extension."
+        "description": "Single page extension that stores standalone page metadata, publication settings, and derived status."
       },
       "SinglePageRequest": {
         "required": [
@@ -6214,7 +6270,7 @@
             ]
           }
         },
-        "description": "Desired content, publication, and rendering configuration of a single page."
+        "description": "Desired single page content, publication, and rendering configuration."
       },
       "SinglePageStatus": {
         "type": "object",
@@ -6274,7 +6330,7 @@
             "description": "Current publishing phase, such as DRAFT, PENDING_APPROVAL, PUBLISHED, or FAILED."
           }
         },
-        "description": "Observed state of a single page."
+        "description": "Observed single page state derived by content reconcilers."
       },
       "Stats": {
         "type": "object",
@@ -6327,7 +6383,7 @@
             "$ref": "#/components/schemas/TagStatus"
           }
         },
-        "description": "Tag extension for grouping posts by free-form labels."
+        "description": "A chunk of items."
       },
       "TagList": {
         "required": [
@@ -6419,7 +6475,7 @@
             "description": "URL slug used to build the tag permalink."
           }
         },
-        "description": "Desired display and rendering configuration of a tag."
+        "description": "Desired tag display and rendering configuration."
       },
       "TagStatus": {
         "type": "object",
@@ -6444,7 +6500,7 @@
             "format": "int32"
           }
         },
-        "description": "Observed state of a tag."
+        "description": "Observed tag state derived by content reconcilers."
       },
       "TemplateDescriptor": {
         "required": [
@@ -6454,18 +6510,22 @@
         "type": "object",
         "properties": {
           "description": {
-            "type": "string"
+            "type": "string",
+            "description": "Human-readable description of when to use this template."
           },
           "file": {
             "minLength": 1,
-            "type": "string"
+            "type": "string",
+            "description": "Template file path relative to the theme templates directory."
           },
           "name": {
             "minLength": 1,
-            "type": "string"
+            "type": "string",
+            "description": "Template display name shown to users."
           },
           "screenshot": {
-            "type": "string"
+            "type": "string",
+            "description": "Screenshot URL or attachment URI for previewing the template."
           }
         },
         "description": "Type used to describe custom template page."
@@ -6520,7 +6580,7 @@
             "$ref": "#/components/schemas/ThemeStatus"
           }
         },
-        "description": "Theme extension."
+        "description": "Theme extension that describes an installable frontend theme and its runtime state."
       },
       "ThemeInstallRequest": {
         "type": "object"
@@ -6595,46 +6655,58 @@
             "$ref": "#/components/schemas/Author"
           },
           "configMapName": {
-            "type": "string"
+            "type": "string",
+            "description": "ConfigMap metadata.name storing the theme configuration values."
           },
           "customTemplates": {
             "$ref": "#/components/schemas/CustomTemplates"
           },
           "description": {
-            "type": "string"
+            "type": "string",
+            "description": "Human-readable theme description."
           },
           "displayName": {
             "minLength": 1,
-            "type": "string"
+            "type": "string",
+            "description": "Display name shown for the theme."
           },
           "homepage": {
-            "type": "string"
+            "type": "string",
+            "description": "Theme homepage URL."
           },
           "issues": {
-            "type": "string"
+            "type": "string",
+            "description": "Issue tracker URL."
           },
           "license": {
             "type": "array",
+            "description": "Licenses declared by the theme.",
             "items": {
               "$ref": "#/components/schemas/License"
             }
           },
           "logo": {
-            "type": "string"
+            "type": "string",
+            "description": "Logo URL or attachment URI for the theme."
           },
           "repo": {
-            "type": "string"
+            "type": "string",
+            "description": "Source repository URL."
           },
           "requires": {
-            "type": "string"
+            "type": "string",
+            "description": "Required Halo version range. The wildcard value means any Halo version."
           },
           "settingName": {
-            "type": "string"
+            "type": "string",
+            "description": "Setting metadata.name used to render the theme configuration form."
           },
           "version": {
-            "type": "string"
+            "type": "string",
+            "description": "Theme version. The wildcard value means any version."
           }
-        }
+        },
+        "description": "Desired theme metadata and configuration references."
       },
       "ThemeStatus": {
         "type": "object",
@@ -6646,6 +6718,7 @@
                 "type": "boolean"
               }
             },
+            "description": "Reconciliation conditions for the theme.",
             "items": {
               "$ref": "#/components/schemas/Condition"
             }
@@ -6655,17 +6728,20 @@
             "description": "Whether the theme appears to be a local development workspace."
           },
           "location": {
-            "type": "string"
+            "type": "string",
+            "description": "Local filesystem location where the theme is loaded from."
           },
           "phase": {
             "type": "string",
+            "description": "Current theme lifecycle phase.",
             "enum": [
               "READY",
               "FAILED",
               "UNKNOWN"
             ]
           }
-        }
+        },
+        "description": "Observed theme lifecycle and installation state."
       },
       "UpgradeFromUriRequest": {
         "required": [
@@ -6760,7 +6836,7 @@
             "$ref": "#/components/schemas/UserStatus"
           }
         },
-        "description": "The extension represents user details of Halo."
+        "description": "User extension that stores profile, authentication, and account state for a Halo user."
       },
       "UserEndpoint.ListedUserList": {
         "required": [
@@ -6857,52 +6933,67 @@
         "type": "object",
         "properties": {
           "avatar": {
-            "type": "string"
+            "type": "string",
+            "description": "Avatar URL or attachment URI for the user."
           },
           "bio": {
-            "type": "string"
+            "type": "string",
+            "description": "User biography shown on profile surfaces."
           },
           "disabled": {
-            "type": "boolean"
+            "type": "boolean",
+            "description": "Whether the user account is disabled."
           },
           "displayName": {
-            "type": "string"
+            "type": "string",
+            "description": "Display name shown for the user."
           },
           "email": {
-            "type": "string"
+            "type": "string",
+            "description": "Email address used for sign-in and notifications."
           },
           "emailVerified": {
-            "type": "boolean"
+            "type": "boolean",
+            "description": "Whether the email address has been verified."
           },
           "loginHistoryLimit": {
             "type": "integer",
+            "description": "Maximum number of login history entries retained for this user.",
             "format": "int32"
           },
           "password": {
-            "type": "string"
+            "type": "string",
+            "description": "Password hash or encoded password value."
           },
           "phone": {
-            "type": "string"
+            "type": "string",
+            "description": "Phone number associated with the user."
           },
           "registeredAt": {
             "type": "string",
+            "description": "Time when the user registered.",
             "format": "date-time"
           },
           "totpEncryptedSecret": {
-            "type": "string"
+            "type": "string",
+            "description": "Encrypted TOTP secret used for two-factor authentication."
           },
           "twoFactorAuthEnabled": {
-            "type": "boolean"
+            "type": "boolean",
+            "description": "Whether two-factor authentication is enabled for this user."
           }
-        }
+        },
+        "description": "Desired user profile and authentication settings."
       },
       "UserStatus": {
         "type": "object",
         "properties": {
           "permalink": {
-            "type": "string"
+            "type": "string",
+            "description": "Public permalink of the user\u0027s profile or author page."
           }
-        }
+        },
+        "description": "Observed user state derived by the application."
       },
       "VerifyCodeRequest": {
         "required": [

--- a/api-docs/openapi/v3_0/apis_extension.api_v1alpha1.json
+++ b/api-docs/openapi/v3_0/apis_extension.api_v1alpha1.json
@@ -9072,7 +9072,8 @@
           "spec": {
             "$ref": "#/components/schemas/AnnotationSettingSpec"
           }
-        }
+        },
+        "description": "Annotation setting extension that defines dynamic annotation forms for a target extension kind."
       },
       "AnnotationSettingList": {
         "required": [
@@ -9143,6 +9144,7 @@
           "formSchema": {
             "minLength": 1,
             "type": "array",
+            "description": "FormKit-compatible schema used to render annotation fields.",
             "items": {
               "minLength": 1,
               "type": "object"
@@ -9151,7 +9153,8 @@
           "targetRef": {
             "$ref": "#/components/schemas/GroupKind"
           }
-        }
+        },
+        "description": "Desired annotation form configuration for a target resource kind."
       },
       "Attachment": {
         "required": [
@@ -9177,7 +9180,8 @@
           "status": {
             "$ref": "#/components/schemas/AttachmentStatus"
           }
-        }
+        },
+        "description": "Attachment extension that describes an uploaded file and its resolved access URLs."
       },
       "AttachmentList": {
         "required": [
@@ -9243,55 +9247,57 @@
         "properties": {
           "displayName": {
             "type": "string",
-            "description": "Display name of attachment"
+            "description": "Display name shown for the attachment."
           },
           "groupName": {
             "type": "string",
-            "description": "Group name"
+            "description": "Attachment group metadata.name this attachment belongs to."
           },
           "mediaType": {
             "type": "string",
-            "description": "Media type of attachment"
+            "description": "Media type detected or supplied for the attachment, such as image/png."
           },
           "ownerName": {
             "type": "string",
-            "description": "Name of User who uploads the attachment"
+            "description": "User metadata.name of the uploader."
           },
           "policyName": {
             "type": "string",
-            "description": "Policy name"
+            "description": "Storage policy metadata.name used to store this attachment."
           },
           "size": {
             "minimum": 0,
             "type": "integer",
-            "description": "Size of attachment. Unit is Byte",
+            "description": "Size of the attachment in bytes.",
             "format": "int64"
           },
           "tags": {
             "uniqueItems": true,
             "type": "array",
-            "description": "Tags of attachment",
+            "description": "Free-form tags assigned to the attachment.",
             "items": {
-              "type": "string",
-              "description": "Tag name"
+              "type": "string"
             }
           }
-        }
+        },
+        "description": "Desired attachment metadata and storage placement."
       },
       "AttachmentStatus": {
         "type": "object",
         "properties": {
           "permalink": {
             "type": "string",
-            "description": "Permalink of attachment.\nIf it is in local storage, the public URL will be set.\nIf it is in s3 storage, the Object URL will be set.\n"
+            "description": "Public permalink for the attachment. Local storage usually exposes a public URL, while object storage may\n expose the object URL."
           },
           "thumbnails": {
             "type": "object",
             "additionalProperties": {
               "type": "string"
-            }
+            },
+            "description": "Generated thumbnail URLs keyed by thumbnail size name."
           }
-        }
+        },
+        "description": "Observed attachment access state."
       },
       "AuthProvider": {
         "required": [
@@ -9315,7 +9321,7 @@
             "$ref": "#/components/schemas/AuthProviderSpec"
           }
         },
-        "description": "Auth provider extension."
+        "description": "Authentication provider extension that describes an external or form-based sign-in integration."
       },
       "AuthProviderList": {
         "required": [
@@ -9394,43 +9400,52 @@
           },
           "authenticationUrl": {
             "type": "string",
-            "description": "Authentication url of the auth provider"
+            "description": "URL that starts the authentication flow."
           },
           "bindingUrl": {
-            "type": "string"
+            "type": "string",
+            "description": "URL that starts account binding for an already signed-in user."
           },
           "configMapRef": {
             "$ref": "#/components/schemas/ConfigMapRef"
           },
           "description": {
-            "type": "string"
+            "type": "string",
+            "description": "Human-readable description of the provider."
           },
           "displayName": {
             "type": "string",
-            "description": "Display name of the auth provider"
+            "description": "Display name shown on sign-in and account binding screens."
           },
           "helpPage": {
-            "type": "string"
+            "type": "string",
+            "description": "Help page URL for users who need sign-in assistance."
           },
           "logo": {
-            "type": "string"
+            "type": "string",
+            "description": "Logo URL or attachment URI for the provider."
           },
           "method": {
-            "type": "string"
+            "type": "string",
+            "description": "HTTP method used when starting the authentication flow."
           },
           "rememberMeSupport": {
-            "type": "boolean"
+            "type": "boolean",
+            "description": "Whether the provider supports remember-me during sign-in."
           },
           "settingRef": {
             "$ref": "#/components/schemas/SettingRef"
           },
           "unbindUrl": {
-            "type": "string"
+            "type": "string",
+            "description": "URL that unbinds the external account from the current user."
           },
           "website": {
-            "type": "string"
+            "type": "string",
+            "description": "Provider website URL."
           }
-        }
+        },
+        "description": "Authentication provider metadata and endpoint configuration."
       },
       "Author": {
         "required": [
@@ -9440,12 +9455,15 @@
         "properties": {
           "name": {
             "minLength": 1,
-            "type": "string"
+            "type": "string",
+            "description": "Author display name."
           },
           "website": {
-            "type": "string"
+            "type": "string",
+            "description": "Author website URL."
           }
-        }
+        },
+        "description": "Theme author metadata."
       },
       "Backup": {
         "required": [
@@ -9470,7 +9488,8 @@
           "status": {
             "$ref": "#/components/schemas/BackupStatus"
           }
-        }
+        },
+        "description": "Backup metadata and runtime state for an exported Halo data package."
       },
       "BackupList": {
         "required": [
@@ -9536,33 +9555,39 @@
         "properties": {
           "expiresAt": {
             "type": "string",
+            "description": "Time after which the generated backup should be considered expired.",
             "format": "date-time"
           },
           "format": {
             "type": "string",
-            "description": "Backup file format. Currently, only zip format is supported."
+            "description": "Backup file format. Currently, only zip is supported."
           }
-        }
+        },
+        "description": "Desired backup options."
       },
       "BackupStatus": {
         "type": "object",
         "properties": {
           "completionTimestamp": {
             "type": "string",
+            "description": "Time when backup execution finished, regardless of success or failure.",
             "format": "date-time"
           },
           "failureMessage": {
-            "type": "string"
+            "type": "string",
+            "description": "Human-readable failure message for a failed backup."
           },
           "failureReason": {
-            "type": "string"
+            "type": "string",
+            "description": "Stable failure reason code for a failed backup."
           },
           "filename": {
             "type": "string",
-            "description": "Name of backup file."
+            "description": "Name of the generated backup file."
           },
           "phase": {
             "type": "string",
+            "description": "Current backup execution phase.",
             "enum": [
               "PENDING",
               "RUNNING",
@@ -9572,14 +9597,16 @@
           },
           "size": {
             "type": "integer",
-            "description": "Size of backup file. Data unit: byte",
+            "description": "Size of the generated backup file in bytes.",
             "format": "int64"
           },
           "startTimestamp": {
             "type": "string",
+            "description": "Time when backup execution started.",
             "format": "date-time"
           }
-        }
+        },
+        "description": "Observed backup execution state."
       },
       "Category": {
         "required": [
@@ -9725,7 +9752,7 @@
             "description": "Theme template used to render the category archive page."
           }
         },
-        "description": "Desired display, hierarchy, and rendering configuration of a category."
+        "description": "Desired category display, hierarchy, and rendering configuration."
       },
       "CategoryStatus": {
         "type": "object",
@@ -9745,7 +9772,7 @@
             "format": "int32"
           }
         },
-        "description": "Observed state of a category."
+        "description": "Observed category state derived by content reconcilers."
       },
       "Comment": {
         "required": [
@@ -9979,7 +10006,7 @@
             "format": "int32"
           }
         },
-        "description": "Observed state of a comment."
+        "description": "Observed state of a top-level comment."
       },
       "Condition": {
         "required": [
@@ -10038,7 +10065,8 @@
             "type": "object",
             "additionalProperties": {
               "type": "string"
-            }
+            },
+            "description": "String key-value configuration entries consumed by Halo or plugins."
           },
           "kind": {
             "type": "string"
@@ -10116,9 +10144,11 @@
         "properties": {
           "name": {
             "minLength": 1,
-            "type": "string"
+            "type": "string",
+            "description": "ConfigMap metadata.name."
           }
-        }
+        },
+        "description": "Reference to a ConfigMap used by this provider."
       },
       "CopyOperation": {
         "required": [
@@ -10161,10 +10191,12 @@
           },
           "approvedComment": {
             "type": "integer",
+            "description": "Number of approved comments recorded for the resource.",
             "format": "int32"
           },
           "downvote": {
             "type": "integer",
+            "description": "Number of downvotes recorded for the resource.",
             "format": "int32"
           },
           "kind": {
@@ -10175,18 +10207,21 @@
           },
           "totalComment": {
             "type": "integer",
+            "description": "Total number of comments recorded for the resource.",
             "format": "int32"
           },
           "upvote": {
             "type": "integer",
+            "description": "Number of upvotes recorded for the resource.",
             "format": "int32"
           },
           "visit": {
             "type": "integer",
+            "description": "Number of visits recorded for the resource.",
             "format": "int32"
           }
         },
-        "description": "A counter for number of requests by extension resource name."
+        "description": "Counter extension that stores aggregate interaction counts for a resource."
       },
       "CounterList": {
         "required": [
@@ -10252,23 +10287,27 @@
         "properties": {
           "category": {
             "type": "array",
+            "description": "Custom templates available for categories.",
             "items": {
               "$ref": "#/components/schemas/TemplateDescriptor"
             }
           },
           "page": {
             "type": "array",
+            "description": "Custom templates available for single pages.",
             "items": {
               "$ref": "#/components/schemas/TemplateDescriptor"
             }
           },
           "post": {
             "type": "array",
+            "description": "Custom templates available for posts.",
             "items": {
               "$ref": "#/components/schemas/TemplateDescriptor"
             }
           }
-        }
+        },
+        "description": "Custom template descriptors grouped by the content type they render."
       },
       "Device": {
         "required": [
@@ -10295,7 +10334,8 @@
           "status": {
             "$ref": "#/components/schemas/DeviceStatus"
           }
-        }
+        },
+        "description": "Device extension that records an authenticated browser session for account security visibility."
       },
       "DeviceList": {
         "required": [
@@ -10366,43 +10406,54 @@
         "properties": {
           "ipAddress": {
             "maxLength": 129,
-            "type": "string"
+            "type": "string",
+            "description": "Client IP address observed for the session."
           },
           "lastAccessedTime": {
             "type": "string",
+            "description": "Last time this session accessed Halo.",
             "format": "date-time"
           },
           "lastAuthenticatedTime": {
             "type": "string",
+            "description": "Last time the user authenticated for this session.",
             "format": "date-time"
           },
           "principalName": {
             "minLength": 1,
-            "type": "string"
+            "type": "string",
+            "description": "Principal name of the authenticated user."
           },
           "rememberMeSeriesId": {
-            "type": "string"
+            "type": "string",
+            "description": "Remember-me series id associated with the session, if any."
           },
           "sessionId": {
             "minLength": 1,
-            "type": "string"
+            "type": "string",
+            "description": "Web session identifier associated with the device."
           },
           "userAgent": {
             "maxLength": 500,
-            "type": "string"
+            "type": "string",
+            "description": "Client user-agent header captured for the session."
           }
-        }
+        },
+        "description": "Session identity and request metadata captured for a device."
       },
       "DeviceStatus": {
         "type": "object",
         "properties": {
           "browser": {
-            "type": "string"
+            "type": "string",
+            "description": "Browser name parsed from the user agent."
           },
           "os": {
-            "type": "string"
+            "type": "string",
+            "description": "Operating system name parsed from the user agent."
           }
-        }
+        },
+        "description": "Parsed browser and operating system details for display."
       },
       "Excerpt": {
         "required": [
@@ -10420,7 +10471,7 @@
             "description": "Manual excerpt text used when autoGenerate is false."
           }
         },
-        "description": "Excerpt generation configuration."
+        "description": "Excerpt generation configuration for a post or single page."
       },
       "ExtensionDefinition": {
         "required": [
@@ -10444,7 +10495,7 @@
             "$ref": "#/components/schemas/ExtensionSpec"
           }
         },
-        "description": "Extension definition. An {@link ExtensionDefinition ExtensionDefinition} is a type of metadata that provides additional information about\n an extension. An extension is a way to add new functionality to an existing class, structure, enumeration, or\n protocol type without needing to subclass it."
+        "description": "Extension definition that describes one plugin-provided implementation of an extension point."
       },
       "ExtensionDefinitionList": {
         "required": [
@@ -10527,7 +10578,7 @@
             "$ref": "#/components/schemas/ExtensionPointSpec"
           }
         },
-        "description": "Extension point definition. An {@link ExtensionPointDefinition ExtensionPointDefinition} is a concept used in \u003ccode\u003eHalo\u003c/code\u003e to allow for\n the dynamic extension of system. It defines a location within \u003ccode\u003eHalo\u003c/code\u003e where additional functionality can be\n added through the use of plugins or extensions."
+        "description": "Extension point definition that advertises where plugins can contribute implementations."
       },
       "ExtensionPointDefinitionList": {
         "required": [
@@ -10597,25 +10648,31 @@
         "type": "object",
         "properties": {
           "className": {
-            "type": "string"
+            "type": "string",
+            "description": "Fully qualified Java class name of the extension point interface."
           },
           "description": {
-            "type": "string"
+            "type": "string",
+            "description": "Human-readable description of what this extension point allows plugins to provide."
           },
           "displayName": {
-            "type": "string"
+            "type": "string",
+            "description": "Display name shown for the extension point."
           },
           "icon": {
-            "type": "string"
+            "type": "string",
+            "description": "Icon URL, class, or identifier shown for the extension point."
           },
           "type": {
             "type": "string",
+            "description": "Registration mode used when loading implementations for this extension point.",
             "enum": [
               "SINGLETON",
               "MULTI_INSTANCE"
             ]
           }
-        }
+        },
+        "description": "Desired extension point metadata."
       },
       "ExtensionSpec": {
         "required": [
@@ -10626,21 +10683,27 @@
         "type": "object",
         "properties": {
           "className": {
-            "type": "string"
+            "type": "string",
+            "description": "Fully qualified Java class name of the implementation."
           },
           "description": {
-            "type": "string"
+            "type": "string",
+            "description": "Human-readable description of what this implementation does."
           },
           "displayName": {
-            "type": "string"
+            "type": "string",
+            "description": "Display name shown for the implementation."
           },
           "extensionPointName": {
-            "type": "string"
+            "type": "string",
+            "description": "ExtensionPointDefinition metadata.name this implementation contributes to."
           },
           "icon": {
-            "type": "string"
+            "type": "string",
+            "description": "Icon URL, class, or identifier shown for the implementation."
           }
-        }
+        },
+        "description": "Desired plugin-provided extension implementation metadata."
       },
       "FileReverseProxyProvider": {
         "type": "object",
@@ -10651,7 +10714,8 @@
           "filename": {
             "type": "string"
           }
-        }
+        },
+        "description": "File provider that resolves a request to a plugin or theme file location."
       },
       "Group": {
         "required": [
@@ -10677,7 +10741,8 @@
           "status": {
             "$ref": "#/components/schemas/GroupStatus"
           }
-        }
+        },
+        "description": "Attachment group extension used to organize attachments and expose aggregate counts."
       },
       "GroupKind": {
         "type": "object",
@@ -10760,9 +10825,10 @@
         "properties": {
           "displayName": {
             "type": "string",
-            "description": "Display name of group"
+            "description": "Display name shown for the attachment group."
           }
-        }
+        },
+        "description": "Desired attachment group metadata."
       },
       "GroupStatus": {
         "type": "object",
@@ -10770,15 +10836,16 @@
           "totalAttachments": {
             "minimum": 0,
             "type": "integer",
-            "description": "Total of attachments under the current group",
+            "description": "Total number of attachments under the group.",
             "format": "int64"
           },
           "updateTimestamp": {
             "type": "string",
-            "description": "Update timestamp of the group",
+            "description": "Last time the group aggregate state was updated.",
             "format": "date-time"
           }
-        }
+        },
+        "description": "Observed attachment group aggregate state."
       },
       "InterestReason": {
         "required": [
@@ -10789,17 +10856,17 @@
         "properties": {
           "expression": {
             "type": "string",
-            "description": "The expression to be interested in"
+            "description": "Optional expression used to match reasons more flexibly than subject matching."
           },
           "reasonType": {
             "type": "string",
-            "description": "The name of the reason definition to be interested in"
+            "description": "ReasonType metadata.name this subscription is interested in."
           },
           "subject": {
             "$ref": "#/components/schemas/InterestReasonSubject"
           }
         },
-        "description": "The reason to be interested in"
+        "description": "Reason selector that decides which notifications match this subscription."
       },
       "InterestReasonSubject": {
         "required": [
@@ -10810,18 +10877,20 @@
         "properties": {
           "apiVersion": {
             "minLength": 1,
-            "type": "string"
+            "type": "string",
+            "description": "Subject API version."
           },
           "kind": {
             "minLength": 1,
-            "type": "string"
+            "type": "string",
+            "description": "Subject kind."
           },
           "name": {
             "type": "string",
-            "description": "if name is not specified, it presents all subjects of the specified reason type and custom resources"
+            "description": "Subject metadata.name. If omitted, all subjects of the selected kind and API version are matched."
           }
         },
-        "description": "The subject name of reason type to be interested in"
+        "description": "Subject selector used by a subscription interest reason."
       },
       "JsonPatch": {
         "minItems": 1,
@@ -10884,7 +10953,8 @@
           "spec": {
             "$ref": "#/components/schemas/MenuSpec"
           }
-        }
+        },
+        "description": "Menu extension that groups ordered menu items for theme navigation."
       },
       "MenuItem": {
         "required": [
@@ -10910,7 +10980,8 @@
           "status": {
             "$ref": "#/components/schemas/MenuItemStatus"
           }
-        }
+        },
+        "description": "Menu item extension that describes a navigable item and its resolved rendering state."
       },
       "MenuItemList": {
         "required": [
@@ -10977,28 +11048,27 @@
           "children": {
             "uniqueItems": true,
             "type": "array",
-            "description": "Children of this menu item",
+            "description": "Child MenuItem metadata.name values shown under this item.",
             "items": {
-              "type": "string",
-              "description": "The name of menu item child"
+              "type": "string"
             }
           },
           "displayName": {
             "type": "string",
-            "description": "The display name of menu item."
+            "description": "Display name shown for the menu item."
           },
           "href": {
             "type": "string",
-            "description": "The href of this menu item."
+            "description": "Direct URL used by the menu item."
           },
           "priority": {
             "type": "integer",
-            "description": "The priority is for ordering.",
+            "description": "Sorting priority. Higher values sort before lower values where priority ordering is applied.",
             "format": "int32"
           },
           "target": {
             "type": "string",
-            "description": "The \u003ca\u003e target attribute of this menu item.",
+            "description": "HTML anchor target used by the menu item.",
             "enum": [
               "_blank",
               "_self",
@@ -11010,21 +11080,21 @@
             "$ref": "#/components/schemas/Ref"
           }
         },
-        "description": "The spec of menu item."
+        "description": "Desired menu item configuration."
       },
       "MenuItemStatus": {
         "type": "object",
         "properties": {
           "displayName": {
             "type": "string",
-            "description": "Calculated Display name of menu item."
+            "description": "Calculated display name after resolving targetRef, falling back to spec.displayName."
           },
           "href": {
             "type": "string",
-            "description": "Calculated href of manu item."
+            "description": "Calculated href after resolving targetRef, falling back to spec.href."
           }
         },
-        "description": "The status of menu item."
+        "description": "Resolved menu item values used for rendering."
       },
       "MenuList": {
         "required": [
@@ -11093,19 +11163,18 @@
         "properties": {
           "displayName": {
             "type": "string",
-            "description": "The display name of the menu."
+            "description": "Display name shown for the menu."
           },
           "menuItems": {
             "uniqueItems": true,
             "type": "array",
-            "description": "Menu items of this menu.",
+            "description": "Ordered MenuItem metadata.name values included in this menu.",
             "items": {
-              "type": "string",
-              "description": "Name of menu item."
+              "type": "string"
             }
           }
         },
-        "description": "The spec of menu."
+        "description": "Desired menu configuration."
       },
       "Metadata": {
         "required": [
@@ -11214,7 +11283,7 @@
             "$ref": "#/components/schemas/NotificationSpec"
           }
         },
-        "description": "{@link Notification Notification} is a custom extension that used to store notification information for inner use, it\u0027s on-site\n notification.\n\n \u003cp\u003eSupports the following operations:\n\n \u003cul\u003e\n   \u003cli\u003eMarked as read: {@link NotificationSpec#setUnread(boolean) NotificationSpec#setUnread(boolean)}\n   \u003cli\u003eGet the last read time: {@link NotificationSpec#getLastReadAt NotificationSpec#getLastReadAt()}\n   \u003cli\u003eFilter by recipient: {@link NotificationSpec#getRecipient NotificationSpec#getRecipient()}\n \u003c/ul\u003e"
+        "description": "Notification extension that stores an on-site notification delivered to a Halo user.\n\n \u003cp\u003eSupports the following operations:\n\n \u003cul\u003e\n   \u003cli\u003eMarked as read: {@link NotificationSpec#setUnread(boolean) NotificationSpec#setUnread(boolean)}\n   \u003cli\u003eGet the last read time: {@link NotificationSpec#getLastReadAt NotificationSpec#getLastReadAt()}\n   \u003cli\u003eFilter by recipient: {@link NotificationSpec#getRecipient NotificationSpec#getRecipient()}\n \u003c/ul\u003e"
       },
       "NotificationList": {
         "required": [
@@ -11286,33 +11355,39 @@
         "type": "object",
         "properties": {
           "htmlContent": {
-            "type": "string"
+            "type": "string",
+            "description": "HTML notification content."
           },
           "lastReadAt": {
             "type": "string",
+            "description": "Last time the recipient marked this notification as read.",
             "format": "date-time"
           },
           "rawContent": {
-            "type": "string"
+            "type": "string",
+            "description": "Plain text or source notification content."
           },
           "reason": {
             "minLength": 1,
             "type": "string",
-            "description": "The name of reason"
+            "description": "Reason metadata.name that generated this notification."
           },
           "recipient": {
             "minLength": 1,
             "type": "string",
-            "description": "The name of user"
+            "description": "User metadata.name that receives the notification."
           },
           "title": {
             "minLength": 1,
-            "type": "string"
+            "type": "string",
+            "description": "Notification title shown in the notification center."
           },
           "unread": {
-            "type": "boolean"
+            "type": "boolean",
+            "description": "Whether the recipient has not read the notification yet."
           }
-        }
+        },
+        "description": "Notification content and read state for one recipient."
       },
       "NotificationTemplate": {
         "required": [
@@ -11335,7 +11410,7 @@
             "$ref": "#/components/schemas/NotificationTemplateSpec"
           }
         },
-        "description": "{@link NotificationTemplate NotificationTemplate} is a custom extension that defines a notification template.\n\n \u003cp\u003eIt describes the notification template\u0027s name, description, and the template content.\n\n \u003cp\u003e{@link Spec#getReasonSelector Spec#getReasonSelector()} is used to select the template by reasonType and language, if multiple templates\n are matched, the best match will be selected. This is useful when you want to override the default template."
+        "description": "Notification template extension that defines localized message content for matching reason types.\n\n \u003cp\u003eIt describes the notification template\u0027s name, description, and the template content.\n\n \u003cp\u003e{@link Spec#getReasonSelector Spec#getReasonSelector()} is used to select the template by reasonType and language, if multiple templates\n are matched, the best match will be selected. This is useful when you want to override the default template."
       },
       "NotificationTemplateList": {
         "required": [
@@ -11405,7 +11480,8 @@
           "template": {
             "$ref": "#/components/schemas/TemplateContent"
           }
-        }
+        },
+        "description": "Desired notification template selector and content."
       },
       "NotifierDescriptor": {
         "required": [
@@ -11428,7 +11504,7 @@
             "$ref": "#/components/schemas/NotifierDescriptorSpec"
           }
         },
-        "description": "{@link NotifierDescriptor NotifierDescriptor} is a custom extension that defines a notifier.\n\n \u003cp\u003eIt describes the notifier\u0027s name, description, and the extension name of the notifier to let the user know what\n the notifier is and what it can do in the UI and also let the \u003ccode\u003eNotificationCenter\u003c/code\u003e know how to load the\n notifier and prepare the notifier\u0027s settings."
+        "description": "Notifier descriptor extension that advertises a notification delivery implementation and its settings.\n\n \u003cp\u003eIt describes the notifier\u0027s name, description, and the extension name of the notifier to let the user know what\n the notifier is and what it can do in the UI and also let the \u003ccode\u003eNotificationCenter\u003c/code\u003e know how to load the\n notifier and prepare the notifier\u0027s settings."
       },
       "NotifierDescriptorList": {
         "required": [
@@ -11497,15 +11573,18 @@
         "type": "object",
         "properties": {
           "description": {
-            "type": "string"
+            "type": "string",
+            "description": "Human-readable description of what the notifier sends."
           },
           "displayName": {
             "minLength": 1,
-            "type": "string"
+            "type": "string",
+            "description": "Display name shown for the notifier."
           },
           "notifierExtName": {
             "minLength": 1,
-            "type": "string"
+            "type": "string",
+            "description": "Extension name of the notifier implementation."
           },
           "receiverSettingRef": {
             "$ref": "#/components/schemas/NotifierSettingRef"
@@ -11513,7 +11592,8 @@
           "senderSettingRef": {
             "$ref": "#/components/schemas/NotifierSettingRef"
           }
-        }
+        },
+        "description": "Desired notifier descriptor metadata and configuration references."
       },
       "NotifierSettingRef": {
         "required": [
@@ -11523,12 +11603,15 @@
         "type": "object",
         "properties": {
           "group": {
-            "type": "string"
+            "type": "string",
+            "description": "Setting form group name."
           },
           "name": {
-            "type": "string"
+            "type": "string",
+            "description": "Setting metadata.name."
           }
-        }
+        },
+        "description": "Reference to a notifier setting form group."
       },
       "PatSpec": {
         "required": [
@@ -11539,45 +11622,56 @@
         "type": "object",
         "properties": {
           "description": {
-            "type": "string"
+            "type": "string",
+            "description": "Optional human-readable description of how the token is used."
           },
           "expiresAt": {
             "type": "string",
+            "description": "Time when the token expires. A null value means the token does not expire by time.",
             "format": "date-time"
           },
           "lastUsed": {
             "type": "string",
+            "description": "Last time the token was used successfully.",
             "format": "date-time"
           },
           "name": {
-            "type": "string"
+            "type": "string",
+            "description": "Display name chosen by the token owner."
           },
           "revoked": {
-            "type": "boolean"
+            "type": "boolean",
+            "description": "Whether the token has been manually revoked."
           },
           "revokesAt": {
             "type": "string",
+            "description": "Time when the token was revoked.",
             "format": "date-time"
           },
           "roles": {
             "type": "array",
+            "description": "Role names granted to this token.",
             "items": {
               "type": "string"
             }
           },
           "scopes": {
             "type": "array",
+            "description": "Scope strings granted to this token.",
             "items": {
               "type": "string"
             }
           },
           "tokenId": {
-            "type": "string"
+            "type": "string",
+            "description": "Stable token identifier stored separately from the secret token value."
           },
           "username": {
-            "type": "string"
+            "type": "string",
+            "description": "User metadata.name that owns this token."
           }
-        }
+        },
+        "description": "Desired personal access token settings and lifecycle flags."
       },
       "PersonalAccessToken": {
         "required": [
@@ -11599,7 +11693,8 @@
           "spec": {
             "$ref": "#/components/schemas/PatSpec"
           }
-        }
+        },
+        "description": "Personal access token extension used for non-interactive API authentication on behalf of a Halo user."
       },
       "PersonalAccessTokenList": {
         "required": [
@@ -11685,7 +11780,7 @@
             "$ref": "#/components/schemas/PluginStatus"
           }
         },
-        "description": "A custom resource for Plugin."
+        "description": "Plugin extension that describes an installed plugin and its runtime lifecycle state."
       },
       "PluginAuthor": {
         "required": [
@@ -11695,12 +11790,15 @@
         "properties": {
           "name": {
             "minLength": 1,
-            "type": "string"
+            "type": "string",
+            "description": "Author display name."
           },
           "website": {
-            "type": "string"
+            "type": "string",
+            "description": "Author website URL."
           }
-        }
+        },
+        "description": "Plugin author metadata."
       },
       "PluginList": {
         "required": [
@@ -11771,54 +11869,66 @@
             "$ref": "#/components/schemas/PluginAuthor"
           },
           "configMapName": {
-            "type": "string"
+            "type": "string",
+            "description": "ConfigMap metadata.name storing plugin configuration values."
           },
           "description": {
-            "type": "string"
+            "type": "string",
+            "description": "Human-readable plugin description."
           },
           "displayName": {
-            "type": "string"
+            "type": "string",
+            "description": "Display name shown for the plugin."
           },
           "enabled": {
-            "type": "boolean"
+            "type": "boolean",
+            "description": "Whether the plugin should be enabled."
           },
           "homepage": {
-            "type": "string"
+            "type": "string",
+            "description": "Plugin homepage URL."
           },
           "issues": {
-            "type": "string"
+            "type": "string",
+            "description": "Issue tracker URL."
           },
           "license": {
             "type": "array",
+            "description": "Licenses declared by the plugin.",
             "items": {
               "$ref": "#/components/schemas/License"
             }
           },
           "logo": {
-            "type": "string"
+            "type": "string",
+            "description": "Logo URL or attachment URI for the plugin."
           },
           "pluginDependencies": {
             "type": "object",
             "additionalProperties": {
               "type": "string"
-            }
+            },
+            "description": "Required plugin dependencies keyed by plugin name with version constraints as values."
           },
           "repo": {
-            "type": "string"
+            "type": "string",
+            "description": "Source repository URL."
           },
           "requires": {
             "type": "string",
             "description": "SemVer format."
           },
           "settingName": {
-            "type": "string"
+            "type": "string",
+            "description": "Setting metadata.name used to render the plugin configuration form."
           },
           "version": {
             "pattern": "^(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)(?:-((?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\\.(?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?$",
             "type": "string",
             "description": "plugin version."
           }
-        }
+        },
+        "description": "Desired plugin metadata and configuration references."
       },
       "PluginStatus": {
         "type": "object",
@@ -11830,15 +11940,18 @@
                 "type": "boolean"
               }
             },
+            "description": "Reconciliation conditions for the plugin.",
             "items": {
               "$ref": "#/components/schemas/Condition"
             }
           },
           "entry": {
-            "type": "string"
+            "type": "string",
+            "description": "JavaScript bundle entry path served for the plugin UI."
           },
           "lastProbeState": {
             "type": "string",
+            "description": "Last PF4J probe state observed for the plugin.",
             "enum": [
               "CREATED",
               "DISABLED",
@@ -11851,18 +11964,21 @@
           },
           "lastStartTime": {
             "type": "string",
+            "description": "Last time the plugin started successfully.",
             "format": "date-time"
           },
           "loadLocation": {
             "type": "string",
-            "description": "Load location of the plugin, often a path.",
+            "description": "URI location where the plugin artifact was loaded from.",
             "format": "uri"
           },
           "logo": {
-            "type": "string"
+            "type": "string",
+            "description": "Resolved logo URL or attachment URI for the plugin."
           },
           "phase": {
             "type": "string",
+            "description": "Current plugin lifecycle phase.",
             "enum": [
               "PENDING",
               "STARTING",
@@ -11877,9 +11993,11 @@
             ]
           },
           "stylesheet": {
-            "type": "string"
+            "type": "string",
+            "description": "Stylesheet bundle path served for the plugin UI."
           }
-        }
+        },
+        "description": "Observed plugin lifecycle and runtime asset state."
       },
       "Policy": {
         "required": [
@@ -11902,7 +12020,8 @@
           "spec": {
             "$ref": "#/components/schemas/PolicySpec"
           }
-        }
+        },
+        "description": "Storage policy extension that binds attachment uploads to a policy template and configuration."
       },
       "PolicyList": {
         "required": [
@@ -11996,7 +12115,7 @@
           },
           "verbs": {
             "type": "array",
-            "description": "about who the rule applies to or which namespace the rule applies to.",
+            "description": "Verbs allowed by this rule, such as get, list, create, update, patch, or delete.",
             "items": {
               "type": "string"
             }
@@ -12013,17 +12132,18 @@
         "properties": {
           "configMapName": {
             "type": "string",
-            "description": "Reference name of ConfigMap extension"
+            "description": "ConfigMap metadata.name storing configuration values for this policy."
           },
           "displayName": {
             "type": "string",
-            "description": "Display name of policy"
+            "description": "Display name shown for the storage policy."
           },
           "templateName": {
             "type": "string",
-            "description": "Reference name of PolicyTemplate"
+            "description": "PolicyTemplate metadata.name that provides the storage implementation."
           }
-        }
+        },
+        "description": "Desired storage policy configuration."
       },
       "PolicyTemplate": {
         "required": [
@@ -12045,7 +12165,8 @@
           "spec": {
             "$ref": "#/components/schemas/PolicyTemplateSpec"
           }
-        }
+        },
+        "description": "Storage policy template extension that declares an attachment storage implementation and its settings form."
       },
       "PolicyTemplateList": {
         "required": [
@@ -12113,12 +12234,15 @@
         "type": "object",
         "properties": {
           "displayName": {
-            "type": "string"
+            "type": "string",
+            "description": "Display name shown for the storage policy template."
           },
           "settingName": {
-            "type": "string"
+            "type": "string",
+            "description": "Setting metadata.name used to render configuration fields for policies created from this template."
           }
-        }
+        },
+        "description": "Desired storage policy template metadata."
       },
       "Post": {
         "required": [
@@ -12145,7 +12269,7 @@
             "$ref": "#/components/schemas/PostStatus"
           }
         },
-        "description": "Post extension."
+        "description": "Post extension that stores article metadata, publication settings, taxonomy, and derived status."
       },
       "PostList": {
         "required": [
@@ -12322,7 +12446,7 @@
             ]
           }
         },
-        "description": "Desired content, publication, taxonomy, and rendering configuration of a post."
+        "description": "Desired post content, publication, taxonomy, and rendering configuration."
       },
       "PostStatus": {
         "type": "object",
@@ -12382,7 +12506,7 @@
             "description": "Current publishing phase, such as DRAFT, PENDING_APPROVAL, PUBLISHED, or FAILED."
           }
         },
-        "description": "Observed state of a content item."
+        "description": "Observed post state derived by content reconcilers."
       },
       "Reason": {
         "required": [
@@ -12405,7 +12529,7 @@
             "$ref": "#/components/schemas/ReasonSpec"
           }
         },
-        "description": "{@link Reason Reason} is a custom extension that defines a reason for a notification, It represents an instance of a\n {@link ReasonType ReasonType}.\n\n \u003cp\u003eIt can be understood as an event that triggers a notification."
+        "description": "Reason extension that represents one notification event instance of a {@link ReasonType ReasonType}.\n\n \u003cp\u003eIt can be understood as an event that triggers a notification."
       },
       "ReasonAttributes": {
         "type": "object",
@@ -12414,7 +12538,7 @@
             "type": "boolean"
           }
         },
-        "description": "Attributes used to transfer data"
+        "description": "{@link ReasonAttributes ReasonAttributes} is a map that stores the attributes of the reason."
       },
       "ReasonList": {
         "required": [
@@ -12483,21 +12607,26 @@
         "type": "object",
         "properties": {
           "description": {
-            "type": "string"
+            "type": "string",
+            "description": "Human-readable description of the attribute."
           },
           "name": {
             "minLength": 1,
-            "type": "string"
+            "type": "string",
+            "description": "Attribute name."
           },
           "optional": {
             "type": "boolean",
+            "description": "Whether the attribute may be absent from a reason.",
             "default": false
           },
           "type": {
             "minLength": 1,
-            "type": "string"
+            "type": "string",
+            "description": "Attribute value type, such as string, number, boolean, or object."
           }
-        }
+        },
+        "description": "Attribute definition for reasons of a reason type."
       },
       "ReasonSelector": {
         "required": [
@@ -12509,13 +12638,16 @@
           "language": {
             "minLength": 1,
             "type": "string",
+            "description": "Language tag this template applies to, or default for the fallback template.",
             "default": "default"
           },
           "reasonType": {
             "minLength": 1,
-            "type": "string"
+            "type": "string",
+            "description": "ReasonType metadata.name this template applies to."
           }
-        }
+        },
+        "description": "Selector used to match a notification template to a reason type and language."
       },
       "ReasonSpec": {
         "required": [
@@ -12529,15 +12661,18 @@
             "$ref": "#/components/schemas/ReasonAttributes"
           },
           "author": {
-            "type": "string"
+            "type": "string",
+            "description": "User metadata.name or system actor that created the reason."
           },
           "reasonType": {
-            "type": "string"
+            "type": "string",
+            "description": "ReasonType metadata.name that defines this reason."
           },
           "subject": {
             "$ref": "#/components/schemas/ReasonSubject"
           }
-        }
+        },
+        "description": "Notification reason data used to render and dispatch notifications."
       },
       "ReasonSubject": {
         "required": [
@@ -12549,21 +12684,27 @@
         "type": "object",
         "properties": {
           "apiVersion": {
-            "type": "string"
+            "type": "string",
+            "description": "Subject API version."
           },
           "kind": {
-            "type": "string"
+            "type": "string",
+            "description": "Subject kind."
           },
           "name": {
-            "type": "string"
+            "type": "string",
+            "description": "Subject metadata.name."
           },
           "title": {
-            "type": "string"
+            "type": "string",
+            "description": "Human-readable subject title shown in notifications."
           },
           "url": {
-            "type": "string"
+            "type": "string",
+            "description": "URL that opens the subject."
           }
-        }
+        },
+        "description": "Resource subject associated with a notification reason."
       },
       "ReasonType": {
         "required": [
@@ -12586,7 +12727,7 @@
             "$ref": "#/components/schemas/ReasonTypeSpec"
           }
         },
-        "description": "{@link ReasonType ReasonType} is a custom extension that defines a type of reason.\n\n \u003cp\u003eOne {@link ReasonType ReasonType} can have multiple {@link Reason Reason}s to notify."
+        "description": "Reason type extension that defines the schema and display metadata for notification reasons.\n\n \u003cp\u003eOne {@link ReasonType ReasonType} can have multiple {@link Reason Reason}s to notify."
       },
       "ReasonTypeList": {
         "required": [
@@ -12656,19 +12797,23 @@
         "properties": {
           "description": {
             "minLength": 1,
-            "type": "string"
+            "type": "string",
+            "description": "Human-readable description of when this reason type is triggered."
           },
           "displayName": {
             "minLength": 1,
-            "type": "string"
+            "type": "string",
+            "description": "Display name shown for this reason type."
           },
           "properties": {
             "type": "array",
+            "description": "Attribute definitions available on reasons of this type.",
             "items": {
               "$ref": "#/components/schemas/ReasonProperty"
             }
           }
-        }
+        },
+        "description": "Desired reason type metadata and properties available to templates."
       },
       "Ref": {
         "required": [
@@ -12718,7 +12863,8 @@
           "spec": {
             "$ref": "#/components/schemas/RememberMeTokenSpec"
           }
-        }
+        },
+        "description": "Persistent remember-me token used to keep a user\u0027s browser session signed in across restarts."
       },
       "RememberMeTokenList": {
         "required": [
@@ -12789,6 +12935,7 @@
         "properties": {
           "lastUsed": {
             "type": "string",
+            "description": "Last time this remember-me token was used successfully.",
             "format": "date-time"
           },
           "previousTokenValue": {
@@ -12797,17 +12944,21 @@
           },
           "series": {
             "minLength": 1,
-            "type": "string"
+            "type": "string",
+            "description": "Browser series identifier used by Spring Security remember-me authentication."
           },
           "tokenValue": {
             "minLength": 1,
-            "type": "string"
+            "type": "string",
+            "description": "Current remember-me token value expected from the browser cookie."
           },
           "username": {
             "minLength": 1,
-            "type": "string"
+            "type": "string",
+            "description": "User metadata.name that owns this remember-me token."
           }
-        }
+        },
+        "description": "Persistent remember-me token values for a user and browser series."
       },
       "RemoveOperation": {
         "required": [
@@ -13055,6 +13206,7 @@
           },
           "rules": {
             "type": "array",
+            "description": "Path mapping rules served by this reverse proxy resource.",
             "items": {
               "$ref": "#/components/schemas/ReverseProxyRule"
             }
@@ -13130,7 +13282,8 @@
           "path": {
             "type": "string"
           }
-        }
+        },
+        "description": "A path mapping from a public request path to a file provider."
       },
       "Role": {
         "required": [
@@ -13152,11 +13305,13 @@
           },
           "rules": {
             "type": "array",
+            "description": "Policy rules granted by this role.",
             "items": {
               "$ref": "#/components/schemas/PolicyRule"
             }
           }
-        }
+        },
+        "description": "Role extension that defines RBAC policy rules for users and other subjects."
       },
       "RoleBinding": {
         "required": [
@@ -13180,13 +13335,13 @@
           },
           "subjects": {
             "type": "array",
-            "description": "Subjects holds references to the objects the role applies to.",
+            "description": "Subjects that receive the permissions from roleRef.",
             "items": {
               "$ref": "#/components/schemas/Subject"
             }
           }
         },
-        "description": "RoleBinding references a role, but does not contain it. It can reference a Role in the global. It adds who\n information via Subjects."
+        "description": "RoleBinding extension that grants a Role to one or more subjects."
       },
       "RoleBindingList": {
         "required": [
@@ -13311,15 +13466,15 @@
         "properties": {
           "apiGroup": {
             "type": "string",
-            "description": "APIGroup is the group for the resource being referenced."
+            "description": "API group of the role resource being referenced."
           },
           "kind": {
             "type": "string",
-            "description": "Kind is the type of resource being referenced."
+            "description": "Kind of the role resource being referenced."
           },
           "name": {
             "type": "string",
-            "description": "Name is the name of resource being referenced."
+            "description": "Metadata name of the role resource being referenced."
           }
         },
         "description": "RoleRef contains information that points to the role being used."
@@ -13444,7 +13599,7 @@
             "$ref": "#/components/schemas/SettingSpec"
           }
         },
-        "description": "{@link Setting Setting} is a custom extension to generate forms based on configuration."
+        "description": "Setting extension that describes one or more configuration forms and their schema."
       },
       "SettingForm": {
         "minLength": 1,
@@ -13456,17 +13611,21 @@
         "properties": {
           "formSchema": {
             "type": "array",
+            "description": "FormKit-compatible schema used to render the form fields.",
             "items": {
               "type": "object"
             }
           },
           "group": {
-            "type": "string"
+            "type": "string",
+            "description": "Stable form group name used to store submitted values."
           },
           "label": {
-            "type": "string"
+            "type": "string",
+            "description": "Display label shown for this form group."
           }
-        }
+        },
+        "description": "A single form group in a setting definition."
       },
       "SettingList": {
         "required": [
@@ -13536,13 +13695,16 @@
         "properties": {
           "group": {
             "minLength": 1,
-            "type": "string"
+            "type": "string",
+            "description": "Setting form group name."
           },
           "name": {
             "minLength": 1,
-            "type": "string"
+            "type": "string",
+            "description": "Setting metadata.name."
           }
-        }
+        },
+        "description": "Reference to a setting definition used by this provider."
       },
       "SettingSpec": {
         "required": [
@@ -13553,11 +13715,13 @@
           "forms": {
             "minLength": 1,
             "type": "array",
+            "description": "Form groups rendered for this setting definition.",
             "items": {
               "$ref": "#/components/schemas/SettingForm"
             }
           }
-        }
+        },
+        "description": "Collection of form groups that make up this setting definition."
       },
       "SinglePage": {
         "required": [
@@ -13584,7 +13748,7 @@
             "$ref": "#/components/schemas/SinglePageStatus"
           }
         },
-        "description": "Single page extension."
+        "description": "Single page extension that stores standalone page metadata, publication settings, and derived status."
       },
       "SinglePageList": {
         "required": [
@@ -13747,7 +13911,7 @@
             ]
           }
         },
-        "description": "Desired content, publication, and rendering configuration of a single page."
+        "description": "Desired single page content, publication, and rendering configuration."
       },
       "SinglePageStatus": {
         "type": "object",
@@ -13807,7 +13971,7 @@
             "description": "Current publishing phase, such as DRAFT, PENDING_APPROVAL, PUBLISHED, or FAILED."
           }
         },
-        "description": "Observed state of a single page."
+        "description": "Observed single page state derived by content reconcilers."
       },
       "SnapShotSpec": {
         "required": [
@@ -13957,7 +14121,8 @@
             "type": "string",
             "description": "Name of the object being referenced."
           }
-        }
+        },
+        "description": "Subject that receives permissions from a RoleBinding."
       },
       "Subscription": {
         "required": [
@@ -13980,7 +14145,7 @@
             "$ref": "#/components/schemas/SubscriptionSpec"
           }
         },
-        "description": "{@link Subscription Subscription} is a custom extension that defines a subscriber to be notified when a certain {@link Reason Reason} is\n triggered.\n\n \u003cp\u003eIt holds a {@link Subscriber Subscriber} to the user to be notified, a {@link InterestReason InterestReason} to subscribe to."
+        "description": "Subscription extension that records which subscriber should be notified when a matching reason is triggered.\n\n \u003cp\u003eIt holds a {@link Subscriber Subscriber} to the user to be notified, a {@link InterestReason InterestReason} to subscribe to."
       },
       "SubscriptionList": {
         "required": [
@@ -14051,7 +14216,7 @@
         "properties": {
           "disabled": {
             "type": "boolean",
-            "description": "Perhaps users need to unsubscribe and interact without receiving notifications again"
+            "description": "Whether the subscription has been disabled, usually after the subscriber unsubscribes."
           },
           "reason": {
             "$ref": "#/components/schemas/InterestReason"
@@ -14061,9 +14226,10 @@
           },
           "unsubscribeToken": {
             "type": "string",
-            "description": "The token to unsubscribe"
+            "description": "Token used to unsubscribe without authenticating as the subscriber."
           }
-        }
+        },
+        "description": "Desired notification subscription settings."
       },
       "SubscriptionSubscriber": {
         "required": [
@@ -14073,10 +14239,11 @@
         "properties": {
           "name": {
             "minLength": 1,
-            "type": "string"
+            "type": "string",
+            "description": "User metadata.name of the subscriber."
           }
         },
-        "description": "The subscriber to be notified"
+        "description": "Subscriber that receives notifications."
       },
       "Tag": {
         "required": [
@@ -14195,7 +14362,7 @@
             "description": "URL slug used to build the tag permalink."
           }
         },
-        "description": "Desired display and rendering configuration of a tag."
+        "description": "Desired tag display and rendering configuration."
       },
       "TagStatus": {
         "type": "object",
@@ -14220,7 +14387,7 @@
             "format": "int32"
           }
         },
-        "description": "Observed state of a tag."
+        "description": "Observed tag state derived by content reconcilers."
       },
       "TemplateContent": {
         "required": [
@@ -14229,16 +14396,20 @@
         "type": "object",
         "properties": {
           "htmlBody": {
-            "type": "string"
+            "type": "string",
+            "description": "HTML body rendered for notification channels that support HTML."
           },
           "rawBody": {
-            "type": "string"
+            "type": "string",
+            "description": "Plain text or source body rendered for notification channels that do not use HTML."
           },
           "title": {
             "minLength": 1,
-            "type": "string"
+            "type": "string",
+            "description": "Rendered notification title."
           }
-        }
+        },
+        "description": "Notification template content."
       },
       "TemplateDescriptor": {
         "required": [
@@ -14248,18 +14419,22 @@
         "type": "object",
         "properties": {
           "description": {
-            "type": "string"
+            "type": "string",
+            "description": "Human-readable description of when to use this template."
           },
           "file": {
             "minLength": 1,
-            "type": "string"
+            "type": "string",
+            "description": "Template file path relative to the theme templates directory."
           },
           "name": {
             "minLength": 1,
-            "type": "string"
+            "type": "string",
+            "description": "Template display name shown to users."
           },
           "screenshot": {
-            "type": "string"
+            "type": "string",
+            "description": "Screenshot URL or attachment URI for previewing the template."
           }
         },
         "description": "Type used to describe custom template page."
@@ -14314,7 +14489,7 @@
             "$ref": "#/components/schemas/ThemeStatus"
           }
         },
-        "description": "Theme extension."
+        "description": "Theme extension that describes an installable frontend theme and its runtime state."
       },
       "ThemeList": {
         "required": [
@@ -14386,46 +14561,58 @@
             "$ref": "#/components/schemas/Author"
           },
           "configMapName": {
-            "type": "string"
+            "type": "string",
+            "description": "ConfigMap metadata.name storing the theme configuration values."
           },
           "customTemplates": {
             "$ref": "#/components/schemas/CustomTemplates"
           },
           "description": {
-            "type": "string"
+            "type": "string",
+            "description": "Human-readable theme description."
           },
           "displayName": {
             "minLength": 1,
-            "type": "string"
+            "type": "string",
+            "description": "Display name shown for the theme."
           },
           "homepage": {
-            "type": "string"
+            "type": "string",
+            "description": "Theme homepage URL."
           },
           "issues": {
-            "type": "string"
+            "type": "string",
+            "description": "Issue tracker URL."
           },
           "license": {
             "type": "array",
+            "description": "Licenses declared by the theme.",
             "items": {
               "$ref": "#/components/schemas/License"
             }
           },
           "logo": {
-            "type": "string"
+            "type": "string",
+            "description": "Logo URL or attachment URI for the theme."
           },
           "repo": {
-            "type": "string"
+            "type": "string",
+            "description": "Source repository URL."
           },
           "requires": {
-            "type": "string"
+            "type": "string",
+            "description": "Required Halo version range. The wildcard value means any Halo version."
           },
           "settingName": {
-            "type": "string"
+            "type": "string",
+            "description": "Setting metadata.name used to render the theme configuration form."
           },
           "version": {
-            "type": "string"
+            "type": "string",
+            "description": "Theme version. The wildcard value means any version."
           }
-        }
+        },
+        "description": "Desired theme metadata and configuration references."
       },
       "ThemeStatus": {
         "type": "object",
@@ -14437,6 +14624,7 @@
                 "type": "boolean"
               }
             },
+            "description": "Reconciliation conditions for the theme.",
             "items": {
               "$ref": "#/components/schemas/Condition"
             }
@@ -14446,17 +14634,20 @@
             "description": "Whether the theme appears to be a local development workspace."
           },
           "location": {
-            "type": "string"
+            "type": "string",
+            "description": "Local filesystem location where the theme is loaded from."
           },
           "phase": {
             "type": "string",
+            "description": "Current theme lifecycle phase.",
             "enum": [
               "READY",
               "FAILED",
               "UNKNOWN"
             ]
           }
-        }
+        },
+        "description": "Observed theme lifecycle and installation state."
       },
       "User": {
         "required": [
@@ -14483,7 +14674,7 @@
             "$ref": "#/components/schemas/UserStatus"
           }
         },
-        "description": "The extension represents user details of Halo."
+        "description": "User extension that stores profile, authentication, and account state for a Halo user."
       },
       "UserConnection": {
         "required": [
@@ -14507,7 +14698,7 @@
             "$ref": "#/components/schemas/UserConnectionSpec"
           }
         },
-        "description": "User connection extension."
+        "description": "User connection extension that links a Halo user to an external OAuth2 account."
       },
       "UserConnectionList": {
         "required": [
@@ -14593,7 +14784,8 @@
             "type": "string",
             "description": "The {@link Metadata#getName Metadata#getName()} of the user associated with the OAuth connection."
           }
-        }
+        },
+        "description": "External OAuth2 account binding for a Halo user."
       },
       "UserList": {
         "required": [
@@ -14662,52 +14854,67 @@
         "type": "object",
         "properties": {
           "avatar": {
-            "type": "string"
+            "type": "string",
+            "description": "Avatar URL or attachment URI for the user."
           },
           "bio": {
-            "type": "string"
+            "type": "string",
+            "description": "User biography shown on profile surfaces."
           },
           "disabled": {
-            "type": "boolean"
+            "type": "boolean",
+            "description": "Whether the user account is disabled."
           },
           "displayName": {
-            "type": "string"
+            "type": "string",
+            "description": "Display name shown for the user."
           },
           "email": {
-            "type": "string"
+            "type": "string",
+            "description": "Email address used for sign-in and notifications."
           },
           "emailVerified": {
-            "type": "boolean"
+            "type": "boolean",
+            "description": "Whether the email address has been verified."
           },
           "loginHistoryLimit": {
             "type": "integer",
+            "description": "Maximum number of login history entries retained for this user.",
             "format": "int32"
           },
           "password": {
-            "type": "string"
+            "type": "string",
+            "description": "Password hash or encoded password value."
           },
           "phone": {
-            "type": "string"
+            "type": "string",
+            "description": "Phone number associated with the user."
           },
           "registeredAt": {
             "type": "string",
+            "description": "Time when the user registered.",
             "format": "date-time"
           },
           "totpEncryptedSecret": {
-            "type": "string"
+            "type": "string",
+            "description": "Encrypted TOTP secret used for two-factor authentication."
           },
           "twoFactorAuthEnabled": {
-            "type": "boolean"
+            "type": "boolean",
+            "description": "Whether two-factor authentication is enabled for this user."
           }
-        }
+        },
+        "description": "Desired user profile and authentication settings."
       },
       "UserStatus": {
         "type": "object",
         "properties": {
           "permalink": {
-            "type": "string"
+            "type": "string",
+            "description": "Public permalink of the user\u0027s profile or author page."
           }
-        }
+        },
+        "description": "Observed user state derived by the application."
       }
     },
     "securitySchemes": {

--- a/api-docs/openapi/v3_0/apis_public.api_v1alpha1.json
+++ b/api-docs/openapi/v3_0/apis_public.api_v1alpha1.json
@@ -1300,7 +1300,7 @@
             "description": "Theme template used to render the category archive page."
           }
         },
-        "description": "Desired display, hierarchy, and rendering configuration of a category."
+        "description": "Desired category display, hierarchy, and rendering configuration."
       },
       "CategoryStatus": {
         "type": "object",
@@ -1320,7 +1320,7 @@
             "format": "int32"
           }
         },
-        "description": "Observed state of a category."
+        "description": "Observed category state derived by content reconcilers."
       },
       "CategoryVo": {
         "required": [
@@ -1648,7 +1648,7 @@
             "format": "int32"
           }
         },
-        "description": "Observed state of a comment."
+        "description": "Observed state of a top-level comment."
       },
       "CommentVo": {
         "required": [
@@ -1976,7 +1976,7 @@
             "description": "Manual excerpt text used when autoGenerate is false."
           }
         },
-        "description": "Excerpt generation configuration."
+        "description": "Excerpt generation configuration for a post or single page."
       },
       "HaloDocument": {
         "required": [
@@ -2358,28 +2358,27 @@
           "children": {
             "uniqueItems": true,
             "type": "array",
-            "description": "Children of this menu item",
+            "description": "Child MenuItem metadata.name values shown under this item.",
             "items": {
-              "type": "string",
-              "description": "The name of menu item child"
+              "type": "string"
             }
           },
           "displayName": {
             "type": "string",
-            "description": "The display name of menu item."
+            "description": "Display name shown for the menu item."
           },
           "href": {
             "type": "string",
-            "description": "The href of this menu item."
+            "description": "Direct URL used by the menu item."
           },
           "priority": {
             "type": "integer",
-            "description": "The priority is for ordering.",
+            "description": "Sorting priority. Higher values sort before lower values where priority ordering is applied.",
             "format": "int32"
           },
           "target": {
             "type": "string",
-            "description": "The \u003ca\u003e target attribute of this menu item.",
+            "description": "HTML anchor target used by the menu item.",
             "enum": [
               "_blank",
               "_self",
@@ -2390,20 +2389,22 @@
           "targetRef": {
             "$ref": "#/components/schemas/Ref"
           }
-        }
+        },
+        "description": "Desired menu item configuration."
       },
       "MenuItemStatus": {
         "type": "object",
         "properties": {
           "displayName": {
             "type": "string",
-            "description": "Calculated Display name of menu item."
+            "description": "Calculated display name after resolving targetRef, falling back to spec.displayName."
           },
           "href": {
             "type": "string",
-            "description": "Calculated href of manu item."
+            "description": "Calculated href after resolving targetRef, falling back to spec.href."
           }
-        }
+        },
+        "description": "Resolved menu item values used for rendering."
       },
       "MenuItemVo": {
         "required": [
@@ -2444,18 +2445,18 @@
         "properties": {
           "displayName": {
             "type": "string",
-            "description": "The display name of the menu."
+            "description": "Display name shown for the menu."
           },
           "menuItems": {
             "uniqueItems": true,
             "type": "array",
-            "description": "Menu items of this menu.",
+            "description": "Ordered MenuItem metadata.name values included in this menu.",
             "items": {
-              "type": "string",
-              "description": "Name of menu item."
+              "type": "string"
             }
           }
-        }
+        },
+        "description": "Desired menu configuration."
       },
       "MenuVo": {
         "required": [
@@ -2718,7 +2719,7 @@
             ]
           }
         },
-        "description": "Desired content, publication, taxonomy, and rendering configuration of a post."
+        "description": "Desired post content, publication, taxonomy, and rendering configuration."
       },
       "PostStatus": {
         "type": "object",
@@ -2778,7 +2779,7 @@
             "description": "Current publishing phase, such as DRAFT, PENDING_APPROVAL, PUBLISHED, or FAILED."
           }
         },
-        "description": "Observed state of a content item."
+        "description": "Observed post state derived by content reconcilers."
       },
       "PostVo": {
         "required": [
@@ -3344,7 +3345,7 @@
             ]
           }
         },
-        "description": "Desired content, publication, and rendering configuration of a single page."
+        "description": "Desired single page content, publication, and rendering configuration."
       },
       "SinglePageStatus": {
         "type": "object",
@@ -3404,7 +3405,7 @@
             "description": "Current publishing phase, such as DRAFT, PENDING_APPROVAL, PUBLISHED, or FAILED."
           }
         },
-        "description": "Observed state of a single page."
+        "description": "Observed single page state derived by content reconcilers."
       },
       "SinglePageVo": {
         "required": [
@@ -3514,7 +3515,7 @@
             "description": "URL slug used to build the tag permalink."
           }
         },
-        "description": "Desired display and rendering configuration of a tag."
+        "description": "Desired tag display and rendering configuration."
       },
       "TagStatus": {
         "type": "object",
@@ -3539,7 +3540,7 @@
             "format": "int32"
           }
         },
-        "description": "Observed state of a tag."
+        "description": "Observed tag state derived by content reconcilers."
       },
       "TagVo": {
         "required": [

--- a/api-docs/openapi/v3_0/apis_uc.api_v1alpha1.json
+++ b/api-docs/openapi/v3_0/apis_uc.api_v1alpha1.json
@@ -1534,7 +1534,8 @@
           "spec": {
             "$ref": "#/components/schemas/AnnotationSettingSpec"
           }
-        }
+        },
+        "description": "Annotation setting extension that defines dynamic annotation forms for a target extension kind."
       },
       "AnnotationSettingSpec": {
         "required": [
@@ -1546,6 +1547,7 @@
           "formSchema": {
             "minLength": 1,
             "type": "array",
+            "description": "FormKit-compatible schema used to render annotation fields.",
             "items": {
               "minLength": 1,
               "type": "object"
@@ -1554,7 +1556,8 @@
           "targetRef": {
             "$ref": "#/components/schemas/GroupKind"
           }
-        }
+        },
+        "description": "Desired annotation form configuration for a target resource kind."
       },
       "Attachment": {
         "required": [
@@ -1580,7 +1583,8 @@
           "status": {
             "$ref": "#/components/schemas/AttachmentStatus"
           }
-        }
+        },
+        "description": "Attachment extension that describes an uploaded file and its resolved access URLs."
       },
       "AttachmentList": {
         "required": [
@@ -1646,55 +1650,57 @@
         "properties": {
           "displayName": {
             "type": "string",
-            "description": "Display name of attachment"
+            "description": "Display name shown for the attachment."
           },
           "groupName": {
             "type": "string",
-            "description": "Group name"
+            "description": "Attachment group metadata.name this attachment belongs to."
           },
           "mediaType": {
             "type": "string",
-            "description": "Media type of attachment"
+            "description": "Media type detected or supplied for the attachment, such as image/png."
           },
           "ownerName": {
             "type": "string",
-            "description": "Name of User who uploads the attachment"
+            "description": "User metadata.name of the uploader."
           },
           "policyName": {
             "type": "string",
-            "description": "Policy name"
+            "description": "Storage policy metadata.name used to store this attachment."
           },
           "size": {
             "minimum": 0,
             "type": "integer",
-            "description": "Size of attachment. Unit is Byte",
+            "description": "Size of the attachment in bytes.",
             "format": "int64"
           },
           "tags": {
             "uniqueItems": true,
             "type": "array",
-            "description": "Tags of attachment",
+            "description": "Free-form tags assigned to the attachment.",
             "items": {
-              "type": "string",
-              "description": "Tag name"
+              "type": "string"
             }
           }
-        }
+        },
+        "description": "Desired attachment metadata and storage placement."
       },
       "AttachmentStatus": {
         "type": "object",
         "properties": {
           "permalink": {
             "type": "string",
-            "description": "Permalink of attachment.\nIf it is in local storage, the public URL will be set.\nIf it is in s3 storage, the Object URL will be set.\n"
+            "description": "Public permalink for the attachment. Local storage usually exposes a public URL, while object storage may\n expose the object URL."
           },
           "thumbnails": {
             "type": "object",
             "additionalProperties": {
               "type": "string"
-            }
+            },
+            "description": "Generated thumbnail URLs keyed by thumbnail size name."
           }
-        }
+        },
+        "description": "Observed attachment access state."
       },
       "Category": {
         "required": [
@@ -1781,7 +1787,7 @@
             "description": "Theme template used to render the category archive page."
           }
         },
-        "description": "Desired display, hierarchy, and rendering configuration of a category."
+        "description": "Desired category display, hierarchy, and rendering configuration."
       },
       "CategoryStatus": {
         "type": "object",
@@ -1801,7 +1807,7 @@
             "format": "int32"
           }
         },
-        "description": "Observed state of a category."
+        "description": "Observed category state derived by content reconcilers."
       },
       "Condition": {
         "required": [
@@ -1916,7 +1922,8 @@
           "status": {
             "$ref": "#/components/schemas/DeviceStatus"
           }
-        }
+        },
+        "description": "Device extension that records an authenticated browser session for account security visibility."
       },
       "DeviceSpec": {
         "required": [
@@ -1928,43 +1935,54 @@
         "properties": {
           "ipAddress": {
             "maxLength": 129,
-            "type": "string"
+            "type": "string",
+            "description": "Client IP address observed for the session."
           },
           "lastAccessedTime": {
             "type": "string",
+            "description": "Last time this session accessed Halo.",
             "format": "date-time"
           },
           "lastAuthenticatedTime": {
             "type": "string",
+            "description": "Last time the user authenticated for this session.",
             "format": "date-time"
           },
           "principalName": {
             "minLength": 1,
-            "type": "string"
+            "type": "string",
+            "description": "Principal name of the authenticated user."
           },
           "rememberMeSeriesId": {
-            "type": "string"
+            "type": "string",
+            "description": "Remember-me series id associated with the session, if any."
           },
           "sessionId": {
             "minLength": 1,
-            "type": "string"
+            "type": "string",
+            "description": "Web session identifier associated with the device."
           },
           "userAgent": {
             "maxLength": 500,
-            "type": "string"
+            "type": "string",
+            "description": "Client user-agent header captured for the session."
           }
-        }
+        },
+        "description": "Session identity and request metadata captured for a device."
       },
       "DeviceStatus": {
         "type": "object",
         "properties": {
           "browser": {
-            "type": "string"
+            "type": "string",
+            "description": "Browser name parsed from the user agent."
           },
           "os": {
-            "type": "string"
+            "type": "string",
+            "description": "Operating system name parsed from the user agent."
           }
-        }
+        },
+        "description": "Parsed browser and operating system details for display."
       },
       "Excerpt": {
         "required": [
@@ -1982,7 +2000,7 @@
             "description": "Manual excerpt text used when autoGenerate is false."
           }
         },
-        "description": "Excerpt generation configuration."
+        "description": "Excerpt generation configuration for a post or single page."
       },
       "GroupKind": {
         "type": "object",
@@ -2247,7 +2265,7 @@
             "$ref": "#/components/schemas/NotificationSpec"
           }
         },
-        "description": "{@link Notification Notification} is a custom extension that used to store notification information for inner use, it\u0027s on-site\n notification.\n\n \u003cp\u003eSupports the following operations:\n\n \u003cul\u003e\n   \u003cli\u003eMarked as read: {@link NotificationSpec#setUnread(boolean) NotificationSpec#setUnread(boolean)}\n   \u003cli\u003eGet the last read time: {@link NotificationSpec#getLastReadAt NotificationSpec#getLastReadAt()}\n   \u003cli\u003eFilter by recipient: {@link NotificationSpec#getRecipient NotificationSpec#getRecipient()}\n \u003c/ul\u003e"
+        "description": "Notification extension that stores an on-site notification delivered to a Halo user.\n\n \u003cp\u003eSupports the following operations:\n\n \u003cul\u003e\n   \u003cli\u003eMarked as read: {@link NotificationSpec#setUnread(boolean) NotificationSpec#setUnread(boolean)}\n   \u003cli\u003eGet the last read time: {@link NotificationSpec#getLastReadAt NotificationSpec#getLastReadAt()}\n   \u003cli\u003eFilter by recipient: {@link NotificationSpec#getRecipient NotificationSpec#getRecipient()}\n \u003c/ul\u003e"
       },
       "NotificationList": {
         "required": [
@@ -2319,33 +2337,39 @@
         "type": "object",
         "properties": {
           "htmlContent": {
-            "type": "string"
+            "type": "string",
+            "description": "HTML notification content."
           },
           "lastReadAt": {
             "type": "string",
+            "description": "Last time the recipient marked this notification as read.",
             "format": "date-time"
           },
           "rawContent": {
-            "type": "string"
+            "type": "string",
+            "description": "Plain text or source notification content."
           },
           "reason": {
             "minLength": 1,
             "type": "string",
-            "description": "The name of reason"
+            "description": "Reason metadata.name that generated this notification."
           },
           "recipient": {
             "minLength": 1,
             "type": "string",
-            "description": "The name of user"
+            "description": "User metadata.name that receives the notification."
           },
           "title": {
             "minLength": 1,
-            "type": "string"
+            "type": "string",
+            "description": "Notification title shown in the notification center."
           },
           "unread": {
-            "type": "boolean"
+            "type": "boolean",
+            "description": "Whether the recipient has not read the notification yet."
           }
-        }
+        },
+        "description": "Notification content and read state for one recipient."
       },
       "NotifierInfo": {
         "type": "object",
@@ -2385,45 +2409,56 @@
         "type": "object",
         "properties": {
           "description": {
-            "type": "string"
+            "type": "string",
+            "description": "Optional human-readable description of how the token is used."
           },
           "expiresAt": {
             "type": "string",
+            "description": "Time when the token expires. A null value means the token does not expire by time.",
             "format": "date-time"
           },
           "lastUsed": {
             "type": "string",
+            "description": "Last time the token was used successfully.",
             "format": "date-time"
           },
           "name": {
-            "type": "string"
+            "type": "string",
+            "description": "Display name chosen by the token owner."
           },
           "revoked": {
-            "type": "boolean"
+            "type": "boolean",
+            "description": "Whether the token has been manually revoked."
           },
           "revokesAt": {
             "type": "string",
+            "description": "Time when the token was revoked.",
             "format": "date-time"
           },
           "roles": {
             "type": "array",
+            "description": "Role names granted to this token.",
             "items": {
               "type": "string"
             }
           },
           "scopes": {
             "type": "array",
+            "description": "Scope strings granted to this token.",
             "items": {
               "type": "string"
             }
           },
           "tokenId": {
-            "type": "string"
+            "type": "string",
+            "description": "Stable token identifier stored separately from the secret token value."
           },
           "username": {
-            "type": "string"
+            "type": "string",
+            "description": "User metadata.name that owns this token."
           }
-        }
+        },
+        "description": "Desired personal access token settings and lifecycle flags."
       },
       "PersonalAccessToken": {
         "required": [
@@ -2445,7 +2480,8 @@
           "spec": {
             "$ref": "#/components/schemas/PatSpec"
           }
-        }
+        },
+        "description": "Personal access token extension used for non-interactive API authentication on behalf of a Halo user."
       },
       "Post": {
         "required": [
@@ -2472,7 +2508,7 @@
             "$ref": "#/components/schemas/PostStatus"
           }
         },
-        "description": "Post extension."
+        "description": "Post extension that stores article metadata, publication settings, taxonomy, and derived status."
       },
       "PostAttachmentRequest": {
         "required": [
@@ -2610,7 +2646,7 @@
             ]
           }
         },
-        "description": "Desired content, publication, taxonomy, and rendering configuration of a post."
+        "description": "Desired post content, publication, taxonomy, and rendering configuration."
       },
       "PostStatus": {
         "type": "object",
@@ -2670,7 +2706,7 @@
             "description": "Current publishing phase, such as DRAFT, PENDING_APPROVAL, PUBLISHED, or FAILED."
           }
         },
-        "description": "Observed state of a content item."
+        "description": "Observed post state derived by content reconcilers."
       },
       "ReasonTypeInfo": {
         "type": "object",
@@ -2978,7 +3014,7 @@
             "description": "URL slug used to build the tag permalink."
           }
         },
-        "description": "Desired display and rendering configuration of a tag."
+        "description": "Desired tag display and rendering configuration."
       },
       "TagStatus": {
         "type": "object",
@@ -3003,7 +3039,7 @@
             "format": "int32"
           }
         },
-        "description": "Observed state of a tag."
+        "description": "Observed tag state derived by content reconcilers."
       },
       "TestOperation": {
         "required": [
@@ -3142,7 +3178,7 @@
             "$ref": "#/components/schemas/UserConnectionSpec"
           }
         },
-        "description": "User connection extension."
+        "description": "User connection extension that links a Halo user to an external OAuth2 account."
       },
       "UserConnectionSpec": {
         "required": [
@@ -3169,7 +3205,8 @@
             "type": "string",
             "description": "The {@link Metadata#getName Metadata#getName()} of the user associated with the OAuth connection."
           }
-        }
+        },
+        "description": "External OAuth2 account binding for a Halo user."
       },
       "UserDevice": {
         "required": [

--- a/api/src/main/java/run/halo/app/core/extension/AnnotationSetting.java
+++ b/api/src/main/java/run/halo/app/core/extension/AnnotationSetting.java
@@ -12,6 +12,7 @@ import run.halo.app.extension.AbstractExtension;
 import run.halo.app.extension.GVK;
 import run.halo.app.extension.GroupKind;
 
+/** Annotation setting extension that defines dynamic annotation forms for a target extension kind. */
 @Data
 @ToString(callSuper = true)
 @EqualsAndHashCode(callSuper = true)
@@ -21,14 +22,18 @@ public class AnnotationSetting extends AbstractExtension {
 
     public static final String KIND = "AnnotationSetting";
 
+    /** Desired target resource kind and annotation form schema. */
     @Schema(requiredMode = REQUIRED)
     private AnnotationSettingSpec spec;
 
+    /** Desired annotation form configuration for a target resource kind. */
     @Data
     public static class AnnotationSettingSpec {
+        /** Target extension group and kind this annotation setting applies to. */
         @Schema(requiredMode = REQUIRED)
         private GroupKind targetRef;
 
+        /** FormKit-compatible schema used to render annotation fields. */
         @Schema(requiredMode = REQUIRED, minLength = 1)
         private List<Object> formSchema;
     }

--- a/api/src/main/java/run/halo/app/core/extension/AuthProvider.java
+++ b/api/src/main/java/run/halo/app/core/extension/AuthProvider.java
@@ -12,7 +12,7 @@ import run.halo.app.extension.AbstractExtension;
 import run.halo.app.extension.GVK;
 
 /**
- * Auth provider extension.
+ * Authentication provider extension that describes an external or form-based sign-in integration.
  *
  * @author guqing
  * @since 2.4.0
@@ -32,42 +32,56 @@ public class AuthProvider extends AbstractExtension {
 
     public static final String PRIVILEGED_LABEL = "auth.halo.run/privileged";
 
+    /** Desired provider metadata, endpoints, and optional setting references. */
     @Schema(requiredMode = REQUIRED)
     private AuthProviderSpec spec;
 
+    /** Authentication provider metadata and endpoint configuration. */
     @Data
     @ToString
     public static class AuthProviderSpec {
 
-        @Schema(requiredMode = REQUIRED, description = "Display name of the auth provider")
+        /** Display name shown on sign-in and account binding screens. */
+        @Schema(requiredMode = REQUIRED)
         private String displayName;
 
+        /** Human-readable description of the provider. */
         private String description;
 
+        /** Logo URL or attachment URI for the provider. */
         private String logo;
 
+        /** Provider website URL. */
         private String website;
 
+        /** Help page URL for users who need sign-in assistance. */
         private String helpPage;
 
-        @Schema(requiredMode = REQUIRED, description = "Authentication url of the auth provider")
+        /** URL that starts the authentication flow. */
+        @Schema(requiredMode = REQUIRED)
         private String authenticationUrl;
 
+        /** HTTP method used when starting the authentication flow. */
         private String method = "GET";
 
+        /** Whether the provider supports remember-me during sign-in. */
         private boolean rememberMeSupport = false;
 
         /** Auth type: form or oauth2. */
         @Schema(requiredMode = REQUIRED)
         private AuthType authType = AuthType.OAUTH2;
 
+        /** URL that starts account binding for an already signed-in user. */
         private String bindingUrl;
 
+        /** URL that unbinds the external account from the current user. */
         private String unbindUrl;
 
+        /** Setting definition used to render provider configuration fields. */
         @Schema(requiredMode = NOT_REQUIRED)
         private SettingRef settingRef;
 
+        /** ConfigMap storing provider configuration values. */
         @Schema(requiredMode = NOT_REQUIRED)
         private ConfigMapRef configMapRef;
 
@@ -76,19 +90,24 @@ public class AuthProvider extends AbstractExtension {
         }
     }
 
+    /** Reference to a setting definition used by this provider. */
     @Data
     @ToString
     public static class SettingRef {
+        /** Setting metadata.name. */
         @Schema(requiredMode = REQUIRED, minLength = 1)
         private String name;
 
+        /** Setting form group name. */
         @Schema(requiredMode = REQUIRED, minLength = 1)
         private String group;
     }
 
+    /** Reference to a ConfigMap used by this provider. */
     @Data
     @ToString
     public static class ConfigMapRef {
+        /** ConfigMap metadata.name. */
         @Schema(requiredMode = REQUIRED, minLength = 1)
         private String name;
     }

--- a/api/src/main/java/run/halo/app/core/extension/Counter.java
+++ b/api/src/main/java/run/halo/app/core/extension/Counter.java
@@ -7,7 +7,7 @@ import run.halo.app.extension.GVK;
 import run.halo.app.extension.Metadata;
 
 /**
- * A counter for number of requests by extension resource name.
+ * Counter extension that stores aggregate interaction counts for a resource.
  *
  * @author guqing
  * @since 2.0.0
@@ -17,14 +17,19 @@ import run.halo.app.extension.Metadata;
 @EqualsAndHashCode(callSuper = true)
 public class Counter extends AbstractExtension {
 
+    /** Number of visits recorded for the resource. */
     private Integer visit;
 
+    /** Number of upvotes recorded for the resource. */
     private Integer upvote;
 
+    /** Number of downvotes recorded for the resource. */
     private Integer downvote;
 
+    /** Total number of comments recorded for the resource. */
     private Integer totalComment;
 
+    /** Number of approved comments recorded for the resource. */
     private Integer approvedComment;
 
     public static Counter emptyCounter(String name) {

--- a/api/src/main/java/run/halo/app/core/extension/Device.java
+++ b/api/src/main/java/run/halo/app/core/extension/Device.java
@@ -11,6 +11,7 @@ import org.jspecify.annotations.Nullable;
 import run.halo.app.extension.AbstractExtension;
 import run.halo.app.extension.GVK;
 
+/** Device extension that records an authenticated browser session for account security visibility. */
 @Data
 @EqualsAndHashCode(callSuper = true)
 @GVK(group = Device.GROUP, version = Device.VERSION, kind = Device.KIND, plural = "devices", singular = "device")
@@ -19,9 +20,11 @@ public class Device extends AbstractExtension {
     public static final String VERSION = "v1alpha1";
     public static final String KIND = "Device";
 
+    /** Desired device/session identity and access timestamps. */
     @Schema(requiredMode = REQUIRED)
     private Spec spec;
 
+    /** Resolved client environment details for display. */
     @Schema(requiredMode = REQUIRED)
     private Status status = new Status();
 
@@ -29,36 +32,48 @@ public class Device extends AbstractExtension {
         this.status = (status == null ? new Status() : status);
     }
 
+    /** Session identity and request metadata captured for a device. */
     @Data
     @Accessors(chain = true)
     @Schema(name = "DeviceSpec")
     public static class Spec {
 
+        /** Web session identifier associated with the device. */
         @Schema(requiredMode = REQUIRED, minLength = 1)
         private String sessionId;
 
+        /** Principal name of the authenticated user. */
         @Schema(requiredMode = REQUIRED, minLength = 1)
         private String principalName;
 
+        /** Client IP address observed for the session. */
         @Schema(requiredMode = REQUIRED, maxLength = 129)
         private String ipAddress;
 
+        /** Client user-agent header captured for the session. */
         @Schema(maxLength = 500)
         private String userAgent;
 
+        /** Remember-me series id associated with the session, if any. */
         @Nullable
         private String rememberMeSeriesId;
 
+        /** Last time this session accessed Halo. */
         private Instant lastAccessedTime;
 
+        /** Last time the user authenticated for this session. */
         private Instant lastAuthenticatedTime;
     }
 
+    /** Parsed browser and operating system details for display. */
     @Data
     @Accessors(chain = true)
     @Schema(name = "DeviceStatus")
     public static class Status {
+        /** Browser name parsed from the user agent. */
         private String browser;
+
+        /** Operating system name parsed from the user agent. */
         private String os;
     }
 }

--- a/api/src/main/java/run/halo/app/core/extension/Menu.java
+++ b/api/src/main/java/run/halo/app/core/extension/Menu.java
@@ -11,26 +11,28 @@ import lombok.ToString;
 import run.halo.app.extension.AbstractExtension;
 import run.halo.app.extension.GVK;
 
+/** Menu extension that groups ordered menu items for theme navigation. */
 @Data
 @ToString(callSuper = true)
 @EqualsAndHashCode(callSuper = true)
 @GVK(group = "", version = "v1alpha1", kind = "Menu", plural = "menus", singular = "menu")
 public class Menu extends AbstractExtension {
 
-    @Schema(description = "The spec of menu.", requiredMode = REQUIRED)
+    /** Desired menu metadata and ordered item references. */
+    @Schema(requiredMode = REQUIRED)
     private Spec spec;
 
+    /** Desired menu configuration. */
     @Data
     @Schema(name = "MenuSpec")
     public static class Spec {
 
-        @Schema(description = "The display name of the menu.", requiredMode = REQUIRED)
+        /** Display name shown for the menu. */
+        @Schema(requiredMode = REQUIRED)
         private String displayName;
 
-        @ArraySchema(
-                uniqueItems = true,
-                arraySchema = @Schema(description = "Menu items of this menu."),
-                schema = @Schema(description = "Name of menu item."))
+        /** Ordered MenuItem metadata.name values included in this menu. */
+        @ArraySchema(uniqueItems = true)
         private LinkedHashSet<String> menuItems;
     }
 }

--- a/api/src/main/java/run/halo/app/core/extension/MenuItem.java
+++ b/api/src/main/java/run/halo/app/core/extension/MenuItem.java
@@ -15,6 +15,7 @@ import run.halo.app.extension.AbstractExtension;
 import run.halo.app.extension.GVK;
 import run.halo.app.extension.Ref;
 
+/** Menu item extension that describes a navigable item and its resolved rendering state. */
 @Data
 @ToString(callSuper = true)
 @EqualsAndHashCode(callSuper = true)
@@ -23,20 +24,23 @@ public class MenuItem extends AbstractExtension {
 
     public static final String REQUEST_TO_UPDATE_ANNO = "halo.run/request-to-update";
 
-    @Schema(description = "The spec of menu item.", requiredMode = REQUIRED)
+    /** Desired menu item configuration, including label, URL, ordering, children, and target resource. */
+    @Schema(requiredMode = REQUIRED)
     @Nullable
     private MenuItemSpec spec;
 
-    @Schema(description = "The status of menu item.")
+    /** Resolved display values calculated from the desired configuration and target resource. */
     @Nullable
     private MenuItemStatus status;
 
+    /** HTML anchor target used when opening this menu item. */
     public enum Target {
         BLANK("_blank"),
         SELF("_self"),
         PARENT("_parent"),
         TOP("_top");
 
+        /** HTML target attribute value. */
         private final String value;
 
         @JsonCreator
@@ -50,40 +54,40 @@ public class MenuItem extends AbstractExtension {
         }
     }
 
+    /** Desired menu item configuration. */
     @Data
     public static class MenuItemSpec {
 
-        @Schema(description = "The display name of menu item.")
+        /** Display name shown for the menu item. */
         private String displayName;
 
-        @Schema(description = "The href of this menu item.")
+        /** Direct URL used by the menu item. */
         private String href;
 
-        @Schema(description = "The <a> target attribute of this menu item.")
+        /** HTML anchor target used by the menu item. */
         private Target target;
 
-        @Schema(description = "The priority is for ordering.")
+        /** Sorting priority. Higher values sort before lower values where priority ordering is applied. */
         private Integer priority;
 
-        @ArraySchema(
-                uniqueItems = true,
-                arraySchema = @Schema(description = "Children of this menu item"),
-                schema = @Schema(description = "The name of menu item child"))
+        /** Child MenuItem metadata.name values shown under this item. */
+        @ArraySchema(uniqueItems = true)
         private LinkedHashSet<String> children;
 
-        @Schema(description = "Target reference. Like Category, Tag, Post or SinglePage")
+        /** Target extension reference, such as a Category, Tag, Post, or SinglePage. */
         @Nullable
         private Ref targetRef;
     }
 
+    /** Resolved menu item values used for rendering. */
     @Data
     public static class MenuItemStatus {
 
-        @Schema(description = "Calculated Display name of menu item.")
+        /** Calculated display name after resolving targetRef, falling back to spec.displayName. */
         @Nullable
         private String displayName;
 
-        @Schema(description = "Calculated href of manu item.")
+        /** Calculated href after resolving targetRef, falling back to spec.href. */
         @Nullable
         private String href;
     }

--- a/api/src/main/java/run/halo/app/core/extension/Plugin.java
+++ b/api/src/main/java/run/halo/app/core/extension/Plugin.java
@@ -20,7 +20,7 @@ import run.halo.app.extension.GVK;
 import run.halo.app.infra.ConditionList;
 
 /**
- * A custom resource for Plugin.
+ * Plugin extension that describes an installed plugin and its runtime lifecycle state.
  *
  * @author guqing
  * @since 2.0.0
@@ -35,9 +35,11 @@ public class Plugin extends AbstractExtension {
 
     public static final String BUILT_IN_KEEPER_FINALIZER = "plugin.halo.run/built-in-keeper";
 
+    /** Desired plugin metadata, dependencies, configuration references, and enabled state. */
     @Schema(requiredMode = REQUIRED)
     private PluginSpec spec;
 
+    /** Observed plugin runtime state reported by the plugin manager. */
     private @Nullable PluginStatus status;
 
     /**
@@ -53,9 +55,11 @@ public class Plugin extends AbstractExtension {
         return status;
     }
 
+    /** Desired plugin metadata and configuration references. */
     @Data
     public static class PluginSpec {
 
+        /** Display name shown for the plugin. */
         private String displayName;
 
         /**
@@ -71,29 +75,40 @@ public class Plugin extends AbstractExtension {
                         + ".[0-9a-zA-Z-]+)*))?$")
         private String version;
 
+        /** Plugin author metadata. */
         private PluginAuthor author;
 
+        /** Logo URL or attachment URI for the plugin. */
         private String logo;
 
+        /** Required plugin dependencies keyed by plugin name with version constraints as values. */
         private Map<String, String> pluginDependencies = new HashMap<>(4);
 
+        /** Plugin homepage URL. */
         private String homepage;
 
+        /** Source repository URL. */
         private String repo;
 
+        /** Issue tracker URL. */
         private String issues;
 
+        /** Human-readable plugin description. */
         private String description;
 
+        /** Licenses declared by the plugin. */
         private List<License> license;
 
         /** SemVer format. */
         private String requires = "*";
 
+        /** Whether the plugin should be enabled. */
         private Boolean enabled = false;
 
+        /** Setting metadata.name used to render the plugin configuration form. */
         private String settingName;
 
+        /** ConfigMap metadata.name storing plugin configuration values. */
         private String configMapName;
     }
 
@@ -103,28 +118,39 @@ public class Plugin extends AbstractExtension {
      */
     @Data
     public static class License {
+        /** License name or identifier. */
         private String name;
+
+        /** URL to the license text. */
         private String url;
     }
 
+    /** Observed plugin lifecycle and runtime asset state. */
     @Data
     public static class PluginStatus {
 
+        /** Current plugin lifecycle phase. */
         private Phase phase;
 
+        /** Reconciliation conditions for the plugin. */
         private ConditionList conditions;
 
+        /** Last time the plugin started successfully. */
         private Instant lastStartTime;
 
+        /** Last PF4J probe state observed for the plugin. */
         private PluginState lastProbeState;
 
+        /** JavaScript bundle entry path served for the plugin UI. */
         private String entry;
 
+        /** Stylesheet bundle path served for the plugin UI. */
         private String stylesheet;
 
+        /** Resolved logo URL or attachment URI for the plugin. */
         private String logo;
 
-        @Schema(description = "Load location of the plugin, often a path.")
+        /** URI location where the plugin artifact was loaded from. */
         private URI loadLocation;
 
         public static ConditionList nullSafeConditions(PluginStatus status) {
@@ -150,13 +176,16 @@ public class Plugin extends AbstractExtension {
         ;
     }
 
+    /** Plugin author metadata. */
     @Data
     @ToString
     public static class PluginAuthor {
 
+        /** Author display name. */
         @Schema(requiredMode = REQUIRED, minLength = 1)
         private String name;
 
+        /** Author website URL. */
         private String website;
     }
 }

--- a/api/src/main/java/run/halo/app/core/extension/RememberMeToken.java
+++ b/api/src/main/java/run/halo/app/core/extension/RememberMeToken.java
@@ -11,6 +11,7 @@ import org.jspecify.annotations.Nullable;
 import run.halo.app.extension.AbstractExtension;
 import run.halo.app.extension.GVK;
 
+/** Persistent remember-me token used to keep a user's browser session signed in across restarts. */
 @Data
 @EqualsAndHashCode(callSuper = true)
 @GVK(
@@ -21,22 +22,28 @@ import run.halo.app.extension.GVK;
         singular = "remembermetoken")
 public class RememberMeToken extends AbstractExtension {
 
+    /** Desired token identity and rotation state. */
     @Schema(requiredMode = REQUIRED)
     private Spec spec;
 
+    /** Persistent remember-me token values for a user and browser series. */
     @Data
     @Accessors(chain = true)
     @Schema(name = "RememberMeTokenSpec")
     public static class Spec {
+        /** User metadata.name that owns this remember-me token. */
         @Schema(requiredMode = REQUIRED, minLength = 1)
         private String username;
 
+        /** Browser series identifier used by Spring Security remember-me authentication. */
         @Schema(requiredMode = REQUIRED, minLength = 1)
         private String series;
 
+        /** Current remember-me token value expected from the browser cookie. */
         @Schema(requiredMode = REQUIRED, minLength = 1)
         private String tokenValue;
 
+        /** Last time this remember-me token was used successfully. */
         @Nullable
         private Instant lastUsed;
 

--- a/api/src/main/java/run/halo/app/core/extension/ReverseProxy.java
+++ b/api/src/main/java/run/halo/app/core/extension/ReverseProxy.java
@@ -23,9 +23,12 @@ import run.halo.app.extension.GVK;
         plural = "reverseproxies",
         singular = "reverseproxy")
 public class ReverseProxy extends AbstractExtension {
+    /** Path mapping rules served by this reverse proxy resource. */
     private List<ReverseProxyRule> rules;
 
+    /** A path mapping from a public request path to a file provider. */
     public record ReverseProxyRule(String path, FileReverseProxyProvider file) {}
 
+    /** File provider that resolves a request to a plugin or theme file location. */
     public record FileReverseProxyProvider(String directory, String filename) {}
 }

--- a/api/src/main/java/run/halo/app/core/extension/Role.java
+++ b/api/src/main/java/run/halo/app/core/extension/Role.java
@@ -15,6 +15,8 @@ import run.halo.app.extension.AbstractExtension;
 import run.halo.app.extension.GVK;
 
 /**
+ * Role extension that defines RBAC policy rules for users and other subjects.
+ *
  * @author guqing
  * @since 2.0.0
  */
@@ -37,6 +39,7 @@ public class Role extends AbstractExtension {
     public static final String VERSION = "v1alpha1";
     public static final String KIND = "Role";
 
+    /** Policy rules granted by this role. */
     @Schema(requiredMode = REQUIRED)
     List<PolicyRule> rules;
 
@@ -77,7 +80,7 @@ public class Role extends AbstractExtension {
          */
         final String[] nonResourceURLs;
 
-        /** about who the rule applies to or which namespace the rule applies to. */
+        /** Verbs allowed by this rule, such as get, list, create, update, patch, or delete. */
         final String[] verbs;
 
         public PolicyRule() {
@@ -127,14 +130,19 @@ public class Role extends AbstractExtension {
         }
 
         public static class Builder {
+            /** API groups to apply to the built policy rule. */
             String[] apiGroups;
 
+            /** Resources to apply to the built policy rule. */
             String[] resources;
 
+            /** Resource names to apply to the built policy rule. */
             String[] resourceNames;
 
+            /** Non-resource URLs to apply to the built policy rule. */
             String[] nonResourceURLs;
 
+            /** Verbs to allow in the built policy rule. */
             String[] verbs;
 
             public Builder apiGroups(String... apiGroups) {

--- a/api/src/main/java/run/halo/app/core/extension/RoleBinding.java
+++ b/api/src/main/java/run/halo/app/core/extension/RoleBinding.java
@@ -14,8 +14,7 @@ import run.halo.app.extension.GVK;
 import run.halo.app.extension.Metadata;
 
 /**
- * RoleBinding references a role, but does not contain it. It can reference a Role in the global. It adds who
- * information via Subjects.
+ * RoleBinding extension that grants a Role to one or more subjects.
  *
  * @author guqing
  * @since 2.0.0
@@ -32,12 +31,12 @@ public class RoleBinding extends AbstractExtension {
 
     public static final String KIND = "RoleBinding";
 
-    /** Subjects holds references to the objects the role applies to. */
+    /** Subjects that receive the permissions from roleRef. */
     List<Subject> subjects;
 
     /**
-     * RoleRef can reference a Role in the current namespace or a ClusterRole in the global namespace. If the RoleRef
-     * cannot be resolved, the Authorizer must return an error.
+     * Reference to the Role whose policy rules are granted to the subjects. If the RoleRef cannot be resolved, the
+     * Authorizer must return an error.
      */
     RoleRef roleRef;
 
@@ -50,17 +49,19 @@ public class RoleBinding extends AbstractExtension {
     @Data
     public static class RoleRef {
 
-        /** Kind is the type of resource being referenced. */
+        /** Kind of the role resource being referenced. */
         String kind;
 
-        /** Name is the name of resource being referenced. */
+        /** Metadata name of the role resource being referenced. */
         String name;
 
-        /** APIGroup is the group for the resource being referenced. */
+        /** API group of the role resource being referenced. */
         String apiGroup;
     }
 
     /**
+     * Subject that receives permissions from a RoleBinding.
+     *
      * @author guqing
      * @since 2.0.0
      */

--- a/api/src/main/java/run/halo/app/core/extension/Setting.java
+++ b/api/src/main/java/run/halo/app/core/extension/Setting.java
@@ -12,7 +12,7 @@ import run.halo.app.extension.GVK;
 import run.halo.app.extension.GroupVersionKind;
 
 /**
- * {@link Setting} is a custom extension to generate forms based on configuration.
+ * Setting extension that describes one or more configuration forms and their schema.
  *
  * @author guqing
  * @since 2.0.0
@@ -26,24 +26,31 @@ public class Setting extends AbstractExtension {
 
     public static final GroupVersionKind GVK = fromExtension(Setting.class);
 
+    /** Desired configuration form groups exposed by this setting definition. */
     @Schema(requiredMode = REQUIRED)
     private SettingSpec spec;
 
+    /** Collection of form groups that make up this setting definition. */
     @Data
     public static class SettingSpec {
 
+        /** Form groups rendered for this setting definition. */
         @Schema(requiredMode = REQUIRED, minLength = 1)
         private List<SettingForm> forms;
     }
 
+    /** A single form group in a setting definition. */
     @Data
     public static class SettingForm {
 
+        /** Stable form group name used to store submitted values. */
         @Schema(requiredMode = REQUIRED)
         private String group;
 
+        /** Display label shown for this form group. */
         private String label;
 
+        /** FormKit-compatible schema used to render the form fields. */
         @Schema(requiredMode = REQUIRED)
         private List<Object> formSchema;
     }

--- a/api/src/main/java/run/halo/app/core/extension/Theme.java
+++ b/api/src/main/java/run/halo/app/core/extension/Theme.java
@@ -16,7 +16,7 @@ import run.halo.app.infra.ConditionList;
 import run.halo.app.infra.model.License;
 
 /**
- * Theme extension.
+ * Theme extension that describes an installable frontend theme and its runtime state.
  *
  * @author guqing
  * @since 2.0.0
@@ -33,54 +33,76 @@ public class Theme extends AbstractExtension {
 
     public static final String REQUEST_RELOAD_ANNOTATION = "theme.halo.run/request-reload";
 
+    /** Desired theme metadata, settings references, compatibility, and template declarations. */
     @Schema(requiredMode = REQUIRED)
     private ThemeSpec spec;
 
+    /** Observed theme lifecycle state reported by the theme manager. */
     private ThemeStatus status;
 
+    /** Desired theme metadata and configuration references. */
     @Data
     @ToString
     public static class ThemeSpec {
         private static final String WILDCARD = "*";
 
+        /** Display name shown for the theme. */
         @Schema(requiredMode = REQUIRED, minLength = 1)
         private String displayName;
 
+        /** Theme author information. */
         @Schema(requiredMode = REQUIRED)
         private Author author;
 
+        /** Human-readable theme description. */
         private String description;
 
+        /** Logo URL or attachment URI for the theme. */
         private String logo;
 
+        /** Theme homepage URL. */
         private String homepage;
 
+        /** Source repository URL. */
         private String repo;
 
+        /** Issue tracker URL. */
         private String issues;
 
+        /** Theme version. The wildcard value means any version. */
         private String version = WILDCARD;
 
+        /** Required Halo version range. The wildcard value means any Halo version. */
         @Schema(requiredMode = NOT_REQUIRED)
         private String requires = WILDCARD;
 
+        /** Setting metadata.name used to render the theme configuration form. */
         private String settingName;
 
+        /** ConfigMap metadata.name storing the theme configuration values. */
         private String configMapName;
 
+        /** Licenses declared by the theme. */
         private List<License> license;
 
+        /** Custom template descriptors exposed by the theme. */
         @Schema
         private CustomTemplates customTemplates;
     }
 
+    /** Observed theme lifecycle and installation state. */
     @Data
     public static class ThemeStatus {
+        /** Current theme lifecycle phase. */
         private ThemePhase phase;
+
+        /** Reconciliation conditions for the theme. */
         private ConditionList conditions;
+
+        /** Local filesystem location where the theme is loaded from. */
         private String location;
 
-        @Schema(description = "Whether the theme appears to be a local development workspace.")
+        /** Whether the theme appears to be a local development workspace. */
         private Boolean inDevelopment;
     }
 
@@ -106,20 +128,29 @@ public class Theme extends AbstractExtension {
         UNKNOWN,
     }
 
+    /** Theme author metadata. */
     @Data
     @ToString
     public static class Author {
 
+        /** Author display name. */
         @Schema(requiredMode = REQUIRED, minLength = 1)
         private String name;
 
+        /** Author website URL. */
         private String website;
     }
 
+    /** Custom template descriptors grouped by the content type they render. */
     @Data
     public static class CustomTemplates {
+        /** Custom templates available for posts. */
         private List<TemplateDescriptor> post;
+
+        /** Custom templates available for categories. */
         private List<TemplateDescriptor> category;
+
+        /** Custom templates available for single pages. */
         private List<TemplateDescriptor> page;
     }
 
@@ -132,13 +163,17 @@ public class Theme extends AbstractExtension {
     @Data
     public static class TemplateDescriptor {
 
+        /** Template display name shown to users. */
         @Schema(requiredMode = REQUIRED, minLength = 1)
         private String name;
 
+        /** Human-readable description of when to use this template. */
         private String description;
 
+        /** Screenshot URL or attachment URI for previewing the template. */
         private String screenshot;
 
+        /** Template file path relative to the theme templates directory. */
         @Schema(requiredMode = REQUIRED, minLength = 1)
         private String file;
     }

--- a/api/src/main/java/run/halo/app/core/extension/User.java
+++ b/api/src/main/java/run/halo/app/core/extension/User.java
@@ -14,7 +14,7 @@ import run.halo.app.extension.AbstractExtension;
 import run.halo.app.extension.GVK;
 
 /**
- * The extension represents user details of Halo.
+ * User extension that stores profile, authentication, and account state for a Halo user.
  *
  * @author johnniang
  */
@@ -42,44 +42,61 @@ public class User extends AbstractExtension {
 
     public static final String REQUEST_TO_UPDATE = "halo.run/request-to-update";
 
+    /** Desired user profile and authentication settings. */
     @Schema(requiredMode = REQUIRED)
     private UserSpec spec = new UserSpec();
 
+    /** Observed user state derived by the application. */
     private UserStatus status = new UserStatus();
 
+    /** Desired user profile and authentication settings. */
     @Data
     public static class UserSpec {
 
+        /** Display name shown for the user. */
         @Schema(requiredMode = REQUIRED)
         private String displayName;
 
+        /** Avatar URL or attachment URI for the user. */
         private String avatar;
 
+        /** Email address used for sign-in and notifications. */
         @Schema(requiredMode = REQUIRED)
         private String email;
 
+        /** Whether the email address has been verified. */
         private boolean emailVerified;
 
+        /** Phone number associated with the user. */
         private String phone;
 
+        /** Password hash or encoded password value. */
         private String password;
 
+        /** User biography shown on profile surfaces. */
         private String bio;
 
+        /** Time when the user registered. */
         private Instant registeredAt;
 
+        /** Whether two-factor authentication is enabled for this user. */
         private Boolean twoFactorAuthEnabled;
 
+        /** Encrypted TOTP secret used for two-factor authentication. */
         private String totpEncryptedSecret;
 
+        /** Whether the user account is disabled. */
         private Boolean disabled;
 
+        /** Maximum number of login history entries retained for this user. */
         private Integer loginHistoryLimit;
     }
 
+    /** Observed user state derived by the application. */
     @Data
     public static class UserStatus {
 
+        /** Public permalink of the user's profile or author page. */
         private String permalink;
     }
 }

--- a/api/src/main/java/run/halo/app/core/extension/UserConnection.java
+++ b/api/src/main/java/run/halo/app/core/extension/UserConnection.java
@@ -11,7 +11,7 @@ import run.halo.app.extension.GVK;
 import run.halo.app.extension.Metadata;
 
 /**
- * User connection extension.
+ * User connection extension that links a Halo user to an external OAuth2 account.
  *
  * @author guqing
  * @since 2.4.0
@@ -26,9 +26,11 @@ import run.halo.app.extension.Metadata;
         plural = "userconnections")
 public class UserConnection extends AbstractExtension {
 
+    /** Desired external account binding information. */
     @Schema(requiredMode = REQUIRED)
     private UserConnectionSpec spec;
 
+    /** External OAuth2 account binding for a Halo user. */
     @Data
     public static class UserConnectionSpec {
 

--- a/api/src/main/java/run/halo/app/core/extension/attachment/Attachment.java
+++ b/api/src/main/java/run/halo/app/core/extension/attachment/Attachment.java
@@ -3,7 +3,6 @@ package run.halo.app.core.extension.attachment;
 import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
 import static run.halo.app.core.extension.attachment.Attachment.KIND;
 
-import io.swagger.v3.oas.annotations.media.ArraySchema;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.util.Map;
 import java.util.Set;
@@ -14,6 +13,7 @@ import org.jspecify.annotations.Nullable;
 import run.halo.app.extension.AbstractExtension;
 import run.halo.app.extension.GVK;
 
+/** Attachment extension that describes an uploaded file and its resolved access URLs. */
 @Data
 @ToString(callSuper = true)
 @EqualsAndHashCode(callSuper = true)
@@ -22,49 +22,52 @@ public class Attachment extends AbstractExtension {
 
     public static final String KIND = "Attachment";
 
+    /** Desired attachment metadata, storage references, and classification fields. */
     @Schema(requiredMode = REQUIRED)
     private AttachmentSpec spec;
 
+    /** Observed attachment access URLs and generated thumbnails. */
     private AttachmentStatus status;
 
+    /** Desired attachment metadata and storage placement. */
     @Data
     public static class AttachmentSpec {
 
-        @Schema(description = "Display name of attachment")
+        /** Display name shown for the attachment. */
         private String displayName;
 
-        @Schema(description = "Group name")
+        /** Attachment group metadata.name this attachment belongs to. */
         private String groupName;
 
-        @Schema(description = "Policy name")
+        /** Storage policy metadata.name used to store this attachment. */
         private String policyName;
 
-        @Schema(description = "Name of User who uploads the attachment")
+        /** User metadata.name of the uploader. */
         private String ownerName;
 
-        @Schema(description = "Media type of attachment")
+        /** Media type detected or supplied for the attachment, such as image/png. */
         @Nullable
         private String mediaType;
 
-        @Schema(description = "Size of attachment. Unit is Byte", minimum = "0")
+        /** Size of the attachment in bytes. */
+        @Schema(minimum = "0")
         private Long size;
 
-        @ArraySchema(
-                arraySchema = @Schema(description = "Tags of attachment"),
-                schema = @Schema(description = "Tag name"))
+        /** Free-form tags assigned to the attachment. */
         private Set<String> tags;
     }
 
+    /** Observed attachment access state. */
     @Data
     public static class AttachmentStatus {
 
-        @Schema(description = """
-            Permalink of attachment.
-            If it is in local storage, the public URL will be set.
-            If it is in s3 storage, the Object URL will be set.
-            """)
+        /**
+         * Public permalink for the attachment. Local storage usually exposes a public URL, while object storage may
+         * expose the object URL.
+         */
         private String permalink;
 
+        /** Generated thumbnail URLs keyed by thumbnail size name. */
         @Nullable
         private Map<String, String> thumbnails;
     }

--- a/api/src/main/java/run/halo/app/core/extension/attachment/Group.java
+++ b/api/src/main/java/run/halo/app/core/extension/attachment/Group.java
@@ -11,6 +11,7 @@ import lombok.ToString;
 import run.halo.app.extension.AbstractExtension;
 import run.halo.app.extension.GVK;
 
+/** Attachment group extension used to organize attachments and expose aggregate counts. */
 @Data
 @ToString(callSuper = true)
 @EqualsAndHashCode(callSuper = true)
@@ -20,25 +21,31 @@ public class Group extends AbstractExtension {
     public static final String KIND = "Group";
     public static final String HIDDEN_LABEL = "halo.run/hidden";
 
+    /** Desired group metadata. */
     @Schema(requiredMode = REQUIRED)
     private GroupSpec spec;
 
+    /** Observed group aggregate state. */
     private GroupStatus status;
 
+    /** Desired attachment group metadata. */
     @Data
     public static class GroupSpec {
 
-        @Schema(requiredMode = REQUIRED, description = "Display name of group")
+        /** Display name shown for the attachment group. */
+        @Schema(requiredMode = REQUIRED)
         private String displayName;
     }
 
+    /** Observed attachment group aggregate state. */
     @Data
     public static class GroupStatus {
 
-        @Schema(description = "Update timestamp of the group")
+        /** Last time the group aggregate state was updated. */
         private Instant updateTimestamp;
 
-        @Schema(description = "Total of attachments under the current group", minimum = "0")
+        /** Total number of attachments under the group. */
+        @Schema(minimum = "0")
         private Long totalAttachments;
     }
 }

--- a/api/src/main/java/run/halo/app/core/extension/attachment/Policy.java
+++ b/api/src/main/java/run/halo/app/core/extension/attachment/Policy.java
@@ -10,6 +10,7 @@ import lombok.ToString;
 import run.halo.app.extension.AbstractExtension;
 import run.halo.app.extension.GVK;
 
+/** Storage policy extension that binds attachment uploads to a policy template and configuration. */
 @Data
 @ToString(callSuper = true)
 @EqualsAndHashCode(callSuper = true)
@@ -19,19 +20,23 @@ public class Policy extends AbstractExtension {
 
     public static final String KIND = "Policy";
 
+    /** Desired storage policy metadata and template references. */
     @Schema(requiredMode = REQUIRED)
     private PolicySpec spec;
 
+    /** Desired storage policy configuration. */
     @Data
     public static class PolicySpec {
 
-        @Schema(requiredMode = REQUIRED, description = "Display name of policy")
+        /** Display name shown for the storage policy. */
+        @Schema(requiredMode = REQUIRED)
         private String displayName;
 
-        @Schema(requiredMode = REQUIRED, description = "Reference name of PolicyTemplate")
+        /** PolicyTemplate metadata.name that provides the storage implementation. */
+        @Schema(requiredMode = REQUIRED)
         private String templateName;
 
-        @Schema(description = "Reference name of ConfigMap extension")
+        /** ConfigMap metadata.name storing configuration values for this policy. */
         private String configMapName;
     }
 }

--- a/api/src/main/java/run/halo/app/core/extension/attachment/PolicyTemplate.java
+++ b/api/src/main/java/run/halo/app/core/extension/attachment/PolicyTemplate.java
@@ -10,6 +10,7 @@ import lombok.ToString;
 import run.halo.app.extension.AbstractExtension;
 import run.halo.app.extension.GVK;
 
+/** Storage policy template extension that declares an attachment storage implementation and its settings form. */
 @Data
 @ToString(callSuper = true)
 @EqualsAndHashCode(callSuper = true)
@@ -23,13 +24,17 @@ public class PolicyTemplate extends AbstractExtension {
 
     public static final String KIND = "PolicyTemplate";
 
+    /** Desired template metadata and setting reference. */
     private PolicyTemplateSpec spec;
 
+    /** Desired storage policy template metadata. */
     @Data
     public static class PolicyTemplateSpec {
 
+        /** Display name shown for the storage policy template. */
         private String displayName;
 
+        /** Setting metadata.name used to render configuration fields for policies created from this template. */
         @Schema(requiredMode = REQUIRED)
         private String settingName;
     }

--- a/api/src/main/java/run/halo/app/core/extension/content/Category.java
+++ b/api/src/main/java/run/halo/app/core/extension/content/Category.java
@@ -23,7 +23,7 @@ import run.halo.app.extension.GroupVersionKind;
  * @since 2.0.0
  */
 @Data
-@Schema(description = "Category extension for grouping posts and building category archives.")
+@Schema(name = "Category")
 @ToString(callSuper = true)
 @GVK(group = Constant.GROUP, version = Constant.VERSION, kind = KIND, plural = "categories", singular = "category")
 @EqualsAndHashCode(callSuper = true)
@@ -48,8 +48,8 @@ public class Category extends AbstractExtension {
         return getMetadata().getDeletionTimestamp() != null;
     }
 
+    /** Desired category display, hierarchy, and rendering configuration. */
     @Data
-    @Schema(description = "Desired display, hierarchy, and rendering configuration of a category.")
     public static class CategorySpec {
 
         /** Display name of the category. */
@@ -102,8 +102,8 @@ public class Category extends AbstractExtension {
         return this.status;
     }
 
+    /** Observed category state derived by content reconcilers. */
     @Data
-    @Schema(description = "Observed state of a category.")
     public static class CategoryStatus {
 
         /** Absolute permalink calculated from the category permalink policy. */

--- a/api/src/main/java/run/halo/app/core/extension/content/Comment.java
+++ b/api/src/main/java/run/halo/app/core/extension/content/Comment.java
@@ -49,10 +49,10 @@ public class Comment extends AbstractExtension {
         return this.status;
     }
 
+    /** Desired state of a top-level comment. */
     @Data
     @ToString(callSuper = true)
     @EqualsAndHashCode(callSuper = true)
-    @Schema(description = "Desired state of a top-level comment.")
     public static class CommentSpec extends BaseCommentSpec {
 
         /** Reference to the comment subject extension, such as a Post or SinglePage. */
@@ -63,8 +63,8 @@ public class Comment extends AbstractExtension {
         private Instant lastReadTime;
     }
 
+    /** Common desired state shared by comments and replies. */
     @Data
-    @Schema(description = "Common desired state shared by comments and replies.")
     public static class BaseCommentSpec {
 
         /** Raw comment body submitted by the owner before HTML sanitization and rendering. */
@@ -112,8 +112,8 @@ public class Comment extends AbstractExtension {
         private Boolean hidden;
     }
 
+    /** Identity of a comment or reply owner. */
     @Data
-    @Schema(description = "Identity of a comment or reply owner.")
     public static class CommentOwner {
         public static final String KIND_EMAIL = "Email";
         public static final String AVATAR_ANNO = "avatar";
@@ -145,8 +145,8 @@ public class Comment extends AbstractExtension {
         }
     }
 
+    /** Observed state of a top-level comment. */
     @Data
-    @Schema(description = "Observed state of a comment.")
     public static class CommentStatus {
 
         /** Creation time of the latest reply under this comment. */

--- a/api/src/main/java/run/halo/app/core/extension/content/Post.java
+++ b/api/src/main/java/run/halo/app/core/extension/content/Post.java
@@ -20,7 +20,7 @@ import run.halo.app.extension.MetadataOperator;
 import run.halo.app.infra.ConditionList;
 
 /**
- * Post extension.
+ * Post extension that stores article metadata, publication settings, taxonomy, and derived status.
  *
  * @author guqing
  * @see <a href="https://github.com/halo-dev/halo/issues/2322">issue#2322</a>
@@ -103,8 +103,8 @@ public class Post extends AbstractExtension {
         return spec.getVisible() == null || VisibleEnum.PUBLIC.equals(spec.getVisible());
     }
 
+    /** Desired post content, publication, taxonomy, and rendering configuration. */
     @Data
-    @Schema(description = "Desired content, publication, taxonomy, and rendering configuration of a post.")
     public static class PostSpec {
         /** Display title of the post. */
         @Schema(requiredMode = RequiredMode.REQUIRED, minLength = 1)
@@ -173,8 +173,8 @@ public class Post extends AbstractExtension {
         private List<Map<String, String>> htmlMetas;
     }
 
+    /** Observed post state derived by content reconcilers. */
     @Data
-    @Schema(description = "Observed state of a content item.")
     public static class PostStatus {
         /** Current publishing phase, such as DRAFT, PENDING_APPROVAL, PUBLISHED, or FAILED. */
         private String phase;
@@ -215,8 +215,8 @@ public class Post extends AbstractExtension {
         }
     }
 
+    /** Excerpt generation configuration for a post or single page. */
     @Data
-    @Schema(description = "Excerpt generation configuration.")
     public static class Excerpt {
 
         /** Whether Halo should generate the excerpt from the released content automatically. */

--- a/api/src/main/java/run/halo/app/core/extension/content/Reply.java
+++ b/api/src/main/java/run/halo/app/core/extension/content/Reply.java
@@ -35,9 +35,9 @@ public class Reply extends AbstractExtension {
     @Schema(requiredMode = REQUIRED)
     private Status status = new Status();
 
+    /** Desired state of a reply. */
     @Data
     @EqualsAndHashCode(callSuper = true)
-    @Schema(description = "Desired state of a reply.")
     public static class ReplySpec extends Comment.BaseCommentSpec {
 
         /** Parent Comment metadata.name. */
@@ -48,8 +48,9 @@ public class Reply extends AbstractExtension {
         private String quoteReply;
     }
 
+    /** Observed state of a reply. */
     @Data
-    @Schema(name = "ReplyStatus", description = "Observed state of a reply.")
+    @Schema(name = "ReplyStatus")
     public static class Status {
         /** Metadata version observed by the last successful reconciliation. */
         private Long observedVersion;

--- a/api/src/main/java/run/halo/app/core/extension/content/SinglePage.java
+++ b/api/src/main/java/run/halo/app/core/extension/content/SinglePage.java
@@ -17,7 +17,7 @@ import run.halo.app.extension.GroupVersionKind;
 import run.halo.app.extension.MetadataUtil;
 
 /**
- * Single page extension.
+ * Single page extension that stores standalone page metadata, publication settings, and derived status.
  *
  * @author guqing
  * @since 2.0.0
@@ -65,8 +65,8 @@ public class SinglePage extends AbstractExtension {
         return labels != null && labels.getOrDefault(PUBLISHED_LABEL, "false").equals("true");
     }
 
+    /** Desired single page content, publication, and rendering configuration. */
     @Data
-    @Schema(description = "Desired content, publication, and rendering configuration of a single page.")
     public static class SinglePageSpec {
         /** Display title of the single page. */
         @Schema(requiredMode = REQUIRED, minLength = 1)
@@ -131,9 +131,9 @@ public class SinglePage extends AbstractExtension {
         private List<Map<String, String>> htmlMetas;
     }
 
+    /** Observed single page state derived by content reconcilers. */
     @Data
     @EqualsAndHashCode(callSuper = true)
-    @Schema(description = "Observed state of a single page.")
     public static class SinglePageStatus extends Post.PostStatus {}
 
     public static void changePublishedState(SinglePage page, boolean value) {

--- a/api/src/main/java/run/halo/app/core/extension/content/Snapshot.java
+++ b/api/src/main/java/run/halo/app/core/extension/content/Snapshot.java
@@ -46,8 +46,8 @@ public class Snapshot extends AbstractExtension {
     @Schema(requiredMode = REQUIRED)
     private SnapShotSpec spec;
 
+    /** Content snapshot payload and metadata. */
     @Data
-    @Schema(description = "Content snapshot payload and metadata.")
     public static class SnapShotSpec {
 
         /** Reference to the content extension that owns this snapshot, such as a Post or SinglePage. */

--- a/api/src/main/java/run/halo/app/core/extension/content/Tag.java
+++ b/api/src/main/java/run/halo/app/core/extension/content/Tag.java
@@ -20,7 +20,7 @@ import run.halo.app.extension.GroupVersionKind;
  * @since 2.0.0
  */
 @Data
-@Schema(description = "Tag extension for grouping posts by free-form labels.")
+@Schema(name = "Tag")
 @ToString(callSuper = true)
 @GVK(group = Constant.GROUP, version = Constant.VERSION, kind = Tag.KIND, plural = "tags", singular = "tag")
 @EqualsAndHashCode(callSuper = true)
@@ -41,8 +41,8 @@ public class Tag extends AbstractExtension {
     @Nullable
     private TagStatus status;
 
+    /** Desired tag display and rendering configuration. */
     @Data
-    @Schema(description = "Desired display and rendering configuration of a tag.")
     public static class TagSpec {
 
         /** Display name of the tag. */
@@ -72,8 +72,8 @@ public class Tag extends AbstractExtension {
         return this.status;
     }
 
+    /** Observed tag state derived by content reconcilers. */
     @Data
-    @Schema(description = "Observed state of a tag.")
     public static class TagStatus {
 
         /** Absolute permalink calculated from the tag permalink policy. */

--- a/api/src/main/java/run/halo/app/core/extension/notification/Notification.java
+++ b/api/src/main/java/run/halo/app/core/extension/notification/Notification.java
@@ -10,8 +10,7 @@ import run.halo.app.extension.AbstractExtension;
 import run.halo.app.extension.GVK;
 
 /**
- * {@link Notification} is a custom extension that used to store notification information for inner use, it's on-site
- * notification.
+ * Notification extension that stores an on-site notification delivered to a Halo user.
  *
  * <p>Supports the following operations:
  *
@@ -36,28 +35,37 @@ import run.halo.app.extension.GVK;
         singular = "notification")
 public class Notification extends AbstractExtension {
 
+    /** Desired notification recipient, content, and read state. */
     @Schema
     private NotificationSpec spec;
 
+    /** Notification content and read state for one recipient. */
     @Data
     public static class NotificationSpec {
-        @Schema(requiredMode = REQUIRED, minLength = 1, description = "The name of user")
+        /** User metadata.name that receives the notification. */
+        @Schema(requiredMode = REQUIRED, minLength = 1)
         private String recipient;
 
-        @Schema(requiredMode = REQUIRED, minLength = 1, description = "The name of reason")
+        /** Reason metadata.name that generated this notification. */
+        @Schema(requiredMode = REQUIRED, minLength = 1)
         private String reason;
 
+        /** Notification title shown in the notification center. */
         @Schema(requiredMode = REQUIRED, minLength = 1)
         private String title;
 
+        /** Plain text or source notification content. */
         @Schema(requiredMode = REQUIRED)
         private String rawContent;
 
+        /** HTML notification content. */
         @Schema(requiredMode = REQUIRED)
         private String htmlContent;
 
+        /** Whether the recipient has not read the notification yet. */
         private boolean unread;
 
+        /** Last time the recipient marked this notification as read. */
         private Instant lastReadAt;
     }
 }

--- a/api/src/main/java/run/halo/app/core/extension/notification/NotificationTemplate.java
+++ b/api/src/main/java/run/halo/app/core/extension/notification/NotificationTemplate.java
@@ -9,7 +9,7 @@ import run.halo.app.extension.AbstractExtension;
 import run.halo.app.extension.GVK;
 
 /**
- * {@link NotificationTemplate} is a custom extension that defines a notification template.
+ * Notification template extension that defines localized message content for matching reason types.
  *
  * <p>It describes the notification template's name, description, and the template content.
  *
@@ -29,35 +29,46 @@ import run.halo.app.extension.GVK;
         singular = "notificationtemplate")
 public class NotificationTemplate extends AbstractExtension {
 
+    /** Desired selector and template content. */
     @Schema
     private Spec spec;
 
+    /** Desired notification template selector and content. */
     @Data
     @Schema(name = "NotificationTemplateSpec")
     public static class Spec {
+        /** Selector that determines which reasons can use this template. */
         @Schema
         private ReasonSelector reasonSelector;
 
+        /** Title and body content rendered for matching reasons. */
         @Schema
         private Template template;
     }
 
+    /** Notification template content. */
     @Data
     @Schema(name = "TemplateContent")
     public static class Template {
+        /** Rendered notification title. */
         @Schema(requiredMode = REQUIRED, minLength = 1)
         private String title;
 
+        /** HTML body rendered for notification channels that support HTML. */
         private String htmlBody;
 
+        /** Plain text or source body rendered for notification channels that do not use HTML. */
         private String rawBody;
     }
 
+    /** Selector used to match a notification template to a reason type and language. */
     @Data
     public static class ReasonSelector {
+        /** ReasonType metadata.name this template applies to. */
         @Schema(requiredMode = REQUIRED, minLength = 1)
         private String reasonType;
 
+        /** Language tag this template applies to, or default for the fallback template. */
         @Schema(requiredMode = REQUIRED, minLength = 1, defaultValue = "default")
         private String language;
     }

--- a/api/src/main/java/run/halo/app/core/extension/notification/NotifierDescriptor.java
+++ b/api/src/main/java/run/halo/app/core/extension/notification/NotifierDescriptor.java
@@ -9,7 +9,7 @@ import run.halo.app.extension.AbstractExtension;
 import run.halo.app.extension.GVK;
 
 /**
- * {@link NotifierDescriptor} is a custom extension that defines a notifier.
+ * Notifier descriptor extension that advertises a notification delivery implementation and its settings.
  *
  * <p>It describes the notifier's name, description, and the extension name of the notifier to let the user know what
  * the notifier is and what it can do in the UI and also let the {@code NotificationCenter} know how to load the
@@ -28,31 +28,41 @@ import run.halo.app.extension.GVK;
         singular = "notifierDescriptor")
 public class NotifierDescriptor extends AbstractExtension {
 
+    /** Desired notifier display metadata and setting references. */
     @Schema
     private Spec spec;
 
+    /** Desired notifier descriptor metadata and configuration references. */
     @Data
     @Schema(name = "NotifierDescriptorSpec")
     public static class Spec {
+        /** Display name shown for the notifier. */
         @Schema(requiredMode = REQUIRED, minLength = 1)
         private String displayName;
 
+        /** Human-readable description of what the notifier sends. */
         private String description;
 
+        /** Extension name of the notifier implementation. */
         @Schema(requiredMode = REQUIRED, minLength = 1)
         private String notifierExtName;
 
+        /** Setting reference used to configure the sender side of the notifier. */
         private SettingRef senderSettingRef;
 
+        /** Setting reference used to configure the receiver side of the notifier. */
         private SettingRef receiverSettingRef;
     }
 
+    /** Reference to a notifier setting form group. */
     @Data
     @Schema(name = "NotifierSettingRef")
     public static class SettingRef {
+        /** Setting metadata.name. */
         @Schema(requiredMode = REQUIRED)
         private String name;
 
+        /** Setting form group name. */
         @Schema(requiredMode = REQUIRED)
         private String group;
     }

--- a/api/src/main/java/run/halo/app/core/extension/notification/Reason.java
+++ b/api/src/main/java/run/halo/app/core/extension/notification/Reason.java
@@ -11,8 +11,7 @@ import run.halo.app.extension.GVK;
 import run.halo.app.notification.ReasonAttributes;
 
 /**
- * {@link Reason} is a custom extension that defines a reason for a notification, It represents an instance of a
- * {@link ReasonType}.
+ * Reason extension that represents one notification event instance of a {@link ReasonType}.
  *
  * <p>It can be understood as an event that triggers a notification.
  *
@@ -24,47 +23,56 @@ import run.halo.app.notification.ReasonAttributes;
 @GVK(group = "notification.halo.run", version = "v1alpha1", kind = "Reason", plural = "reasons", singular = "reason")
 public class Reason extends AbstractExtension {
 
+    /** Desired notification reason data, including type, subject, author, and template attributes. */
     @Schema
     private Spec spec;
 
+    /** Notification reason data used to render and dispatch notifications. */
     @Data
     @Accessors(chain = true)
     @Schema(name = "ReasonSpec")
     public static class Spec {
+        /** ReasonType metadata.name that defines this reason. */
         @Schema(requiredMode = REQUIRED)
         private String reasonType;
 
+        /** Subject resource this reason is about. */
         @Schema(requiredMode = REQUIRED)
         private Subject subject;
 
+        /** User metadata.name or system actor that created the reason. */
         @Schema(requiredMode = REQUIRED)
         private String author;
 
-        @Schema(
-                implementation = ReasonAttributes.class,
-                requiredMode = NOT_REQUIRED,
-                description = "Attributes used to transfer data")
+        /** Additional key-value attributes passed to notification templates. */
+        @Schema(implementation = ReasonAttributes.class, requiredMode = NOT_REQUIRED)
         private ReasonAttributes attributes;
     }
 
+    /** Resource subject associated with a notification reason. */
     @Data
     @Builder
     @NoArgsConstructor
     @AllArgsConstructor
     @Schema(name = "ReasonSubject")
     public static class Subject {
+        /** Subject API version. */
         @Schema(requiredMode = REQUIRED)
         private String apiVersion;
 
+        /** Subject kind. */
         @Schema(requiredMode = REQUIRED)
         private String kind;
 
+        /** Subject metadata.name. */
         @Schema(requiredMode = REQUIRED)
         private String name;
 
+        /** Human-readable subject title shown in notifications. */
         @Schema(requiredMode = REQUIRED)
         private String title;
 
+        /** URL that opens the subject. */
         private String url;
     }
 }

--- a/api/src/main/java/run/halo/app/core/extension/notification/ReasonType.java
+++ b/api/src/main/java/run/halo/app/core/extension/notification/ReasonType.java
@@ -10,7 +10,7 @@ import run.halo.app.extension.AbstractExtension;
 import run.halo.app.extension.GVK;
 
 /**
- * {@link ReasonType} is a custom extension that defines a type of reason.
+ * Reason type extension that defines the schema and display metadata for notification reasons.
  *
  * <p>One {@link ReasonType} can have multiple {@link Reason}s to notify.
  *
@@ -30,32 +30,42 @@ import run.halo.app.extension.GVK;
 public class ReasonType extends AbstractExtension {
     public static final String LOCALIZED_RESOURCE_NAME_ANNO = "notification.halo.run/localized-resource-name";
 
+    /** Desired reason type display metadata and attribute definitions. */
     @Schema
     private Spec spec;
 
+    /** Desired reason type metadata and properties available to templates. */
     @Data
     @Schema(name = "ReasonTypeSpec")
     public static class Spec {
 
+        /** Display name shown for this reason type. */
         @Schema(requiredMode = REQUIRED, minLength = 1)
         private String displayName;
 
+        /** Human-readable description of when this reason type is triggered. */
         @Schema(requiredMode = REQUIRED, minLength = 1)
         private String description;
 
+        /** Attribute definitions available on reasons of this type. */
         private List<ReasonProperty> properties;
     }
 
+    /** Attribute definition for reasons of a reason type. */
     @Data
     public static class ReasonProperty {
+        /** Attribute name. */
         @Schema(requiredMode = REQUIRED, minLength = 1)
         private String name;
 
+        /** Attribute value type, such as string, number, boolean, or object. */
         @Schema(requiredMode = REQUIRED, minLength = 1)
         private String type;
 
+        /** Human-readable description of the attribute. */
         private String description;
 
+        /** Whether the attribute may be absent from a reason. */
         @Schema(defaultValue = "false")
         private boolean optional;
     }

--- a/api/src/main/java/run/halo/app/core/extension/notification/Subscription.java
+++ b/api/src/main/java/run/halo/app/core/extension/notification/Subscription.java
@@ -11,8 +11,7 @@ import run.halo.app.extension.AbstractExtension;
 import run.halo.app.extension.GVK;
 
 /**
- * {@link Subscription} is a custom extension that defines a subscriber to be notified when a certain {@link Reason} is
- * triggered.
+ * Subscription extension that records which subscriber should be notified when a matching reason is triggered.
  *
  * <p>It holds a {@link Subscriber} to the user to be notified, a {@link InterestReason} to subscribe to.
  *
@@ -29,36 +28,43 @@ import run.halo.app.extension.GVK;
         singular = "subscription")
 public class Subscription extends AbstractExtension {
 
+    /** Desired subscriber, unsubscribe token, interest expression, and disabled state. */
     @Schema
     private Spec spec;
 
+    /** Desired notification subscription settings. */
     @Data
     @Schema(name = "SubscriptionSpec")
     public static class Spec {
-        @Schema(requiredMode = REQUIRED, description = "The subscriber to be notified")
+        /** Subscriber that receives matching notifications. */
+        @Schema(requiredMode = REQUIRED)
         private Subscriber subscriber;
 
-        @Schema(requiredMode = REQUIRED, description = "The token to unsubscribe")
+        /** Token used to unsubscribe without authenticating as the subscriber. */
+        @Schema(requiredMode = REQUIRED)
         private String unsubscribeToken;
 
-        @Schema(requiredMode = REQUIRED, description = "The reason to be interested in")
+        /** Reason and optional subject or expression this subscription is interested in. */
+        @Schema(requiredMode = REQUIRED)
         private InterestReason reason;
 
-        @Schema(
-                description =
-                        "Perhaps users need to unsubscribe and " + "interact without receiving notifications again")
+        /** Whether the subscription has been disabled, usually after the subscriber unsubscribes. */
         private boolean disabled;
     }
 
+    /** Reason selector that decides which notifications match this subscription. */
     @Data
     public static class InterestReason {
-        @Schema(requiredMode = REQUIRED, description = "The name of the reason definition to be " + "interested in")
+        /** ReasonType metadata.name this subscription is interested in. */
+        @Schema(requiredMode = REQUIRED)
         private String reasonType;
 
-        @Schema(requiredMode = REQUIRED, description = "The subject name of reason type to be" + " interested in")
+        /** Subject this subscription is interested in. */
+        @Schema(requiredMode = REQUIRED)
         private ReasonSubject subject;
 
-        @Schema(requiredMode = NOT_REQUIRED, description = "The expression to be interested in")
+        /** Optional expression used to match reasons more flexibly than subject matching. */
+        @Schema(requiredMode = NOT_REQUIRED)
         private String expression;
 
         /**
@@ -95,6 +101,7 @@ public class Subscription extends AbstractExtension {
         }
     }
 
+    /** Subject selector used by a subscription interest reason. */
     @Data
     @Builder
     @AllArgsConstructor
@@ -102,15 +109,15 @@ public class Subscription extends AbstractExtension {
     @Schema(name = "InterestReasonSubject")
     public static class ReasonSubject {
 
-        @Schema(
-                requiredMode = NOT_REQUIRED,
-                description = "if name is not specified, it presents "
-                        + "all subjects of the specified reason type and custom resources")
+        /** Subject metadata.name. If omitted, all subjects of the selected kind and API version are matched. */
+        @Schema(requiredMode = NOT_REQUIRED)
         private String name;
 
+        /** Subject API version. */
         @Schema(requiredMode = REQUIRED, minLength = 1)
         private String apiVersion;
 
+        /** Subject kind. */
         @Schema(requiredMode = REQUIRED, minLength = 1)
         private String kind;
 
@@ -120,9 +127,11 @@ public class Subscription extends AbstractExtension {
         }
     }
 
+    /** Subscriber that receives notifications. */
     @Data
     @Schema(name = "SubscriptionSubscriber")
     public static class Subscriber {
+        /** User metadata.name of the subscriber. */
         @Schema(requiredMode = REQUIRED, minLength = 1)
         private String name;
 

--- a/api/src/main/java/run/halo/app/extension/ConfigMap.java
+++ b/api/src/main/java/run/halo/app/extension/ConfigMap.java
@@ -21,6 +21,7 @@ public class ConfigMap extends AbstractExtension {
 
     public static final String KIND = "ConfigMap";
 
+    /** String key-value configuration entries consumed by Halo or plugins. */
     @Nullable
     private Map<String, String> data;
 

--- a/api/src/main/java/run/halo/app/extension/Secret.java
+++ b/api/src/main/java/run/halo/app/extension/Secret.java
@@ -9,7 +9,7 @@ import lombok.EqualsAndHashCode;
  *
  * @author guqing
  * @see <a
- *     href="https://github.com/kubernetes/kubernetes/blob/f33498a8256b455b677ad4d30440869318b84204/staging/src/k8s.io/api/core/v1/types.go">kebernetes
+ *     href="https://github.com/kubernetes/kubernetes/blob/f33498a8256b455b677ad4d30440869318b84204/staging/src/k8s.io/api/core/v1/types.go">Kubernetes
  *     Secret</a>
  * @since 2.0.0
  */

--- a/api/src/main/java/run/halo/app/migration/Backup.java
+++ b/api/src/main/java/run/halo/app/migration/Backup.java
@@ -8,44 +8,55 @@ import lombok.ToString;
 import run.halo.app.extension.AbstractExtension;
 import run.halo.app.extension.GVK;
 
+/** Backup metadata and runtime state for an exported Halo data package. */
 @Data
 @ToString(callSuper = true)
 @EqualsAndHashCode(callSuper = true)
 @GVK(group = "migration.halo.run", version = "v1alpha1", kind = "Backup", plural = "backups", singular = "backup")
 public class Backup extends AbstractExtension {
 
+    /** Desired backup options, such as the file format and expiration time. */
     private Spec spec = new Spec();
 
+    /** Observed backup execution state and generated file information. */
     private Status status = new Status();
 
+    /** Desired backup options. */
     @Data
     @Schema(name = "BackupSpec")
     public static class Spec {
 
-        @Schema(description = "Backup file format. Currently, only zip format is supported.")
+        /** Backup file format. Currently, only zip is supported. */
         private String format;
 
+        /** Time after which the generated backup should be considered expired. */
         private Instant expiresAt;
     }
 
+    /** Observed backup execution state. */
     @Data
     @Schema(name = "BackupStatus")
     public static class Status {
 
+        /** Current backup execution phase. */
         private Phase phase = Phase.PENDING;
 
+        /** Time when backup execution started. */
         private Instant startTimestamp;
 
+        /** Time when backup execution finished, regardless of success or failure. */
         private Instant completionTimestamp;
 
+        /** Stable failure reason code for a failed backup. */
         private String failureReason;
 
+        /** Human-readable failure message for a failed backup. */
         private String failureMessage;
 
-        /** Size of backup file. Data unit: byte */
+        /** Size of the generated backup file in bytes. */
         private Long size;
 
-        /** Name of backup file. */
+        /** Name of the generated backup file. */
         private String filename;
     }
 

--- a/api/src/main/java/run/halo/app/security/PersonalAccessToken.java
+++ b/api/src/main/java/run/halo/app/security/PersonalAccessToken.java
@@ -11,6 +11,7 @@ import lombok.ToString;
 import run.halo.app.extension.AbstractExtension;
 import run.halo.app.extension.GVK;
 
+/** Personal access token extension used for non-interactive API authentication on behalf of a Halo user. */
 @Data
 @ToString(callSuper = true)
 @EqualsAndHashCode(callSuper = true)
@@ -26,32 +27,44 @@ public class PersonalAccessToken extends AbstractExtension {
 
     public static final String PAT_TOKEN_PREFIX = "pat_";
 
+    /** Desired token metadata, ownership, access grants, and lifecycle state. */
     private Spec spec = new Spec();
 
+    /** Desired personal access token settings and lifecycle flags. */
     @Data
     @Schema(name = "PatSpec")
     public static class Spec {
 
+        /** Display name chosen by the token owner. */
         @Schema(requiredMode = REQUIRED)
         private String name;
 
+        /** Optional human-readable description of how the token is used. */
         private String description;
 
+        /** Time when the token expires. A null value means the token does not expire by time. */
         private Instant expiresAt;
 
+        /** Role names granted to this token. */
         private List<String> roles;
 
+        /** Scope strings granted to this token. */
         private List<String> scopes;
 
+        /** User metadata.name that owns this token. */
         @Schema(requiredMode = REQUIRED)
         private String username;
 
+        /** Whether the token has been manually revoked. */
         private boolean revoked;
 
+        /** Time when the token was revoked. */
         private Instant revokesAt;
 
+        /** Last time the token was used successfully. */
         private Instant lastUsed;
 
+        /** Stable token identifier stored separately from the secret token value. */
         @Schema(requiredMode = REQUIRED)
         private String tokenId;
     }

--- a/application/src/main/java/run/halo/app/content/ListedPost.java
+++ b/application/src/main/java/run/halo/app/content/ListedPost.java
@@ -24,10 +24,12 @@ public class ListedPost {
     @Schema(description = "Post extension data.", requiredMode = REQUIRED)
     private Post post;
 
-    @Schema(description = "Resolved categories referenced by the post spec.", requiredMode = REQUIRED)
+    /** Resolved categories referenced by the post spec. */
+    @Schema(requiredMode = REQUIRED)
     private List<Category> categories;
 
-    @Schema(description = "Resolved tags referenced by the post spec.", requiredMode = REQUIRED)
+    /** Resolved tags referenced by the post spec. */
+    @Schema(requiredMode = REQUIRED)
     private List<Tag> tags;
 
     @Schema(description = "Users that have contributed to the post content snapshots.", requiredMode = REQUIRED)

--- a/application/src/main/java/run/halo/app/plugin/extensionpoint/ExtensionDefinition.java
+++ b/application/src/main/java/run/halo/app/plugin/extensionpoint/ExtensionDefinition.java
@@ -10,9 +10,7 @@ import run.halo.app.extension.AbstractExtension;
 import run.halo.app.extension.GVK;
 
 /**
- * Extension definition. An {@link ExtensionDefinition} is a type of metadata that provides additional information about
- * an extension. An extension is a way to add new functionality to an existing class, structure, enumeration, or
- * protocol type without needing to subclass it.
+ * Extension definition that describes one plugin-provided implementation of an extension point.
  *
  * @author guqing
  * @since 2.4.0
@@ -28,22 +26,29 @@ import run.halo.app.extension.GVK;
         plural = "extensiondefinitions")
 public class ExtensionDefinition extends AbstractExtension {
 
+    /** Desired extension implementation metadata. */
     @Schema(requiredMode = REQUIRED)
     private ExtensionSpec spec;
 
+    /** Desired plugin-provided extension implementation metadata. */
     @Data
     public static class ExtensionSpec {
+        /** Fully qualified Java class name of the implementation. */
         @Schema(requiredMode = REQUIRED)
         private String className;
 
+        /** ExtensionPointDefinition metadata.name this implementation contributes to. */
         @Schema(requiredMode = REQUIRED)
         private String extensionPointName;
 
+        /** Display name shown for the implementation. */
         @Schema(requiredMode = REQUIRED)
         private String displayName;
 
+        /** Human-readable description of what this implementation does. */
         private String description;
 
+        /** Icon URL, class, or identifier shown for the implementation. */
         private String icon;
     }
 }

--- a/application/src/main/java/run/halo/app/plugin/extensionpoint/ExtensionPointDefinition.java
+++ b/application/src/main/java/run/halo/app/plugin/extensionpoint/ExtensionPointDefinition.java
@@ -10,9 +10,7 @@ import run.halo.app.extension.AbstractExtension;
 import run.halo.app.extension.GVK;
 
 /**
- * Extension point definition. An {@link ExtensionPointDefinition} is a concept used in <code>Halo</code> to allow for
- * the dynamic extension of system. It defines a location within <code>Halo</code> where additional functionality can be
- * added through the use of plugins or extensions.
+ * Extension point definition that advertises where plugins can contribute implementations.
  *
  * @author guqing
  * @since 2.4.0
@@ -28,22 +26,29 @@ import run.halo.app.extension.GVK;
         plural = "extensionpointdefinitions")
 public class ExtensionPointDefinition extends AbstractExtension {
 
+    /** Desired extension point metadata and registration behavior. */
     @Schema(requiredMode = REQUIRED)
     private ExtensionPointSpec spec;
 
+    /** Desired extension point metadata. */
     @Data
     public static class ExtensionPointSpec {
+        /** Fully qualified Java class name of the extension point interface. */
         @Schema(requiredMode = REQUIRED)
         private String className;
 
+        /** Display name shown for the extension point. */
         @Schema(requiredMode = REQUIRED)
         private String displayName;
 
+        /** Registration mode used when loading implementations for this extension point. */
         @Schema(requiredMode = REQUIRED)
         private ExtensionPointType type;
 
+        /** Human-readable description of what this extension point allows plugins to provide. */
         private String description;
 
+        /** Icon URL, class, or identifier shown for the extension point. */
         private String icon;
     }
 

--- a/ui/packages/api-client/src/models/annotation-setting-spec.ts
+++ b/ui/packages/api-client/src/models/annotation-setting-spec.ts
@@ -17,7 +17,13 @@
 // @ts-ignore
 import type { GroupKind } from './group-kind';
 
+/**
+ * Desired annotation form configuration for a target resource kind.
+ */
 export interface AnnotationSettingSpec {
+    /**
+     * FormKit-compatible schema used to render annotation fields.
+     */
     'formSchema': Array<object>;
     'targetRef': GroupKind;
 }

--- a/ui/packages/api-client/src/models/annotation-setting.ts
+++ b/ui/packages/api-client/src/models/annotation-setting.ts
@@ -20,6 +20,9 @@ import type { AnnotationSettingSpec } from './annotation-setting-spec';
 // @ts-ignore
 import type { Metadata } from './metadata';
 
+/**
+ * Annotation setting extension that defines dynamic annotation forms for a target extension kind.
+ */
 export interface AnnotationSetting {
     'apiVersion': string;
     'kind': string;

--- a/ui/packages/api-client/src/models/attachment-spec.ts
+++ b/ui/packages/api-client/src/models/attachment-spec.ts
@@ -14,33 +14,36 @@
 
 
 
+/**
+ * Desired attachment metadata and storage placement.
+ */
 export interface AttachmentSpec {
     /**
-     * Display name of attachment
+     * Display name shown for the attachment.
      */
     'displayName'?: string;
     /**
-     * Group name
+     * Attachment group metadata.name this attachment belongs to.
      */
     'groupName'?: string;
     /**
-     * Media type of attachment
+     * Media type detected or supplied for the attachment, such as image/png.
      */
     'mediaType'?: string;
     /**
-     * Name of User who uploads the attachment
+     * User metadata.name of the uploader.
      */
     'ownerName'?: string;
     /**
-     * Policy name
+     * Storage policy metadata.name used to store this attachment.
      */
     'policyName'?: string;
     /**
-     * Size of attachment. Unit is Byte
+     * Size of the attachment in bytes.
      */
     'size'?: number;
     /**
-     * Tags of attachment
+     * Free-form tags assigned to the attachment.
      */
     'tags'?: Array<string>;
 }

--- a/ui/packages/api-client/src/models/attachment-status.ts
+++ b/ui/packages/api-client/src/models/attachment-status.ts
@@ -14,11 +14,17 @@
 
 
 
+/**
+ * Observed attachment access state.
+ */
 export interface AttachmentStatus {
     /**
-     * Permalink of attachment. If it is in local storage, the public URL will be set. If it is in s3 storage, the Object URL will be set. 
+     * Public permalink for the attachment. Local storage usually exposes a public URL, while object storage may  expose the object URL.
      */
     'permalink'?: string;
+    /**
+     * Generated thumbnail URLs keyed by thumbnail size name.
+     */
     'thumbnails'?: { [key: string]: string; };
 }
 

--- a/ui/packages/api-client/src/models/attachment.ts
+++ b/ui/packages/api-client/src/models/attachment.ts
@@ -23,6 +23,9 @@ import type { AttachmentStatus } from './attachment-status';
 // @ts-ignore
 import type { Metadata } from './metadata';
 
+/**
+ * Attachment extension that describes an uploaded file and its resolved access URLs.
+ */
 export interface Attachment {
     'apiVersion': string;
     'kind': string;

--- a/ui/packages/api-client/src/models/auth-provider-spec.ts
+++ b/ui/packages/api-client/src/models/auth-provider-spec.ts
@@ -20,28 +20,55 @@ import type { ConfigMapRef } from './config-map-ref';
 // @ts-ignore
 import type { SettingRef } from './setting-ref';
 
+/**
+ * Authentication provider metadata and endpoint configuration.
+ */
 export interface AuthProviderSpec {
     /**
      * Auth type: form or oauth2.
      */
     'authType': AuthProviderSpecAuthTypeEnum;
     /**
-     * Authentication url of the auth provider
+     * URL that starts the authentication flow.
      */
     'authenticationUrl': string;
+    /**
+     * URL that starts account binding for an already signed-in user.
+     */
     'bindingUrl'?: string;
     'configMapRef'?: ConfigMapRef;
+    /**
+     * Human-readable description of the provider.
+     */
     'description'?: string;
     /**
-     * Display name of the auth provider
+     * Display name shown on sign-in and account binding screens.
      */
     'displayName': string;
+    /**
+     * Help page URL for users who need sign-in assistance.
+     */
     'helpPage'?: string;
+    /**
+     * Logo URL or attachment URI for the provider.
+     */
     'logo'?: string;
+    /**
+     * HTTP method used when starting the authentication flow.
+     */
     'method'?: string;
+    /**
+     * Whether the provider supports remember-me during sign-in.
+     */
     'rememberMeSupport'?: boolean;
     'settingRef'?: SettingRef;
+    /**
+     * URL that unbinds the external account from the current user.
+     */
     'unbindUrl'?: string;
+    /**
+     * Provider website URL.
+     */
     'website'?: string;
 }
 

--- a/ui/packages/api-client/src/models/auth-provider.ts
+++ b/ui/packages/api-client/src/models/auth-provider.ts
@@ -21,7 +21,7 @@ import type { AuthProviderSpec } from './auth-provider-spec';
 import type { Metadata } from './metadata';
 
 /**
- * Auth provider extension.
+ * Authentication provider extension that describes an external or form-based sign-in integration.
  */
 export interface AuthProvider {
     'apiVersion': string;

--- a/ui/packages/api-client/src/models/author.ts
+++ b/ui/packages/api-client/src/models/author.ts
@@ -14,8 +14,17 @@
 
 
 
+/**
+ * Theme author metadata.
+ */
 export interface Author {
+    /**
+     * Author display name.
+     */
     'name': string;
+    /**
+     * Author website URL.
+     */
     'website'?: string;
 }
 

--- a/ui/packages/api-client/src/models/backup-spec.ts
+++ b/ui/packages/api-client/src/models/backup-spec.ts
@@ -14,10 +14,16 @@
 
 
 
+/**
+ * Desired backup options.
+ */
 export interface BackupSpec {
+    /**
+     * Time after which the generated backup should be considered expired.
+     */
     'expiresAt'?: string;
     /**
-     * Backup file format. Currently, only zip format is supported.
+     * Backup file format. Currently, only zip is supported.
      */
     'format'?: string;
 }

--- a/ui/packages/api-client/src/models/backup-status.ts
+++ b/ui/packages/api-client/src/models/backup-status.ts
@@ -14,19 +14,37 @@
 
 
 
+/**
+ * Observed backup execution state.
+ */
 export interface BackupStatus {
+    /**
+     * Time when backup execution finished, regardless of success or failure.
+     */
     'completionTimestamp'?: string;
+    /**
+     * Human-readable failure message for a failed backup.
+     */
     'failureMessage'?: string;
+    /**
+     * Stable failure reason code for a failed backup.
+     */
     'failureReason'?: string;
     /**
-     * Name of backup file.
+     * Name of the generated backup file.
      */
     'filename'?: string;
+    /**
+     * Current backup execution phase.
+     */
     'phase'?: BackupStatusPhaseEnum;
     /**
-     * Size of backup file. Data unit: byte
+     * Size of the generated backup file in bytes.
      */
     'size'?: number;
+    /**
+     * Time when backup execution started.
+     */
     'startTimestamp'?: string;
 }
 

--- a/ui/packages/api-client/src/models/backup.ts
+++ b/ui/packages/api-client/src/models/backup.ts
@@ -23,6 +23,9 @@ import type { BackupStatus } from './backup-status';
 // @ts-ignore
 import type { Metadata } from './metadata';
 
+/**
+ * Backup metadata and runtime state for an exported Halo data package.
+ */
 export interface Backup {
     'apiVersion': string;
     'kind': string;

--- a/ui/packages/api-client/src/models/category-spec.ts
+++ b/ui/packages/api-client/src/models/category-spec.ts
@@ -15,7 +15,7 @@
 
 
 /**
- * Desired display, hierarchy, and rendering configuration of a category.
+ * Desired category display, hierarchy, and rendering configuration.
  */
 export interface CategorySpec {
     /**

--- a/ui/packages/api-client/src/models/category-status.ts
+++ b/ui/packages/api-client/src/models/category-status.ts
@@ -15,7 +15,7 @@
 
 
 /**
- * Observed state of a category.
+ * Observed category state derived by content reconcilers.
  */
 export interface CategoryStatus {
     /**

--- a/ui/packages/api-client/src/models/comment-status.ts
+++ b/ui/packages/api-client/src/models/comment-status.ts
@@ -15,7 +15,7 @@
 
 
 /**
- * Observed state of a comment.
+ * Observed state of a top-level comment.
  */
 export interface CommentStatus {
     /**

--- a/ui/packages/api-client/src/models/config-map-ref.ts
+++ b/ui/packages/api-client/src/models/config-map-ref.ts
@@ -14,7 +14,13 @@
 
 
 
+/**
+ * Reference to a ConfigMap used by this provider.
+ */
 export interface ConfigMapRef {
+    /**
+     * ConfigMap metadata.name.
+     */
     'name': string;
 }
 

--- a/ui/packages/api-client/src/models/config-map.ts
+++ b/ui/packages/api-client/src/models/config-map.ts
@@ -22,6 +22,9 @@ import type { Metadata } from './metadata';
  */
 export interface ConfigMap {
     'apiVersion': string;
+    /**
+     * String key-value configuration entries consumed by Halo or plugins.
+     */
     'data'?: { [key: string]: string; };
     'kind': string;
     'metadata': Metadata;

--- a/ui/packages/api-client/src/models/counter.ts
+++ b/ui/packages/api-client/src/models/counter.ts
@@ -18,16 +18,31 @@
 import type { Metadata } from './metadata';
 
 /**
- * A counter for number of requests by extension resource name.
+ * Counter extension that stores aggregate interaction counts for a resource.
  */
 export interface Counter {
     'apiVersion': string;
+    /**
+     * Number of approved comments recorded for the resource.
+     */
     'approvedComment'?: number;
+    /**
+     * Number of downvotes recorded for the resource.
+     */
     'downvote'?: number;
     'kind': string;
     'metadata': Metadata;
+    /**
+     * Total number of comments recorded for the resource.
+     */
     'totalComment'?: number;
+    /**
+     * Number of upvotes recorded for the resource.
+     */
     'upvote'?: number;
+    /**
+     * Number of visits recorded for the resource.
+     */
     'visit'?: number;
 }
 

--- a/ui/packages/api-client/src/models/custom-templates.ts
+++ b/ui/packages/api-client/src/models/custom-templates.ts
@@ -17,9 +17,21 @@
 // @ts-ignore
 import type { TemplateDescriptor } from './template-descriptor';
 
+/**
+ * Custom template descriptors grouped by the content type they render.
+ */
 export interface CustomTemplates {
+    /**
+     * Custom templates available for categories.
+     */
     'category'?: Array<TemplateDescriptor>;
+    /**
+     * Custom templates available for single pages.
+     */
     'page'?: Array<TemplateDescriptor>;
+    /**
+     * Custom templates available for posts.
+     */
     'post'?: Array<TemplateDescriptor>;
 }
 

--- a/ui/packages/api-client/src/models/device-spec.ts
+++ b/ui/packages/api-client/src/models/device-spec.ts
@@ -14,13 +14,37 @@
 
 
 
+/**
+ * Session identity and request metadata captured for a device.
+ */
 export interface DeviceSpec {
+    /**
+     * Client IP address observed for the session.
+     */
     'ipAddress': string;
+    /**
+     * Last time this session accessed Halo.
+     */
     'lastAccessedTime'?: string;
+    /**
+     * Last time the user authenticated for this session.
+     */
     'lastAuthenticatedTime'?: string;
+    /**
+     * Principal name of the authenticated user.
+     */
     'principalName': string;
+    /**
+     * Remember-me series id associated with the session, if any.
+     */
     'rememberMeSeriesId'?: string;
+    /**
+     * Web session identifier associated with the device.
+     */
     'sessionId': string;
+    /**
+     * Client user-agent header captured for the session.
+     */
     'userAgent'?: string;
 }
 

--- a/ui/packages/api-client/src/models/device-status.ts
+++ b/ui/packages/api-client/src/models/device-status.ts
@@ -14,8 +14,17 @@
 
 
 
+/**
+ * Parsed browser and operating system details for display.
+ */
 export interface DeviceStatus {
+    /**
+     * Browser name parsed from the user agent.
+     */
     'browser'?: string;
+    /**
+     * Operating system name parsed from the user agent.
+     */
     'os'?: string;
 }
 

--- a/ui/packages/api-client/src/models/device.ts
+++ b/ui/packages/api-client/src/models/device.ts
@@ -23,6 +23,9 @@ import type { DeviceStatus } from './device-status';
 // @ts-ignore
 import type { Metadata } from './metadata';
 
+/**
+ * Device extension that records an authenticated browser session for account security visibility.
+ */
 export interface Device {
     'apiVersion': string;
     'kind': string;

--- a/ui/packages/api-client/src/models/excerpt.ts
+++ b/ui/packages/api-client/src/models/excerpt.ts
@@ -15,7 +15,7 @@
 
 
 /**
- * Excerpt generation configuration.
+ * Excerpt generation configuration for a post or single page.
  */
 export interface Excerpt {
     /**

--- a/ui/packages/api-client/src/models/extension-definition.ts
+++ b/ui/packages/api-client/src/models/extension-definition.ts
@@ -21,7 +21,7 @@ import type { ExtensionSpec } from './extension-spec';
 import type { Metadata } from './metadata';
 
 /**
- * Extension definition. An {@link ExtensionDefinition ExtensionDefinition} is a type of metadata that provides additional information about  an extension. An extension is a way to add new functionality to an existing class, structure, enumeration, or  protocol type without needing to subclass it.
+ * Extension definition that describes one plugin-provided implementation of an extension point.
  */
 export interface ExtensionDefinition {
     'apiVersion': string;

--- a/ui/packages/api-client/src/models/extension-point-definition.ts
+++ b/ui/packages/api-client/src/models/extension-point-definition.ts
@@ -21,7 +21,7 @@ import type { ExtensionPointSpec } from './extension-point-spec';
 import type { Metadata } from './metadata';
 
 /**
- * Extension point definition. An {@link ExtensionPointDefinition ExtensionPointDefinition} is a concept used in <code>Halo</code> to allow for  the dynamic extension of system. It defines a location within <code>Halo</code> where additional functionality can be  added through the use of plugins or extensions.
+ * Extension point definition that advertises where plugins can contribute implementations.
  */
 export interface ExtensionPointDefinition {
     'apiVersion': string;

--- a/ui/packages/api-client/src/models/extension-point-spec.ts
+++ b/ui/packages/api-client/src/models/extension-point-spec.ts
@@ -14,11 +14,29 @@
 
 
 
+/**
+ * Desired extension point metadata.
+ */
 export interface ExtensionPointSpec {
+    /**
+     * Fully qualified Java class name of the extension point interface.
+     */
     'className': string;
+    /**
+     * Human-readable description of what this extension point allows plugins to provide.
+     */
     'description'?: string;
+    /**
+     * Display name shown for the extension point.
+     */
     'displayName': string;
+    /**
+     * Icon URL, class, or identifier shown for the extension point.
+     */
     'icon'?: string;
+    /**
+     * Registration mode used when loading implementations for this extension point.
+     */
     'type': ExtensionPointSpecTypeEnum;
 }
 

--- a/ui/packages/api-client/src/models/extension-spec.ts
+++ b/ui/packages/api-client/src/models/extension-spec.ts
@@ -14,11 +14,29 @@
 
 
 
+/**
+ * Desired plugin-provided extension implementation metadata.
+ */
 export interface ExtensionSpec {
+    /**
+     * Fully qualified Java class name of the implementation.
+     */
     'className': string;
+    /**
+     * Human-readable description of what this implementation does.
+     */
     'description'?: string;
+    /**
+     * Display name shown for the implementation.
+     */
     'displayName': string;
+    /**
+     * ExtensionPointDefinition metadata.name this implementation contributes to.
+     */
     'extensionPointName': string;
+    /**
+     * Icon URL, class, or identifier shown for the implementation.
+     */
     'icon'?: string;
 }
 

--- a/ui/packages/api-client/src/models/file-reverse-proxy-provider.ts
+++ b/ui/packages/api-client/src/models/file-reverse-proxy-provider.ts
@@ -14,6 +14,9 @@
 
 
 
+/**
+ * File provider that resolves a request to a plugin or theme file location.
+ */
 export interface FileReverseProxyProvider {
     'directory'?: string;
     'filename'?: string;

--- a/ui/packages/api-client/src/models/group-spec.ts
+++ b/ui/packages/api-client/src/models/group-spec.ts
@@ -14,9 +14,12 @@
 
 
 
+/**
+ * Desired attachment group metadata.
+ */
 export interface GroupSpec {
     /**
-     * Display name of group
+     * Display name shown for the attachment group.
      */
     'displayName': string;
 }

--- a/ui/packages/api-client/src/models/group-status.ts
+++ b/ui/packages/api-client/src/models/group-status.ts
@@ -14,13 +14,16 @@
 
 
 
+/**
+ * Observed attachment group aggregate state.
+ */
 export interface GroupStatus {
     /**
-     * Total of attachments under the current group
+     * Total number of attachments under the group.
      */
     'totalAttachments'?: number;
     /**
-     * Update timestamp of the group
+     * Last time the group aggregate state was updated.
      */
     'updateTimestamp'?: string;
 }

--- a/ui/packages/api-client/src/models/group.ts
+++ b/ui/packages/api-client/src/models/group.ts
@@ -23,6 +23,9 @@ import type { GroupStatus } from './group-status';
 // @ts-ignore
 import type { Metadata } from './metadata';
 
+/**
+ * Attachment group extension used to organize attachments and expose aggregate counts.
+ */
 export interface Group {
     'apiVersion': string;
     'kind': string;

--- a/ui/packages/api-client/src/models/interest-reason-subject.ts
+++ b/ui/packages/api-client/src/models/interest-reason-subject.ts
@@ -15,13 +15,19 @@
 
 
 /**
- * The subject name of reason type to be interested in
+ * Subject selector used by a subscription interest reason.
  */
 export interface InterestReasonSubject {
+    /**
+     * Subject API version.
+     */
     'apiVersion': string;
+    /**
+     * Subject kind.
+     */
     'kind': string;
     /**
-     * if name is not specified, it presents all subjects of the specified reason type and custom resources
+     * Subject metadata.name. If omitted, all subjects of the selected kind and API version are matched.
      */
     'name'?: string;
 }

--- a/ui/packages/api-client/src/models/interest-reason.ts
+++ b/ui/packages/api-client/src/models/interest-reason.ts
@@ -18,15 +18,15 @@
 import type { InterestReasonSubject } from './interest-reason-subject';
 
 /**
- * The reason to be interested in
+ * Reason selector that decides which notifications match this subscription.
  */
 export interface InterestReason {
     /**
-     * The expression to be interested in
+     * Optional expression used to match reasons more flexibly than subject matching.
      */
     'expression'?: string;
     /**
-     * The name of the reason definition to be interested in
+     * ReasonType metadata.name this subscription is interested in.
      */
     'reasonType': string;
     'subject': InterestReasonSubject;

--- a/ui/packages/api-client/src/models/menu-item-spec.ts
+++ b/ui/packages/api-client/src/models/menu-item-spec.ts
@@ -17,25 +17,28 @@
 // @ts-ignore
 import type { Ref } from './ref';
 
+/**
+ * Desired menu item configuration.
+ */
 export interface MenuItemSpec {
     /**
-     * Children of this menu item
+     * Child MenuItem metadata.name values shown under this item.
      */
     'children'?: Array<string>;
     /**
-     * The display name of menu item.
+     * Display name shown for the menu item.
      */
     'displayName'?: string;
     /**
-     * The href of this menu item.
+     * Direct URL used by the menu item.
      */
     'href'?: string;
     /**
-     * The priority is for ordering.
+     * Sorting priority. Higher values sort before lower values where priority ordering is applied.
      */
     'priority'?: number;
     /**
-     * The <a> target attribute of this menu item.
+     * HTML anchor target used by the menu item.
      */
     'target'?: MenuItemSpecTargetEnum;
     'targetRef'?: Ref;

--- a/ui/packages/api-client/src/models/menu-item-status.ts
+++ b/ui/packages/api-client/src/models/menu-item-status.ts
@@ -14,13 +14,16 @@
 
 
 
+/**
+ * Resolved menu item values used for rendering.
+ */
 export interface MenuItemStatus {
     /**
-     * Calculated Display name of menu item.
+     * Calculated display name after resolving targetRef, falling back to spec.displayName.
      */
     'displayName'?: string;
     /**
-     * Calculated href of manu item.
+     * Calculated href after resolving targetRef, falling back to spec.href.
      */
     'href'?: string;
 }

--- a/ui/packages/api-client/src/models/menu-item.ts
+++ b/ui/packages/api-client/src/models/menu-item.ts
@@ -23,6 +23,9 @@ import type { MenuItemStatus } from './menu-item-status';
 // @ts-ignore
 import type { Metadata } from './metadata';
 
+/**
+ * Menu item extension that describes a navigable item and its resolved rendering state.
+ */
 export interface MenuItem {
     'apiVersion': string;
     'kind': string;

--- a/ui/packages/api-client/src/models/menu-spec.ts
+++ b/ui/packages/api-client/src/models/menu-spec.ts
@@ -14,13 +14,16 @@
 
 
 
+/**
+ * Desired menu configuration.
+ */
 export interface MenuSpec {
     /**
-     * The display name of the menu.
+     * Display name shown for the menu.
      */
     'displayName': string;
     /**
-     * Menu items of this menu.
+     * Ordered MenuItem metadata.name values included in this menu.
      */
     'menuItems'?: Array<string>;
 }

--- a/ui/packages/api-client/src/models/menu.ts
+++ b/ui/packages/api-client/src/models/menu.ts
@@ -20,6 +20,9 @@ import type { MenuSpec } from './menu-spec';
 // @ts-ignore
 import type { Metadata } from './metadata';
 
+/**
+ * Menu extension that groups ordered menu items for theme navigation.
+ */
 export interface Menu {
     'apiVersion': string;
     'kind': string;

--- a/ui/packages/api-client/src/models/notification-spec.ts
+++ b/ui/packages/api-client/src/models/notification-spec.ts
@@ -14,19 +14,37 @@
 
 
 
+/**
+ * Notification content and read state for one recipient.
+ */
 export interface NotificationSpec {
+    /**
+     * HTML notification content.
+     */
     'htmlContent': string;
+    /**
+     * Last time the recipient marked this notification as read.
+     */
     'lastReadAt'?: string;
+    /**
+     * Plain text or source notification content.
+     */
     'rawContent': string;
     /**
-     * The name of reason
+     * Reason metadata.name that generated this notification.
      */
     'reason': string;
     /**
-     * The name of user
+     * User metadata.name that receives the notification.
      */
     'recipient': string;
+    /**
+     * Notification title shown in the notification center.
+     */
     'title': string;
+    /**
+     * Whether the recipient has not read the notification yet.
+     */
     'unread'?: boolean;
 }
 

--- a/ui/packages/api-client/src/models/notification-template-spec.ts
+++ b/ui/packages/api-client/src/models/notification-template-spec.ts
@@ -20,6 +20,9 @@ import type { ReasonSelector } from './reason-selector';
 // @ts-ignore
 import type { TemplateContent } from './template-content';
 
+/**
+ * Desired notification template selector and content.
+ */
 export interface NotificationTemplateSpec {
     'reasonSelector'?: ReasonSelector;
     'template'?: TemplateContent;

--- a/ui/packages/api-client/src/models/notification-template.ts
+++ b/ui/packages/api-client/src/models/notification-template.ts
@@ -21,7 +21,7 @@ import type { Metadata } from './metadata';
 import type { NotificationTemplateSpec } from './notification-template-spec';
 
 /**
- * {@link NotificationTemplate NotificationTemplate} is a custom extension that defines a notification template.   <p>It describes the notification template\'s name, description, and the template content.   <p>{@link Spec#getReasonSelector Spec#getReasonSelector()} is used to select the template by reasonType and language, if multiple templates  are matched, the best match will be selected. This is useful when you want to override the default template.
+ * Notification template extension that defines localized message content for matching reason types.   <p>It describes the notification template\'s name, description, and the template content.   <p>{@link Spec#getReasonSelector Spec#getReasonSelector()} is used to select the template by reasonType and language, if multiple templates  are matched, the best match will be selected. This is useful when you want to override the default template.
  */
 export interface NotificationTemplate {
     'apiVersion': string;

--- a/ui/packages/api-client/src/models/notification.ts
+++ b/ui/packages/api-client/src/models/notification.ts
@@ -21,7 +21,7 @@ import type { Metadata } from './metadata';
 import type { NotificationSpec } from './notification-spec';
 
 /**
- * {@link Notification Notification} is a custom extension that used to store notification information for inner use, it\'s on-site  notification.   <p>Supports the following operations:   <ul>    <li>Marked as read: {@link NotificationSpec#setUnread(boolean) NotificationSpec#setUnread(boolean)}    <li>Get the last read time: {@link NotificationSpec#getLastReadAt NotificationSpec#getLastReadAt()}    <li>Filter by recipient: {@link NotificationSpec#getRecipient NotificationSpec#getRecipient()}  </ul>
+ * Notification extension that stores an on-site notification delivered to a Halo user.   <p>Supports the following operations:   <ul>    <li>Marked as read: {@link NotificationSpec#setUnread(boolean) NotificationSpec#setUnread(boolean)}    <li>Get the last read time: {@link NotificationSpec#getLastReadAt NotificationSpec#getLastReadAt()}    <li>Filter by recipient: {@link NotificationSpec#getRecipient NotificationSpec#getRecipient()}  </ul>
  */
 export interface Notification {
     'apiVersion': string;

--- a/ui/packages/api-client/src/models/notifier-descriptor-spec.ts
+++ b/ui/packages/api-client/src/models/notifier-descriptor-spec.ts
@@ -17,9 +17,21 @@
 // @ts-ignore
 import type { NotifierSettingRef } from './notifier-setting-ref';
 
+/**
+ * Desired notifier descriptor metadata and configuration references.
+ */
 export interface NotifierDescriptorSpec {
+    /**
+     * Human-readable description of what the notifier sends.
+     */
     'description'?: string;
+    /**
+     * Display name shown for the notifier.
+     */
     'displayName': string;
+    /**
+     * Extension name of the notifier implementation.
+     */
     'notifierExtName': string;
     'receiverSettingRef'?: NotifierSettingRef;
     'senderSettingRef'?: NotifierSettingRef;

--- a/ui/packages/api-client/src/models/notifier-descriptor.ts
+++ b/ui/packages/api-client/src/models/notifier-descriptor.ts
@@ -21,7 +21,7 @@ import type { Metadata } from './metadata';
 import type { NotifierDescriptorSpec } from './notifier-descriptor-spec';
 
 /**
- * {@link NotifierDescriptor NotifierDescriptor} is a custom extension that defines a notifier.   <p>It describes the notifier\'s name, description, and the extension name of the notifier to let the user know what  the notifier is and what it can do in the UI and also let the <code>NotificationCenter</code> know how to load the  notifier and prepare the notifier\'s settings.
+ * Notifier descriptor extension that advertises a notification delivery implementation and its settings.   <p>It describes the notifier\'s name, description, and the extension name of the notifier to let the user know what  the notifier is and what it can do in the UI and also let the <code>NotificationCenter</code> know how to load the  notifier and prepare the notifier\'s settings.
  */
 export interface NotifierDescriptor {
     'apiVersion': string;

--- a/ui/packages/api-client/src/models/notifier-setting-ref.ts
+++ b/ui/packages/api-client/src/models/notifier-setting-ref.ts
@@ -14,8 +14,17 @@
 
 
 
+/**
+ * Reference to a notifier setting form group.
+ */
 export interface NotifierSettingRef {
+    /**
+     * Setting form group name.
+     */
     'group': string;
+    /**
+     * Setting metadata.name.
+     */
     'name': string;
 }
 

--- a/ui/packages/api-client/src/models/pat-spec.ts
+++ b/ui/packages/api-client/src/models/pat-spec.ts
@@ -14,16 +14,49 @@
 
 
 
+/**
+ * Desired personal access token settings and lifecycle flags.
+ */
 export interface PatSpec {
+    /**
+     * Optional human-readable description of how the token is used.
+     */
     'description'?: string;
+    /**
+     * Time when the token expires. A null value means the token does not expire by time.
+     */
     'expiresAt'?: string;
+    /**
+     * Last time the token was used successfully.
+     */
     'lastUsed'?: string;
+    /**
+     * Display name chosen by the token owner.
+     */
     'name': string;
+    /**
+     * Whether the token has been manually revoked.
+     */
     'revoked'?: boolean;
+    /**
+     * Time when the token was revoked.
+     */
     'revokesAt'?: string;
+    /**
+     * Role names granted to this token.
+     */
     'roles'?: Array<string>;
+    /**
+     * Scope strings granted to this token.
+     */
     'scopes'?: Array<string>;
+    /**
+     * Stable token identifier stored separately from the secret token value.
+     */
     'tokenId': string;
+    /**
+     * User metadata.name that owns this token.
+     */
     'username': string;
 }
 

--- a/ui/packages/api-client/src/models/personal-access-token.ts
+++ b/ui/packages/api-client/src/models/personal-access-token.ts
@@ -20,6 +20,9 @@ import type { Metadata } from './metadata';
 // @ts-ignore
 import type { PatSpec } from './pat-spec';
 
+/**
+ * Personal access token extension used for non-interactive API authentication on behalf of a Halo user.
+ */
 export interface PersonalAccessToken {
     'apiVersion': string;
     'kind': string;

--- a/ui/packages/api-client/src/models/plugin-author.ts
+++ b/ui/packages/api-client/src/models/plugin-author.ts
@@ -14,8 +14,17 @@
 
 
 
+/**
+ * Plugin author metadata.
+ */
 export interface PluginAuthor {
+    /**
+     * Author display name.
+     */
     'name': string;
+    /**
+     * Author website URL.
+     */
     'website'?: string;
 }
 

--- a/ui/packages/api-client/src/models/plugin-spec.ts
+++ b/ui/packages/api-client/src/models/plugin-spec.ts
@@ -20,22 +20,58 @@ import type { License } from './license';
 // @ts-ignore
 import type { PluginAuthor } from './plugin-author';
 
+/**
+ * Desired plugin metadata and configuration references.
+ */
 export interface PluginSpec {
     'author'?: PluginAuthor;
+    /**
+     * ConfigMap metadata.name storing plugin configuration values.
+     */
     'configMapName'?: string;
+    /**
+     * Human-readable plugin description.
+     */
     'description'?: string;
+    /**
+     * Display name shown for the plugin.
+     */
     'displayName'?: string;
+    /**
+     * Whether the plugin should be enabled.
+     */
     'enabled'?: boolean;
+    /**
+     * Plugin homepage URL.
+     */
     'homepage'?: string;
+    /**
+     * Issue tracker URL.
+     */
     'issues'?: string;
+    /**
+     * Licenses declared by the plugin.
+     */
     'license'?: Array<License>;
+    /**
+     * Logo URL or attachment URI for the plugin.
+     */
     'logo'?: string;
+    /**
+     * Required plugin dependencies keyed by plugin name with version constraints as values.
+     */
     'pluginDependencies'?: { [key: string]: string; };
+    /**
+     * Source repository URL.
+     */
     'repo'?: string;
     /**
      * SemVer format.
      */
     'requires'?: string;
+    /**
+     * Setting metadata.name used to render the plugin configuration form.
+     */
     'settingName'?: string;
     /**
      * plugin version.

--- a/ui/packages/api-client/src/models/plugin-status.ts
+++ b/ui/packages/api-client/src/models/plugin-status.ts
@@ -17,17 +17,41 @@
 // @ts-ignore
 import type { Condition } from './condition';
 
+/**
+ * Observed plugin lifecycle and runtime asset state.
+ */
 export interface PluginStatus {
+    /**
+     * Reconciliation conditions for the plugin.
+     */
     'conditions'?: Array<Condition>;
+    /**
+     * JavaScript bundle entry path served for the plugin UI.
+     */
     'entry'?: string;
+    /**
+     * Last PF4J probe state observed for the plugin.
+     */
     'lastProbeState'?: PluginStatusLastProbeStateEnum;
+    /**
+     * Last time the plugin started successfully.
+     */
     'lastStartTime'?: string;
     /**
-     * Load location of the plugin, often a path.
+     * URI location where the plugin artifact was loaded from.
      */
     'loadLocation'?: string;
+    /**
+     * Resolved logo URL or attachment URI for the plugin.
+     */
     'logo'?: string;
+    /**
+     * Current plugin lifecycle phase.
+     */
     'phase'?: PluginStatusPhaseEnum;
+    /**
+     * Stylesheet bundle path served for the plugin UI.
+     */
     'stylesheet'?: string;
 }
 

--- a/ui/packages/api-client/src/models/plugin.ts
+++ b/ui/packages/api-client/src/models/plugin.ts
@@ -24,7 +24,7 @@ import type { PluginSpec } from './plugin-spec';
 import type { PluginStatus } from './plugin-status';
 
 /**
- * A custom resource for Plugin.
+ * Plugin extension that describes an installed plugin and its runtime lifecycle state.
  */
 export interface Plugin {
     'apiVersion': string;

--- a/ui/packages/api-client/src/models/policy-rule.ts
+++ b/ui/packages/api-client/src/models/policy-rule.ts
@@ -35,7 +35,7 @@ export interface PolicyRule {
      */
     'resources'?: Array<string>;
     /**
-     * about who the rule applies to or which namespace the rule applies to.
+     * Verbs allowed by this rule, such as get, list, create, update, patch, or delete.
      */
     'verbs'?: Array<string>;
 }

--- a/ui/packages/api-client/src/models/policy-spec.ts
+++ b/ui/packages/api-client/src/models/policy-spec.ts
@@ -14,17 +14,20 @@
 
 
 
+/**
+ * Desired storage policy configuration.
+ */
 export interface PolicySpec {
     /**
-     * Reference name of ConfigMap extension
+     * ConfigMap metadata.name storing configuration values for this policy.
      */
     'configMapName'?: string;
     /**
-     * Display name of policy
+     * Display name shown for the storage policy.
      */
     'displayName': string;
     /**
-     * Reference name of PolicyTemplate
+     * PolicyTemplate metadata.name that provides the storage implementation.
      */
     'templateName': string;
 }

--- a/ui/packages/api-client/src/models/policy-template-spec.ts
+++ b/ui/packages/api-client/src/models/policy-template-spec.ts
@@ -14,8 +14,17 @@
 
 
 
+/**
+ * Desired storage policy template metadata.
+ */
 export interface PolicyTemplateSpec {
+    /**
+     * Display name shown for the storage policy template.
+     */
     'displayName'?: string;
+    /**
+     * Setting metadata.name used to render configuration fields for policies created from this template.
+     */
     'settingName': string;
 }
 

--- a/ui/packages/api-client/src/models/policy-template.ts
+++ b/ui/packages/api-client/src/models/policy-template.ts
@@ -20,6 +20,9 @@ import type { Metadata } from './metadata';
 // @ts-ignore
 import type { PolicyTemplateSpec } from './policy-template-spec';
 
+/**
+ * Storage policy template extension that declares an attachment storage implementation and its settings form.
+ */
 export interface PolicyTemplate {
     'apiVersion': string;
     'kind': string;

--- a/ui/packages/api-client/src/models/policy.ts
+++ b/ui/packages/api-client/src/models/policy.ts
@@ -20,6 +20,9 @@ import type { Metadata } from './metadata';
 // @ts-ignore
 import type { PolicySpec } from './policy-spec';
 
+/**
+ * Storage policy extension that binds attachment uploads to a policy template and configuration.
+ */
 export interface Policy {
     'apiVersion': string;
     'kind': string;

--- a/ui/packages/api-client/src/models/post-spec.ts
+++ b/ui/packages/api-client/src/models/post-spec.ts
@@ -18,7 +18,7 @@
 import type { Excerpt } from './excerpt';
 
 /**
- * Desired content, publication, taxonomy, and rendering configuration of a post.
+ * Desired post content, publication, taxonomy, and rendering configuration.
  */
 export interface PostSpec {
     /**

--- a/ui/packages/api-client/src/models/post-status.ts
+++ b/ui/packages/api-client/src/models/post-status.ts
@@ -18,7 +18,7 @@
 import type { Condition } from './condition';
 
 /**
- * Observed state of a content item.
+ * Observed post state derived by content reconcilers.
  */
 export interface PostStatus {
     /**

--- a/ui/packages/api-client/src/models/post.ts
+++ b/ui/packages/api-client/src/models/post.ts
@@ -24,7 +24,7 @@ import type { PostSpec } from './post-spec';
 import type { PostStatus } from './post-status';
 
 /**
- * Post extension.
+ * Post extension that stores article metadata, publication settings, taxonomy, and derived status.
  */
 export interface Post {
     'apiVersion': string;

--- a/ui/packages/api-client/src/models/reason-attributes.ts
+++ b/ui/packages/api-client/src/models/reason-attributes.ts
@@ -15,7 +15,7 @@
 
 
 /**
- * Attributes used to transfer data
+ * {@link ReasonAttributes ReasonAttributes} is a map that stores the attributes of the reason.
  */
 export interface ReasonAttributes {
     'empty'?: boolean;

--- a/ui/packages/api-client/src/models/reason-property.ts
+++ b/ui/packages/api-client/src/models/reason-property.ts
@@ -14,10 +14,25 @@
 
 
 
+/**
+ * Attribute definition for reasons of a reason type.
+ */
 export interface ReasonProperty {
+    /**
+     * Human-readable description of the attribute.
+     */
     'description'?: string;
+    /**
+     * Attribute name.
+     */
     'name': string;
+    /**
+     * Whether the attribute may be absent from a reason.
+     */
     'optional'?: boolean;
+    /**
+     * Attribute value type, such as string, number, boolean, or object.
+     */
     'type': string;
 }
 

--- a/ui/packages/api-client/src/models/reason-selector.ts
+++ b/ui/packages/api-client/src/models/reason-selector.ts
@@ -14,8 +14,17 @@
 
 
 
+/**
+ * Selector used to match a notification template to a reason type and language.
+ */
 export interface ReasonSelector {
+    /**
+     * Language tag this template applies to, or default for the fallback template.
+     */
     'language': string;
+    /**
+     * ReasonType metadata.name this template applies to.
+     */
     'reasonType': string;
 }
 

--- a/ui/packages/api-client/src/models/reason-spec.ts
+++ b/ui/packages/api-client/src/models/reason-spec.ts
@@ -20,9 +20,18 @@ import type { ReasonAttributes } from './reason-attributes';
 // @ts-ignore
 import type { ReasonSubject } from './reason-subject';
 
+/**
+ * Notification reason data used to render and dispatch notifications.
+ */
 export interface ReasonSpec {
     'attributes'?: ReasonAttributes;
+    /**
+     * User metadata.name or system actor that created the reason.
+     */
     'author': string;
+    /**
+     * ReasonType metadata.name that defines this reason.
+     */
     'reasonType': string;
     'subject': ReasonSubject;
 }

--- a/ui/packages/api-client/src/models/reason-subject.ts
+++ b/ui/packages/api-client/src/models/reason-subject.ts
@@ -14,11 +14,29 @@
 
 
 
+/**
+ * Resource subject associated with a notification reason.
+ */
 export interface ReasonSubject {
+    /**
+     * Subject API version.
+     */
     'apiVersion': string;
+    /**
+     * Subject kind.
+     */
     'kind': string;
+    /**
+     * Subject metadata.name.
+     */
     'name': string;
+    /**
+     * Human-readable subject title shown in notifications.
+     */
     'title': string;
+    /**
+     * URL that opens the subject.
+     */
     'url'?: string;
 }
 

--- a/ui/packages/api-client/src/models/reason-type-spec.ts
+++ b/ui/packages/api-client/src/models/reason-type-spec.ts
@@ -17,9 +17,21 @@
 // @ts-ignore
 import type { ReasonProperty } from './reason-property';
 
+/**
+ * Desired reason type metadata and properties available to templates.
+ */
 export interface ReasonTypeSpec {
+    /**
+     * Human-readable description of when this reason type is triggered.
+     */
     'description': string;
+    /**
+     * Display name shown for this reason type.
+     */
     'displayName': string;
+    /**
+     * Attribute definitions available on reasons of this type.
+     */
     'properties'?: Array<ReasonProperty>;
 }
 

--- a/ui/packages/api-client/src/models/reason-type.ts
+++ b/ui/packages/api-client/src/models/reason-type.ts
@@ -21,7 +21,7 @@ import type { Metadata } from './metadata';
 import type { ReasonTypeSpec } from './reason-type-spec';
 
 /**
- * {@link ReasonType ReasonType} is a custom extension that defines a type of reason.   <p>One {@link ReasonType ReasonType} can have multiple {@link Reason Reason}s to notify.
+ * Reason type extension that defines the schema and display metadata for notification reasons.   <p>One {@link ReasonType ReasonType} can have multiple {@link Reason Reason}s to notify.
  */
 export interface ReasonType {
     'apiVersion': string;

--- a/ui/packages/api-client/src/models/reason.ts
+++ b/ui/packages/api-client/src/models/reason.ts
@@ -21,7 +21,7 @@ import type { Metadata } from './metadata';
 import type { ReasonSpec } from './reason-spec';
 
 /**
- * {@link Reason Reason} is a custom extension that defines a reason for a notification, It represents an instance of a  {@link ReasonType ReasonType}.   <p>It can be understood as an event that triggers a notification.
+ * Reason extension that represents one notification event instance of a {@link ReasonType ReasonType}.   <p>It can be understood as an event that triggers a notification.
  */
 export interface Reason {
     'apiVersion': string;

--- a/ui/packages/api-client/src/models/remember-me-token-spec.ts
+++ b/ui/packages/api-client/src/models/remember-me-token-spec.ts
@@ -14,14 +14,29 @@
 
 
 
+/**
+ * Persistent remember-me token values for a user and browser series.
+ */
 export interface RememberMeTokenSpec {
+    /**
+     * Last time this remember-me token was used successfully.
+     */
     'lastUsed'?: string;
     /**
      * The previous token value, stored when the token is rotated. Used to accept recently-rotated tokens within a  grace period to prevent false-positive cookie theft detection during concurrent requests.
      */
     'previousTokenValue'?: string;
+    /**
+     * Browser series identifier used by Spring Security remember-me authentication.
+     */
     'series': string;
+    /**
+     * Current remember-me token value expected from the browser cookie.
+     */
     'tokenValue': string;
+    /**
+     * User metadata.name that owns this remember-me token.
+     */
     'username': string;
 }
 

--- a/ui/packages/api-client/src/models/remember-me-token.ts
+++ b/ui/packages/api-client/src/models/remember-me-token.ts
@@ -20,6 +20,9 @@ import type { Metadata } from './metadata';
 // @ts-ignore
 import type { RememberMeTokenSpec } from './remember-me-token-spec';
 
+/**
+ * Persistent remember-me token used to keep a user\'s browser session signed in across restarts.
+ */
 export interface RememberMeToken {
     'apiVersion': string;
     'kind': string;

--- a/ui/packages/api-client/src/models/reverse-proxy-rule.ts
+++ b/ui/packages/api-client/src/models/reverse-proxy-rule.ts
@@ -17,6 +17,9 @@
 // @ts-ignore
 import type { FileReverseProxyProvider } from './file-reverse-proxy-provider';
 
+/**
+ * A path mapping from a public request path to a file provider.
+ */
 export interface ReverseProxyRule {
     'file'?: FileReverseProxyProvider;
     'path'?: string;

--- a/ui/packages/api-client/src/models/reverse-proxy.ts
+++ b/ui/packages/api-client/src/models/reverse-proxy.ts
@@ -27,6 +27,9 @@ export interface ReverseProxy {
     'apiVersion': string;
     'kind': string;
     'metadata': Metadata;
+    /**
+     * Path mapping rules served by this reverse proxy resource.
+     */
     'rules'?: Array<ReverseProxyRule>;
 }
 

--- a/ui/packages/api-client/src/models/role-binding.ts
+++ b/ui/packages/api-client/src/models/role-binding.ts
@@ -24,7 +24,7 @@ import type { RoleRef } from './role-ref';
 import type { Subject } from './subject';
 
 /**
- * RoleBinding references a role, but does not contain it. It can reference a Role in the global. It adds who  information via Subjects.
+ * RoleBinding extension that grants a Role to one or more subjects.
  */
 export interface RoleBinding {
     'apiVersion': string;
@@ -32,7 +32,7 @@ export interface RoleBinding {
     'metadata': Metadata;
     'roleRef'?: RoleRef;
     /**
-     * Subjects holds references to the objects the role applies to.
+     * Subjects that receive the permissions from roleRef.
      */
     'subjects'?: Array<Subject>;
 }

--- a/ui/packages/api-client/src/models/role-ref.ts
+++ b/ui/packages/api-client/src/models/role-ref.ts
@@ -19,15 +19,15 @@
  */
 export interface RoleRef {
     /**
-     * APIGroup is the group for the resource being referenced.
+     * API group of the role resource being referenced.
      */
     'apiGroup'?: string;
     /**
-     * Kind is the type of resource being referenced.
+     * Kind of the role resource being referenced.
      */
     'kind'?: string;
     /**
-     * Name is the name of resource being referenced.
+     * Metadata name of the role resource being referenced.
      */
     'name'?: string;
 }

--- a/ui/packages/api-client/src/models/role.ts
+++ b/ui/packages/api-client/src/models/role.ts
@@ -20,10 +20,16 @@ import type { Metadata } from './metadata';
 // @ts-ignore
 import type { PolicyRule } from './policy-rule';
 
+/**
+ * Role extension that defines RBAC policy rules for users and other subjects.
+ */
 export interface Role {
     'apiVersion': string;
     'kind': string;
     'metadata': Metadata;
+    /**
+     * Policy rules granted by this role.
+     */
     'rules': Array<PolicyRule>;
 }
 

--- a/ui/packages/api-client/src/models/setting-form.ts
+++ b/ui/packages/api-client/src/models/setting-form.ts
@@ -14,9 +14,21 @@
 
 
 
+/**
+ * A single form group in a setting definition.
+ */
 export interface SettingForm {
+    /**
+     * FormKit-compatible schema used to render the form fields.
+     */
     'formSchema': Array<object>;
+    /**
+     * Stable form group name used to store submitted values.
+     */
     'group': string;
+    /**
+     * Display label shown for this form group.
+     */
     'label'?: string;
 }
 

--- a/ui/packages/api-client/src/models/setting-ref.ts
+++ b/ui/packages/api-client/src/models/setting-ref.ts
@@ -14,8 +14,17 @@
 
 
 
+/**
+ * Reference to a setting definition used by this provider.
+ */
 export interface SettingRef {
+    /**
+     * Setting form group name.
+     */
     'group': string;
+    /**
+     * Setting metadata.name.
+     */
     'name': string;
 }
 

--- a/ui/packages/api-client/src/models/setting-spec.ts
+++ b/ui/packages/api-client/src/models/setting-spec.ts
@@ -17,7 +17,13 @@
 // @ts-ignore
 import type { SettingForm } from './setting-form';
 
+/**
+ * Collection of form groups that make up this setting definition.
+ */
 export interface SettingSpec {
+    /**
+     * Form groups rendered for this setting definition.
+     */
     'forms': Array<SettingForm>;
 }
 

--- a/ui/packages/api-client/src/models/setting.ts
+++ b/ui/packages/api-client/src/models/setting.ts
@@ -21,7 +21,7 @@ import type { Metadata } from './metadata';
 import type { SettingSpec } from './setting-spec';
 
 /**
- * {@link Setting Setting} is a custom extension to generate forms based on configuration.
+ * Setting extension that describes one or more configuration forms and their schema.
  */
 export interface Setting {
     'apiVersion': string;

--- a/ui/packages/api-client/src/models/single-page-spec.ts
+++ b/ui/packages/api-client/src/models/single-page-spec.ts
@@ -18,7 +18,7 @@
 import type { Excerpt } from './excerpt';
 
 /**
- * Desired content, publication, and rendering configuration of a single page.
+ * Desired single page content, publication, and rendering configuration.
  */
 export interface SinglePageSpec {
     /**

--- a/ui/packages/api-client/src/models/single-page-status.ts
+++ b/ui/packages/api-client/src/models/single-page-status.ts
@@ -18,7 +18,7 @@
 import type { Condition } from './condition';
 
 /**
- * Observed state of a single page.
+ * Observed single page state derived by content reconcilers.
  */
 export interface SinglePageStatus {
     /**

--- a/ui/packages/api-client/src/models/single-page.ts
+++ b/ui/packages/api-client/src/models/single-page.ts
@@ -24,7 +24,7 @@ import type { SinglePageSpec } from './single-page-spec';
 import type { SinglePageStatus } from './single-page-status';
 
 /**
- * Single page extension.
+ * Single page extension that stores standalone page metadata, publication settings, and derived status.
  */
 export interface SinglePage {
     'apiVersion': string;

--- a/ui/packages/api-client/src/models/subject.ts
+++ b/ui/packages/api-client/src/models/subject.ts
@@ -14,6 +14,9 @@
 
 
 
+/**
+ * Subject that receives permissions from a RoleBinding.
+ */
 export interface Subject {
     /**
      * APIGroup holds the API group of the referenced subject. Defaults to \"\" for ServiceAccount subjects. Defaults  to \"rbac.authorization.halo.run\" for User and Group subjects.

--- a/ui/packages/api-client/src/models/subscription-spec.ts
+++ b/ui/packages/api-client/src/models/subscription-spec.ts
@@ -20,15 +20,18 @@ import type { InterestReason } from './interest-reason';
 // @ts-ignore
 import type { SubscriptionSubscriber } from './subscription-subscriber';
 
+/**
+ * Desired notification subscription settings.
+ */
 export interface SubscriptionSpec {
     /**
-     * Perhaps users need to unsubscribe and interact without receiving notifications again
+     * Whether the subscription has been disabled, usually after the subscriber unsubscribes.
      */
     'disabled'?: boolean;
     'reason': InterestReason;
     'subscriber': SubscriptionSubscriber;
     /**
-     * The token to unsubscribe
+     * Token used to unsubscribe without authenticating as the subscriber.
      */
     'unsubscribeToken': string;
 }

--- a/ui/packages/api-client/src/models/subscription-subscriber.ts
+++ b/ui/packages/api-client/src/models/subscription-subscriber.ts
@@ -15,9 +15,12 @@
 
 
 /**
- * The subscriber to be notified
+ * Subscriber that receives notifications.
  */
 export interface SubscriptionSubscriber {
+    /**
+     * User metadata.name of the subscriber.
+     */
     'name': string;
 }
 

--- a/ui/packages/api-client/src/models/subscription.ts
+++ b/ui/packages/api-client/src/models/subscription.ts
@@ -21,7 +21,7 @@ import type { Metadata } from './metadata';
 import type { SubscriptionSpec } from './subscription-spec';
 
 /**
- * {@link Subscription Subscription} is a custom extension that defines a subscriber to be notified when a certain {@link Reason Reason} is  triggered.   <p>It holds a {@link Subscriber Subscriber} to the user to be notified, a {@link InterestReason InterestReason} to subscribe to.
+ * Subscription extension that records which subscriber should be notified when a matching reason is triggered.   <p>It holds a {@link Subscriber Subscriber} to the user to be notified, a {@link InterestReason InterestReason} to subscribe to.
  */
 export interface Subscription {
     'apiVersion': string;

--- a/ui/packages/api-client/src/models/tag-spec.ts
+++ b/ui/packages/api-client/src/models/tag-spec.ts
@@ -15,7 +15,7 @@
 
 
 /**
- * Desired display and rendering configuration of a tag.
+ * Desired tag display and rendering configuration.
  */
 export interface TagSpec {
     /**

--- a/ui/packages/api-client/src/models/tag-status.ts
+++ b/ui/packages/api-client/src/models/tag-status.ts
@@ -15,7 +15,7 @@
 
 
 /**
- * Observed state of a tag.
+ * Observed tag state derived by content reconcilers.
  */
 export interface TagStatus {
     /**

--- a/ui/packages/api-client/src/models/template-content.ts
+++ b/ui/packages/api-client/src/models/template-content.ts
@@ -14,9 +14,21 @@
 
 
 
+/**
+ * Notification template content.
+ */
 export interface TemplateContent {
+    /**
+     * HTML body rendered for notification channels that support HTML.
+     */
     'htmlBody'?: string;
+    /**
+     * Plain text or source body rendered for notification channels that do not use HTML.
+     */
     'rawBody'?: string;
+    /**
+     * Rendered notification title.
+     */
     'title': string;
 }
 

--- a/ui/packages/api-client/src/models/template-descriptor.ts
+++ b/ui/packages/api-client/src/models/template-descriptor.ts
@@ -18,9 +18,21 @@
  * Type used to describe custom template page.
  */
 export interface TemplateDescriptor {
+    /**
+     * Human-readable description of when to use this template.
+     */
     'description'?: string;
+    /**
+     * Template file path relative to the theme templates directory.
+     */
     'file': string;
+    /**
+     * Template display name shown to users.
+     */
     'name': string;
+    /**
+     * Screenshot URL or attachment URI for previewing the template.
+     */
     'screenshot'?: string;
 }
 

--- a/ui/packages/api-client/src/models/theme-spec.ts
+++ b/ui/packages/api-client/src/models/theme-spec.ts
@@ -23,19 +23,55 @@ import type { CustomTemplates } from './custom-templates';
 // @ts-ignore
 import type { License } from './license';
 
+/**
+ * Desired theme metadata and configuration references.
+ */
 export interface ThemeSpec {
     'author': Author;
+    /**
+     * ConfigMap metadata.name storing the theme configuration values.
+     */
     'configMapName'?: string;
     'customTemplates'?: CustomTemplates;
+    /**
+     * Human-readable theme description.
+     */
     'description'?: string;
+    /**
+     * Display name shown for the theme.
+     */
     'displayName': string;
+    /**
+     * Theme homepage URL.
+     */
     'homepage'?: string;
+    /**
+     * Issue tracker URL.
+     */
     'issues'?: string;
+    /**
+     * Licenses declared by the theme.
+     */
     'license'?: Array<License>;
+    /**
+     * Logo URL or attachment URI for the theme.
+     */
     'logo'?: string;
+    /**
+     * Source repository URL.
+     */
     'repo'?: string;
+    /**
+     * Required Halo version range. The wildcard value means any Halo version.
+     */
     'requires'?: string;
+    /**
+     * Setting metadata.name used to render the theme configuration form.
+     */
     'settingName'?: string;
+    /**
+     * Theme version. The wildcard value means any version.
+     */
     'version'?: string;
 }
 

--- a/ui/packages/api-client/src/models/theme-status.ts
+++ b/ui/packages/api-client/src/models/theme-status.ts
@@ -17,13 +17,25 @@
 // @ts-ignore
 import type { Condition } from './condition';
 
+/**
+ * Observed theme lifecycle and installation state.
+ */
 export interface ThemeStatus {
+    /**
+     * Reconciliation conditions for the theme.
+     */
     'conditions'?: Array<Condition>;
     /**
      * Whether the theme appears to be a local development workspace.
      */
     'inDevelopment'?: boolean;
+    /**
+     * Local filesystem location where the theme is loaded from.
+     */
     'location'?: string;
+    /**
+     * Current theme lifecycle phase.
+     */
     'phase'?: ThemeStatusPhaseEnum;
 }
 

--- a/ui/packages/api-client/src/models/theme.ts
+++ b/ui/packages/api-client/src/models/theme.ts
@@ -24,7 +24,7 @@ import type { ThemeSpec } from './theme-spec';
 import type { ThemeStatus } from './theme-status';
 
 /**
- * Theme extension.
+ * Theme extension that describes an installable frontend theme and its runtime state.
  */
 export interface Theme {
     'apiVersion': string;

--- a/ui/packages/api-client/src/models/user-connection-spec.ts
+++ b/ui/packages/api-client/src/models/user-connection-spec.ts
@@ -14,6 +14,9 @@
 
 
 
+/**
+ * External OAuth2 account binding for a Halo user.
+ */
 export interface UserConnectionSpec {
     /**
      * The unique identifier for the user\'s connection to the OAuth provider. for example, the user\'s GitHub id.

--- a/ui/packages/api-client/src/models/user-connection.ts
+++ b/ui/packages/api-client/src/models/user-connection.ts
@@ -21,7 +21,7 @@ import type { Metadata } from './metadata';
 import type { UserConnectionSpec } from './user-connection-spec';
 
 /**
- * User connection extension.
+ * User connection extension that links a Halo user to an external OAuth2 account.
  */
 export interface UserConnection {
     'apiVersion': string;

--- a/ui/packages/api-client/src/models/user-spec.ts
+++ b/ui/packages/api-client/src/models/user-spec.ts
@@ -14,18 +14,57 @@
 
 
 
+/**
+ * Desired user profile and authentication settings.
+ */
 export interface UserSpec {
+    /**
+     * Avatar URL or attachment URI for the user.
+     */
     'avatar'?: string;
+    /**
+     * User biography shown on profile surfaces.
+     */
     'bio'?: string;
+    /**
+     * Whether the user account is disabled.
+     */
     'disabled'?: boolean;
+    /**
+     * Display name shown for the user.
+     */
     'displayName': string;
+    /**
+     * Email address used for sign-in and notifications.
+     */
     'email': string;
+    /**
+     * Whether the email address has been verified.
+     */
     'emailVerified'?: boolean;
+    /**
+     * Maximum number of login history entries retained for this user.
+     */
     'loginHistoryLimit'?: number;
+    /**
+     * Password hash or encoded password value.
+     */
     'password'?: string;
+    /**
+     * Phone number associated with the user.
+     */
     'phone'?: string;
+    /**
+     * Time when the user registered.
+     */
     'registeredAt'?: string;
+    /**
+     * Encrypted TOTP secret used for two-factor authentication.
+     */
     'totpEncryptedSecret'?: string;
+    /**
+     * Whether two-factor authentication is enabled for this user.
+     */
     'twoFactorAuthEnabled'?: boolean;
 }
 

--- a/ui/packages/api-client/src/models/user-status.ts
+++ b/ui/packages/api-client/src/models/user-status.ts
@@ -14,7 +14,13 @@
 
 
 
+/**
+ * Observed user state derived by the application.
+ */
 export interface UserStatus {
+    /**
+     * Public permalink of the user\'s profile or author page.
+     */
     'permalink'?: string;
 }
 

--- a/ui/packages/api-client/src/models/user.ts
+++ b/ui/packages/api-client/src/models/user.ts
@@ -24,7 +24,7 @@ import type { UserSpec } from './user-spec';
 import type { UserStatus } from './user-status';
 
 /**
- * The extension represents user details of Halo.
+ * User extension that stores profile, authentication, and account state for a Halo user.
  */
 export interface User {
     'apiVersion': string;


### PR DESCRIPTION
#### What type of PR is this?

/kind documentation

#### What this PR does / why we need it:

This PR improves OpenAPI documentation for extension models that extend `AbstractExtension`.

It adds and refines Javadocs for extension classes, nested schema classes, and fields so Swagger/OpenAPI consumers can understand model intent without relying on duplicated `@Schema(description = ...)` annotations.

It also removes duplicated `description` attributes from `@Schema` and `@ArraySchema` annotations in those extension models while preserving structural schema metadata such as `requiredMode`, `name`, validation constraints, and `uniqueItems`.

The generated OpenAPI JSON and TypeScript API client were regenerated from the updated Javadocs.

#### Which issue(s) this PR fixes:

N/A

#### Special notes for your reviewer:

This PR was prepared with AI assistance and the generated OpenAPI/client output was reviewed after regeneration.

Validation performed:

- `./gradlew :api:spotlessApply :application:spotlessApply generateOpenApiDocs`
- `pnpm -C ui api-client:gen`
- `pnpm -C ui typecheck`
- `pnpm -C ui lint`
- `git diff --check`
- Scanned direct `AbstractExtension` classes to verify no `@Schema` / `@ArraySchema` annotations still use `description`

#### Does this PR introduce a user-facing change?

```release-note
None
```
