### PR TITLE
Support auto-enable options for preset plugins

### DIFF
--- a/application/build.gradle
+++ b/application/build.gradle
@@ -1,4 +1,5 @@
 import de.undercouch.gradle.tasks.download.Download
+import groovy.json.JsonOutput
 import org.gradle.crypto.checksum.Checksum
 import org.springframework.boot.gradle.tasks.bundling.BootBuildImage
 import org.springframework.boot.gradle.tasks.bundling.BootJar
@@ -141,23 +142,60 @@ tasks.named('jacocoTestReport', JacocoReport) {
 }
 
 tasks.register('downloadPluginPresets', Download) {
-    def presetPluginUrls = [
-        'https://github.com/halo-dev/plugin-comment-widget/releases/download/v3.1.2/plugin-comment-widget-3.1.2.jar'               : 'plugin-comment-widget.jar',
-        'https://github.com/halo-dev/plugin-search-widget/releases/download/v1.7.1/plugin-search-widget-1.7.1.jar'                 : 'plugin-search-widget.jar',
-        'https://github.com/halo-dev/plugin-sitemap/releases/download/v1.3.0/plugin-sitemap-1.3.0.jar'                             : 'plugin-sitemap.jar',
-        'https://github.com/halo-dev/plugin-feed/releases/download/v1.5.0/plugin-feed-1.5.0.jar'                                   : 'plugin-feed.jar',
-        'https://github.com/halo-sigs/plugin-shiki/releases/download/v1.3.2/plugin-shiki-1.3.2.jar'                                : 'plugin-shiki.jar',
-        'https://github.com/halo-sigs/plugin-editor-hyperlink-card/releases/download/v1.9.1/plugin-editor-hyperlink-card-1.9.1.jar': 'plugin-editor-hyperlink-card.jar',
+    def presetPlugins = [
+        [
+            url       : 'https://github.com/halo-dev/plugin-comment-widget/releases/download/v3.1.2/plugin-comment-widget-3.1.2.jar',
+            filename  : 'plugin-comment-widget.jar',
+            autoEnable: true,
+        ],
+        [
+            url       : 'https://github.com/halo-dev/plugin-search-widget/releases/download/v1.7.1/plugin-search-widget-1.7.1.jar',
+            filename  : 'plugin-search-widget.jar',
+            autoEnable: true,
+        ],
+        [
+            url       : 'https://github.com/halo-dev/plugin-sitemap/releases/download/v1.3.0/plugin-sitemap-1.3.0.jar',
+            filename  : 'plugin-sitemap.jar',
+            autoEnable: true,
+        ],
+        [
+            url       : 'https://github.com/halo-dev/plugin-feed/releases/download/v1.5.0/plugin-feed-1.5.0.jar',
+            filename  : 'plugin-feed.jar',
+            autoEnable: true,
+        ],
+        [
+            url       : 'https://github.com/halo-sigs/plugin-shiki/releases/download/v1.3.2/plugin-shiki-1.3.2.jar',
+            filename  : 'plugin-shiki.jar',
+            autoEnable: true,
+        ],
+        [
+            url       : 'https://github.com/halo-sigs/plugin-editor-hyperlink-card/releases/download/v1.9.1/plugin-editor-hyperlink-card-1.9.1.jar',
+            filename  : 'plugin-editor-hyperlink-card.jar',
+            autoEnable: true,
+        ],
 
         // Currently, plugin-app-store is not open source, so we need to download it from the official website.
         // Please see https://github.com/halo-dev/plugin-app-store/issues/55
         // https://www.halo.run/store/apps/app-VYJbF/releases/app-release-qafgml3o
-        'https://www.halo.run/store/apps/app-VYJbF/releases/download/app-release-qafgml3o/assets/app-release-qafgml3o-wt4v7err'    : 'appstore.jar',
+        [
+            url       : 'https://www.halo.run/store/apps/app-VYJbF/releases/download/app-release-qafgml3o/assets/app-release-qafgml3o-wt4v7err',
+            filename  : 'appstore.jar',
+            autoEnable: false,
+        ],
     ]
-    src presetPluginUrls.keySet()
-    dest layout.buildDirectory.dir('resources/main/presets/plugins')
+    def presetPluginUrls = presetPlugins.collectEntries { [it.url, it.filename] }
+    def presetPluginsDest = layout.buildDirectory.dir('resources/main/presets/plugins')
+    src presetPlugins*.url
+    dest presetPluginsDest
     eachFile { f ->
         f.name = presetPluginUrls[f.sourceURL.toString()]
+    }
+    doLast {
+        def presetOptions = presetPlugins.collectEntries {
+            [(it.filename): [autoEnable: it.autoEnable]]
+        }
+        presetPluginsDest.get().file('presets.json').asFile.text =
+            JsonOutput.prettyPrint(JsonOutput.toJson(presetOptions))
     }
 }
 

--- a/application/src/main/java/run/halo/app/plugin/PluginServiceImpl.java
+++ b/application/src/main/java/run/halo/app/plugin/PluginServiceImpl.java
@@ -6,9 +6,11 @@ import static java.nio.file.StandardOpenOption.TRUNCATE_EXISTING;
 import static org.pf4j.PluginState.STARTED;
 import static run.halo.app.plugin.PluginConst.RELOAD_ANNO;
 
+import com.fasterxml.jackson.core.type.TypeReference;
 import com.github.zafarkhaja.semver.Version;
 import com.google.common.hash.HashCode;
 import com.google.common.hash.Hashing;
+import io.swagger.v3.core.util.Json;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
@@ -19,6 +21,7 @@ import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Predicate;
@@ -71,6 +74,7 @@ public class PluginServiceImpl implements PluginService, InitializingBean, Dispo
 
     private static final String PRESET_LOCATION_PREFIX = "classpath:/presets/plugins/";
     private static final String PRESETS_LOCATION_PATTERN = PRESET_LOCATION_PREFIX + "*.jar";
+    private static final String PRESET_OPTIONS_LOCATION = PRESET_LOCATION_PREFIX + "presets.json";
 
     private final ReactiveExtensionClient client;
 
@@ -116,11 +120,12 @@ public class PluginServiceImpl implements PluginService, InitializingBean, Dispo
 
     @Override
     public Mono<Void> installPresetPlugins() {
-        return getPresetJars()
-                .flatMap(path -> this.install(path)
+        return getPresetPlugins()
+                .flatMap(preset -> this.install(preset.path())
                         .onErrorResume(PluginAlreadyExistsException.class, e -> Mono.empty())
-                        .flatMap(plugin -> FileUtils.deleteFileSilently(path).thenReturn(plugin)))
-                .flatMap(this::enablePlugin)
+                        .flatMap(plugin ->
+                                FileUtils.deleteFileSilently(preset.path()).thenReturn(plugin))
+                        .flatMap(plugin -> preset.autoEnable() ? enablePlugin(plugin) : Mono.just(plugin)))
                 .subscribeOn(Schedulers.boundedElastic())
                 .then();
     }
@@ -488,9 +493,10 @@ public class PluginServiceImpl implements PluginService, InitializingBean, Dispo
         }
     }
 
-    private Flux<Path> getPresetJars() {
+    private Flux<PresetPlugin> getPresetPlugins() {
         var resolver = new PathMatchingResourcePatternResolver();
         try {
+            var presetPluginOptions = loadPresetPluginOptions(resolver);
             var resources = resolver.getResources(PRESETS_LOCATION_PATTERN);
             return Flux.fromArray(resources).mapNotNull(resource -> {
                 var filename = resource.getFilename();
@@ -499,11 +505,34 @@ public class PluginServiceImpl implements PluginService, InitializingBean, Dispo
                 }
                 var path = tempDir.resolve(filename);
                 FileUtils.copyResource(resource, path);
-                return path;
+                return new PresetPlugin(
+                        path,
+                        presetPluginOptions
+                                .getOrDefault(filename, new PresetPluginOptions(null))
+                                .autoEnableOrDefault());
             });
         } catch (IOException e) {
             log.debug("Failed to load preset plugins: {}", e.getMessage());
             return Flux.empty();
+        }
+    }
+
+    private Map<String, PresetPluginOptions> loadPresetPluginOptions(PathMatchingResourcePatternResolver resolver)
+            throws IOException {
+        var resource = resolver.getResource(PRESET_OPTIONS_LOCATION);
+        if (!resource.exists()) {
+            return Map.of();
+        }
+        var json = resource.getContentAsString(StandardCharsets.UTF_8);
+        return Json.mapper().readValue(json, new TypeReference<>() {});
+    }
+
+    private record PresetPlugin(Path path, boolean autoEnable) {}
+
+    private record PresetPluginOptions(Boolean autoEnable) {
+
+        boolean autoEnableOrDefault() {
+            return autoEnable == null || autoEnable;
         }
     }
 

--- a/application/src/test/java/run/halo/app/plugin/PluginServiceImplTest.java
+++ b/application/src/test/java/run/halo/app/plugin/PluginServiceImplTest.java
@@ -36,12 +36,14 @@ import java.util.concurrent.Future;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.RepeatedTest;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.io.TempDir;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Spy;
@@ -302,6 +304,67 @@ class PluginServiceImplTest {
                 .as(StepVerifier::create)
                 .expectNext("plugin-1", "plugin-2")
                 .verifyComplete();
+    }
+
+    @Nested
+    class PresetPluginInstallTest {
+
+        @TempDir
+        Path tempDir;
+
+        Path presetOptionsPath;
+
+        @BeforeEach
+        void setUp() throws IOException, URISyntaxException {
+            presetOptionsPath = Paths.get(ResourceUtils.getURL("classpath:presets/plugins/fake-plugin.jar")
+                            .toURI())
+                    .getParent()
+                    .resolve("presets.json");
+            pluginService.setTempDir(tempDir);
+            lenient().when(systemVersionSupplier.get()).thenReturn(Version.parse("2.0.0"));
+            lenient().when(pluginsRootGetter.get()).thenReturn(tempDir.resolve("plugins"));
+        }
+
+        @AfterEach
+        void tearDown() throws IOException {
+            Files.deleteIfExists(presetOptionsPath);
+        }
+
+        @Test
+        void shouldAutoEnablePresetPluginByDefault() {
+            when(client.fetch(Plugin.class, "fake-plugin")).thenReturn(Mono.empty());
+            when(client.create(isA(Plugin.class)))
+                    .thenAnswer(invocation -> Mono.just(invocation.getArgument(0, Plugin.class)));
+            when(client.update(isA(Plugin.class)))
+                    .thenAnswer(invocation -> Mono.just(invocation.getArgument(0, Plugin.class)));
+
+            pluginService.installPresetPlugins().as(StepVerifier::create).verifyComplete();
+
+            var captor = ArgumentCaptor.forClass(Plugin.class);
+            verify(client).update(captor.capture());
+            assertTrue(captor.getValue().getSpec().getEnabled());
+        }
+
+        @Test
+        void shouldInstallPresetPluginWithoutAutoEnable() throws IOException {
+            Files.writeString(presetOptionsPath, """
+                    {
+                      "fake-plugin.jar": {
+                        "autoEnable": false
+                      }
+                    }
+                    """);
+            when(client.fetch(Plugin.class, "fake-plugin")).thenReturn(Mono.empty());
+            when(client.create(isA(Plugin.class)))
+                    .thenAnswer(invocation -> Mono.just(invocation.getArgument(0, Plugin.class)));
+
+            pluginService.installPresetPlugins().as(StepVerifier::create).verifyComplete();
+
+            var captor = ArgumentCaptor.forClass(Plugin.class);
+            verify(client).create(captor.capture());
+            verify(client, never()).update(isA(Plugin.class));
+            assertFalse(captor.getValue().getSpec().getEnabled());
+        }
     }
 
     @Test


### PR DESCRIPTION
#### What type of PR is this?

- [ ] Feature
- [ ] Bug fix
- [x] Improvement
- [ ] Cleanup
- [ ] Documentation

#### What this PR does / why we need it:

This PR lets preset plugin packaging declare whether each preset plugin should be enabled automatically after first-time system setup.

The preset download task now writes a `presets/plugins/presets.json` file alongside the downloaded JARs. During setup, Halo reads that metadata by JAR filename and keeps the existing default behavior of auto-enabling preset plugins unless `autoEnable` is explicitly set to `false`.

This avoids hard-coding individual plugin names in runtime code while allowing preset plugins such as the app store to be installed but left disabled.

#### Which issue(s) this PR fixes:

Fixes #

#### Special notes for your reviewer:

- Missing `presets.json` or missing entries default to `autoEnable: true` for backward compatibility.
- `appstore.jar` is configured with `autoEnable: false`; other current preset plugins remain auto-enabled.
- AI-assisted code generation was used, and the changes were reviewed before submission.

#### Does this PR introduce a user-facing change?

```release-note
Preset plugins can now be packaged to install without being automatically enabled during system setup.
```
