### PR TITLE
Fix excerpt generator not called when autoGenerate becomes true

### DIFF
--- a/application/src/main/java/run/halo/app/core/reconciler/PostReconciler.java
+++ b/application/src/main/java/run/halo/app/core/reconciler/PostReconciler.java
@@ -370,13 +370,16 @@ public class PostReconciler implements Reconciler<Reconciler.Request> {
 
         var contentChecksum =
                 Hashing.sha256().hashString(content.getContent(), UTF_8).toString();
+        var excerpt = post.getSpec().getExcerpt();
+        var isAutoGenerate = excerpt == null || excerpt.getAutoGenerate() == null || excerpt.getAutoGenerate();
+        var cacheKey = contentChecksum + ":" + isAutoGenerate;
         var annotations = MetadataUtil.nullSafeAnnotations(post);
-        var oldChecksum = annotations.get(Constant.CONTENT_CHECKSUM_ANNO);
-        if (Objects.equals(oldChecksum, contentChecksum)) {
+        var oldCacheKey = annotations.get(Constant.CONTENT_CHECKSUM_ANNO);
+        if (Objects.equals(oldCacheKey, cacheKey)) {
             return post.getStatusOrDefault().getExcerpt();
         }
         // update the checksum and generate new excerpt
-        annotations.put(Constant.CONTENT_CHECKSUM_ANNO, contentChecksum);
+        annotations.put(Constant.CONTENT_CHECKSUM_ANNO, cacheKey);
 
         var tags = listTagDisplayNames(post);
 

--- a/application/src/main/java/run/halo/app/core/reconciler/SinglePageReconciler.java
+++ b/application/src/main/java/run/halo/app/core/reconciler/SinglePageReconciler.java
@@ -371,13 +371,16 @@ public class SinglePageReconciler implements Reconciler<Reconciler.Request> {
 
         var contentChecksum =
                 Hashing.sha256().hashString(content.getContent(), UTF_8).toString();
+        var excerpt = singlePage.getSpec().getExcerpt();
+        var isAutoGenerate = excerpt == null || excerpt.getAutoGenerate() == null || excerpt.getAutoGenerate();
+        var cacheKey = contentChecksum + ":" + isAutoGenerate;
         var annotations = MetadataUtil.nullSafeAnnotations(singlePage);
-        var oldChecksum = annotations.get(Constant.CONTENT_CHECKSUM_ANNO);
-        if (Objects.equals(oldChecksum, contentChecksum)) {
+        var oldCacheKey = annotations.get(Constant.CONTENT_CHECKSUM_ANNO);
+        if (Objects.equals(oldCacheKey, cacheKey)) {
             return singlePage.getStatusOrDefault().getExcerpt();
         }
         // update the checksum and generate new excerpt
-        annotations.put(Constant.CONTENT_CHECKSUM_ANNO, contentChecksum);
+        annotations.put(Constant.CONTENT_CHECKSUM_ANNO, cacheKey);
 
         var context = new ExcerptGenerator.Context()
                 .setRaw(content.getRaw())

--- a/application/src/test/java/run/halo/app/core/reconciler/PostReconcilerTest.java
+++ b/application/src/test/java/run/halo/app/core/reconciler/PostReconcilerTest.java
@@ -21,6 +21,7 @@ import org.springframework.context.ApplicationEventPublisher;
 import reactor.core.publisher.Mono;
 import run.halo.app.content.*;
 import run.halo.app.content.permalinks.PostPermalinkPolicy;
+import run.halo.app.core.extension.content.Constant;
 import run.halo.app.core.extension.content.Post;
 import run.halo.app.core.extension.content.Snapshot;
 import run.halo.app.core.extension.notification.Subscription;
@@ -166,6 +167,62 @@ class PostReconcilerTest {
         verify(client, times(1)).update(captor.capture());
         Post value = captor.getValue();
         assertThat(value.getStatus().getExcerpt()).isEqualTo("hello world");
+    }
+
+    @Test
+    void shouldRegenerateExcerptWhenAutoGenerateBecomesTrue() {
+        // https://github.com/halo-dev/halo/issues/10039
+        String name = "post-A";
+        Post post = TestPost.postV1();
+        post.getSpec().setPublish(true);
+        post.getSpec().setHeadSnapshot("post-A-head-snapshot");
+        post.getSpec().setReleaseSnapshot("post-fake-released-snapshot");
+
+        // simulate a previous state where autoGenerate was false
+        var oldCacheKey = "old-checksum:false";
+        post.getMetadata().setAnnotations(new HashMap<>());
+        post.getMetadata().getAnnotations().put(Constant.CONTENT_CHECKSUM_ANNO, oldCacheKey);
+
+        // now switch to autoGenerate=true
+        var excerpt = new Post.Excerpt();
+        excerpt.setAutoGenerate(true);
+        post.getSpec().setExcerpt(excerpt);
+
+        // old excerpt that should be regenerated
+        post.getStatusOrDefault().setExcerpt("old-excerpt");
+
+        when(client.fetch(eq(Post.class), eq(name))).thenReturn(Optional.of(post));
+        when(postService.getContent(
+                        eq(post.getSpec().getReleaseSnapshot()),
+                        eq(post.getSpec().getBaseSnapshot())))
+                .thenReturn(Mono.just(ContentWrapper.builder()
+                        .snapshotName(post.getSpec().getHeadSnapshot())
+                        .raw("hello world")
+                        .content("<p>hello world</p>")
+                        .rawType("markdown")
+                        .build()));
+
+        Snapshot snapshotV2 = TestPost.snapshotV2();
+        snapshotV2.getMetadata().setLabels(new HashMap<>());
+        snapshotV2.getSpec().setContributors(Set.of("guqing", "zhangsan"));
+
+        Snapshot snapshotV1 = TestPost.snapshotV1();
+        snapshotV1.getSpec().setContributors(Set.of("guqing"));
+
+        when(extensionGetter.getEnabledExtension(eq(ExcerptGenerator.class))).thenReturn(Mono.empty());
+
+        when(client.listAll(eq(Snapshot.class), any(), any())).thenReturn(List.of(snapshotV1, snapshotV2));
+
+        ArgumentCaptor<Post> captor = ArgumentCaptor.forClass(Post.class);
+        postReconciler.reconcile(new Reconciler.Request(name));
+
+        verify(client, times(1)).update(captor.capture());
+        Post value = captor.getValue();
+        // should regenerate excerpt instead of returning cached old value
+        assertThat(value.getStatus().getExcerpt()).isEqualTo("hello world");
+        // annotation should be updated with new cache key ending with :true
+        assertThat(value.getMetadata().getAnnotations().get(Constant.CONTENT_CHECKSUM_ANNO))
+                .endsWith(":true");
     }
 
     @Nested

--- a/application/src/test/java/run/halo/app/core/reconciler/SinglePageReconcilerTest.java
+++ b/application/src/test/java/run/halo/app/core/reconciler/SinglePageReconcilerTest.java
@@ -7,6 +7,7 @@ import static run.halo.app.content.TestPost.snapshotV1;
 
 import java.net.URI;
 import java.time.Instant;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
@@ -22,6 +23,7 @@ import org.springframework.context.ApplicationContext;
 import reactor.core.publisher.Mono;
 import run.halo.app.content.*;
 import run.halo.app.core.counter.CounterService;
+import run.halo.app.core.extension.content.Constant;
 import run.halo.app.core.extension.content.Post;
 import run.halo.app.core.extension.content.SinglePage;
 import run.halo.app.core.extension.content.Snapshot;
@@ -104,6 +106,61 @@ class SinglePageReconcilerTest {
         SinglePage value = captor.getValue();
         assertThat(value.getStatus().getExcerpt()).isEqualTo("hello world");
         assertThat(value.getStatus().getContributors()).isEqualTo(List.of("guqing", "zhangsan"));
+    }
+
+    @Test
+    void shouldRegenerateExcerptWhenAutoGenerateBecomesTrue() {
+        // https://github.com/halo-dev/halo/issues/10039
+        String name = "page-A";
+        when(externalUrlSupplier.get()).thenReturn(URI.create(""));
+
+        SinglePage page = pageV1();
+        page.getSpec().setHeadSnapshot("page-A-head-snapshot");
+        page.getSpec().setReleaseSnapshot(page.getSpec().getHeadSnapshot());
+
+        // simulate a previous state where autoGenerate was false
+        var oldCacheKey = "old-checksum:false";
+        page.getMetadata().setAnnotations(new HashMap<>());
+        page.getMetadata().getAnnotations().put(Constant.CONTENT_CHECKSUM_ANNO, oldCacheKey);
+
+        // now switch to autoGenerate=true
+        var excerpt = new Post.Excerpt();
+        excerpt.setAutoGenerate(true);
+        page.getSpec().setExcerpt(excerpt);
+
+        // old excerpt that should be regenerated
+        page.getStatusOrDefault().setExcerpt("old-excerpt");
+
+        when(client.fetch(eq(SinglePage.class), eq(name))).thenReturn(Optional.of(page));
+        when(singlePageService.getContent(
+                        eq(page.getSpec().getReleaseSnapshot()),
+                        eq(page.getSpec().getBaseSnapshot())))
+                .thenReturn(Mono.just(ContentWrapper.builder()
+                        .snapshotName(page.getSpec().getHeadSnapshot())
+                        .raw("hello world")
+                        .content("<p>hello world</p>")
+                        .rawType("markdown")
+                        .build()));
+
+        Snapshot snapshotV1 = snapshotV1();
+        Snapshot snapshotV2 = TestPost.snapshotV2();
+        snapshotV1.getSpec().setContributors(Set.of("guqing"));
+        snapshotV2.getSpec().setContributors(Set.of("guqing", "zhangsan"));
+        when(client.listAll(eq(Snapshot.class), any(), any())).thenReturn(List.of(snapshotV1, snapshotV2));
+
+        when(extensionGetter.getEnabledExtension(eq(ExcerptGenerator.class))).thenReturn(Mono.empty());
+
+        ArgumentCaptor<SinglePage> captor = ArgumentCaptor.forClass(SinglePage.class);
+        singlePageReconciler.reconcile(new Reconciler.Request(name));
+
+        verify(client, times(3)).update(captor.capture());
+
+        SinglePage value = captor.getValue();
+        // should regenerate excerpt instead of returning cached old value
+        assertThat(value.getStatus().getExcerpt()).isEqualTo("hello world");
+        // annotation should be updated with new cache key ending with :true
+        assertThat(value.getMetadata().getAnnotations().get(Constant.CONTENT_CHECKSUM_ANNO))
+                .endsWith(":true");
     }
 
     @Test


### PR DESCRIPTION
#### What type of PR is this?

- [x] Bug fix

#### What this PR does / why we need it:

`PostReconciler` and `SinglePageReconciler` use content SHA256 checksum alone as the cache key in `getExcerpt()`. When the article content is unchanged but `excerpt.autoGenerate` switches from `false` to `true`, the cache hits and the old excerpt is returned directly, skipping all `ExcerptGenerator` calls (including plugin extensions and the `DefaultExcerptGenerator` fallback).

This PR includes the `autoGenerate` flag into the cache key so that the excerpt is regenerated whenever the `autoGenerate` state changes, even if the content itself has not been modified.

#### Which issue(s) this PR fixes:

Fixes #10039

#### Special notes for your reviewer:

This change is backward compatible: the old `checksum/content` annotation stores a pure content checksum (e.g. `abc123`), while the new cache key format is `abc123:true` or `abc123:false`. On the first reconcile after upgrade, the old key will not match, triggering a one-time regeneration and updating the annotation to the new format.

#### Does this PR introduce a user-facing change?

```release-note
修复在文章内容未修改时切换「自动生成摘要」设置后摘要未重新生成的问题
```