### PR TITLE
Restore enabledPlugins compatibility in UI plugin bundle

### DIFF
--- a/application/src/main/java/run/halo/app/plugin/UiPluginBundleServiceImpl.java
+++ b/application/src/main/java/run/halo/app/plugin/UiPluginBundleServiceImpl.java
@@ -209,13 +209,19 @@ public class UiPluginBundleServiceImpl implements UiPluginBundleService, Initial
 
     private static String enabledUiPluginsScript(Iterable<PluginWrapper> plugins, Theme theme) {
         var sb = new StringBuilder("this.enabledUiPlugins = [");
+        var enabledPlugins = new StringBuilder("this.enabledPlugins = [");
         var first = true;
         for (var plugin : plugins) {
             if (!first) {
                 sb.append(',');
+                enabledPlugins.append(',');
             }
             sb.append("""
                 {"name":"%s","type":"plugin","version":"%s"}\
+                """.formatted(plugin.getPluginId(), plugin.getDescriptor().getVersion()));
+            enabledPlugins.append(
+                    """
+                {"name":"%s","version":"%s"}\
                 """.formatted(plugin.getPluginId(), plugin.getDescriptor().getVersion()));
             first = false;
         }
@@ -232,6 +238,8 @@ public class UiPluginBundleServiceImpl implements UiPluginBundleService, Initial
                             Objects.toString(theme.getSpec().getVersion(), "")));
         }
         sb.append(']');
+        enabledPlugins.append(']');
+        sb.append(';').append(enabledPlugins);
         return sb.toString();
     }
 

--- a/application/src/main/java/run/halo/app/plugin/UiPluginBundleServiceImpl.java
+++ b/application/src/main/java/run/halo/app/plugin/UiPluginBundleServiceImpl.java
@@ -209,6 +209,7 @@ public class UiPluginBundleServiceImpl implements UiPluginBundleService, Initial
 
     private static String enabledUiPluginsScript(Iterable<PluginWrapper> plugins, Theme theme) {
         var sb = new StringBuilder("this.enabledUiPlugins = [");
+        // Keep enabledPlugins temporarily for compatibility. It will be removed in a future release.
         var enabledPlugins = new StringBuilder("this.enabledPlugins = [");
         var first = true;
         for (var plugin : plugins) {

--- a/application/src/test/java/run/halo/app/plugin/UiPluginBundleServiceImplTest.java
+++ b/application/src/test/java/run/halo/app/plugin/UiPluginBundleServiceImplTest.java
@@ -81,6 +81,9 @@ class UiPluginBundleServiceImplTest {
                         .contains("""
                             this.enabledUiPlugins = [{"name":"fake-plugin","type":"plugin","version":"1.0.0"},{"name":"theme:active","type":"theme","themeName":"active","version":"1.0.0"}]\
                             """)
+                        .contains("""
+                            this.enabledPlugins = [{"name":"fake-plugin","version":"1.0.0"}]\
+                            """)
                         .doesNotContain("console.log(\"inactive\");"))
                 .verifyComplete();
     }
@@ -140,8 +143,11 @@ class UiPluginBundleServiceImplTest {
 
         toString(uiPluginBundleService.uglifyJsBundle())
                 .as(StepVerifier::create)
-                .assertNext(content -> assertThat(content).contains("""
+                .assertNext(content ->
+                        assertThat(content).contains("""
                             this.enabledUiPlugins = [{"name":"fake-plugin","type":"plugin","version":"1.0.0"}]\
+                            """).contains("""
+                            this.enabledPlugins = [{"name":"fake-plugin","version":"1.0.0"}]\
                             """).doesNotContain("theme:active"))
                 .verifyComplete();
     }


### PR DESCRIPTION
#### What type of PR is this?

- [ ] Feature
- [x] Bug fix
- [ ] Improvement
- [ ] Cleanup
- [ ] Documentation

#### What this PR does / why we need it:

`ui-plugins/-/bundle.js` now exposes both `this.enabledUiPlugins` and the legacy `this.enabledPlugins` metadata.

`this.enabledUiPlugins` keeps the new metadata shape and can include theme UI modules. `this.enabledPlugins` keeps the previous plugin-only shape so existing plugins that still read it continue to work during the migration period. Theme modules are intentionally excluded from the legacy field.

This was assisted by AI and the generated changes were reviewed.

#### Which issue(s) this PR fixes:

N/A

#### Special notes for your reviewer:

This keeps the legacy field out of theme metadata while preserving compatibility for plugin bundles.

Validation:

```bash
./gradlew :application:spotlessApply
./gradlew :application:test --tests "run.halo.app.plugin.UiPluginBundleServiceImplTest"
```

#### Does this PR introduce a user-facing change?

```release-note
None
```