### PR TITLE
Fix inaccessible pages by removing Vite experimental bundledDev option

### DIFF
--- a/ui/vite.config.ts
+++ b/ui/vite.config.ts
@@ -16,12 +16,8 @@ const DEV_SERVER_PORT = 3000;
 const __dirname = path.dirname(new URL(import.meta.url).pathname);
 const command = process.env.VP_COMMAND;
 const isBuild = command === "build";
-const isTest = command === "test";
 
 export default defineConfig({
-  experimental: {
-    bundledDev: !isTest,
-  },
   plugins: [
     Vue(),
     VueJsx(),


### PR DESCRIPTION
#### What type of PR is this?

- [ ] Feature
- [x] Bug fix
- [ ] Improvement
- [ ] Cleanup
- [ ] Documentation

#### What this PR does / why we need it:

Removes the `experimental.bundledDev` option from `ui/vite.config.ts` (along with the now-unused `isTest` variable).

When this option is enabled, some pages become inaccessible in development. Removing it restores normal page access.

#### Which issue(s) this PR fixes:

Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
