### PR TITLE
perf: push subject filtering to database in subscription resolution

### DIFF
--- a/application/src/main/java/run/halo/app/notification/RecipientResolverImpl.java
+++ b/application/src/main/java/run/halo/app/notification/RecipientResolverImpl.java
@@ -35,7 +35,7 @@ public class RecipientResolverImpl implements RecipientResolver {
     public Flux<Subscriber> resolve(Reason reason) {
         var reasonType = reason.getSpec().getReasonType();
         return subscriptionService
-                .listByPerPage(reasonType)
+                .listByPerPage(reasonType, reason.getSpec().getSubject())
                 .filter(this::isNotDisabled)
                 .filter(subscription -> {
                     var interestReason = subscription.getSpec().getReason();

--- a/application/src/main/java/run/halo/app/notification/SubscriptionService.java
+++ b/application/src/main/java/run/halo/app/notification/SubscriptionService.java
@@ -29,7 +29,7 @@ public interface SubscriptionService {
      * @param reasonType the reason type to match
      * @param reasonSubject the reason's subject used to build the subject filter
      * @return a paginated flux of matching subscriptions
-     * @since 2.27.0
+     * @since 2.25.3
      */
     Flux<Subscription> listByPerPage(String reasonType, Reason.Subject reasonSubject);
 

--- a/application/src/main/java/run/halo/app/notification/SubscriptionService.java
+++ b/application/src/main/java/run/halo/app/notification/SubscriptionService.java
@@ -9,13 +9,6 @@ import run.halo.app.extension.ListOptions;
 public interface SubscriptionService {
 
     /**
-     * List subscriptions by page one by one.only consume one page then next page will be loaded.
-     *
-     * <p>Note that: result can not be used to delete the subscription, it is only used to query the subscription.
-     */
-    Flux<Subscription> listByPerPage(String reasonType);
-
-    /**
      * List subscriptions by reasonType with subject-based filtering to avoid pulling all subscriptions for a reason
      * type into memory.
      *

--- a/application/src/main/java/run/halo/app/notification/SubscriptionService.java
+++ b/application/src/main/java/run/halo/app/notification/SubscriptionService.java
@@ -2,6 +2,7 @@ package run.halo.app.notification;
 
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
+import run.halo.app.core.extension.notification.Reason;
 import run.halo.app.core.extension.notification.Subscription;
 import run.halo.app.extension.ListOptions;
 
@@ -13,6 +14,24 @@ public interface SubscriptionService {
      * <p>Note that: result can not be used to delete the subscription, it is only used to query the subscription.
      */
     Flux<Subscription> listByPerPage(String reasonType);
+
+    /**
+     * List subscriptions by reasonType with subject-based filtering to avoid pulling all subscriptions for a reason
+     * type into memory.
+     *
+     * <p>This method constructs two targeted queries:
+     *
+     * <ol>
+     *   <li>Subscriptions whose subject matches the given subject (exact name or wildcard)
+     *   <li>Subscriptions that use expression-based matching (isNotNull on spec.reason.expression)
+     * </ol>
+     *
+     * @param reasonType the reason type to match
+     * @param reasonSubject the reason's subject used to build the subject filter
+     * @return a paginated flux of matching subscriptions
+     * @since 2.27.0
+     */
+    Flux<Subscription> listByPerPage(String reasonType, Reason.Subject reasonSubject);
 
     Mono<Void> remove(Subscription.Subscriber subscriber, Subscription.InterestReason interestReasons);
 

--- a/application/src/main/java/run/halo/app/notification/SubscriptionServiceImpl.java
+++ b/application/src/main/java/run/halo/app/notification/SubscriptionServiceImpl.java
@@ -88,22 +88,22 @@ public class SubscriptionServiceImpl implements SubscriptionService {
         var exactMatch = subjectPrefix + reasonSubject.getName();
 
         // Subject query: exact name match OR wildcard (no name) subscriptions.
-        var subjectListOptions = new ListOptions();
-        var subjectFieldQuery = and(
-                isNull("metadata.deletionTimestamp"),
-                equal("spec.reason.reasonType", reasonType),
-                or(equal("spec.reason.subject", exactMatch), equal("spec.reason.subject", subjectPrefix)));
-        subjectListOptions.setFieldSelector(FieldSelector.of(subjectFieldQuery));
+        var subjectListOptions = ListOptions.builder()
+                .fieldQuery(and(
+                        isNull("metadata.deletionTimestamp"),
+                        equal("spec.reason.reasonType", reasonType),
+                        or(equal("spec.reason.subject", exactMatch), equal("spec.reason.subject", subjectPrefix))))
+                .build();
 
         var subjectFlux = paginatedOperator.list(Subscription.class, subjectListOptions);
 
         // Expression query: subscriptions that use expression-based matching.
-        var exprListOptions = new ListOptions();
-        var exprFieldQuery = and(
-                isNull("metadata.deletionTimestamp"),
-                equal("spec.reason.reasonType", reasonType),
-                not(isNull("spec.reason.expression")));
-        exprListOptions.setFieldSelector(FieldSelector.of(exprFieldQuery));
+        var exprListOptions = ListOptions.builder()
+                .fieldQuery(and(
+                        isNull("metadata.deletionTimestamp"),
+                        equal("spec.reason.reasonType", reasonType),
+                        not(isNull("spec.reason.expression"))))
+                .build();
 
         return subjectFlux.concatWith(paginatedOperator.list(Subscription.class, exprListOptions));
     }

--- a/application/src/main/java/run/halo/app/notification/SubscriptionServiceImpl.java
+++ b/application/src/main/java/run/halo/app/notification/SubscriptionServiceImpl.java
@@ -89,20 +89,18 @@ public class SubscriptionServiceImpl implements SubscriptionService {
 
         // Subject query: exact name match OR wildcard (no name) subscriptions.
         var subjectListOptions = ListOptions.builder()
-                .fieldQuery(and(
-                        isNull("metadata.deletionTimestamp"),
-                        equal("spec.reason.reasonType", reasonType),
-                        or(equal("spec.reason.subject", exactMatch), equal("spec.reason.subject", subjectPrefix))))
+                .andQuery(isNull("metadata.deletionTimestamp"))
+                .andQuery(equal("spec.reason.reasonType", reasonType))
+                .andQuery(or(equal("spec.reason.subject", exactMatch), equal("spec.reason.subject", subjectPrefix)))
                 .build();
 
         var subjectFlux = paginatedOperator.list(Subscription.class, subjectListOptions);
 
         // Expression query: subscriptions that use expression-based matching.
         var exprListOptions = ListOptions.builder()
-                .fieldQuery(and(
-                        isNull("metadata.deletionTimestamp"),
-                        equal("spec.reason.reasonType", reasonType),
-                        not(isNull("spec.reason.expression"))))
+                .andQuery(isNull("metadata.deletionTimestamp"))
+                .andQuery(equal("spec.reason.reasonType", reasonType))
+                .andQuery(not(isNull("spec.reason.expression")))
                 .build();
 
         return subjectFlux.concatWith(paginatedOperator.list(Subscription.class, exprListOptions));

--- a/application/src/main/java/run/halo/app/notification/SubscriptionServiceImpl.java
+++ b/application/src/main/java/run/halo/app/notification/SubscriptionServiceImpl.java
@@ -11,6 +11,7 @@ import org.springframework.util.Assert;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import reactor.util.retry.Retry;
+import run.halo.app.core.extension.notification.Reason;
 import run.halo.app.core.extension.notification.Subscription;
 import run.halo.app.extension.ListOptions;
 import run.halo.app.extension.ReactiveExtensionClient;
@@ -79,6 +80,32 @@ public class SubscriptionServiceImpl implements SubscriptionService {
         var fieldQuery = and(isNull("metadata.deletionTimestamp"), equal("spec.reason.reasonType", reasonType));
         listOptions.setFieldSelector(FieldSelector.of(fieldQuery));
         return paginatedOperator.list(Subscription.class, listOptions);
+    }
+
+    @Override
+    public Flux<Subscription> listByPerPage(String reasonType, Reason.Subject reasonSubject) {
+        var subjectPrefix = reasonSubject.getKind() + "#" + reasonSubject.getApiVersion() + "/";
+        var exactMatch = subjectPrefix + reasonSubject.getName();
+
+        // Subject query: exact name match OR wildcard (no name) subscriptions.
+        var subjectListOptions = new ListOptions();
+        var subjectFieldQuery = and(
+                isNull("metadata.deletionTimestamp"),
+                equal("spec.reason.reasonType", reasonType),
+                or(equal("spec.reason.subject", exactMatch), equal("spec.reason.subject", subjectPrefix)));
+        subjectListOptions.setFieldSelector(FieldSelector.of(subjectFieldQuery));
+
+        var subjectFlux = paginatedOperator.list(Subscription.class, subjectListOptions);
+
+        // Expression query: subscriptions that use expression-based matching.
+        var exprListOptions = new ListOptions();
+        var exprFieldQuery = and(
+                isNull("metadata.deletionTimestamp"),
+                equal("spec.reason.reasonType", reasonType),
+                not(isNull("spec.reason.expression")));
+        exprListOptions.setFieldSelector(FieldSelector.of(exprFieldQuery));
+
+        return subjectFlux.concatWith(paginatedOperator.list(Subscription.class, exprListOptions));
     }
 
     private Mono<Subscription> attemptToDelete(String subscriptionName) {

--- a/application/src/main/java/run/halo/app/notification/SubscriptionServiceImpl.java
+++ b/application/src/main/java/run/halo/app/notification/SubscriptionServiceImpl.java
@@ -75,14 +75,6 @@ public class SubscriptionServiceImpl implements SubscriptionService {
     }
 
     @Override
-    public Flux<Subscription> listByPerPage(String reasonType) {
-        final var listOptions = new ListOptions();
-        var fieldQuery = and(isNull("metadata.deletionTimestamp"), equal("spec.reason.reasonType", reasonType));
-        listOptions.setFieldSelector(FieldSelector.of(fieldQuery));
-        return paginatedOperator.list(Subscription.class, listOptions);
-    }
-
-    @Override
     public Flux<Subscription> listByPerPage(String reasonType, Reason.Subject reasonSubject) {
         var subjectPrefix = reasonSubject.getKind() + "#" + reasonSubject.getApiVersion() + "/";
         var exactMatch = subjectPrefix + reasonSubject.getName();

--- a/application/src/test/java/run/halo/app/notification/RecipientResolverImplTest.java
+++ b/application/src/test/java/run/halo/app/notification/RecipientResolverImplTest.java
@@ -1,6 +1,7 @@
 package run.halo.app.notification;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -58,7 +59,8 @@ class RecipientResolverImplTest {
         reasonAttributes.put("owner", "guqing");
         reason.getSpec().setAttributes(reasonAttributes);
 
-        when(subscriptionService.listByPerPage(anyString())).thenReturn(Flux.just(subscription1, subscription2));
+        when(subscriptionService.listByPerPage(anyString(), any(Reason.Subject.class)))
+                .thenReturn(Flux.just(subscription1, subscription2));
 
         recipientResolver
                 .resolve(reason)
@@ -66,7 +68,7 @@ class RecipientResolverImplTest {
                 .expectNext(new Subscriber(UserIdentity.of("guqing"), "guqing-subscription"))
                 .verifyComplete();
 
-        verify(subscriptionService).listByPerPage(anyString());
+        verify(subscriptionService).listByPerPage(anyString(), any(Reason.Subject.class));
     }
 
     @Test
@@ -75,7 +77,8 @@ class RecipientResolverImplTest {
         subscriber.setName("test");
         Subscription subscription = createSubscription(subscriber);
 
-        when(subscriptionService.listByPerPage(anyString())).thenReturn(Flux.just(subscription));
+        when(subscriptionService.listByPerPage(anyString(), any(Reason.Subject.class)))
+                .thenReturn(Flux.just(subscription));
 
         var reason = new Reason();
         reason.setSpec(new Reason.Spec());
@@ -91,7 +94,7 @@ class RecipientResolverImplTest {
                 .expectNext(new Subscriber(UserIdentity.of("test"), "fake-subscription"))
                 .verifyComplete();
 
-        verify(subscriptionService).listByPerPage(anyString());
+        verify(subscriptionService).listByPerPage(anyString(), any(Reason.Subject.class));
     }
 
     @Test
@@ -108,7 +111,8 @@ class RecipientResolverImplTest {
         subscription2.getSpec().getReason().setSubject(null);
         subscription2.getSpec().getReason().setExpression("props.owner == 'guqing'");
 
-        when(subscriptionService.listByPerPage(anyString())).thenReturn(Flux.just(subscription1, subscription2));
+        when(subscriptionService.listByPerPage(anyString(), any(Reason.Subject.class)))
+                .thenReturn(Flux.just(subscription1, subscription2));
 
         var reason = new Reason();
         reason.setSpec(new Reason.Spec());
@@ -127,7 +131,7 @@ class RecipientResolverImplTest {
                 .expectNextCount(1)
                 .verifyComplete();
 
-        verify(subscriptionService).listByPerPage(anyString());
+        verify(subscriptionService).listByPerPage(anyString(), any(Reason.Subject.class));
     }
 
     @Test


### PR DESCRIPTION
#### What type of PR is this?

- [x] Improvement

#### What this PR does / why we need it:

`RecipientResolverImpl#resolve` 此前调用 `listByPerPage(reasonType)` 将某个 ReasonType 下的**全部** Subscription 拉入内存，再逐条做 subject/expression 匹配。当某个 ReasonType 有数万条订阅时，99% 的数据都是无意义的传输和过滤。

本 PR 将 `listByPerPage` 扩展为两参数版本 `listByPerPage(reasonType, reasonSubject)`，拆成两次精准查询：

1. **Subject 查询**：利用 reason 的 subject 构建数据库精确过滤 — `kind#apiVersion/name` 精确匹配 或 `kind#apiVersion/` 通配匹配
2. **Expression 查询**：仅查询 expression 不为空的 subscription

数据量从 O(所有同类型订阅) 降为 O(匹配的 subject 订阅 + 有 expression 的订阅)。

#### Which issue(s) this PR fixes:

Fixes #N/A

#### Does this PR introduce a user-facing change?

```release-note
优化通知订阅匹配性能：将 subject 匹配从内存过滤改为数据库精准查询，大幅降低大规模订阅场景下的数据传输量。
```