### PR TITLE
Bump UI package versions to 2.25.2

### DIFF
--- a/ui/packages/api-client/package.json
+++ b/ui/packages/api-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@halo-dev/api-client",
-  "version": "2.25.1",
+  "version": "2.25.2",
   "description": "API Client for Halo 2",
   "homepage": "https://github.com/halo-dev/halo/tree/main/ui/packages/api-client#readme",
   "bugs": {

--- a/ui/packages/components/package.json
+++ b/ui/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@halo-dev/components",
-  "version": "2.25.1",
+  "version": "2.25.2",
   "description": "",
   "keywords": [
     "@halo-dev/components",

--- a/ui/packages/editor/package.json
+++ b/ui/packages/editor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@halo-dev/richtext-editor",
-  "version": "2.25.1",
+  "version": "2.25.2",
   "description": "Default editor for Halo",
   "homepage": "https://github.com/halo-dev/halo/tree/main/ui/packages/editor#readme",
   "bugs": {

--- a/ui/packages/shared/package.json
+++ b/ui/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@halo-dev/ui-shared",
-  "version": "2.25.1",
+  "version": "2.25.2",
   "description": "",
   "keywords": [],
   "homepage": "https://github.com/halo-dev/halo/tree/main/ui/packages/shared#readme",

--- a/ui/packages/ui-plugin-bundler-kit/package.json
+++ b/ui/packages/ui-plugin-bundler-kit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@halo-dev/ui-plugin-bundler-kit",
-  "version": "2.25.1",
+  "version": "2.25.2",
   "homepage": "https://github.com/halo-dev/halo/tree/main/ui/packages/ui-plugin-bundler-kit#readme",
   "bugs": {
     "url": "https://github.com/halo-dev/halo/issues"


### PR DESCRIPTION
#### What type of PR is this?

- [ ] Feature
- [ ] Bug fix
- [x] Improvement
- [ ] Cleanup
- [ ] Documentation

#### What this PR does / why we need it:

Bumps the published UI workspace package versions from `2.25.1` to `2.25.2` for:

- `@halo-dev/api-client`
- `@halo-dev/components`
- `@halo-dev/richtext-editor`
- `@halo-dev/ui-shared`
- `@halo-dev/ui-plugin-bundler-kit`

This keeps the package metadata aligned for the next UI package release.

#### Which issue(s) this PR fixes:

N/A

#### Special notes for your reviewer:

Prepared with AI assistance and reviewed before submission.

Validation:

- `corepack pnpm@10.30.3 -C ui format:check`
- `corepack pnpm@10.30.3 -C ui typecheck`
- `corepack pnpm@10.30.3 -C ui lint`

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
