### PR TITLE
fix: do not enable signup agreements by default

### DIFF
--- a/application/src/main/resources/extensions/system-configurable-configmap.yaml
+++ b/application/src/main/resources/extensions/system-configurable-configmap.yaml
@@ -9,11 +9,7 @@ data:
       "mustVerifyEmailOnRegistration": false,
       "defaultRole": "guest",
       "avatarPolicy": "default-policy",
-      "ucAttachmentPolicy": "default-policy",
-      "requiredAgreementPages": [
-        "user-agreement",
-        "privacy-policy"
-      ]
+      "ucAttachmentPolicy": "default-policy"
     }
   attachment: |
     {


### PR DESCRIPTION
#### What type of PR is this?

- [ ] Feature
- [x] Bug fix
- [ ] Improvement
- [ ] Cleanup
- [ ] Documentation

#### What this PR does / why we need it:

This PR removes the default `requiredAgreementPages` values from the system default ConfigMap.

Agreement pages can still be selected in System Settings, but fresh installations and upgraded instances no longer require signup agreement consent unless an administrator explicitly configures the required agreement pages.

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

This fixes the case where registration can require agreement consent even when the administrator has not configured required agreement pages.

LLM-assisted coding was used for investigation and implementation; the generated change was reviewed and verified.

#### Does this PR introduce a user-facing change?

```release-note
修复 2.25.0-beta.1 中注册页面可能因为没有配置协议导致无法提交的问题
```
