### PR TITLE
Support theme screenshot previews

### DIFF
--- a/api-docs/openapi/v3_0/aggregated.json
+++ b/api-docs/openapi/v3_0/aggregated.json
@@ -23404,6 +23404,10 @@
               "FAILED",
               "UNKNOWN"
             ]
+          },
+          "screenshot": {
+            "type": "string",
+            "description": "Resolved preview screenshot URL served from the theme root."
           }
         },
         "description": "Observed theme lifecycle and installation state."

--- a/api-docs/openapi/v3_0/apis_console.api_v1alpha1.json
+++ b/api-docs/openapi/v3_0/apis_console.api_v1alpha1.json
@@ -6869,6 +6869,10 @@
               "FAILED",
               "UNKNOWN"
             ]
+          },
+          "screenshot": {
+            "type": "string",
+            "description": "Resolved preview screenshot URL served from the theme root."
           }
         },
         "description": "Observed theme lifecycle and installation state."

--- a/api-docs/openapi/v3_0/apis_extension.api_v1alpha1.json
+++ b/api-docs/openapi/v3_0/apis_extension.api_v1alpha1.json
@@ -14645,6 +14645,10 @@
               "FAILED",
               "UNKNOWN"
             ]
+          },
+          "screenshot": {
+            "type": "string",
+            "description": "Resolved preview screenshot URL served from the theme root."
           }
         },
         "description": "Observed theme lifecycle and installation state."

--- a/api/src/main/java/run/halo/app/core/extension/Theme.java
+++ b/api/src/main/java/run/halo/app/core/extension/Theme.java
@@ -104,6 +104,9 @@ public class Theme extends AbstractExtension {
 
         /** Whether the theme appears to be a local development workspace. */
         private Boolean inDevelopment;
+
+        /** Resolved preview screenshot URL served from the theme root. */
+        private String screenshot;
     }
 
     /**

--- a/api/src/test/java/run/halo/app/core/extension/ThemeTest.java
+++ b/api/src/test/java/run/halo/app/core/extension/ThemeTest.java
@@ -1,0 +1,19 @@
+package run.halo.app.core.extension;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+import run.halo.app.infra.utils.JsonUtils;
+
+class ThemeTest {
+
+    @Test
+    void shouldSerializeStatusScreenshot() {
+        var theme = new Theme();
+        var status = new Theme.ThemeStatus();
+        status.setScreenshot("/themes/test-theme/screenshot.png");
+        theme.setStatus(status);
+
+        assertThat(JsonUtils.objectToJson(theme)).contains("\"screenshot\":\"/themes/test-theme/screenshot.png\"");
+    }
+}

--- a/application/src/main/java/run/halo/app/core/reconciler/ThemeReconciler.java
+++ b/application/src/main/java/run/halo/app/core/reconciler/ThemeReconciler.java
@@ -49,6 +49,7 @@ import run.halo.app.infra.utils.ReactiveUtils;
 import run.halo.app.infra.utils.SettingUtils;
 import run.halo.app.infra.utils.VersionUtils;
 import run.halo.app.theme.TemplateEngineManager;
+import run.halo.app.theme.ThemeScreenshots;
 import run.halo.app.theme.service.ThemeUtils;
 
 /**
@@ -160,6 +161,9 @@ class ThemeReconciler implements Reconciler<Request> {
         var themePath = themeRoot.get().resolve(name);
         status.setLocation(themePath.toAbsolutePath().toString());
         status.setInDevelopment(hasLocalDevelopmentIndicators(themePath));
+        status.setScreenshot(ThemeScreenshots.findScreenshot(themePath)
+                .map(screenshot -> ThemeScreenshots.buildScreenshotUrl(name, screenshot))
+                .orElse(null));
 
         status.setPhase(Theme.ThemePhase.READY);
         var conditionBuilder = Condition.builder()

--- a/application/src/main/java/run/halo/app/infra/config/WebServerSecurityConfig.java
+++ b/application/src/main/java/run/halo/app/infra/config/WebServerSecurityConfig.java
@@ -56,6 +56,7 @@ public class WebServerSecurityConfig {
                 HttpMethod.GET,
                 "/ui-assets/**",
                 "/themes/{themeName}/assets/{*resourcePaths}",
+                "/themes/{themeName}/screenshot.{extension}",
                 "/plugins/{pluginName}/assets/**",
                 "/webjars/**",
                 "/js/**",

--- a/application/src/main/java/run/halo/app/theme/ThemeScreenshots.java
+++ b/application/src/main/java/run/halo/app/theme/ThemeScreenshots.java
@@ -1,0 +1,34 @@
+package run.halo.app.theme;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Optional;
+import org.springframework.web.util.UriComponentsBuilder;
+
+public final class ThemeScreenshots {
+
+    private static final List<String> SUPPORTED_FILENAMES =
+            List.of("screenshot.png", "screenshot.jpeg", "screenshot.jpg", "screenshot.webp");
+
+    private ThemeScreenshots() {}
+
+    public static Optional<Path> findScreenshot(Path themePath) {
+        return SUPPORTED_FILENAMES.stream()
+                .map(themePath::resolve)
+                .filter(Files::isRegularFile)
+                .filter(Files::isReadable)
+                .findFirst();
+    }
+
+    public static boolean isSupportedFilename(String filename) {
+        return SUPPORTED_FILENAMES.contains(filename);
+    }
+
+    public static String buildScreenshotUrl(String themeName, Path screenshotPath) {
+        return UriComponentsBuilder.newInstance()
+                .pathSegment("themes", themeName, screenshotPath.getFileName().toString())
+                .build()
+                .toString();
+    }
+}

--- a/application/src/main/java/run/halo/app/theme/config/ThemeWebFluxConfigurer.java
+++ b/application/src/main/java/run/halo/app/theme/config/ThemeWebFluxConfigurer.java
@@ -1,5 +1,6 @@
 package run.halo.app.theme.config;
 
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.Map;
@@ -18,7 +19,9 @@ import org.springframework.web.reactive.resource.ResourceResolverChain;
 import org.springframework.web.server.ServerWebExchange;
 import reactor.core.publisher.Mono;
 import run.halo.app.infra.ThemeRootGetter;
+import run.halo.app.infra.exception.AccessDeniedException;
 import run.halo.app.infra.utils.FileUtils;
+import run.halo.app.theme.ThemeScreenshots;
 
 @Component
 public class ThemeWebFluxConfigurer implements WebFluxConfigurer {
@@ -39,6 +42,12 @@ public class ThemeWebFluxConfigurer implements WebFluxConfigurer {
             cacheControl = CacheControl.empty();
         }
         var useLastModified = resourcesProperties.getCache().isUseLastModified();
+        registry.addResourceHandler("/themes/{themeName}/screenshot.{extension}")
+                .setCacheControl(cacheControl)
+                .setUseLastModified(useLastModified)
+                .resourceChain(true)
+                .addResolver(new EncodedResourceResolver())
+                .addResolver(new ThemeScreenshotResourceResolver(themeRootGetter.get()));
         registry.addResourceHandler("/themes/{themeName}/assets/{*resourcePaths}")
                 .setCacheControl(cacheControl)
                 .setUseLastModified(useLastModified)
@@ -85,6 +94,53 @@ public class ThemeWebFluxConfigurer implements WebFluxConfigurer {
                 return Mono.empty();
             }
             return Mono.just(location);
+        }
+
+        @Override
+        protected Mono<String> resolveUrlPathInternal(
+                String resourceUrlPath, List<? extends Resource> locations, ResourceResolverChain chain) {
+            throw new UnsupportedOperationException();
+        }
+    }
+
+    /** Theme screenshot resource resolver. The resolver only exposes supported screenshot files from the theme root. */
+    private static class ThemeScreenshotResourceResolver extends AbstractResourceResolver {
+
+        private final Path themeRoot;
+
+        private ThemeScreenshotResourceResolver(Path themeRoot) {
+            this.themeRoot = themeRoot;
+        }
+
+        @Override
+        protected Mono<Resource> resolveResourceInternal(
+                ServerWebExchange exchange,
+                String requestPath,
+                List<? extends Resource> locations,
+                ResourceResolverChain chain) {
+            if (exchange == null) {
+                return Mono.empty();
+            }
+            Map<String, String> requiredAttribute =
+                    exchange.getRequiredAttribute(HandlerMapping.URI_TEMPLATE_VARIABLES_ATTRIBUTE);
+            var themeName = requiredAttribute.get("themeName");
+            var extension = requiredAttribute.get("extension");
+            var filename = "screenshot." + extension;
+
+            if (StringUtils.isAnyBlank(themeName, extension) || !ThemeScreenshots.isSupportedFilename(filename)) {
+                return Mono.empty();
+            }
+
+            var screenshotPath = themeRoot.resolve(themeName).resolve(filename);
+            try {
+                FileUtils.checkDirectoryTraversal(themeRoot, screenshotPath);
+            } catch (AccessDeniedException e) {
+                return Mono.empty();
+            }
+            if (!Files.isRegularFile(screenshotPath) || !Files.isReadable(screenshotPath)) {
+                return Mono.empty();
+            }
+            return Mono.just(new FileSystemResource(screenshotPath));
         }
 
         @Override

--- a/application/src/test/java/run/halo/app/config/WebFluxConfigTest.java
+++ b/application/src/test/java/run/halo/app/config/WebFluxConfigTest.java
@@ -1,13 +1,19 @@
 package run.halo.app.config;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.when;
 
 import java.net.URI;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.List;
 import java.util.Set;
 import org.hamcrest.core.StringStartsWith;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -22,6 +28,7 @@ import org.springframework.context.annotation.Import;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
 import org.springframework.test.web.reactive.server.WebTestClient;
+import org.springframework.util.FileSystemUtils;
 import org.springframework.web.filter.reactive.ServerWebExchangeContextFilter;
 import org.springframework.web.reactive.function.server.RouterFunction;
 import org.springframework.web.reactive.function.server.RouterFunctions;
@@ -38,7 +45,9 @@ import run.halo.app.core.user.service.RoleService;
 import run.halo.app.extension.GroupVersion;
 import run.halo.app.extension.Metadata;
 
-@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@SpringBootTest(
+        webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
+        properties = "halo.work-dir=${java.io.tmpdir}/halo-next-test")
 @Import({
     WebFluxConfigTest.WebSocketSupportTest.TestWebSocketConfiguration.class,
     WebFluxConfigTest.ServerWebExchangeContextFilterTest.TestConfig.class,
@@ -46,6 +55,9 @@ import run.halo.app.extension.Metadata;
 })
 @AutoConfigureWebTestClient
 class WebFluxConfigTest {
+
+    private static final Path TEST_WORK_DIR = Paths.get(System.getProperty("java.io.tmpdir"), "halo-next-test");
+    private static final Path TEST_THEME_DIR = TEST_WORK_DIR.resolve("themes").resolve("fake-theme");
 
     @Autowired
     WebTestClient webClient;
@@ -192,6 +204,11 @@ class WebFluxConfigTest {
     @Nested
     class StaticResourcesTest {
 
+        @AfterEach
+        void cleanUp() throws Exception {
+            FileSystemUtils.deleteRecursively(TEST_THEME_DIR);
+        }
+
         @Test
         void shouldRespond404WhenThemeResourceNotFound() {
             webClient
@@ -200,6 +217,55 @@ class WebFluxConfigTest {
                     .exchange()
                     .expectStatus()
                     .isNotFound();
+        }
+
+        @Test
+        void shouldServeThemeScreenshotWithoutAuthentication() throws Exception {
+            Files.createDirectories(TEST_THEME_DIR);
+            Files.writeString(TEST_THEME_DIR.resolve("screenshot.png"), "fake screenshot");
+
+            webClient
+                    .get()
+                    .uri("/themes/fake-theme/screenshot.png")
+                    .exchange()
+                    .expectStatus()
+                    .isOk()
+                    .expectBody()
+                    .consumeWith(
+                            result -> assertArrayEquals("fake screenshot".getBytes(UTF_8), result.getResponseBody()));
+        }
+
+        @Test
+        void shouldRespond404WhenThemeScreenshotExtensionIsUnsupported() throws Exception {
+            Files.createDirectories(TEST_THEME_DIR);
+            Files.writeString(TEST_THEME_DIR.resolve("screenshot.gif"), "fake screenshot");
+
+            webClient
+                    .get()
+                    .uri("/themes/fake-theme/screenshot.gif")
+                    .exchange()
+                    .expectStatus()
+                    .isNotFound();
+        }
+
+        @Test
+        void shouldRespond404WhenThemeScreenshotDoesNotExist() {
+            webClient
+                    .get()
+                    .uri("/themes/fake-theme/screenshot.png")
+                    .exchange()
+                    .expectStatus()
+                    .isNotFound();
+        }
+
+        @Test
+        void shouldRejectThemeScreenshotDirectoryTraversal() {
+            webClient
+                    .get()
+                    .uri("/themes/%2E%2E/screenshot.png")
+                    .exchange()
+                    .expectStatus()
+                    .is4xxClientError();
         }
     }
 

--- a/application/src/test/java/run/halo/app/core/extension/ThemeTest.java
+++ b/application/src/test/java/run/halo/app/core/extension/ThemeTest.java
@@ -74,6 +74,22 @@ class ThemeTest {
     }
 
     @Test
+    void themeStatusScreenshot() throws JSONException {
+        Theme theme = new Theme();
+        Theme.ThemeStatus status = new Theme.ThemeStatus();
+        status.setScreenshot("/themes/test-theme/screenshot.png");
+        theme.setStatus(status);
+
+        JSONAssert.assertEquals("""
+                {
+                    "status": {
+                        "screenshot": "/themes/test-theme/screenshot.png"
+                    }
+                }
+                """, JsonUtils.objectToJson(theme), false);
+    }
+
+    @Test
     void themeCustomTemplate() throws JSONException {
         String themeYaml = """
             apiVersion: theme.halo.run/v1alpha1

--- a/application/src/test/java/run/halo/app/core/reconciler/ThemeReconcilerTest.java
+++ b/application/src/test/java/run/halo/app/core/reconciler/ThemeReconcilerTest.java
@@ -269,6 +269,71 @@ class ThemeReconcilerTest {
         assertThat(themeUpdateCaptor.getValue().getStatus().getInDevelopment()).isTrue();
     }
 
+    @Test
+    void shouldResolveThemeScreenshotWhenSupportedFileExists() throws IOException {
+        when(systemVersionSupplier.get()).thenReturn(Version.parse("2.3.0"));
+        var testWorkDir = tempDirectory.resolve("reconcile-screenshot");
+        Files.createDirectories(testWorkDir.resolve("theme-test"));
+        Files.writeString(testWorkDir.resolve("theme-test").resolve("screenshot.png"), "fake screenshot");
+        when(themeRoot.get()).thenReturn(testWorkDir);
+        var theme = fakeTheme();
+        theme.setStatus(null);
+        theme.getSpec().setRequires(">=2.3.0");
+        theme.getSpec().setSettingName(null);
+        when(extensionClient.fetch(Theme.class, "theme-test")).thenReturn(Optional.of(theme));
+        var themeUpdateCaptor = ArgumentCaptor.forClass(Theme.class);
+
+        themeReconciler.reconcile(new Reconciler.Request(theme.getMetadata().getName()));
+
+        verify(extensionClient).update(themeUpdateCaptor.capture());
+        assertThat(themeUpdateCaptor.getValue().getStatus().getScreenshot())
+                .isEqualTo("/themes/theme-test/screenshot.png");
+    }
+
+    @Test
+    void shouldResolveThemeScreenshotByDeterministicPriority() throws IOException {
+        when(systemVersionSupplier.get()).thenReturn(Version.parse("2.3.0"));
+        var testWorkDir = tempDirectory.resolve("reconcile-screenshot-priority");
+        Files.createDirectories(testWorkDir.resolve("theme-test"));
+        Files.writeString(testWorkDir.resolve("theme-test").resolve("screenshot.webp"), "fake webp");
+        Files.writeString(testWorkDir.resolve("theme-test").resolve("screenshot.jpg"), "fake jpg");
+        Files.writeString(testWorkDir.resolve("theme-test").resolve("screenshot.jpeg"), "fake jpeg");
+        when(themeRoot.get()).thenReturn(testWorkDir);
+        var theme = fakeTheme();
+        theme.setStatus(null);
+        theme.getSpec().setRequires(">=2.3.0");
+        theme.getSpec().setSettingName(null);
+        when(extensionClient.fetch(Theme.class, "theme-test")).thenReturn(Optional.of(theme));
+        var themeUpdateCaptor = ArgumentCaptor.forClass(Theme.class);
+
+        themeReconciler.reconcile(new Reconciler.Request(theme.getMetadata().getName()));
+
+        verify(extensionClient).update(themeUpdateCaptor.capture());
+        assertThat(themeUpdateCaptor.getValue().getStatus().getScreenshot())
+                .isEqualTo("/themes/theme-test/screenshot.jpeg");
+    }
+
+    @Test
+    void shouldClearThemeScreenshotWhenSupportedFileDoesNotExist() throws IOException {
+        when(systemVersionSupplier.get()).thenReturn(Version.parse("2.3.0"));
+        var testWorkDir = tempDirectory.resolve("reconcile-missing-screenshot");
+        Files.createDirectories(testWorkDir.resolve("theme-test"));
+        when(themeRoot.get()).thenReturn(testWorkDir);
+        var theme = fakeTheme();
+        var status = new Theme.ThemeStatus();
+        status.setScreenshot("/themes/theme-test/screenshot.png");
+        theme.setStatus(status);
+        theme.getSpec().setRequires(">=2.3.0");
+        theme.getSpec().setSettingName(null);
+        when(extensionClient.fetch(Theme.class, "theme-test")).thenReturn(Optional.of(theme));
+        var themeUpdateCaptor = ArgumentCaptor.forClass(Theme.class);
+
+        themeReconciler.reconcile(new Reconciler.Request(theme.getMetadata().getName()));
+
+        verify(extensionClient).update(themeUpdateCaptor.capture());
+        assertThat(themeUpdateCaptor.getValue().getStatus().getScreenshot()).isNull();
+    }
+
     private Theme fakeTheme() {
         Theme theme = new Theme();
         Metadata metadata = new Metadata();

--- a/openspec/changes/archive/2026-06-03-support-theme-screenshot-preview/.openspec.yaml
+++ b/openspec/changes/archive/2026-06-03-support-theme-screenshot-preview/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-02

--- a/openspec/changes/archive/2026-06-03-support-theme-screenshot-preview/design.md
+++ b/openspec/changes/archive/2026-06-03-support-theme-screenshot-preview/design.md
@@ -1,0 +1,86 @@
+## Context
+
+Installed themes are stored under the theme root and reconciled into `Theme.status`. The Console currently uses
+`Theme.spec.logo` as the visual preview in theme lists and preview selectors, which is a poor fit for themes that want to
+show a page-like cover image instead of a square logo.
+
+Theme assets are already exposed through `/themes/{themeName}/assets/**`, but that route resolves files from
+`templates/assets/`. Issue #10048 asks for root-level `screenshot.*` files, so reusing the existing assets route would
+either miss the requested location or require changing established theme asset semantics.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Detect `screenshot.png`, `screenshot.jpeg`, `screenshot.jpg`, or `screenshot.webp` from an installed theme root during
+  theme reconciliation.
+- Expose the detected screenshot as an optional `Theme.status.screenshot` URL.
+- Serve only the detected root-level screenshot file through a narrow public static route.
+- Update Console theme list/preview image selection to prefer the screenshot and fall back to the existing logo.
+
+**Non-Goals:**
+
+- Do not require or introduce a new theme manifest field.
+- Do not change how `/themes/{themeName}/assets/**` resolves template assets.
+- Do not add screenshot upload, editing, cropping, or validation beyond supported file-name detection.
+- Do not change uninstalled theme discovery beyond keeping existing fallback rendering.
+
+## Decisions
+
+1. Add `screenshot` to `ThemeStatus`, not `ThemeSpec`.
+
+   `ThemeSpec` is authored by the theme manifest. The requested screenshot is an observed runtime resource discovered
+   from installed files, matching existing status fields such as `location` and `inDevelopment`. Keeping it in status
+   avoids changing theme manifest compatibility and lets reconciliation clear stale values when files are removed.
+
+   Alternative considered: add a manifest-level `spec.screenshot`. This would not satisfy automatic root-file discovery
+   and would force theme authors to maintain redundant metadata.
+
+2. Detect screenshots in `ThemeReconciler.reconcileStatus`.
+
+   Reconciliation already owns observed theme state and has access to the theme root. Detection there keeps install,
+   upgrade, reload, and local file changes represented through the same status update path.
+
+   Alternative considered: populate the screenshot only during install/upgrade. That would miss local development
+   changes and stale file removal until another lifecycle operation rewrites the status.
+
+3. Serve screenshots through `/themes/{themeName}/screenshot.{extension}`.
+
+   This route is intentionally separate from `/themes/{themeName}/assets/**` because screenshots live in the theme root,
+   while assets resolve from `templates/assets/`. The resource resolver should only allow the four supported filenames
+   and must keep the existing directory traversal protection.
+
+   Alternative considered: expose root screenshots under the existing assets route. That would blur the meaning of
+   `assets` and may surprise theme authors that already rely on `templates/assets/`.
+
+4. Use deterministic file priority.
+
+   If multiple supported files exist, reconciliation should choose the first readable file in this order:
+   `screenshot.png`, `screenshot.jpeg`, `screenshot.jpg`, `screenshot.webp`. This makes behavior stable without requiring
+   extra configuration.
+
+5. Keep UI rendering as a fallback-only change.
+
+   Console image components should derive one display source: `theme.status?.screenshot || theme.spec.logo`. Existing
+   behavior remains intact for themes without screenshots and for uninstalled themes that have no reconciled status.
+
+## Risks / Trade-offs
+
+- Public route expands static theme surface area -> Limit the resolver to exact supported screenshot filenames and keep
+  directory traversal checks.
+- Cached screenshots may not refresh immediately in local development -> Include a cache-busting version query where
+  practical and rely on the static resource handler's last-modified behavior.
+- OpenAPI model change affects generated UI client -> Regenerate OpenAPI docs and the api-client instead of editing
+  generated TypeScript by hand.
+
+## Migration Plan
+
+No database migration is required. Existing themes continue to work without screenshot files. After deployment, theme
+reconciliation will populate or clear `status.screenshot` as themes are reconciled.
+
+Rollback removes the optional status field usage and the screenshot route. Existing theme manifests and stored theme
+objects remain compatible because the field is optional observed status.
+
+## Open Questions
+
+- None for the initial implementation.

--- a/openspec/changes/archive/2026-06-03-support-theme-screenshot-preview/proposal.md
+++ b/openspec/changes/archive/2026-06-03-support-theme-screenshot-preview/proposal.md
@@ -1,0 +1,35 @@
+## Why
+
+Theme management currently relies on the theme logo as the visual cue in theme lists and previews. Themes should be able
+to provide a dedicated preview cover so users can identify installed themes more quickly, especially when many themes are
+available.
+
+## What Changes
+
+- Detect a root-level screenshot file in installed theme directories using the supported names `screenshot.png`,
+  `screenshot.jpeg`, `screenshot.jpg`, and `screenshot.webp`.
+- Expose the resolved screenshot URL on `Theme.status` so console and integration clients can consume it without parsing
+  theme files.
+- Serve the detected screenshot through a narrow public theme resource route.
+- Update Console theme list and preview surfaces to prefer `status.screenshot` while falling back to the existing
+  `spec.logo` behavior.
+- No breaking changes: existing theme manifests, theme logos, and installed theme APIs continue to work.
+
+## Capabilities
+
+### New Capabilities
+
+- `theme-screenshot-preview`: Defines how installed themes expose and display preview cover screenshots.
+
+### Modified Capabilities
+
+- None.
+
+## Impact
+
+- API model: adds an optional `Theme.status.screenshot` field.
+- Backend: updates theme reconciliation and static resource handling for root-level theme screenshot files.
+- Security: adds only the screenshot route to public static resource matching; no new management permission is introduced.
+- UI: updates Console theme list/preview rendering to use the screenshot when present.
+- OpenAPI/UI client: requires regenerating OpenAPI docs and the generated `ui/packages/api-client` models.
+- Dependencies/database: no new dependencies and no database migration.

--- a/openspec/changes/archive/2026-06-03-support-theme-screenshot-preview/specs/theme-screenshot-preview/spec.md
+++ b/openspec/changes/archive/2026-06-03-support-theme-screenshot-preview/specs/theme-screenshot-preview/spec.md
@@ -1,0 +1,61 @@
+## ADDED Requirements
+
+### Requirement: Installed theme status exposes screenshot preview
+
+The system SHALL expose a preview screenshot URL in `Theme.status.screenshot` when an installed theme provides a
+supported screenshot file in the theme root directory.
+
+#### Scenario: Theme root contains a supported screenshot file
+
+- **WHEN** the Theme reconciler reconciles an installed Theme named `earth`
+- **AND** the directory for `earth` contains a readable root-level `screenshot.png`
+- **THEN** the reconciled Theme status SHALL set `screenshot` to a public URL for that screenshot file
+
+#### Scenario: Theme root contains multiple supported screenshot files
+
+- **WHEN** the Theme reconciler reconciles an installed Theme
+- **AND** the theme root contains more than one supported screenshot file
+- **THEN** the reconciled Theme status SHALL choose the first readable file in the order `screenshot.png`,
+  `screenshot.jpeg`, `screenshot.jpg`, `screenshot.webp`
+
+#### Scenario: Theme root does not contain a supported screenshot file
+
+- **WHEN** the Theme reconciler reconciles an installed Theme
+- **AND** the theme root does not contain `screenshot.png`, `screenshot.jpeg`, `screenshot.jpg`, or `screenshot.webp`
+- **THEN** the reconciled Theme status SHALL NOT expose a screenshot URL
+
+### Requirement: Theme screenshot files are served as public static resources
+
+The system SHALL serve root-level theme screenshot files through a public static route that only exposes supported
+screenshot filenames.
+
+#### Scenario: Client requests a detected screenshot
+
+- **WHEN** a client sends a GET request to the URL exposed by `Theme.status.screenshot`
+- **AND** the corresponding root-level screenshot file exists and is readable
+- **THEN** the system SHALL respond with the screenshot file content
+
+#### Scenario: Client requests an unsupported root-level file
+
+- **WHEN** a client requests a root-level theme file that is not one of `screenshot.png`, `screenshot.jpeg`,
+  `screenshot.jpg`, or `screenshot.webp`
+- **THEN** the system SHALL NOT serve that file through the screenshot route
+
+#### Scenario: Client requests a path traversal screenshot URL
+
+- **WHEN** a client requests a screenshot URL that would resolve outside the configured theme root
+- **THEN** the system SHALL reject the request instead of serving filesystem content outside the theme root
+
+### Requirement: Console displays theme screenshot preview when available
+
+The Console SHALL prefer `Theme.status.screenshot` over `Theme.spec.logo` for theme preview cover images.
+
+#### Scenario: Installed theme has a screenshot status URL
+
+- **WHEN** the Console renders an installed Theme with `status.screenshot` set
+- **THEN** the theme list and theme preview selector SHALL display the screenshot URL as the preview image
+
+#### Scenario: Theme has no screenshot status URL
+
+- **WHEN** the Console renders a Theme without `status.screenshot`
+- **THEN** the Console SHALL continue to use `spec.logo` as the preview image when a logo is present

--- a/openspec/changes/archive/2026-06-03-support-theme-screenshot-preview/tasks.md
+++ b/openspec/changes/archive/2026-06-03-support-theme-screenshot-preview/tasks.md
@@ -1,0 +1,34 @@
+## 1. API Contract
+
+- [x] 1.1 Add optional `screenshot` to `Theme.ThemeStatus` with a concise schema/documentation comment.
+- [x] 1.2 Add or update API-level tests that assert `Theme.status.screenshot` serializes as part of Theme status.
+
+## 2. Backend Implementation
+
+- [x] 2.1 Add deterministic screenshot detection for `screenshot.png`, `screenshot.jpeg`, `screenshot.jpg`, and
+  `screenshot.webp` in `ThemeReconciler.reconcileStatus`.
+- [x] 2.2 Set `Theme.status.screenshot` to a public screenshot URL when a supported root-level file is readable, and clear
+  it when no supported file exists.
+- [x] 2.3 Add focused `ThemeReconcilerTest` coverage for detected screenshots, deterministic file priority, and missing
+  screenshots.
+- [x] 2.4 Add a narrow static route or resource handler for `/themes/{themeName}/screenshot.{extension}` that serves only
+  supported root-level screenshot files.
+- [x] 2.5 Preserve directory traversal protection and add route/resource tests for successful serving, unsupported files,
+  missing files, and traversal attempts.
+- [x] 2.6 Add the screenshot route to the public static resource matcher in WebFlux security configuration.
+
+## 3. OpenAPI And Console
+
+- [x] 3.1 Regenerate OpenAPI docs and the generated UI api-client after the Theme status model change.
+- [x] 3.2 Update Console theme list cards to derive the preview image from `theme.status?.screenshot || theme.spec.logo`.
+- [x] 3.3 Update Console theme preview selector rows to use the same screenshot-first fallback.
+- [x] 3.4 Keep existing empty/error/loading image states and behavior for themes without screenshots.
+
+## 4. Verification
+
+- [x] 4.1 Run `./gradlew :api:test --tests "*ThemeTest*"`.
+- [x] 4.2 Run `./gradlew :application:test --tests "*ThemeReconcilerTest*"`.
+- [x] 4.3 Run focused route/security tests covering theme screenshot static resources.
+- [x] 4.4 Run `./gradlew spotlessCheck`.
+- [x] 4.5 Run `pnpm -C ui typecheck && pnpm -C ui lint`.
+- [x] 4.6 Run `openspec validate support-theme-screenshot-preview --strict`.

--- a/openspec/specs/theme-screenshot-preview/spec.md
+++ b/openspec/specs/theme-screenshot-preview/spec.md
@@ -1,0 +1,65 @@
+# theme-screenshot-preview Specification
+
+## Purpose
+Allow installed themes to provide root-level screenshot files that Halo exposes and uses as Console preview images.
+
+## Requirements
+### Requirement: Installed theme status exposes screenshot preview
+
+The system SHALL expose a preview screenshot URL in `Theme.status.screenshot` when an installed theme provides a
+supported screenshot file in the theme root directory.
+
+#### Scenario: Theme root contains a supported screenshot file
+
+- **WHEN** the Theme reconciler reconciles an installed Theme named `earth`
+- **AND** the directory for `earth` contains a readable root-level `screenshot.png`
+- **THEN** the reconciled Theme status SHALL set `screenshot` to a public URL for that screenshot file
+
+#### Scenario: Theme root contains multiple supported screenshot files
+
+- **WHEN** the Theme reconciler reconciles an installed Theme
+- **AND** the theme root contains more than one supported screenshot file
+- **THEN** the reconciled Theme status SHALL choose the first readable file in the order `screenshot.png`,
+  `screenshot.jpeg`, `screenshot.jpg`, `screenshot.webp`
+
+#### Scenario: Theme root does not contain a supported screenshot file
+
+- **WHEN** the Theme reconciler reconciles an installed Theme
+- **AND** the theme root does not contain `screenshot.png`, `screenshot.jpeg`, `screenshot.jpg`, or `screenshot.webp`
+- **THEN** the reconciled Theme status SHALL NOT expose a screenshot URL
+
+### Requirement: Theme screenshot files are served as public static resources
+
+The system SHALL serve root-level theme screenshot files through a public static route that only exposes supported
+screenshot filenames.
+
+#### Scenario: Client requests a detected screenshot
+
+- **WHEN** a client sends a GET request to the URL exposed by `Theme.status.screenshot`
+- **AND** the corresponding root-level screenshot file exists and is readable
+- **THEN** the system SHALL respond with the screenshot file content
+
+#### Scenario: Client requests an unsupported root-level file
+
+- **WHEN** a client requests a root-level theme file that is not one of `screenshot.png`, `screenshot.jpeg`,
+  `screenshot.jpg`, or `screenshot.webp`
+- **THEN** the system SHALL NOT serve that file through the screenshot route
+
+#### Scenario: Client requests a path traversal screenshot URL
+
+- **WHEN** a client requests a screenshot URL that would resolve outside the configured theme root
+- **THEN** the system SHALL reject the request instead of serving filesystem content outside the theme root
+
+### Requirement: Console displays theme screenshot preview when available
+
+The Console SHALL prefer `Theme.status.screenshot` over `Theme.spec.logo` for theme preview cover images.
+
+#### Scenario: Installed theme has a screenshot status URL
+
+- **WHEN** the Console renders an installed Theme with `status.screenshot` set
+- **THEN** the theme list and theme preview selector SHALL display the screenshot URL as the preview image
+
+#### Scenario: Theme has no screenshot status URL
+
+- **WHEN** the Console renders a Theme without `status.screenshot`
+- **THEN** the Console SHALL continue to use `spec.logo` as the preview image when a logo is present

--- a/ui/console-src/modules/interface/themes/components/ThemeListItem.vue
+++ b/ui/console-src/modules/interface/themes/components/ThemeListItem.vue
@@ -43,6 +43,9 @@ const emit = defineEmits<{
 
 const { theme } = toRefs(props);
 
+const screenshot = computed(() => theme.value.status?.screenshot);
+const logo = computed(() => theme.value.spec.logo);
+
 const activeTabId = inject<Ref<string>>("activeTabId", ref(""));
 
 const {
@@ -151,16 +154,29 @@ const { data: operationItems } = useOperationItemExtensionPoint<Theme>(
     <div class="col-span-2">
       <div class="relative block">
         <div class="aspect-h-9 aspect-w-16">
+          <div v-if="screenshot" class="overflow-hidden rounded bg-gray-100">
+            <img
+              class="h-full w-full object-cover"
+              :src="screenshot"
+              :alt="theme.spec.displayName"
+            />
+          </div>
           <div
+            v-else
             class="transform-gpu rounded-none bg-cover bg-center bg-no-repeat sm:rounded"
             :style="{
-              backgroundImage: `url(${theme.spec.logo})`,
+              backgroundImage: logo ? `url(${logo})` : undefined,
             }"
           >
             <div
               class="flex h-full w-full items-center justify-center rounded-none backdrop-blur-3xl sm:rounded"
             >
-              <img class="h-16 w-16 rounded" :src="theme.spec.logo" />
+              <img
+                v-if="logo"
+                class="h-16 w-16 rounded"
+                :src="logo"
+                :alt="theme.spec.displayName"
+              />
             </div>
           </div>
         </div>

--- a/ui/console-src/modules/interface/themes/components/preview/ThemePreviewListItem.vue
+++ b/ui/console-src/modules/interface/themes/components/preview/ThemePreviewListItem.vue
@@ -7,7 +7,7 @@ import {
   VTag,
 } from "@halo-dev/components";
 import { UseImage } from "@vueuse/components";
-import { toRefs } from "vue";
+import { computed, toRefs } from "vue";
 import { useThemeLifeCycle } from "../../composables/use-theme";
 
 const props = withDefaults(
@@ -26,20 +26,24 @@ const emit = defineEmits<{
 
 const { theme } = toRefs(props);
 
+const previewImage = computed(
+  () => theme.value.status?.screenshot || theme.value.spec.logo
+);
+
 const { isActivated, handleActiveTheme } = useThemeLifeCycle(theme);
 </script>
 
 <template>
   <VEntity :is-selected="isSelected">
     <template #start>
-      <VEntityField v-if="theme.spec.logo">
+      <VEntityField v-if="previewImage">
         <template #description>
           <div class="w-20">
             <div
               class="group aspect-h-3 aspect-w-4 block w-full overflow-hidden rounded border bg-gray-100"
             >
               <UseImage
-                :src="theme.spec.logo"
+                :src="previewImage"
                 :alt="theme.spec.displayName"
                 class="pointer-events-none object-cover group-hover:opacity-75"
               >

--- a/ui/packages/api-client/src/models/theme-status.ts
+++ b/ui/packages/api-client/src/models/theme-status.ts
@@ -37,6 +37,10 @@ export interface ThemeStatus {
      * Current theme lifecycle phase.
      */
     'phase'?: ThemeStatusPhaseEnum;
+    /**
+     * Resolved preview screenshot URL served from the theme root.
+     */
+    'screenshot'?: string;
 }
 
 export const ThemeStatusPhaseEnum = {


### PR DESCRIPTION
#### What type of PR is this?

- [x] Feature
- [ ] Bug fix
- [ ] Improvement
- [ ] Cleanup
- [ ] Documentation

#### What this PR does / why we need it:

This PR adds support for theme-provided preview screenshots.

It adds an optional `Theme.status.screenshot` field, resolves root-level theme screenshot files during theme reconciliation, exposes supported screenshots through a narrow public static resource route, and updates Console theme cards and preview selector rows to prefer the resolved screenshot before falling back to `theme.spec.logo`.

Supported root-level filenames are checked in deterministic order: `screenshot.png`, `screenshot.jpeg`, `screenshot.jpg`, and `screenshot.webp`.

#### Which issue(s) this PR fixes:

Fixes #10048

#### Special notes for your reviewer:

Directory traversal protection is preserved for the screenshot route, and unsupported or missing screenshot files return 404. The OpenAPI docs and generated UI API client were regenerated.

This PR was prepared with AI assistance and reviewed before submission.

Validation performed:

- `./gradlew :api:test --tests "*ThemeTest*"`
- `./gradlew :application:test --tests "*ThemeReconcilerTest*" --tests "*WebFluxConfigTest*" -x :application:generateGitProperties`
- `./gradlew generateOpenApiDocs -x :application:generateGitProperties`
- `pnpm -C ui api-client:gen`
- `pnpm -C ui build:packages`
- `pnpm -C ui format`
- `pnpm -C ui typecheck && pnpm -C ui lint`
- `./gradlew spotlessCheck`
- `openspec validate support-theme-screenshot-preview --strict`
- `git diff --check`

#### Does this PR introduce a user-facing change?

```release-note
主题管理列表支持显示预览图
```
