### PR TITLE
Fix plugin asset resource scope

### DIFF
--- a/application/src/main/java/run/halo/app/core/reconciler/PluginReconciler.java
+++ b/application/src/main/java/run/halo/app/core/reconciler/PluginReconciler.java
@@ -484,6 +484,8 @@ class PluginReconciler implements Reconciler<Request>, DisposableBean {
             pluginVersion = String.valueOf(clock.instant().toEpochMilli());
         }
         var status = plugin.statusNonNull();
+        status.setEntry(null);
+        status.setStylesheet(null);
         var specLogo = plugin.getSpec().getLogo();
         if (StringUtils.isNotBlank(specLogo)) {
             log.info("Resolving logo resource for plugin {}", pluginName);

--- a/application/src/main/java/run/halo/app/plugin/resources/BundleResourceUtils.java
+++ b/application/src/main/java/run/halo/app/plugin/resources/BundleResourceUtils.java
@@ -1,11 +1,20 @@
 package run.halo.app.plugin.resources;
 
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import org.jspecify.annotations.Nullable;
 import org.pf4j.PluginManager;
 import org.pf4j.PluginWrapper;
 import org.springframework.core.io.DefaultResourceLoader;
+import org.springframework.core.io.DescriptiveResource;
+import org.springframework.core.io.FileSystemResource;
 import org.springframework.core.io.Resource;
+import org.springframework.core.io.ResourceLoader;
+import org.springframework.core.io.UrlResource;
 import org.springframework.util.Assert;
+import org.springframework.util.ResourceUtils;
 import org.springframework.util.StringUtils;
 import run.halo.app.infra.utils.FileUtils;
 import run.halo.app.infra.utils.PathUtils;
@@ -126,6 +135,66 @@ public abstract class BundleResourceUtils {
         if (plugin == null) {
             return null;
         }
-        return new DefaultResourceLoader(plugin.getPluginClassLoader());
+        return new PluginResourceLoader(plugin.getPluginClassLoader());
+    }
+
+    private static class PluginResourceLoader extends DefaultResourceLoader {
+        private final ClassLoader pluginClassLoader;
+
+        PluginResourceLoader(ClassLoader pluginClassLoader) {
+            super(pluginClassLoader);
+            this.pluginClassLoader = pluginClassLoader;
+        }
+
+        @Override
+        public Resource getResource(String location) {
+            if (location.startsWith(ResourceLoader.CLASSPATH_URL_PREFIX)) {
+                return getResourceByPath(location.substring(ResourceLoader.CLASSPATH_URL_PREFIX.length()));
+            }
+            return super.getResource(location);
+        }
+
+        @Override
+        protected Resource getResourceByPath(String path) {
+            var resource = getOwnClasspathResource(path);
+            return resource == null ? super.getResourceByPath(path) : resource;
+        }
+
+        private @Nullable Resource getOwnClasspathResource(String path) {
+            if (!(pluginClassLoader instanceof URLClassLoader urlClassLoader)) {
+                return null;
+            }
+            var urls = urlClassLoader.getURLs();
+            if (urls == null || urls.length == 0) {
+                return null;
+            }
+            var resourcePath = StringUtils.trimLeadingCharacter(path, '/');
+            for (URL url : urls) {
+                var resource = getResourceFromClasspathUrl(url, resourcePath);
+                if (resource.exists()) {
+                    return resource;
+                }
+            }
+            return new DescriptiveResource("Plugin resource [" + resourcePath + "] does not exist");
+        }
+
+        private Resource getResourceFromClasspathUrl(URL classpathUrl, String resourcePath) {
+            try {
+                if (ResourceUtils.isJarURL(classpathUrl)) {
+                    return new UrlResource(new URL(classpathUrl, resourcePath));
+                }
+                if (ResourceUtils.isFileURL(classpathUrl)) {
+                    Path path = Path.of(classpathUrl.toURI());
+                    if (Files.isDirectory(path)) {
+                        return new FileSystemResource(path.resolve(resourcePath));
+                    }
+                    return new UrlResource(new URL("jar:" + classpathUrl.toExternalForm() + "!/" + resourcePath));
+                }
+                return new UrlResource(new URL(classpathUrl, resourcePath));
+            } catch (Exception e) {
+                return new DescriptiveResource(
+                        "Plugin resource [" + resourcePath + "] from [" + classpathUrl + "] is invalid");
+            }
+        }
     }
 }

--- a/application/src/test/java/run/halo/app/core/reconciler/PluginReconcilerTest.java
+++ b/application/src/test/java/run/halo/app/core/reconciler/PluginReconcilerTest.java
@@ -241,6 +241,8 @@ class PluginReconcilerTest {
                 spec.setSettingName(settingName);
                 spec.setConfigMapName(configMapName);
             });
+            fakePlugin.getStatus().setEntry("/plugins/fake-plugin/assets/ui/main.js?version=1.2.3");
+            fakePlugin.getStatus().setStylesheet("/plugins/fake-plugin/assets/ui/style.css?version=1.2.3");
 
             when(client.fetch(Plugin.class, name)).thenReturn(Optional.of(fakePlugin));
             when(pluginManager.getPluginsRoots()).thenReturn(List.of(tempPath));

--- a/application/src/test/java/run/halo/app/plugin/PluginAutoConfigurationTest.java
+++ b/application/src/test/java/run/halo/app/plugin/PluginAutoConfigurationTest.java
@@ -84,6 +84,33 @@ class PluginAutoConfigurationTest {
     }
 
     @Test
+    void shouldNotServeAssetsFromParentClassLoader() throws IOException {
+        var pluginWrapper = mock(PluginWrapper.class);
+        var dependencyRoot = ResourceUtils.getURL("classpath:plugin/plugin-for-ui-assets/");
+        var pluginRoot = ResourceUtils.getURL("classpath:plugin/plugin-for-console-assets/");
+        var dependencyClassLoader = new URLClassLoader(new URL[] {dependencyRoot}, null);
+        var classLoader = new URLClassLoader(new URL[] {pluginRoot}, dependencyClassLoader);
+        lenient().when(pluginWrapper.getPluginClassLoader()).thenReturn(classLoader);
+        lenient().when(pluginManager.getPlugin("fake-plugin")).thenReturn(pluginWrapper);
+
+        webClient
+                .get()
+                .uri("/plugins/fake-plugin/assets/ui/main.js")
+                .exchange()
+                .expectStatus()
+                .isNotFound();
+
+        webClient
+                .get()
+                .uri("/plugins/fake-plugin/assets/console/main.js")
+                .exchange()
+                .expectStatus()
+                .isOk()
+                .expectBody(String.class)
+                .value(body -> assertThat(body).contains("console.log(\"console-only\");"));
+    }
+
+    @Test
     void shouldReturnNotFoundWhenPluginIsMissing() {
         webClient
                 .get()

--- a/application/src/test/java/run/halo/app/plugin/resources/BundleResourceUtilsTest.java
+++ b/application/src/test/java/run/halo/app/plugin/resources/BundleResourceUtilsTest.java
@@ -8,6 +8,7 @@ import static org.mockito.Mockito.lenient;
 import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.net.URLClassLoader;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -18,6 +19,7 @@ import org.pf4j.PluginClassLoader;
 import org.pf4j.PluginManager;
 import org.pf4j.PluginWrapper;
 import org.springframework.core.io.Resource;
+import org.springframework.util.ResourceUtils;
 import run.halo.app.infra.exception.AccessDeniedException;
 
 /**
@@ -104,6 +106,28 @@ class BundleResourceUtilsTest {
                 BundleResourceUtils.getSelectedBundleResource(pluginManager, "fake-plugin", "style.css");
         assertThat(cssBundleResource).isNotNull();
         assertThat(cssBundleResource.getURL().toString()).isEqualTo("file://ui/style.css");
+    }
+
+    @Test
+    void shouldIgnoreParentClassLoaderResourcesWhenSelectingBundleLocation() throws IOException {
+        var dependencyRoot = ResourceUtils.getURL("classpath:plugin/plugin-for-ui-assets/");
+        var pluginRoot = ResourceUtils.getURL("classpath:plugin/plugin-for-console-assets/");
+        var dependencyClassLoader = new URLClassLoader(new URL[] {dependencyRoot}, null);
+        var pluginClassLoader = new URLClassLoader(new URL[] {pluginRoot}, dependencyClassLoader);
+        var pluginWrapper = Mockito.mock(PluginWrapper.class);
+        lenient().when(pluginWrapper.getPluginClassLoader()).thenReturn(pluginClassLoader);
+        lenient().when(pluginManager.getPlugin(eq("console-plugin"))).thenReturn(pluginWrapper);
+
+        assertThat(BundleResourceUtils.getBundleResource(
+                        pluginManager, "console-plugin", BundleResourceUtils.UI_BUNDLE_LOCATION, "main.js"))
+                .isNull();
+        assertThat(BundleResourceUtils.selectBundleLocation(pluginManager, "console-plugin"))
+                .isEqualTo(BundleResourceUtils.CONSOLE_BUNDLE_LOCATION);
+
+        var jsBundleResource =
+                BundleResourceUtils.getSelectedBundleResource(pluginManager, "console-plugin", "main.js");
+        assertThat(jsBundleResource).isNotNull();
+        assertThat(jsBundleResource.getURL().toString()).contains("plugin-for-console-assets/console/main.js");
     }
 
     @Test


### PR DESCRIPTION
#### What type of PR is this?

- [ ] Feature
- [x] Bug fix
- [ ] Improvement
- [ ] Cleanup
- [ ] Documentation

#### What this PR does / why we need it:

This PR prevents plugin asset lookup from resolving resources from dependency plugin classloaders.

PF4J's `PluginClassLoader#getResource()` searches the current plugin and then dependency plugins. After UI bundle lookup started preferring `ui/` over `console/`, a plugin without its own `ui/main.js` could accidentally resolve a dependency plugin's `ui/main.js`. That produced a status entry under the dependent plugin path while serving the dependency plugin's bundle content.

The change adds a plugin resource loader that resolves assets only from the current plugin's classpath URLs. It also clears stale `entry` and `stylesheet` values before static resource resolution so previously polluted status fields are removed when no valid bundle exists.

#### Which issue(s) this PR fixes:

N/A

#### Special notes for your reviewer:

This was assisted by AI and the generated changes were reviewed before submission.

Validation:

```bash
./gradlew :application:test --tests "run.halo.app.plugin.resources.BundleResourceUtilsTest" --tests "run.halo.app.plugin.PluginAutoConfigurationTest" --tests "run.halo.app.core.reconciler.PluginReconcilerTest"
./gradlew :application:spotlessApply
git diff --check
```

#### Does this PR introduce a user-facing change?

```release-note
修复插件依赖插件的场景下，插件的 UI 资源解析路径错误的问题
```
