### PR TITLE
chore: upgrade Spring Boot to 4.1.0

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -40,7 +40,7 @@ apache = ['apache-commons-lang3', 'apache-tika-core']
 therapi = ['therapi-runtime-javadoc', 'therapi-runtime-javadoc-scribe']
 
 [plugins]
-spring-boot = 'org.springframework.boot:4.1.0-RC1'
+spring-boot = 'org.springframework.boot:4.1.0'
 spring-dependency-management = 'io.spring.dependency-management:1.1.7'
 git-properties = 'com.gorylenko.gradle-git-properties:2.5.2'
 undercouch-download = 'de.undercouch.download:5.6.0'


### PR DESCRIPTION
#### What type of PR is this?

/kind improvement

#### What this PR does / why we need it:

Upgrade Spring Boot from 4.1.0-RC1 to 4.1.0 GA release.

Spring Boot 4.1.0 was officially released. This upgrade brings the latest bug fixes and dependency upgrades including:
- MailSender auto-configuration hostname verification fix
- SSL bundle handling improvements
- Configuration property metadata fixes
- Various dependency upgrades (Micrometer 1.17.0, Jetty 12.1.10, Lettuce 7.5.2, etc.)

#### Which issue(s) this PR fixes:

Fixes #

#### Special notes for your reviewer:

None — straightforward version bump from RC1 to GA.

#### Does this PR introduce a user-facing change?

```release-note
Upgrade Spring Boot to 4.1.0
```
