### PR TITLE
Restore App Store preset auto-enable

### DIFF
--- a/application/build.gradle
+++ b/application/build.gradle
@@ -180,7 +180,7 @@ tasks.register('downloadPluginPresets', Download) {
         [
             url       : 'https://www.halo.run/store/apps/app-VYJbF/releases/download/app-release-qafgml3o/assets/app-release-qafgml3o-wt4v7err',
             filename  : 'appstore.jar',
-            autoEnable: false,
+            autoEnable: true,
         ],
     ]
     def presetPluginUrls = presetPlugins.collectEntries { [it.url, it.filename] }


### PR DESCRIPTION
#### What type of PR is this?

- [ ] Feature
- [x] Bug fix
- [ ] Improvement
- [ ] Cleanup
- [ ] Documentation

#### What this PR does / why we need it:

This restores `autoEnable: true` for the bundled App Store preset plugin.

PR #10074 added per-preset auto-enable options, but it accidentally set the App Store preset plugin to `autoEnable: false`. That prevents the App Store plugin from being enabled automatically with the rest of the preset plugins.

#### Which issue(s) this PR fixes:

Refs #10074

#### Special notes for your reviewer:

Validation:

- `./gradlew :application:compileJava`

AI assistance: Used Codex to inspect the diff, run validation, and prepare this PR.

#### Does this PR introduce a user-facing change?

```release-note
None
```
