### PR TITLE
Support building theme UI plugin bundles

### DIFF
--- a/openspec/changes/archive/2026-06-08-support-theme-ui-plugin-bundling/.openspec.yaml
+++ b/openspec/changes/archive/2026-06-08-support-theme-ui-plugin-bundling/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-08

--- a/openspec/changes/archive/2026-06-08-support-theme-ui-plugin-bundling/design.md
+++ b/openspec/changes/archive/2026-06-08-support-theme-ui-plugin-bundling/design.md
@@ -1,0 +1,147 @@
+## Context
+
+The runtime support for theme-provided Console and User Center UI plugin bundles
+uses the same frontend `PluginModule` shape as plugins, but serves theme build
+output from a different resource model:
+
+```text
+{themeRoot}/{themeName}/ui-plugin/dist/**
+```
+
+and exposes those assets from:
+
+```text
+/themes/{themeName}/ui-plugin/assets/**
+```
+
+`@halo-dev/ui-plugin-bundler-kit` currently assumes plugin projects. It reads a
+plugin manifest, emits plugin bundle files, and configures plugin asset public
+paths. Theme authors can work around this manually today, but the package should
+provide first-class defaults that match the runtime contract.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Support plugin and theme providers through one modern configuration API.
+- Keep existing plugin helper behavior compatible by default.
+- Provide theme defaults for manifest path, output directory, module name, and
+  asset public path.
+- Support both Vite and Rsbuild helpers.
+- Cover the provider defaults with focused unit tests and README examples.
+
+**Non-Goals:**
+
+- Update the deprecated `HaloUIPluginBundlerKit` Vite plugin.
+- Auto-detect provider type from nearby manifest files.
+- Support arbitrary theme project layouts beyond existing manifest and bundler
+  override hooks.
+- Change the runtime theme UI resource endpoints or frontend module contract.
+- Add new dependencies.
+
+## Decisions
+
+### Use `provider?: "plugin" | "theme"`
+
+The modern Vite and Rsbuild config helpers will accept an optional `provider`
+field. The default is `"plugin"` so existing calls remain valid:
+
+```ts
+viteConfig({ vite: {} });
+rsbuildConfig({ rsbuild: {} });
+```
+
+Theme projects opt in explicitly:
+
+```ts
+viteConfig({ provider: "theme", vite: {} });
+rsbuildConfig({ provider: "theme", rsbuild: {} });
+```
+
+Alternative considered: separate `themeViteConfig` and `themeRsbuildConfig`
+exports. Separate exports are explicit, but they split what is still one UI
+plugin bundling API. The provider field better reflects that plugin and theme
+are two providers for the same frontend module contract.
+
+### Do not auto-detect the provider
+
+The helper will not switch behavior based on whether `theme.yaml` or
+`plugin.yaml` exists. Auto-detection would make builds sensitive to directory
+layout and could surprise existing plugin projects. Explicit provider selection
+keeps behavior predictable.
+
+### Keep legacy helper unchanged
+
+The deprecated `HaloUIPluginBundlerKit` helper will not gain theme support. It
+still carries old production output compatibility for plugin bundles, and
+extending it would increase the compatibility matrix while encouraging new
+theme projects to adopt deprecated API.
+
+### Use provider-specific manifest defaults
+
+Plugin provider keeps the existing default:
+
+```text
+../src/main/resources/plugin.yaml
+```
+
+Theme provider defaults to:
+
+```text
+../theme.yaml
+```
+
+This assumes the recommended theme UI plugin project layout:
+
+```text
+theme-root/
+├── theme.yaml
+└── ui-plugin/
+    ├── package.json
+    ├── src/index.ts
+    └── vite.config.ts
+```
+
+The existing `manifestPath` option remains available for non-standard layouts.
+
+### Define a minimal theme manifest type
+
+The bundler only needs the theme metadata name to generate the module name and
+asset public path. It should parse theme manifests using a small internal type
+instead of depending on a full generated API-client `Theme` model.
+
+### Theme provider uses fixed runtime paths
+
+Theme provider does not inspect `spec.requires` or use plugin bundle location
+compatibility. Theme UI support is a new runtime feature with one resource
+location: `ui-plugin/dist/**`.
+
+Theme provider defaults:
+
+- output root: `dist`
+- module/global name: `theme:{metadata.name}`
+- Vite `base`: `/themes/{metadata.name}/ui-plugin/assets/`
+- Rsbuild `output.publicPath`: `/themes/{metadata.name}/ui-plugin/assets/`
+
+User config still merges after presets, so advanced projects can override these
+values. The README should make clear that overriding the public path can break
+dynamic chunks and emitted assets.
+
+### Reuse existing externals and globals
+
+Theme UI bundles run in the same Console/UC environment and use the same
+`PluginModule` contract as plugins. They should reuse the existing external
+dependency and global mapping defaults to avoid duplicate Vue/runtime copies and
+keep output size consistent with plugin UI bundles.
+
+## Risks / Trade-offs
+
+- Public path can be overridden incorrectly -> Document the expected theme
+  public path and cover defaults with tests.
+- Provider defaults increase config branching -> Keep provider-specific logic in
+  small helpers and leave legacy API untouched.
+- Theme manifest parsing may accept malformed manifests until build config
+  generation fails -> Validate the minimal fields needed by the bundler and let
+  Halo runtime continue to own full theme compatibility checks.
+- Package-level tests may require adding a test script to this workspace package
+  -> Use the existing workspace Vitest tooling, not a new dependency.

--- a/openspec/changes/archive/2026-06-08-support-theme-ui-plugin-bundling/proposal.md
+++ b/openspec/changes/archive/2026-06-08-support-theme-ui-plugin-bundling/proposal.md
@@ -1,0 +1,41 @@
+## Why
+
+Themes can now provide Console and User Center UI plugin bundles at runtime, but
+`@halo-dev/ui-plugin-bundler-kit` still only provides plugin-oriented build
+defaults. Theme authors need the same build helper to emit bundles that match
+the theme runtime resource contract without hand-writing Vite or Rsbuild
+details.
+
+## What Changes
+
+- Add a `provider?: "plugin" | "theme"` option to the modern Vite and Rsbuild
+  config helpers, defaulting to `"plugin"` for compatibility.
+- Keep existing plugin provider behavior unchanged, including plugin manifest
+  defaults and legacy bundle location compatibility.
+- Add theme provider defaults that read `../theme.yaml`, emit to `dist`, expose
+  assets from `/themes/{name}/ui-plugin/assets/`, and publish the module under
+  `theme:{name}`.
+- Keep the deprecated `HaloUIPluginBundlerKit` helper unchanged and unsupported
+  for theme providers.
+- Document theme UI plugin project layout and minimal Vite/Rsbuild usage.
+- Add focused tests for provider defaults and generated config shape.
+
+## Capabilities
+
+### New Capabilities
+
+- `ui-plugin-bundler-provider`: Defines provider-specific build defaults for
+  Halo UI plugin bundles produced by `@halo-dev/ui-plugin-bundler-kit`.
+
+### Modified Capabilities
+
+- None.
+
+## Impact
+
+- Affected package: `ui/packages/ui-plugin-bundler-kit`.
+- Public API impact: non-breaking optional `provider` config on `viteConfig`
+  and `rsbuildConfig`; default remains plugin behavior.
+- Documentation impact: README examples for theme UI plugin projects.
+- Test impact: package-level unit tests for Vite/Rsbuild config generation.
+- No backend, database, OpenAPI, or generated API client changes are expected.

--- a/openspec/changes/archive/2026-06-08-support-theme-ui-plugin-bundling/specs/ui-plugin-bundler-provider/spec.md
+++ b/openspec/changes/archive/2026-06-08-support-theme-ui-plugin-bundling/specs/ui-plugin-bundler-provider/spec.md
@@ -1,0 +1,94 @@
+## ADDED Requirements
+
+### Requirement: Provider selection
+
+`@halo-dev/ui-plugin-bundler-kit` SHALL allow modern Vite and Rsbuild config
+helpers to select the UI plugin provider type with `provider?: "plugin" |
+"theme"`.
+
+#### Scenario: Default provider remains plugin
+
+- **WHEN** a caller invokes `viteConfig` or `rsbuildConfig` without `provider`
+- **THEN** the helper SHALL use plugin provider defaults
+
+#### Scenario: Theme provider is selected explicitly
+
+- **WHEN** a caller invokes `viteConfig` or `rsbuildConfig` with `provider:
+  "theme"`
+- **THEN** the helper SHALL use theme provider defaults
+
+#### Scenario: Legacy helper remains unchanged
+
+- **WHEN** a caller uses the deprecated `HaloUIPluginBundlerKit` helper
+- **THEN** the helper SHALL NOT provide theme provider behavior
+
+### Requirement: Plugin provider compatibility
+
+The plugin provider SHALL preserve existing Vite and Rsbuild helper behavior.
+
+#### Scenario: Plugin manifest default is preserved
+
+- **WHEN** a caller uses the plugin provider without `manifestPath`
+- **THEN** the helper SHALL read `../src/main/resources/plugin.yaml`
+
+#### Scenario: Plugin bundle defaults are preserved
+
+- **WHEN** a caller uses the plugin provider
+- **THEN** the helper SHALL keep existing plugin output, global name, externals,
+  globals, and bundle location compatibility behavior
+
+### Requirement: Theme provider manifest
+
+The theme provider SHALL read the theme manifest by default and use its metadata
+name to derive bundler defaults.
+
+#### Scenario: Theme manifest default is used
+
+- **WHEN** a caller uses the theme provider without `manifestPath`
+- **THEN** the helper SHALL read `../theme.yaml`
+
+#### Scenario: Theme manifest path can be overridden
+
+- **WHEN** a caller uses the theme provider with `manifestPath`
+- **THEN** the helper SHALL read the manifest at the provided path
+
+#### Scenario: Theme module name is derived from metadata name
+
+- **WHEN** the theme manifest has `metadata.name` equal to `earth`
+- **THEN** the helper SHALL configure the bundle global module name as
+  `theme:earth`
+
+### Requirement: Theme provider build output
+
+The theme provider SHALL configure build output to match the theme UI resource
+runtime contract.
+
+#### Scenario: Theme Vite output defaults are generated
+
+- **WHEN** a caller uses `viteConfig` with `provider: "theme"`
+- **THEN** the helper SHALL configure production output to `dist`
+- **THEN** the helper SHALL configure the Vite base URL as
+  `/themes/{metadata.name}/ui-plugin/assets/`
+- **THEN** the helper SHALL emit `main.js` and `style.css` as the primary bundle
+  files
+
+#### Scenario: Theme Rsbuild output defaults are generated
+
+- **WHEN** a caller uses `rsbuildConfig` with `provider: "theme"`
+- **THEN** the helper SHALL configure the output root to `dist`
+- **THEN** the helper SHALL configure the public path as
+  `/themes/{metadata.name}/ui-plugin/assets/`
+- **THEN** the helper SHALL emit `main.js` and `style.css` as the primary bundle
+  files
+
+#### Scenario: Theme provider reuses UI plugin externals
+
+- **WHEN** a caller uses the theme provider
+- **THEN** the helper SHALL apply the same external dependency and global
+  variable mappings used by plugin UI bundles
+
+#### Scenario: User config can override theme defaults
+
+- **WHEN** a caller provides Vite or Rsbuild config that overrides provider
+  defaults
+- **THEN** the helper SHALL merge the caller config after provider defaults

--- a/openspec/changes/archive/2026-06-08-support-theme-ui-plugin-bundling/tasks.md
+++ b/openspec/changes/archive/2026-06-08-support-theme-ui-plugin-bundling/tasks.md
@@ -1,0 +1,30 @@
+## 1. Provider Model
+
+- [x] 1.1 Add a shared `provider?: "plugin" | "theme"` option for modern Vite and Rsbuild user configs, defaulting to `plugin`.
+- [x] 1.2 Split manifest parsing into provider-aware helpers that preserve plugin manifest behavior and add minimal theme manifest parsing.
+- [x] 1.3 Define provider defaults for manifest path, module name, output directory, asset public path, and bundle location without changing the deprecated legacy helper.
+
+## 2. Bundler Configs
+
+- [x] 2.1 Update `viteConfig` to apply plugin defaults unchanged when provider is omitted or `plugin`.
+- [x] 2.2 Update `viteConfig` theme provider defaults for `../theme.yaml`, `dist`, `theme:{name}`, `/themes/{name}/ui-plugin/assets/`, `main.js`, and `style.css`.
+- [x] 2.3 Update `rsbuildConfig` to apply plugin defaults unchanged when provider is omitted or `plugin`.
+- [x] 2.4 Update `rsbuildConfig` theme provider defaults for `../theme.yaml`, `dist`, `theme:{name}`, `/themes/{name}/ui-plugin/assets/`, `main.js`, and `style.css`.
+- [x] 2.5 Preserve user config override behavior by merging caller config after provider presets.
+
+## 3. Tests and Documentation
+
+- [x] 3.1 Add package-level unit tests for plugin default compatibility and theme provider Vite/Rsbuild config shape.
+- [x] 3.2 Add a package `test:unit` script using existing workspace Vitest tooling if needed.
+- [x] 3.3 Update the README with plugin default behavior, theme provider configuration, and the recommended `theme-root/ui-plugin` project layout.
+- [x] 3.4 Document that the deprecated `HaloUIPluginBundlerKit` helper does not support theme provider builds.
+
+## 4. Validation
+
+- [x] 4.1 Run the focused `ui-plugin-bundler-kit` unit tests.
+- [x] 4.2 Run `pnpm -C ui build:packages` to validate package build output.
+- [x] 4.3 Run `pnpm -C ui typecheck` for workspace type compatibility.
+
+## 5. Supplemental Test Coverage
+
+- [x] 5.1 Add broader unit coverage for manifest utilities, plugin bundle location selection, legacy Vite plugin defaults, output overrides, custom manifest paths, and function-based user config merging.

--- a/openspec/specs/ui-plugin-bundler-provider/spec.md
+++ b/openspec/specs/ui-plugin-bundler-provider/spec.md
@@ -1,0 +1,101 @@
+# ui-plugin-bundler-provider Specification
+
+## Purpose
+
+Defines provider-specific build defaults for Halo UI plugin bundles produced by
+`@halo-dev/ui-plugin-bundler-kit`.
+
+## Requirements
+
+### Requirement: Provider selection
+
+`@halo-dev/ui-plugin-bundler-kit` SHALL allow modern Vite and Rsbuild config
+helpers to select the UI plugin provider type with `provider?: "plugin" |
+"theme"`.
+
+#### Scenario: Default provider remains plugin
+
+- **WHEN** a caller invokes `viteConfig` or `rsbuildConfig` without `provider`
+- **THEN** the helper SHALL use plugin provider defaults
+
+#### Scenario: Theme provider is selected explicitly
+
+- **WHEN** a caller invokes `viteConfig` or `rsbuildConfig` with `provider:
+  "theme"`
+- **THEN** the helper SHALL use theme provider defaults
+
+#### Scenario: Legacy helper remains unchanged
+
+- **WHEN** a caller uses the deprecated `HaloUIPluginBundlerKit` helper
+- **THEN** the helper SHALL NOT provide theme provider behavior
+
+### Requirement: Plugin provider compatibility
+
+The plugin provider SHALL preserve existing Vite and Rsbuild helper behavior.
+
+#### Scenario: Plugin manifest default is preserved
+
+- **WHEN** a caller uses the plugin provider without `manifestPath`
+- **THEN** the helper SHALL read `../src/main/resources/plugin.yaml`
+
+#### Scenario: Plugin bundle defaults are preserved
+
+- **WHEN** a caller uses the plugin provider
+- **THEN** the helper SHALL keep existing plugin output, global name, externals,
+  globals, and bundle location compatibility behavior
+
+### Requirement: Theme provider manifest
+
+The theme provider SHALL read the theme manifest by default and use its metadata
+name to derive bundler defaults.
+
+#### Scenario: Theme manifest default is used
+
+- **WHEN** a caller uses the theme provider without `manifestPath`
+- **THEN** the helper SHALL read `../theme.yaml`
+
+#### Scenario: Theme manifest path can be overridden
+
+- **WHEN** a caller uses the theme provider with `manifestPath`
+- **THEN** the helper SHALL read the manifest at the provided path
+
+#### Scenario: Theme module name is derived from metadata name
+
+- **WHEN** the theme manifest has `metadata.name` equal to `earth`
+- **THEN** the helper SHALL configure the bundle global module name as
+  `theme:earth`
+
+### Requirement: Theme provider build output
+
+The theme provider SHALL configure build output to match the theme UI resource
+runtime contract.
+
+#### Scenario: Theme Vite output defaults are generated
+
+- **WHEN** a caller uses `viteConfig` with `provider: "theme"`
+- **THEN** the helper SHALL configure production output to `dist`
+- **THEN** the helper SHALL configure the Vite base URL as
+  `/themes/{metadata.name}/ui-plugin/assets/`
+- **THEN** the helper SHALL emit `main.js` and `style.css` as the primary bundle
+  files
+
+#### Scenario: Theme Rsbuild output defaults are generated
+
+- **WHEN** a caller uses `rsbuildConfig` with `provider: "theme"`
+- **THEN** the helper SHALL configure the output root to `dist`
+- **THEN** the helper SHALL configure the public path as
+  `/themes/{metadata.name}/ui-plugin/assets/`
+- **THEN** the helper SHALL emit `main.js` and `style.css` as the primary bundle
+  files
+
+#### Scenario: Theme provider reuses UI plugin externals
+
+- **WHEN** a caller uses the theme provider
+- **THEN** the helper SHALL apply the same external dependency and global
+  variable mappings used by plugin UI bundles
+
+#### Scenario: User config can override theme defaults
+
+- **WHEN** a caller provides Vite or Rsbuild config that overrides provider
+  defaults
+- **THEN** the helper SHALL merge the caller config after provider defaults

--- a/ui/packages/ui-plugin-bundler-kit/README.md
+++ b/ui/packages/ui-plugin-bundler-kit/README.md
@@ -1,17 +1,17 @@
 # @halo-dev/ui-plugin-bundler-kit
 
-A frontend build toolkit for Halo plugin development, supporting both Vite and Rsbuild build systems.
+A frontend build toolkit for Halo UI plugin development, supporting both Vite and Rsbuild build systems.
 
 ## Introduction
 
-`@halo-dev/ui-plugin-bundler-kit` is a frontend build configuration toolkit specifically designed for Halo plugin development. It provides pre-configured build settings to help developers quickly set up and build frontend interfaces for Halo plugins.
+`@halo-dev/ui-plugin-bundler-kit` is a frontend build configuration toolkit specifically designed for Halo UI plugin development. It provides pre-configured build settings to help developers quickly set up and build frontend interfaces for Halo plugins and theme-provided UI plugins.
 
 ### Key Features
 
 - 🚀 **Ready to Use** - Provides pre-configured Vite and Rsbuild build settings
 - 📦 **Multi-Build Tool Support** - Supports both Vite and Rsbuild
 - 🔧 **Flexible Configuration** - Supports custom build configurations
-- 🎯 **Halo Optimized** - External dependencies and global variables optimized for Halo plugin development
+- 🎯 **Halo Optimized** - External dependencies and global variables optimized for Halo UI plugin development
 - 📁 **Smart Output** - Automatically selects output directory based on environment
 
 ## Installation
@@ -45,12 +45,13 @@ npm install @rsbuild/core
 
 ### Vite Configuration
 
-Create or update `vite.config.ts` file in your project root:
+Create or update `vite.config.ts` file in your UI plugin project root:
 
 ```typescript
 import { viteConfig } from "@halo-dev/ui-plugin-bundler-kit";
 
 export default viteConfig({
+  // provider defaults to "plugin"
   vite: {
     // Your custom Vite configuration
     plugins: [
@@ -65,12 +66,13 @@ export default viteConfig({
 
 ### Rsbuild Configuration
 
-Create or update `rsbuild.config.ts` file in your project root:
+Create or update `rsbuild.config.ts` file in your UI plugin project root:
 
 ```typescript
 import { rsbuildConfig } from "@halo-dev/ui-plugin-bundler-kit";
 
 export default rsbuildConfig({
+  // provider defaults to "plugin"
   rsbuild: {
     // Your custom Rsbuild configuration
     plugins: [
@@ -83,9 +85,46 @@ export default rsbuildConfig({
 
 > **Note**: Vue plugin is pre-configured, no need to add it manually.
 
+### Theme UI Plugin Configuration
+
+For theme-provided Console/User Center UI plugins, place the frontend project under the theme's `ui-plugin/` directory:
+
+```text
+theme-root/
+├── theme.yaml
+└── ui-plugin/
+    ├── package.json
+    ├── src/index.ts
+    └── vite.config.ts
+```
+
+Vite:
+
+```typescript
+import { viteConfig } from "@halo-dev/ui-plugin-bundler-kit";
+
+export default viteConfig({
+  provider: "theme",
+  vite: {},
+});
+```
+
+Rsbuild:
+
+```typescript
+import { rsbuildConfig } from "@halo-dev/ui-plugin-bundler-kit";
+
+export default rsbuildConfig({
+  provider: "theme",
+  rsbuild: {},
+});
+```
+
+The theme provider reads `../theme.yaml`, outputs to `dist`, registers the module as `theme:{metadata.name}`, and configures assets for `/themes/{metadata.name}/ui-plugin/assets/`. Halo reads only `ui-plugin/dist/**` from the theme package.
+
 ### Legacy Configuration (Deprecated)
 
-> ⚠️ **Note**: The `HaloUIPluginBundlerKit` function is deprecated. Please use `viteConfig` or `rsbuildConfig` instead.
+> ⚠️ **Note**: The `HaloUIPluginBundlerKit` function is deprecated. Please use `viteConfig` or `rsbuildConfig` instead. It does not support `provider: "theme"`.
 
 ```typescript
 import { HaloUIPluginBundlerKit } from "@halo-dev/ui-plugin-bundler-kit";
@@ -106,8 +145,14 @@ export default {
 ```typescript
 interface ViteUserConfig {
   /**
-   * Halo plugin manifest file path
-   * @default "../src/main/resources/plugin.yaml"
+   * UI plugin provider type
+   * @default "plugin"
+   */
+  provider?: "plugin" | "theme";
+
+  /**
+   * Halo plugin or theme manifest file path
+   * @default "../src/main/resources/plugin.yaml" for plugins, "../theme.yaml" for themes
    */
   manifestPath?: string;
 
@@ -123,8 +168,14 @@ interface ViteUserConfig {
 ```typescript
 interface RsBuildUserConfig {
   /**
-   * Halo plugin manifest file path
-   * @default "../src/main/resources/plugin.yaml"
+   * UI plugin provider type
+   * @default "plugin"
+   */
+  provider?: "plugin" | "theme";
+
+  /**
+   * Halo plugin or theme manifest file path
+   * @default "../src/main/resources/plugin.yaml" for plugins, "../theme.yaml" for themes
    */
   manifestPath?: string;
 
@@ -216,6 +267,20 @@ export default viteConfig({
 });
 ```
 
+### Custom Theme Manifest Path
+
+```typescript
+import { viteConfig } from "@halo-dev/ui-plugin-bundler-kit";
+
+export default viteConfig({
+  provider: "theme",
+  manifestPath: "../custom-theme.yaml",
+  vite: {
+    // Other configurations...
+  },
+});
+```
+
 ## Development Scripts
 
 Recommended scripts to add to your `package.json`:
@@ -242,10 +307,17 @@ For Rsbuild:
 
 ## Build Output
 
-> Relative to the root directory of the Halo plugin project
+> Relative to the UI plugin project root
 
-- **Development**: `build/resources/main/console`
-- **Production**: `ui/build/dist`
+Plugin provider:
+
+- **Development**: `../build/resources/main/ui` or `../build/resources/main/console`
+- **Production**: `./build/dist`
+
+Theme provider:
+
+- **Development**: `dist`
+- **Production**: `dist`
 
 > **Note**: The production build output directory of `HaloUIPluginBundlerKit` is still `src/main/resources/console` to ensure compatibility.
 

--- a/ui/packages/ui-plugin-bundler-kit/package.json
+++ b/ui/packages/ui-plugin-bundler-kit/package.json
@@ -21,6 +21,7 @@
   "scripts": {
     "build": "vp pack",
     "dev": "vp pack --watch",
+    "test:unit": "vp test --run",
     "prepublishOnly": "vp run build"
   },
   "dependencies": {

--- a/ui/packages/ui-plugin-bundler-kit/src/__tests__/halo-plugin.spec.ts
+++ b/ui/packages/ui-plugin-bundler-kit/src/__tests__/halo-plugin.spec.ts
@@ -1,0 +1,102 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  getHaloPluginBundleLocation,
+  getHaloPluginManifest,
+  getHaloThemeAssetPublicPath,
+  getHaloThemeManifest,
+  getHaloThemeModuleName,
+  getManifestName,
+} from "../utils/halo-plugin";
+
+const tempDirs: string[] = [];
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  while (tempDirs.length > 0) {
+    const tempDir = tempDirs.pop();
+    if (tempDir) {
+      fs.rmSync(tempDir, { recursive: true, force: true });
+    }
+  }
+});
+
+describe("halo manifest utilities", () => {
+  it("reads plugin manifests", () => {
+    const manifestPath = writeManifest([
+      "metadata:",
+      "  name: plugin-a",
+      "spec:",
+      "  requires: '>=2.25.0'",
+      "",
+    ]);
+
+    const manifest = getHaloPluginManifest(manifestPath);
+
+    expect(getManifestName(manifest)).toBe("plugin-a");
+    expect(manifest.spec.requires).toBe(">=2.25.0");
+  });
+
+  it("reads theme manifests and derives theme bundle values", () => {
+    const manifestPath = writeManifest(["metadata:", "  name: theme-a", ""]);
+
+    const manifest = getHaloThemeManifest(manifestPath);
+
+    expect(getManifestName(manifest)).toBe("theme-a");
+    expect(getHaloThemeModuleName(manifest)).toBe("theme:theme-a");
+    expect(getHaloThemeAssetPublicPath(manifest)).toBe(
+      "/themes/theme-a/ui-plugin/assets/"
+    );
+  });
+
+  it("selects ui bundle location for plugins requiring Halo 2.25 or newer", () => {
+    expect(
+      getHaloPluginBundleLocation({
+        metadata: { name: "plugin-a" },
+        spec: { requires: ">=2.25.0" },
+      } as never)
+    ).toBe("ui");
+  });
+
+  it("falls back to console bundle location for older or missing requirements", () => {
+    expect(
+      getHaloPluginBundleLocation({
+        metadata: { name: "plugin-a" },
+        spec: { requires: ">=2.24.0" },
+      } as never)
+    ).toBe("console");
+    expect(
+      getHaloPluginBundleLocation({
+        metadata: { name: "plugin-a" },
+        spec: {},
+      } as never)
+    ).toBe("console");
+  });
+
+  it("warns and falls back to console bundle location for invalid requirements", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+
+    expect(
+      getHaloPluginBundleLocation({
+        metadata: { name: "plugin-a" },
+        spec: { requires: "not semver" },
+      } as never)
+    ).toBe("console");
+    expect(warn).toHaveBeenCalledWith(
+      '[ui-plugin-bundler-kit] Invalid semver range in plugin manifest "spec.requires": "not semver". ' +
+        'Falling back to "console" bundle location.'
+    );
+  });
+});
+
+function writeManifest(lines: string[]) {
+  const tempDir = fs.mkdtempSync(
+    path.join(os.tmpdir(), "halo-ui-plugin-manifest-")
+  );
+  tempDirs.push(tempDir);
+  const manifestPath = path.join(tempDir, "manifest.yaml");
+  fs.writeFileSync(manifestPath, lines.join("\n"));
+  return manifestPath;
+}

--- a/ui/packages/ui-plugin-bundler-kit/src/__tests__/legacy.spec.ts
+++ b/ui/packages/ui-plugin-bundler-kit/src/__tests__/legacy.spec.ts
@@ -1,0 +1,128 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import type { Plugin } from "vite";
+import { afterEach, describe, expect, it } from "vitest";
+import { HaloUIPluginBundlerKit } from "../legacy";
+
+const originalCwd = process.cwd();
+const tempDirs: string[] = [];
+
+afterEach(() => {
+  process.chdir(originalCwd);
+  while (tempDirs.length > 0) {
+    const tempDir = tempDirs.pop();
+    if (tempDir) {
+      fs.rmSync(tempDir, { recursive: true, force: true });
+    }
+  }
+});
+
+describe("HaloUIPluginBundlerKit", () => {
+  it("keeps legacy default output directories", () => {
+    const uiDir = setupPluginProject("legacy-plugin");
+    process.chdir(uiDir);
+
+    const plugin = HaloUIPluginBundlerKit();
+
+    expect(resolveLegacyConfig(plugin, "development").build).toMatchObject({
+      outDir: "../build/resources/main/console",
+      emptyOutDir: true,
+      lib: {
+        entry: "src/index.ts",
+        name: "legacy-plugin",
+        formats: ["iife"],
+      },
+    });
+    expect(resolveLegacyConfig(plugin, "production").build).toMatchObject({
+      outDir: "../src/main/resources/console",
+    });
+  });
+
+  it("applies string outDir override for every mode", () => {
+    const uiDir = setupPluginProject("legacy-plugin");
+    process.chdir(uiDir);
+
+    const plugin = HaloUIPluginBundlerKit({ outDir: "custom" });
+
+    expect(resolveLegacyConfig(plugin, "development").build).toMatchObject({
+      outDir: "custom",
+    });
+    expect(resolveLegacyConfig(plugin, "production").build).toMatchObject({
+      outDir: "custom",
+    });
+  });
+
+  it("applies mode-specific outDir overrides", () => {
+    const uiDir = setupPluginProject("legacy-plugin");
+    process.chdir(uiDir);
+
+    const plugin = HaloUIPluginBundlerKit({
+      outDir: {
+        dev: "dev-dist",
+        prod: "prod-dist",
+      },
+    });
+
+    expect(resolveLegacyConfig(plugin, "development").build).toMatchObject({
+      outDir: "dev-dist",
+    });
+    expect(resolveLegacyConfig(plugin, "production").build).toMatchObject({
+      outDir: "prod-dist",
+    });
+  });
+
+  it("uses custom manifest path", () => {
+    const projectRoot = createTempDir();
+    const manifestPath = path.join(projectRoot, "plugin.yaml");
+    fs.writeFileSync(
+      manifestPath,
+      ["metadata:", "  name: custom-legacy-plugin", "spec:", ""].join("\n")
+    );
+
+    const plugin = HaloUIPluginBundlerKit({ manifestPath });
+
+    expect(resolveLegacyConfig(plugin, "production").build).toMatchObject({
+      lib: {
+        name: "custom-legacy-plugin",
+      },
+    });
+  });
+});
+
+function resolveLegacyConfig(plugin: Plugin, mode: string) {
+  if (typeof plugin.config !== "function") {
+    throw new Error("Expected plugin config hook");
+  }
+  return plugin.config(
+    {},
+    {
+      command: "build",
+      mode,
+      isSsrBuild: false,
+      isPreview: false,
+    }
+  );
+}
+
+function setupPluginProject(name: string) {
+  const projectRoot = createTempDir();
+  const uiDir = path.join(projectRoot, "ui");
+  fs.mkdirSync(path.join(projectRoot, "src/main/resources"), {
+    recursive: true,
+  });
+  fs.mkdirSync(uiDir, { recursive: true });
+  fs.writeFileSync(
+    path.join(projectRoot, "src/main/resources/plugin.yaml"),
+    ["metadata:", `  name: ${name}`, "spec:", ""].join("\n")
+  );
+  return uiDir;
+}
+
+function createTempDir() {
+  const tempDir = fs.mkdtempSync(
+    path.join(os.tmpdir(), "halo-ui-plugin-legacy-")
+  );
+  tempDirs.push(tempDir);
+  return tempDir;
+}

--- a/ui/packages/ui-plugin-bundler-kit/src/__tests__/provider.spec.ts
+++ b/ui/packages/ui-plugin-bundler-kit/src/__tests__/provider.spec.ts
@@ -1,0 +1,301 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import type { ConfigParams, RsbuildConfig } from "@rsbuild/core";
+import type { ConfigEnv, UserConfig } from "vite";
+import { afterEach, describe, expect, it } from "vitest";
+import { rsbuildConfig } from "../rsbuild";
+import { viteConfig } from "../vite";
+
+const originalCwd = process.cwd();
+const tempDirs: string[] = [];
+
+afterEach(() => {
+  process.chdir(originalCwd);
+  while (tempDirs.length > 0) {
+    const tempDir = tempDirs.pop();
+    if (tempDir) {
+      fs.rmSync(tempDir, { recursive: true, force: true });
+    }
+  }
+});
+
+describe("provider defaults", () => {
+  it("keeps plugin provider defaults when provider is omitted", () => {
+    const uiDir = setupPluginProject();
+    process.chdir(uiDir);
+
+    const vite = resolveViteConfig(viteConfig({ vite: {} }), "development");
+    expect(vite.base).toBeUndefined();
+    expect(vite.build?.outDir).toBe("../build/resources/main/ui");
+    expect(vite.build?.lib).toMatchObject({
+      entry: "src/index.ts",
+      name: "fake-plugin",
+      formats: ["iife"],
+      cssFileName: "style",
+    });
+
+    const rsbuild = resolveRsbuildConfig(
+      rsbuildConfig({ rsbuild: {} }),
+      "development"
+    );
+    expect(rsbuild.output?.distPath?.root).toBe("../build/resources/main/ui");
+    expect(rsbuild.tools?.rspack?.output?.publicPath).toBe(
+      "/plugins/fake-plugin/assets/ui/"
+    );
+    expect(rsbuild.tools?.rspack?.output?.library).toMatchObject({
+      type: "window",
+      export: "default",
+      name: "fake-plugin",
+    });
+
+    const productionVite = resolveViteConfig(viteConfig({ vite: {} }));
+    expect(productionVite.build?.outDir).toBe("./build/dist");
+
+    const productionRsbuild = resolveRsbuildConfig(
+      rsbuildConfig({ rsbuild: {} })
+    );
+    expect(productionRsbuild.output?.distPath?.root).toBe("./build/dist");
+  });
+
+  it("keeps plugin provider defaults when provider is explicit", () => {
+    const uiDir = setupPluginProject();
+    process.chdir(uiDir);
+
+    const vite = resolveViteConfig(
+      viteConfig({ provider: "plugin", vite: {} }),
+      "development"
+    );
+    expect(vite.build?.outDir).toBe("../build/resources/main/ui");
+
+    const rsbuild = resolveRsbuildConfig(
+      rsbuildConfig({ provider: "plugin", rsbuild: {} }),
+      "development"
+    );
+    expect(rsbuild.tools?.rspack?.output?.publicPath).toBe(
+      "/plugins/fake-plugin/assets/ui/"
+    );
+  });
+
+  it("uses custom manifest paths for plugin and theme providers", () => {
+    const projectRoot = createTempDir();
+    const pluginManifestPath = path.join(projectRoot, "custom-plugin.yaml");
+    const themeManifestPath = path.join(projectRoot, "custom-theme.yaml");
+    fs.writeFileSync(
+      pluginManifestPath,
+      [
+        "metadata:",
+        "  name: custom-plugin",
+        "spec:",
+        "  requires: '>=2.25.0'",
+        "",
+      ].join("\n")
+    );
+    fs.writeFileSync(
+      themeManifestPath,
+      ["metadata:", "  name: custom-theme", ""].join("\n")
+    );
+
+    const pluginConfig = resolveViteConfig(
+      viteConfig({
+        manifestPath: pluginManifestPath,
+        vite: {},
+      })
+    );
+    expect(pluginConfig.build?.lib).toMatchObject({
+      name: "custom-plugin",
+    });
+
+    const themeConfig = resolveRsbuildConfig(
+      rsbuildConfig({
+        provider: "theme",
+        manifestPath: themeManifestPath,
+        rsbuild: {},
+      })
+    );
+    expect(themeConfig.tools?.rspack?.output?.publicPath).toBe(
+      "/themes/custom-theme/ui-plugin/assets/"
+    );
+    expect(themeConfig.tools?.rspack?.output?.library).toMatchObject({
+      name: "theme:custom-theme",
+    });
+  });
+
+  it("generates Vite theme provider defaults", () => {
+    const uiPluginDir = setupThemeProject();
+    process.chdir(uiPluginDir);
+
+    const config = resolveViteConfig(
+      viteConfig({ provider: "theme", vite: {} })
+    );
+
+    expect(config.base).toBe("/themes/earth/ui-plugin/assets/");
+    expect(config.build?.outDir).toBe("dist");
+    expect(config.build?.lib).toMatchObject({
+      entry: "src/index.ts",
+      name: "theme:earth",
+      formats: ["iife"],
+      cssFileName: "style",
+    });
+    expect(config.build?.rollupOptions?.external).toContain("vue");
+    expect(config.build?.rollupOptions?.output).toMatchObject({
+      globals: expect.objectContaining({
+        vue: "Vue",
+      }),
+      extend: true,
+    });
+  });
+
+  it("generates Rsbuild theme provider defaults", () => {
+    const uiPluginDir = setupThemeProject();
+    process.chdir(uiPluginDir);
+
+    const config = resolveRsbuildConfig(
+      rsbuildConfig({ provider: "theme", rsbuild: {} })
+    );
+
+    expect(config.output?.distPath?.root).toBe("dist");
+    expect(config.output?.filename?.js).toBeDefined();
+    expect(config.output?.filename?.css).toBeDefined();
+    expect(config.output?.externals).toMatchObject({
+      vue: "Vue",
+    });
+    expect(config.tools?.rspack?.output?.publicPath).toBe(
+      "/themes/earth/ui-plugin/assets/"
+    );
+    expect(config.tools?.rspack?.output?.library).toMatchObject({
+      type: "window",
+      export: "default",
+      name: "theme:earth",
+    });
+  });
+
+  it("merges user config after provider defaults", () => {
+    const uiPluginDir = setupThemeProject();
+    process.chdir(uiPluginDir);
+
+    const vite = resolveViteConfig(
+      viteConfig({
+        provider: "theme",
+        vite: {
+          base: "/custom/",
+          build: {
+            outDir: "custom-dist",
+          },
+        },
+      })
+    );
+    expect(vite.base).toBe("/custom/");
+    expect(vite.build?.outDir).toBe("custom-dist");
+
+    const rsbuild = resolveRsbuildConfig(
+      rsbuildConfig({
+        provider: "theme",
+        rsbuild: {
+          output: {
+            distPath: {
+              root: "custom-dist",
+            },
+          },
+          tools: {
+            rspack: {
+              output: {
+                publicPath: "/custom/",
+              },
+            },
+          },
+        },
+      })
+    );
+    expect(rsbuild.output?.distPath?.root).toBe("custom-dist");
+    expect(rsbuild.tools?.rspack?.output?.publicPath).toBe("/custom/");
+  });
+
+  it("merges function user config after provider defaults", () => {
+    const uiPluginDir = setupThemeProject();
+    process.chdir(uiPluginDir);
+
+    const vite = resolveViteConfig(
+      viteConfig({
+        provider: "theme",
+        vite: ({ mode }) => ({
+          define: {
+            __MODE__: JSON.stringify(mode),
+          },
+        }),
+      })
+    );
+    expect(vite.define).toMatchObject({
+      "process.env.NODE_ENV": "'production'",
+      __MODE__: '"production"',
+    });
+
+    const rsbuild = resolveRsbuildConfig(
+      rsbuildConfig({
+        provider: "theme",
+        rsbuild: ({ envMode }) => ({
+          output: {
+            filename: {
+              js: `custom-${envMode}.js`,
+            },
+          },
+        }),
+      })
+    );
+    expect(rsbuild.output?.filename?.js).toBe("custom-production.js");
+  });
+});
+
+function setupPluginProject() {
+  const projectRoot = createTempDir();
+  const uiDir = path.join(projectRoot, "ui");
+  fs.mkdirSync(path.join(projectRoot, "src/main/resources"), {
+    recursive: true,
+  });
+  fs.mkdirSync(uiDir, { recursive: true });
+  fs.writeFileSync(
+    path.join(projectRoot, "src/main/resources/plugin.yaml"),
+    [
+      "metadata:",
+      "  name: fake-plugin",
+      "spec:",
+      "  requires: '>=2.25.0'",
+      "",
+    ].join("\n")
+  );
+  return uiDir;
+}
+
+function setupThemeProject() {
+  const projectRoot = createTempDir();
+  const uiPluginDir = path.join(projectRoot, "ui-plugin");
+  fs.mkdirSync(uiPluginDir, { recursive: true });
+  fs.writeFileSync(
+    path.join(projectRoot, "theme.yaml"),
+    ["metadata:", "  name: earth", ""].join("\n")
+  );
+  return uiPluginDir;
+}
+
+function createTempDir() {
+  const tempDir = fs.mkdtempSync(
+    path.join(os.tmpdir(), "halo-ui-plugin-bundler-kit-")
+  );
+  tempDirs.push(tempDir);
+  return tempDir;
+}
+
+function resolveViteConfig(config: unknown, mode = "production") {
+  return (config as (env: ConfigEnv) => UserConfig)({
+    command: "build",
+    mode,
+    isSsrBuild: false,
+    isPreview: false,
+  });
+}
+
+function resolveRsbuildConfig(config: unknown, envMode = "production") {
+  return (config as (env: ConfigParams) => RsbuildConfig)({
+    envMode,
+  } as ConfigParams);
+}

--- a/ui/packages/ui-plugin-bundler-kit/src/constants/build.ts
+++ b/ui/packages/ui-plugin-bundler-kit/src/constants/build.ts
@@ -1,9 +1,15 @@
 const DEFAULT_OUT_DIR_DEV = "../build/resources/main/console";
 const DEFAULT_OUT_DIR_DEV_BASE = "../build/resources/main";
 const DEFAULT_OUT_DIR_PROD = "./build/dist";
+const DEFAULT_THEME_OUT_DIR = "dist";
 
 function getDefaultOutDirDev(bundleLocation: string) {
   return `${DEFAULT_OUT_DIR_DEV_BASE}/${bundleLocation}`;
 }
 
-export { DEFAULT_OUT_DIR_DEV, DEFAULT_OUT_DIR_PROD, getDefaultOutDirDev };
+export {
+  DEFAULT_OUT_DIR_DEV,
+  DEFAULT_OUT_DIR_PROD,
+  DEFAULT_THEME_OUT_DIR,
+  getDefaultOutDirDev,
+};

--- a/ui/packages/ui-plugin-bundler-kit/src/constants/halo-plugin.ts
+++ b/ui/packages/ui-plugin-bundler-kit/src/constants/halo-plugin.ts
@@ -1,3 +1,9 @@
-const DEFAULT_MANIFEST_PATH = "../src/main/resources/plugin.yaml";
+const DEFAULT_PLUGIN_MANIFEST_PATH = "../src/main/resources/plugin.yaml";
+const DEFAULT_THEME_MANIFEST_PATH = "../theme.yaml";
+const DEFAULT_MANIFEST_PATH = DEFAULT_PLUGIN_MANIFEST_PATH;
 
-export { DEFAULT_MANIFEST_PATH };
+export {
+  DEFAULT_MANIFEST_PATH,
+  DEFAULT_PLUGIN_MANIFEST_PATH,
+  DEFAULT_THEME_MANIFEST_PATH,
+};

--- a/ui/packages/ui-plugin-bundler-kit/src/rsbuild.ts
+++ b/ui/packages/ui-plugin-bundler-kit/src/rsbuild.ts
@@ -6,19 +6,39 @@ import {
   type RsbuildMode,
 } from "@rsbuild/core";
 import { pluginVue } from "@rsbuild/plugin-vue";
-import { DEFAULT_OUT_DIR_PROD, getDefaultOutDirDev } from "./constants/build";
+import {
+  DEFAULT_OUT_DIR_PROD,
+  DEFAULT_THEME_OUT_DIR,
+  getDefaultOutDirDev,
+} from "./constants/build";
 import { GLOBALS } from "./constants/externals";
-import { DEFAULT_MANIFEST_PATH } from "./constants/halo-plugin";
+import {
+  DEFAULT_PLUGIN_MANIFEST_PATH,
+  DEFAULT_THEME_MANIFEST_PATH,
+} from "./constants/halo-plugin";
 import {
   getHaloPluginBundleLocation,
   getHaloPluginManifest,
+  getHaloThemeAssetPublicPath,
+  getHaloThemeManifest,
+  getHaloThemeModuleName,
+  getManifestName,
 } from "./utils/halo-plugin";
+
+type Provider = "plugin" | "theme";
 
 export interface RsBuildUserConfig {
   /**
-   * Halo plugin manifest path.
+   * UI plugin provider type.
    *
-   * @default "../src/main/resources/plugin.yaml"
+   * @default "plugin"
+   */
+  provider?: "plugin" | "theme";
+
+  /**
+   * Halo plugin or theme manifest path.
+   *
+   * @default "../src/main/resources/plugin.yaml" for plugins, "../theme.yaml" for themes
    */
   manifestPath?: string;
 
@@ -28,16 +48,16 @@ export interface RsBuildUserConfig {
   rsbuild: RsbuildConfig | ((env: ConfigParams) => RsbuildConfig);
 }
 
-function createRsbuildPresetsConfig(manifestPath: string) {
-  const manifest = getHaloPluginManifest(manifestPath);
-  const bundleLocation = getHaloPluginBundleLocation(manifest);
+function createRsbuildPresetsConfig(provider: Provider, manifestPath: string) {
+  const defaults =
+    provider === "theme"
+      ? getThemeProviderDefaults(manifestPath)
+      : getPluginProviderDefaults(manifestPath);
 
   return defineConfig(({ envMode }) => {
     const isProduction = envMode === "production";
 
-    const outDir = isProduction
-      ? DEFAULT_OUT_DIR_PROD
-      : getDefaultOutDirDev(bundleLocation);
+    const outDir = isProduction ? defaults.outDir.prod : defaults.outDir.dev;
 
     return {
       mode: (envMode as RsbuildMode) || "production",
@@ -78,11 +98,11 @@ function createRsbuildPresetsConfig(manifestPath: string) {
             },
           },
           output: {
-            publicPath: `/plugins/${manifest.metadata.name}/assets/${bundleLocation}/`,
+            publicPath: defaults.publicPath,
             library: {
               type: "window",
               export: "default",
-              name: manifest.metadata.name,
+              name: defaults.moduleName,
             },
             globalObject: "window",
             iife: true,
@@ -119,6 +139,46 @@ function createRsbuildPresetsConfig(manifestPath: string) {
   });
 }
 
+function getPluginProviderDefaults(manifestPath: string) {
+  const manifest = getHaloPluginManifest(manifestPath);
+  const bundleLocation = getHaloPluginBundleLocation(manifest);
+
+  return {
+    moduleName: getManifestName(manifest),
+    outDir: {
+      prod: DEFAULT_OUT_DIR_PROD,
+      dev: getDefaultOutDirDev(bundleLocation),
+    },
+    publicPath: `/plugins/${getManifestName(manifest)}/assets/${bundleLocation}/`,
+  };
+}
+
+function getThemeProviderDefaults(manifestPath: string) {
+  const manifest = getHaloThemeManifest(manifestPath);
+
+  return {
+    moduleName: getHaloThemeModuleName(manifest),
+    outDir: {
+      prod: DEFAULT_THEME_OUT_DIR,
+      dev: DEFAULT_THEME_OUT_DIR,
+    },
+    publicPath: getHaloThemeAssetPublicPath(manifest),
+  };
+}
+
+function getProvider(config?: RsBuildUserConfig): Provider {
+  return config?.provider || "plugin";
+}
+
+function getManifestPath(provider: Provider, config?: RsBuildUserConfig) {
+  if (config?.manifestPath) {
+    return config.manifestPath;
+  }
+  return provider === "theme"
+    ? DEFAULT_THEME_MANIFEST_PATH
+    : DEFAULT_PLUGIN_MANIFEST_PATH;
+}
+
 /**
  * Rsbuild config for Halo UI Plugin.
  *
@@ -138,8 +198,10 @@ function createRsbuildPresetsConfig(manifestPath: string) {
 export function rsbuildConfig(
   config?: RsBuildUserConfig
 ): (env: ConfigParams) => RsbuildConfig {
+  const provider = getProvider(config);
   const presetsConfigFn = createRsbuildPresetsConfig(
-    config?.manifestPath || DEFAULT_MANIFEST_PATH
+    provider,
+    getManifestPath(provider, config)
   );
   return defineConfig((env) => {
     const presetsConfig = presetsConfigFn(env);

--- a/ui/packages/ui-plugin-bundler-kit/src/utils/halo-plugin.ts
+++ b/ui/packages/ui-plugin-bundler-kit/src/utils/halo-plugin.ts
@@ -6,13 +6,34 @@ import { gte, minVersion } from "semver";
 const UI_BUNDLE_MIN_HALO_VERSION = "2.25.0";
 const UI_BUNDLE_LOCATION = "ui";
 const CONSOLE_BUNDLE_LOCATION = "console";
+const THEME_MODULE_NAME_PREFIX = "theme:";
+
+interface HaloThemeManifest {
+  metadata: {
+    name: string;
+  };
+}
 
 export function getHaloPluginManifest(manifestPath: string) {
-  const manifest = yaml.load(
-    fs.readFileSync(manifestPath, "utf8")
-  ) as HaloPlugin;
+  return readManifest<HaloPlugin>(manifestPath);
+}
 
-  return manifest;
+export function getHaloThemeManifest(manifestPath: string) {
+  return readManifest<HaloThemeManifest>(manifestPath);
+}
+
+export function getManifestName(
+  manifest: Pick<HaloPlugin, "metadata"> | HaloThemeManifest
+) {
+  return manifest.metadata.name;
+}
+
+export function getHaloThemeModuleName(manifest: HaloThemeManifest) {
+  return `${THEME_MODULE_NAME_PREFIX}${getManifestName(manifest)}`;
+}
+
+export function getHaloThemeAssetPublicPath(manifest: HaloThemeManifest) {
+  return `/themes/${getManifestName(manifest)}/ui-plugin/assets/`;
 }
 
 export function getHaloPluginBundleLocation(manifest: HaloPlugin) {
@@ -39,4 +60,8 @@ function getRequiresMinVersion(requires: string | undefined) {
     );
     return;
   }
+}
+
+function readManifest<T>(manifestPath: string) {
+  return yaml.load(fs.readFileSync(manifestPath, "utf8")) as T;
 }

--- a/ui/packages/ui-plugin-bundler-kit/src/vite.ts
+++ b/ui/packages/ui-plugin-bundler-kit/src/vite.ts
@@ -5,19 +5,39 @@ import {
   UserConfig,
   UserConfigFnObject,
 } from "vite";
-import { DEFAULT_OUT_DIR_PROD, getDefaultOutDirDev } from "./constants/build";
+import {
+  DEFAULT_OUT_DIR_PROD,
+  DEFAULT_THEME_OUT_DIR,
+  getDefaultOutDirDev,
+} from "./constants/build";
 import { EXTERNALS, GLOBALS } from "./constants/externals";
-import { DEFAULT_MANIFEST_PATH } from "./constants/halo-plugin";
+import {
+  DEFAULT_PLUGIN_MANIFEST_PATH,
+  DEFAULT_THEME_MANIFEST_PATH,
+} from "./constants/halo-plugin";
 import {
   getHaloPluginBundleLocation,
   getHaloPluginManifest,
+  getHaloThemeAssetPublicPath,
+  getHaloThemeManifest,
+  getHaloThemeModuleName,
+  getManifestName,
 } from "./utils/halo-plugin";
+
+type Provider = "plugin" | "theme";
 
 export interface ViteUserConfig {
   /**
-   * Halo plugin manifest path.
+   * UI plugin provider type.
    *
-   * @default "../src/main/resources/plugin.yaml"
+   * @default "plugin"
+   */
+  provider?: "plugin" | "theme";
+
+  /**
+   * Halo plugin or theme manifest path.
+   *
+   * @default "../src/main/resources/plugin.yaml" for plugins, "../theme.yaml" for themes
    */
   manifestPath?: string;
 
@@ -27,25 +47,26 @@ export interface ViteUserConfig {
   vite: UserConfig | UserConfigFnObject;
 }
 
-function createVitePresetsConfig(manifestPath: string) {
-  const manifest = getHaloPluginManifest(manifestPath);
-  const bundleLocation = getHaloPluginBundleLocation(manifest);
+function createVitePresetsConfig(provider: Provider, manifestPath: string) {
+  const defaults =
+    provider === "theme"
+      ? getThemeProviderDefaults(manifestPath)
+      : getPluginProviderDefaults(manifestPath);
 
   return defineConfig(({ mode }) => {
     const isProduction = mode === "production";
 
     return {
       mode: mode || "production",
+      base: defaults.base,
       plugins: [Vue()],
       define: { "process.env.NODE_ENV": "'production'" },
       build: {
-        outDir: isProduction
-          ? DEFAULT_OUT_DIR_PROD
-          : getDefaultOutDirDev(bundleLocation),
+        outDir: isProduction ? defaults.outDir.prod : defaults.outDir.dev,
         emptyOutDir: true,
         lib: {
           entry: "src/index.ts",
-          name: manifest.metadata.name,
+          name: defaults.moduleName,
           formats: ["iife"],
           fileName: () => "main.js",
           cssFileName: "style",
@@ -60,6 +81,46 @@ function createVitePresetsConfig(manifestPath: string) {
       },
     };
   });
+}
+
+function getPluginProviderDefaults(manifestPath: string) {
+  const manifest = getHaloPluginManifest(manifestPath);
+  const bundleLocation = getHaloPluginBundleLocation(manifest);
+
+  return {
+    moduleName: getManifestName(manifest),
+    outDir: {
+      prod: DEFAULT_OUT_DIR_PROD,
+      dev: getDefaultOutDirDev(bundleLocation),
+    },
+    base: undefined,
+  };
+}
+
+function getThemeProviderDefaults(manifestPath: string) {
+  const manifest = getHaloThemeManifest(manifestPath);
+
+  return {
+    moduleName: getHaloThemeModuleName(manifest),
+    outDir: {
+      prod: DEFAULT_THEME_OUT_DIR,
+      dev: DEFAULT_THEME_OUT_DIR,
+    },
+    base: getHaloThemeAssetPublicPath(manifest),
+  };
+}
+
+function getProvider(config?: ViteUserConfig): Provider {
+  return config?.provider || "plugin";
+}
+
+function getManifestPath(provider: Provider, config?: ViteUserConfig) {
+  if (config?.manifestPath) {
+    return config.manifestPath;
+  }
+  return provider === "theme"
+    ? DEFAULT_THEME_MANIFEST_PATH
+    : DEFAULT_PLUGIN_MANIFEST_PATH;
 }
 
 /**
@@ -77,8 +138,10 @@ function createVitePresetsConfig(manifestPath: string) {
  * ```
  */
 export function viteConfig(config?: ViteUserConfig) {
+  const provider = getProvider(config);
   const presetsConfigFn = createVitePresetsConfig(
-    config?.manifestPath || DEFAULT_MANIFEST_PATH
+    provider,
+    getManifestPath(provider, config)
   );
   return defineConfig((env) => {
     const presetsConfig = presetsConfigFn(env);


### PR DESCRIPTION
#### What type of PR is this?

- [x] Feature
- [ ] Bug fix
- [ ] Improvement
- [ ] Cleanup
- [ ] Documentation

#### What this PR does / why we need it:

This PR updates @halo-dev/ui-plugin-bundler-kit so the modern Vite and Rsbuild helpers can build UI plugin bundles for both plugins and themes.

It adds an optional provider setting that defaults to plugin for compatibility. When provider is theme, the helpers read ../theme.yaml, emit to dist, configure the public asset path as /themes/{name}/ui-plugin/assets/, and publish the bundle module as theme:{name}, matching the runtime support added in #10053.

The deprecated HaloUIPluginBundlerKit helper is intentionally unchanged and remains plugin-only. The README now documents the recommended theme-root/ui-plugin project layout and both Vite/Rsbuild theme examples.

This PR also adds focused unit coverage for provider defaults, manifest utilities, plugin bundle location selection, legacy helper behavior, output overrides, custom manifest paths, and function-based config merging.

This PR uses AI-assisted implementation and has been reviewed before submission.

#### Which issue(s) this PR fixes:

Part of #9993

#### Special notes for your reviewer:

The plugin provider remains the default and preserves the existing plugin manifest and bundle location behavior. Theme provider selection is explicit; the helper does not auto-detect theme.yaml.

Validation run:

- npx --yes pnpm@10.30.3 -C ui --filter @halo-dev/ui-plugin-bundler-kit test:unit
- npx --yes pnpm@10.30.3 -C ui typecheck
- npx --yes pnpm@10.30.3 -C ui build:packages
- openspec validate ui-plugin-bundler-provider --strict

Note: build:packages exited 0, while still printing pre-existing components package vite:dts declaration diagnostics.

#### Does this PR introduce a user-facing change?

```release-note
支持使用 ui-plugin-bundler-kit 构建主题 UI 插件 bundle
```