### PR TITLE
Fix Windows Vite config path resolution

### DIFF
--- a/ui/vite.config.ts
+++ b/ui/vite.config.ts
@@ -13,7 +13,7 @@ import { devPlugin } from "./src/vite/plugin-dev.ts";
 
 const DEV_SERVER_PORT = 3000;
 
-const __dirname = path.dirname(new URL(import.meta.url).pathname);
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const command = process.env.VP_COMMAND;
 const isBuild = command === "build";
 


### PR DESCRIPTION
#### What type of PR is this?

- [ ] Feature
- [x] Bug fix
- [ ] Improvement
- [ ] Cleanup
- [ ] Documentation

#### What this PR does / why we need it:

This PR fixes the UI Vite config path resolution on Windows by converting `import.meta.url` with `fileURLToPath` instead of reading `URL.pathname` directly.

On Windows, `URL.pathname` can produce paths such as `/E:/Project%20Files/...`, which keeps URL escaping and adds an invalid leading slash before the drive letter. That breaks Vite alias resolution for paths like `@console/modules` when running the UI dev server from a directory containing spaces.

#### Which issue(s) this PR fixes:

Fixes #10085

#### Special notes for your reviewer:

This change was prepared with AI assistance and reviewed locally.

Validation performed:

- `corepack pnpm@10.30.3 -C ui format:check`
- `corepack pnpm@10.30.3 -C ui typecheck`
- `corepack pnpm@10.30.3 -C ui lint`
- `corepack pnpm@10.30.3 -C ui build`
- `git diff --check`

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
