### PR TITLE
Fix UI package publish workflow

### DIFF
--- a/.github/workflows/release-ui-packages.yaml
+++ b/.github/workflows/release-ui-packages.yaml
@@ -21,4 +21,4 @@ jobs:
         uses: ./.github/actions/setup-env
       - run: ./gradlew pnpmInstall
       - name: Publish to NPM
-        run: cd ui && pnpm build:packages && pnpm run publish:packages
+        run: cd ui && pnpm build:packages && pnpm -r publish --access public --no-git-checks

--- a/ui/package.json
+++ b/ui/package.json
@@ -15,8 +15,7 @@
     "typecheck": "vue-tsc --noEmit -p tsconfig.app.json --composite false && vp run --parallel --filter @halo-dev/* typecheck",
     "lint": "eslint . --max-warnings=0 -f html -o build/lint-result/index.html",
     "format": "vp fmt",
-    "format:check": "vp fmt --check",
-    "publish:packages": "npm publish -ws --access public"
+    "format:check": "vp fmt --check"
   },
   "dependencies": {
     "@ckpack/vue-color": "^1.6.0",


### PR DESCRIPTION
#### What type of PR is this?

- [ ] Feature
- [x] Bug fix
- [ ] Improvement
- [ ] Cleanup
- [ ] Documentation

#### What this PR does / why we need it:

Updates the UI package release workflow to publish workspace packages with pnpm directly:

- Runs `pnpm -r publish --access public --no-git-checks` in `.github/workflows/release-ui-packages.yaml`
- Removes the root `publish:packages` script that used `npm publish -ws`

This is a follow-up to https://github.com/halo-dev/halo/pull/9990, which changed the UI package publishing flow to batch publish packages with npm. That caused some workspace dependency versions to not be replaced correctly during publishing. Restoring pnpm recursive publishing keeps the release workflow aligned with pnpm workspace package metadata handling.

#### Which issue(s) this PR fixes:

None.

#### Special notes for your reviewer:

AI-assisted and reviewed before submission.

Validation:

- `node -e "JSON.parse(require('fs').readFileSync('ui/package.json','utf8')); console.log('ui/package.json is valid JSON')"`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/release-ui-packages.yaml"); puts "release-ui-packages.yaml is valid YAML"'`
- `corepack pnpm@10.30.3 -C ui format:check`

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
