### PR TITLE
fix: add null check for remember-me checkbox in gateway fragments

### DIFF
--- a/application/src/main/resources/templates/gateway_fragments/common.html
+++ b/application/src/main/resources/templates/gateway_fragments/common.html
@@ -154,6 +154,10 @@
       const rememberMeCheckbox = document.getElementById("remember-me");
       const socialAuthProviders = document.querySelectorAll(".social-auth-provider-form");
 
+      if (!rememberMeCheckbox) {
+        return;
+      }
+
       rememberMeCheckbox.addEventListener("change", function (e) {
         const rememberMe = e.target.checked;
 


### PR DESCRIPTION
#### What type of PR is this?

- [x] Bug fix

#### What this PR does / why we need it:

Added a null check for the `rememberMeCheckbox` element before attaching the `change` event listener. This prevents a JavaScript error when the remember-me checkbox is not present in the DOM (e.g., on pages where the remember-me feature is not used).

#### Which issue(s) this PR fixes:

Fixes #

#### Special notes for your reviewer:

None.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```