### PR TITLE
Bump UI package versions to 2.25.1

### DIFF
--- a/ui/packages/api-client/package.json
+++ b/ui/packages/api-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@halo-dev/api-client",
-  "version": "2.25.0",
+  "version": "2.25.1",
   "description": "API Client for Halo 2",
   "homepage": "https://github.com/halo-dev/halo/tree/main/ui/packages/api-client#readme",
   "bugs": {

--- a/ui/packages/components/package.json
+++ b/ui/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@halo-dev/components",
-  "version": "2.25.0",
+  "version": "2.25.1",
   "description": "",
   "keywords": [
     "@halo-dev/components",

--- a/ui/packages/editor/package.json
+++ b/ui/packages/editor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@halo-dev/richtext-editor",
-  "version": "2.25.0",
+  "version": "2.25.1",
   "description": "Default editor for Halo",
   "homepage": "https://github.com/halo-dev/halo/tree/main/ui/packages/editor#readme",
   "bugs": {

--- a/ui/packages/shared/package.json
+++ b/ui/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@halo-dev/ui-shared",
-  "version": "2.25.0",
+  "version": "2.25.1",
   "description": "",
   "keywords": [],
   "homepage": "https://github.com/halo-dev/halo/tree/main/ui/packages/shared#readme",

--- a/ui/packages/ui-plugin-bundler-kit/package.json
+++ b/ui/packages/ui-plugin-bundler-kit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@halo-dev/ui-plugin-bundler-kit",
-  "version": "2.25.0",
+  "version": "2.25.1",
   "homepage": "https://github.com/halo-dev/halo/tree/main/ui/packages/ui-plugin-bundler-kit#readme",
   "bugs": {
     "url": "https://github.com/halo-dev/halo/issues"


### PR DESCRIPTION
#### What type of PR is this?

- [ ] Feature
- [ ] Bug fix
- [ ] Improvement
- [x] Cleanup
- [ ] Documentation

#### What this PR does / why we need it:

Bumps the published UI workspace package versions from `2.25.0` to `2.25.1`:

- `@halo-dev/api-client`
- `@halo-dev/components`
- `@halo-dev/richtext-editor`
- `@halo-dev/ui-shared`
- `@halo-dev/ui-plugin-bundler-kit`

This prepares the package metadata for the `2.25.1` patch release.

The patch release is needed because https://github.com/halo-dev/halo/pull/9990 changed the UI package publishing flow to batch publish packages with npm (`npm publish -ws`). After that change, some package workspace dependency versions were not replaced correctly during publishing. Publishing `2.25.1` lets us republish the affected packages with corrected package metadata.

#### Which issue(s) this PR fixes:

None.

#### Special notes for your reviewer:

Created with Codex assistance and reviewed before submission.

Validation:

- `node -e "const fs=require('fs'); for (const f of process.argv.slice(1)) JSON.parse(fs.readFileSync(f,'utf8')); console.log('package.json files are valid JSON')" ui/packages/api-client/package.json ui/packages/components/package.json ui/packages/editor/package.json ui/packages/shared/package.json ui/packages/ui-plugin-bundler-kit/package.json`
- `corepack pnpm@10.30.3 -C ui build:packages`
- `corepack pnpm@10.30.3 -C ui typecheck`
- `corepack pnpm@10.30.3 -C ui lint`

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
