### PR TITLE
Expose plugin scheduled tasks in actuator

### DIFF
--- a/application/src/main/java/run/halo/app/plugin/PluginAutoConfiguration.java
+++ b/application/src/main/java/run/halo/app/plugin/PluginAutoConfiguration.java
@@ -17,6 +17,7 @@ import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.CacheControl;
+import org.springframework.scheduling.config.ScheduledTaskHolder;
 import org.springframework.web.reactive.accept.RequestedContentTypeResolver;
 import org.springframework.web.reactive.function.BodyInserters;
 import org.springframework.web.reactive.function.server.RouterFunction;
@@ -54,6 +55,11 @@ public class PluginAutoConfiguration {
             PluginsRootGetter pluginsRootGetter)
             throws FileNotFoundException, URISyntaxException {
         return new HaloPluginManager(context, pluginProperties, systemVersionSupplier, pluginsRootGetter);
+    }
+
+    @Bean
+    public ScheduledTaskHolder pluginScheduledTaskHolder(SpringPluginManager pluginManager) {
+        return new PluginScheduledTaskHolder(pluginManager);
     }
 
     @Bean

--- a/application/src/main/java/run/halo/app/plugin/PluginScheduledTaskHolder.java
+++ b/application/src/main/java/run/halo/app/plugin/PluginScheduledTaskHolder.java
@@ -1,0 +1,42 @@
+package run.halo.app.plugin;
+
+import java.util.LinkedHashSet;
+import java.util.Set;
+import org.pf4j.PluginWrapper;
+import org.springframework.scheduling.config.ScheduledTask;
+import org.springframework.scheduling.config.ScheduledTaskHolder;
+
+/** Exposes scheduled tasks from started plugins to Spring Boot Actuator. */
+final class PluginScheduledTaskHolder implements ScheduledTaskHolder {
+
+    private final SpringPluginManager pluginManager;
+
+    PluginScheduledTaskHolder(SpringPluginManager pluginManager) {
+        this.pluginManager = pluginManager;
+    }
+
+    @Override
+    public Set<ScheduledTask> getScheduledTasks() {
+        var scheduledTasks = new LinkedHashSet<ScheduledTask>();
+        for (PluginWrapper pluginWrapper : pluginManager.startedPlugins()) {
+            if (pluginWrapper.getPlugin() instanceof SpringPlugin springPlugin) {
+                scheduledTasks.addAll(getScheduledTasks(springPlugin));
+            }
+        }
+        return scheduledTasks;
+    }
+
+    private Set<ScheduledTask> getScheduledTasks(SpringPlugin springPlugin) {
+        try {
+            var scheduledTasks = new LinkedHashSet<ScheduledTask>();
+            springPlugin
+                    .getApplicationContext()
+                    .getBeansOfType(ScheduledTaskHolder.class, false, false)
+                    .values()
+                    .forEach(holder -> scheduledTasks.addAll(holder.getScheduledTasks()));
+            return scheduledTasks;
+        } catch (IllegalStateException e) {
+            return Set.of();
+        }
+    }
+}

--- a/application/src/test/java/run/halo/app/plugin/PluginScheduledTaskHolderTest.java
+++ b/application/src/test/java/run/halo/app/plugin/PluginScheduledTaskHolderTest.java
@@ -1,0 +1,88 @@
+package run.halo.app.plugin;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.withSettings;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.pf4j.Plugin;
+import org.pf4j.PluginWrapper;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+import org.springframework.scheduling.config.FixedRateTask;
+import org.springframework.scheduling.config.ScheduledTask;
+import org.springframework.scheduling.config.ScheduledTaskHolder;
+import org.springframework.scheduling.config.ScheduledTaskRegistrar;
+
+@ExtendWith(MockitoExtension.class)
+class PluginScheduledTaskHolderTest {
+
+    @Mock
+    SpringPluginManager pluginManager;
+
+    @Test
+    void shouldExposeScheduledTasksFromStartedSpringPlugins() {
+        var task1 = scheduledTask();
+        var task2 = scheduledTask();
+        var context = new AnnotationConfigApplicationContext();
+        try {
+            context.registerBean("holder1", ScheduledTaskHolder.class, () -> () -> Set.of(task1));
+            context.registerBean("holder2", ScheduledTaskHolder.class, () -> () -> Set.of(task2));
+            context.refresh();
+            var plugin = springPlugin(context);
+            var pluginWrapper = pluginWrapper(plugin);
+            when(pluginManager.startedPlugins()).thenReturn(List.of(pluginWrapper));
+
+            var holder = new PluginScheduledTaskHolder(pluginManager);
+
+            assertThat(holder.getScheduledTasks()).containsExactly(task1, task2);
+        } finally {
+            context.close();
+        }
+    }
+
+    @Test
+    void shouldIgnoreNonSpringPlugins() {
+        var pluginWrapper = pluginWrapper(mock(Plugin.class));
+        when(pluginManager.startedPlugins()).thenReturn(List.of(pluginWrapper));
+
+        var holder = new PluginScheduledTaskHolder(pluginManager);
+
+        assertThat(holder.getScheduledTasks()).isEmpty();
+    }
+
+    @Test
+    void shouldIgnoreUnavailablePluginApplicationContext() {
+        var plugin = mock(Plugin.class, withSettings().extraInterfaces(SpringPlugin.class));
+        when(((SpringPlugin) plugin).getApplicationContext()).thenThrow(IllegalStateException.class);
+        var pluginWrapper = pluginWrapper(plugin);
+        when(pluginManager.startedPlugins()).thenReturn(List.of(pluginWrapper));
+
+        var holder = new PluginScheduledTaskHolder(pluginManager);
+
+        assertThat(holder.getScheduledTasks()).isEmpty();
+    }
+
+    private static ScheduledTask scheduledTask() {
+        var registrar = new ScheduledTaskRegistrar();
+        return registrar.scheduleFixedRateTask(new FixedRateTask(() -> {}, Duration.ofSeconds(1), Duration.ZERO));
+    }
+
+    private static Plugin springPlugin(AnnotationConfigApplicationContext context) {
+        var plugin = mock(Plugin.class, withSettings().extraInterfaces(SpringPlugin.class));
+        when(((SpringPlugin) plugin).getApplicationContext()).thenReturn(context);
+        return plugin;
+    }
+
+    private static PluginWrapper pluginWrapper(Plugin plugin) {
+        var pluginWrapper = mock(PluginWrapper.class);
+        when(pluginWrapper.getPlugin()).thenReturn(plugin);
+        return pluginWrapper;
+    }
+}


### PR DESCRIPTION
#### What type of PR is this?

- [ ] Feature
- [ ] Bug fix
- [x] Improvement
- [ ] Cleanup
- [ ] Documentation

#### What this PR does / why we need it:

This PR exposes scheduled tasks registered by started Spring plugins through Spring Boot Actuator's `/actuator/scheduledtasks` endpoint.

Previously, plugin-provided scheduled tasks could run inside each plugin `ApplicationContext`, but the Actuator endpoint only received `ScheduledTaskHolder` beans from the root application context. As a result, users had no built-in way to inspect which scheduled tasks were currently provided by plugins.

The change adds a root-context `ScheduledTaskHolder` that dynamically gathers scheduled tasks from started Spring plugin contexts when Actuator reads the endpoint.

#### Which issue(s) this PR fixes:

N/A

#### Special notes for your reviewer:

This PR was implemented with Codex assistance and reviewed before submission.

Validation performed:

- `./gradlew :application:spotlessApply`
- `./gradlew :application:test --tests "*PluginScheduledTaskHolderTest"`
- `git diff --check`

#### Does this PR introduce a user-facing change?

```release-note
Users can now inspect plugin-provided scheduled tasks through the `/actuator/scheduledtasks` endpoint.
```
