### PR TITLE
chore: bump UI package versions to 2.25.0

### DIFF
--- a/ui/packages/api-client/package.json
+++ b/ui/packages/api-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@halo-dev/api-client",
-  "version": "2.24.0",
+  "version": "2.25.0",
   "description": "API Client for Halo 2",
   "homepage": "https://github.com/halo-dev/halo/tree/main/ui/packages/api-client#readme",
   "bugs": {

--- a/ui/packages/components/package.json
+++ b/ui/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@halo-dev/components",
-  "version": "2.24.0",
+  "version": "2.25.0",
   "description": "",
   "keywords": [
     "@halo-dev/components",

--- a/ui/packages/editor/package.json
+++ b/ui/packages/editor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@halo-dev/richtext-editor",
-  "version": "2.24.0",
+  "version": "2.25.0",
   "description": "Default editor for Halo",
   "homepage": "https://github.com/halo-dev/halo/tree/main/ui/packages/editor#readme",
   "bugs": {

--- a/ui/packages/shared/package.json
+++ b/ui/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@halo-dev/ui-shared",
-  "version": "2.24.0",
+  "version": "2.25.0",
   "description": "",
   "keywords": [],
   "homepage": "https://github.com/halo-dev/halo/tree/main/ui/packages/shared#readme",

--- a/ui/packages/ui-plugin-bundler-kit/package.json
+++ b/ui/packages/ui-plugin-bundler-kit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@halo-dev/ui-plugin-bundler-kit",
-  "version": "2.24.0",
+  "version": "2.25.0",
   "homepage": "https://github.com/halo-dev/halo/tree/main/ui/packages/ui-plugin-bundler-kit#readme",
   "bugs": {
     "url": "https://github.com/halo-dev/halo/issues"


### PR DESCRIPTION
#### What type of PR is this?

- [x] Improvement

#### What this PR does / why we need it:

Bumps the version of the following UI packages from `2.24.0` to `2.25.0` to align with the upcoming release:

- `@halo-dev/api-client`
- `@halo-dev/components`
- `@halo-dev/richtext-editor`
- `@halo-dev/ui-shared`
- `@halo-dev/ui-plugin-bundler-kit`

#### Which issue(s) this PR fixes:

Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```