### PR TITLE
Sync FormKit core version in UI shared package

### DIFF
--- a/ui/packages/shared/package.json
+++ b/ui/packages/shared/package.json
@@ -48,7 +48,7 @@
     "vue-router": "^5.0.x"
   },
   "inlinedDependencies": {
-    "@formkit/core": "1.7.2",
+    "@formkit/core": "2.1.0",
     "dayjs": "1.11.19",
     "mitt": "3.0.1",
     "uuid": "13.0.0"


### PR DESCRIPTION
#### What type of PR is this?

- [ ] Feature
- [ ] Bug fix
- [x] Improvement
- [ ] Cleanup
- [ ] Documentation

#### What this PR does / why we need it:

Updates the `@halo-dev/ui-shared` inlined `@formkit/core` dependency to `2.1.0` so the shared package stays aligned with the FormKit upgrade from #10075.

#### Which issue(s) this PR fixes:

N/A

#### Special notes for your reviewer:

This only syncs the inlined dependency metadata. The root UI package and lockfile already resolve FormKit packages to `2.1.0`.

AI-assisted contribution: prepared with Codex and reviewed before submission.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
