### PR TITLE
Update App Store preset download URL

### DIFF
--- a/application/build.gradle
+++ b/application/build.gradle
@@ -178,7 +178,7 @@ tasks.register('downloadPluginPresets', Download) {
         // Please see https://github.com/halo-dev/plugin-app-store/issues/55
         // https://www.halo.run/store/apps/app-VYJbF/releases/app-release-qafgml3o
         [
-            url       : 'https://www.halo.run/store/apps/app-VYJbF/releases/download/app-release-qafgml3o/assets/app-release-qafgml3o-wt4v7err',
+            url       : 'https://www.halo.run/store/apps/app-VYJbF/releases/download/app-release-1tbawcta/assets/app-release-1tbawcta-gkb19umt',
             filename  : 'appstore.jar',
             autoEnable: true,
         ],


### PR DESCRIPTION
#### What type of PR is this?

- [ ] Feature
- [ ] Bug fix
- [x] Improvement
- [ ] Cleanup
- [ ] Documentation

#### What this PR does / why we need it:

Updates the bundled App Store preset plugin download URL to the current Halo Store release asset.

This keeps the `downloadPluginPresets` Gradle task using an available App Store plugin asset when assembling the application presets.

#### Which issue(s) this PR fixes:

N/A

#### Special notes for your reviewer:

Validated with:

- `git diff --check`
- `./gradlew :application:downloadPluginPresets --rerun-tasks`

AI assistance was used to prepare this PR, and the resulting change was reviewed before submission.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
