### PR TITLE
Refine UI plugin runtime setup

### DIFF
--- a/ui/console-src/main.ts
+++ b/ui/console-src/main.ts
@@ -5,21 +5,13 @@ import { createPinia } from "pinia";
 import "@/setup/setupStyles";
 import { createApp } from "vue";
 import { builtinFormKitInputs } from "@/formkit/inputs";
-import { collectPluginFormKitInputs } from "@/formkit/plugin-inputs";
 import { setLanguage, setupI18n } from "@/locales";
 import { setupApiClient } from "@/setup/setupApiClient";
 import {
   setupComponents,
   type SetupComponentsOptions,
 } from "@/setup/setupComponents";
-import {
-  loadEnabledUiPluginModules,
-  notifyPluginLoadError,
-  setupCoreModules,
-  setupPluginModules,
-  setupPluginStyles,
-  type LoadedPluginModule,
-} from "@/setup/setupModules";
+import { setupCoreModules, setupUiPluginRuntime } from "@/setup/setupModules";
 import "core-js/es/object/has-own";
 import { setupUserPermissions } from "@/setup/setupUserPermissions";
 import { setupVueQuery } from "@/setup/setupVueQuery";
@@ -51,10 +43,6 @@ function setupAppComponents(options?: SetupComponentsOptions) {
 await initApp();
 
 async function initApp() {
-  let pluginBundleLoaded = false;
-  let pluginModulesInitialized = false;
-  let uiPluginModules: LoadedPluginModule[] = [];
-
   try {
     setupCoreModules({ app, router, platform: "console", modules });
 
@@ -73,39 +61,13 @@ async function initApp() {
 
     await setupUserPermissions(app);
 
-    try {
-      uiPluginModules = await loadEnabledUiPluginModules();
-      pluginBundleLoaded = true;
-    } catch (e) {
-      notifyPluginLoadError(e);
-    }
-
-    setupAppComponents({
-      formkitInputs: collectPluginFormKitInputs(
-        uiPluginModules.filter((module) => module.type === "plugin"),
-        builtinFormKitInputs
-      ),
+    await setupUiPluginRuntime({
+      app,
+      router,
+      platform: "console",
+      setupComponents: setupAppComponents,
+      registeredFormKitInputs: builtinFormKitInputs,
     });
-
-    try {
-      setupPluginModules({
-        app,
-        router,
-        platform: "console",
-        modules: uiPluginModules,
-      });
-      pluginModulesInitialized = true;
-    } catch (e) {
-      notifyPluginLoadError(e);
-    }
-
-    if (pluginBundleLoaded && pluginModulesInitialized) {
-      try {
-        await setupPluginStyles();
-      } catch (e) {
-        notifyPluginLoadError(e);
-      }
-    }
 
     await loadActivatedTheme();
   } catch (e) {

--- a/ui/src/setup/setupModules.spec.ts
+++ b/ui/src/setup/setupModules.spec.ts
@@ -5,10 +5,9 @@ import type { App } from "vue";
 import type { Router, RouteRecordRaw } from "vue-router";
 import { usePluginModuleStore } from "@/stores/plugin";
 import {
-  loadEnabledUiPluginModules,
   notifyPluginLoadError,
-  setupPluginModules,
   setupPluginStyles,
+  setupUiPluginRuntime,
 } from "./setupModules";
 
 const mocks = vi.hoisted(() => ({
@@ -59,12 +58,30 @@ describe("setupPluginModules", () => {
       name: "ThemeRoute",
       component: {},
     } as RouteRecordRaw;
+    const pluginInput = {
+      type: "input",
+      schema: [],
+    };
+    const themeInput = {
+      type: "input",
+      schema: [],
+    };
     const pluginModule: PluginModule = {
+      formkit: {
+        inputs: {
+          "plugin-input": pluginInput,
+        },
+      },
       routes: [pluginRoute],
-    };
+    } as PluginModule;
     const themeModule: PluginModule = {
+      formkit: {
+        inputs: {
+          "theme-input": themeInput,
+        },
+      },
       routes: [themeRoute],
-    };
+    } as PluginModule;
     mocks.useScriptTag.mockImplementation((src: string) => ({
       load: vi.fn(async () => {
         if (src.includes("/ui-plugins/-/bundle.js")) {
@@ -91,20 +108,24 @@ describe("setupPluginModules", () => {
       addRoute: vi.fn(),
       removeRoute: vi.fn(),
     } as unknown as Router;
+    const setupComponents = vi.fn();
 
-    const uiPluginModules = await loadEnabledUiPluginModules();
-
-    setupPluginModules({
+    await setupUiPluginRuntime({
       app,
       router,
       platform: "console",
-      modules: uiPluginModules,
+      setupComponents,
+      registeredFormKitInputs: {},
     });
-    await setupPluginStyles();
 
     const store = usePluginModuleStore();
     expect(store.pluginModuleMap["plugin-one"]).toBe(pluginModule);
     expect(store.pluginModuleMap["theme:earth"]).toBe(themeModule);
+    expect(setupComponents).toHaveBeenCalledWith({
+      formkitInputs: {
+        "plugin-input": pluginInput,
+      },
+    });
     expect(router.addRoute).toHaveBeenCalledWith(pluginRoute);
     expect(router.addRoute).toHaveBeenCalledWith(themeRoute);
     expect(mocks.loadStyle).toHaveBeenCalledWith(

--- a/ui/src/setup/setupModules.ts
+++ b/ui/src/setup/setupModules.ts
@@ -1,11 +1,14 @@
+import type { FormKitLibrary } from "@formkit/core";
 import { Toast } from "@halo-dev/components";
 import type { PluginModule, RouteRecordAppend } from "@halo-dev/ui-shared";
 import { useScriptTag } from "@vueuse/core";
 import type { App } from "vue";
 import type { Router, RouteRecordRaw } from "vue-router";
+import { collectPluginFormKitInputs } from "@/formkit/plugin-inputs";
 import { i18n } from "@/locales";
 import { usePluginModuleStore } from "@/stores/plugin";
 import { loadStyle } from "@/utils/load-style";
+import type { SetupComponentsOptions } from "./setupComponents";
 
 export type Platform = "console" | "uc";
 
@@ -28,6 +31,60 @@ export interface LoadedPluginModule {
   name: string;
   type: EnabledUiPlugin["type"];
   module: PluginModule;
+}
+
+export async function setupUiPluginRuntime({
+  app,
+  router,
+  platform,
+  setupComponents,
+  registeredFormKitInputs,
+}: {
+  app: App;
+  router: Router;
+  platform: Platform;
+  setupComponents: (options?: SetupComponentsOptions) => void;
+  registeredFormKitInputs: FormKitLibrary;
+}) {
+  let pluginBundleLoaded = false;
+  let pluginModulesInitialized = false;
+  let uiPluginModules: LoadedPluginModule[] = [];
+
+  try {
+    uiPluginModules = await loadEnabledUiPluginModules();
+    pluginBundleLoaded = true;
+  } catch (e) {
+    notifyPluginLoadError(e);
+  }
+
+  setupComponents({
+    formkitInputs: collectPluginFormKitInputs(
+      uiPluginModules.filter((module) => module.type === "plugin"),
+      registeredFormKitInputs
+    ),
+  });
+
+  try {
+    setupPluginModules({
+      app,
+      router,
+      platform,
+      modules: uiPluginModules,
+    });
+    pluginModulesInitialized = true;
+  } catch (e) {
+    notifyPluginLoadError(e);
+  }
+
+  if (pluginBundleLoaded && pluginModulesInitialized) {
+    try {
+      await setupPluginStyles();
+    } catch (e) {
+      notifyPluginLoadError(e);
+    }
+  }
+
+  return uiPluginModules;
 }
 
 export function setupCoreModules({

--- a/ui/uc-src/main.ts
+++ b/ui/uc-src/main.ts
@@ -5,21 +5,13 @@ import { createPinia } from "pinia";
 import "@/setup/setupStyles";
 import { createApp } from "vue";
 import { builtinFormKitInputs } from "@/formkit/inputs";
-import { collectPluginFormKitInputs } from "@/formkit/plugin-inputs";
 import { setLanguage, setupI18n } from "@/locales";
 import { setupApiClient } from "@/setup/setupApiClient";
 import {
   setupComponents,
   type SetupComponentsOptions,
 } from "@/setup/setupComponents";
-import {
-  loadEnabledUiPluginModules,
-  notifyPluginLoadError,
-  setupCoreModules,
-  setupPluginModules,
-  setupPluginStyles,
-  type LoadedPluginModule,
-} from "@/setup/setupModules";
+import { setupCoreModules, setupUiPluginRuntime } from "@/setup/setupModules";
 import "core-js/es/object/has-own";
 import { setupUserPermissions } from "@/setup/setupUserPermissions";
 import { setupVueQuery } from "@/setup/setupVueQuery";
@@ -45,10 +37,6 @@ function setupAppComponents(options?: SetupComponentsOptions) {
 await initApp();
 
 async function initApp() {
-  let pluginBundleLoaded = false;
-  let pluginModulesInitialized = false;
-  let uiPluginModules: LoadedPluginModule[] = [];
-
   try {
     setupCoreModules({ app, router, platform: "uc", modules });
 
@@ -67,39 +55,13 @@ async function initApp() {
 
     await setupUserPermissions(app);
 
-    try {
-      uiPluginModules = await loadEnabledUiPluginModules();
-      pluginBundleLoaded = true;
-    } catch (e) {
-      notifyPluginLoadError(e);
-    }
-
-    setupAppComponents({
-      formkitInputs: collectPluginFormKitInputs(
-        uiPluginModules.filter((module) => module.type === "plugin"),
-        builtinFormKitInputs
-      ),
+    await setupUiPluginRuntime({
+      app,
+      router,
+      platform: "uc",
+      setupComponents: setupAppComponents,
+      registeredFormKitInputs: builtinFormKitInputs,
     });
-
-    try {
-      setupPluginModules({
-        app,
-        router,
-        platform: "uc",
-        modules: uiPluginModules,
-      });
-      pluginModulesInitialized = true;
-    } catch (e) {
-      notifyPluginLoadError(e);
-    }
-
-    if (pluginBundleLoaded && pluginModulesInitialized) {
-      try {
-        await setupPluginStyles();
-      } catch (e) {
-        notifyPluginLoadError(e);
-      }
-    }
   } catch (error) {
     console.error("Failed to init app", error);
   } finally {


### PR DESCRIPTION
#### What type of PR is this?

- [ ] Feature
- [ ] Bug fix
- [x] Improvement
- [ ] Cleanup
- [ ] Documentation

#### What this PR does / why we need it:

This PR consolidates the shared Console and UC UI plugin startup flow into `setupUiPluginRuntime`.

It keeps the existing loading order intact while removing duplicated startup state from both entrypoints:

- load enabled UI plugin modules
- collect plugin-provided FormKit inputs before FormKit is installed
- register plugin modules for the active platform
- load plugin styles only after the bundle and module registration succeed

The plugin API and backend endpoints are unchanged.

#### Which issue(s) this PR fixes:

N/A

#### Special notes for your reviewer:

Prepared with AI assistance and reviewed locally.

Validation performed:

```bash
npx --yes pnpm@10.30.3 -C ui exec eslint console-src/main.ts uc-src/main.ts src/setup/setupModules.ts src/setup/setupModules.spec.ts --max-warnings=0
npx --yes pnpm@10.30.3 -C ui exec vp test --run src/setup/setupModules.spec.ts --reporter=verbose
npx --yes pnpm@10.30.3 -C ui exec vp fmt console-src/main.ts uc-src/main.ts src/setup/setupModules.ts src/setup/setupModules.spec.ts
npx --yes pnpm@10.30.3 -C ui typecheck
git diff --check
```

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
