### PR TITLE
Fix sticky action bar shadow updates

### DIFF
--- a/ui/src/components/sticky-block/StickyBlock.vue
+++ b/ui/src/components/sticky-block/StickyBlock.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
-import { useEventListener } from "@vueuse/core";
-import { onMounted, ref } from "vue";
+import { useEventListener, useResizeObserver } from "@vueuse/core";
+import { computed, onMounted, ref, shallowRef } from "vue";
 
 const props = withDefaults(
   defineProps<{
@@ -12,7 +12,8 @@ const props = withDefaults(
 );
 
 const stickyBlock = ref<HTMLElement | null>(null);
-const isSticky = ref(false);
+const resizeTarget = computed(() => stickyBlock.value?.parentElement);
+const isSticky = shallowRef(false);
 
 function computeSticky() {
   if (!stickyBlock.value) return;
@@ -30,6 +31,8 @@ onMounted(() => {
 });
 
 useEventListener("scroll", computeSticky);
+useEventListener("resize", computeSticky);
+useResizeObserver(resizeTarget, computeSticky);
 </script>
 
 <template>

--- a/ui/src/components/sticky-block/__tests__/StickyBlock.spec.ts
+++ b/ui/src/components/sticky-block/__tests__/StickyBlock.spec.ts
@@ -1,0 +1,113 @@
+import { mount } from "@vue/test-utils";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { nextTick } from "vue";
+import StickyBlock from "../StickyBlock.vue";
+
+let rectBottom = 0;
+const originalInnerHeight = window.innerHeight;
+const resizeObservers: ResizeObserverMock[] = [];
+
+class ResizeObserverMock {
+  readonly observedElements = new Set<Element>();
+
+  constructor(readonly callback: ResizeObserverCallback) {
+    resizeObservers.push(this);
+  }
+
+  observe(target: Element) {
+    this.observedElements.add(target);
+  }
+
+  unobserve(target: Element) {
+    this.observedElements.delete(target);
+  }
+
+  disconnect() {
+    this.observedElements.clear();
+  }
+
+  trigger() {
+    this.callback([], this as unknown as ResizeObserver);
+  }
+}
+
+describe("StickyBlock", () => {
+  beforeEach(() => {
+    rectBottom = 900;
+    resizeObservers.length = 0;
+
+    vi.stubGlobal("ResizeObserver", ResizeObserverMock);
+    Object.defineProperty(window, "innerHeight", {
+      configurable: true,
+      value: 800,
+    });
+    vi.spyOn(HTMLElement.prototype, "getBoundingClientRect").mockImplementation(
+      () => ({
+        bottom: rectBottom,
+        height: 0,
+        left: 0,
+        right: 0,
+        top: 0,
+        width: 0,
+        x: 0,
+        y: 0,
+        toJSON: () => ({}),
+      })
+    );
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+    Object.defineProperty(window, "innerHeight", {
+      configurable: true,
+      value: originalInnerHeight,
+    });
+  });
+
+  it("recomputes the bottom shadow when the viewport resizes", async () => {
+    const wrapper = mount(StickyBlock, {
+      props: {
+        position: "bottom",
+      },
+      slots: {
+        default: "Save",
+      },
+    });
+    await nextTick();
+
+    expect(wrapper.classes()).toContain("sticky-shadow");
+
+    rectBottom = 700;
+    window.dispatchEvent(new Event("resize"));
+    await nextTick();
+
+    expect(wrapper.classes()).not.toContain("sticky-shadow");
+  });
+
+  it("recomputes the bottom shadow when the parent layout changes", async () => {
+    const wrapper = mount({
+      components: {
+        StickyBlock,
+      },
+      template: `<div><StickyBlock position="bottom">Save</StickyBlock></div>`,
+    });
+    await nextTick();
+    await nextTick();
+
+    const stickyBlock = wrapper.findComponent(StickyBlock);
+    expect(stickyBlock.classes()).toContain("sticky-shadow");
+
+    const parentElement = stickyBlock.element.parentElement;
+    const parentObserver = resizeObservers.find((observer) => {
+      return parentElement && observer.observedElements.has(parentElement);
+    });
+    expect(parentObserver).toBeDefined();
+
+    rectBottom = 700;
+    parentObserver?.trigger();
+    await nextTick();
+
+    expect(stickyBlock.classes()).not.toContain("sticky-shadow");
+  });
+});


### PR DESCRIPTION
#### What type of PR is this?

- [ ] Feature
- [x] Bug fix
- [ ] Improvement
- [ ] Cleanup
- [ ] Documentation

#### What this PR does / why we need it:

This updates the shared `StickyBlock` component so its sticky shadow is recomputed when the viewport size changes or when its parent layout changes.

Theme setting pages can change from scrollable to non-scrollable after tab switches or window resize, so the save action bar should not keep stale shadow state.

#### Which issue(s) this PR fixes:

Fixes #10083
Fixes #10084

#### Special notes for your reviewer:

AI-assisted change, reviewed and validated locally.

Validation:
- `corepack pnpm@10.30.3 -C ui exec vp test --run src/components/sticky-block/__tests__/StickyBlock.spec.ts`
- `corepack pnpm@10.30.3 -C ui typecheck`
- `corepack pnpm@10.30.3 -C ui lint`
- Manual verification at `http://127.0.0.1:8090/console/theme/settings/layout` with viewport resize and tab switching.

#### Does this PR introduce a user-facing change?

```release-note
修复主题、插件、系统设置表单底部悬浮条阴影可能出现不正常消除的问题
```
