### PR TITLE
fix: add path traversal check in backup download (GHSA-h8wj-chr2-hf66)

### DIFF
--- a/application/src/main/java/run/halo/app/migration/impl/MigrationServiceImpl.java
+++ b/application/src/main/java/run/halo/app/migration/impl/MigrationServiceImpl.java
@@ -132,7 +132,9 @@ class MigrationServiceImpl implements MigrationService, InitializingBean {
                 sink.error(new ServerWebInputException("Current backup is not downloadable."));
                 return;
             }
-            var backupFile = getBackupsRoot().resolve(status.getFilename());
+            var backupsRoot = getBackupsRoot();
+            var backupFile = backupsRoot.resolve(status.getFilename());
+            checkDirectoryTraversal(backupsRoot, backupFile);
             var resource = new FileSystemResource(backupFile);
             if (!resource.exists()) {
                 sink.error(new NotFoundException(


### PR DESCRIPTION
## Summary

A path traversal vulnerability in the backup download endpoint allows authenticated administrators to read arbitrary files from the server filesystem.

## Severity

**Medium** — CVSS 5.5

CVSS:3.1/AV:N/AC:L/PR:H/UI:N/S:U/C:H/I:N/A:L

## Affected Versions

Halo versions <= 2.24.2

## Patched Versions

>= 2.24.3 (upcoming)

## Description

The backup download endpoint (`GET /apis/console.api.migration.halo.run/v1alpha1/backups/{name}/files/{filename}`) in `MigrationServiceImpl.download()` resolves the backup filename via `Path.resolve()` without validating that the resolved path stays within the designated backups directory.

Combined with the fact that the Backup creation endpoint (`POST /apis/migration.halo.run/v1alpha1/backups`) does not sanitize the `status` fields during creation, an authenticated administrator can:

1. Create a Backup resource with `status.phase=SUCCEEDED` and `status.filename=../../../etc/passwd`
2. The BackupReconciler skips `SUCCEEDED` backups, preserving the malicious filename
3. Download the backup to trigger path traversal and read arbitrary files

The `checkDirectoryTraversal()` utility exists in `FileUtils.java` and is already used in `cleanup()` and `getBackupFile()` methods of the same class — the omission in `download()` is an oversight.

## Impact

An attacker with administrator privileges can read arbitrary files accessible to the Halo server process, potentially exposing configuration files, credentials, or other sensitive data. No file modification or code execution occurs.

## Acknowledgements

Reported by @h311ow0rld via GitHub issue #10064.

## References

- [Issue #10064](https://github.com/halo-dev/halo/issues/10064)
- [CWE-22: Improper Limitation of a Pathname to a Restricted Directory](https://cwe.mitre.org/data/definitions/22.html)
