### PR TITLE
Refine login username field copy

### DIFF
--- a/application/src/main/resources/templates/login_local.html
+++ b/application/src/main/resources/templates/login_local.html
@@ -13,6 +13,7 @@
         spellcheck="false"
         autocorrect="off"
         autocapitalize="off"
+        th:placeholder="#{form.username.placeholder}"
         required
         autofocus
         th:value="${username}"

--- a/application/src/main/resources/templates/login_local.properties
+++ b/application/src/main/resources/templates/login_local.properties
@@ -1,3 +1,4 @@
-form.username.label=用户名或邮箱地址
+form.username.label=用户名
+form.username.placeholder=用户名或邮箱地址
 form.password.label=密码
 form.password.forgot=忘记密码？

--- a/application/src/main/resources/templates/login_local_en.properties
+++ b/application/src/main/resources/templates/login_local_en.properties
@@ -1,3 +1,4 @@
-form.username.label=Username or email address
+form.username.label=Username
+form.username.placeholder=Username or email address
 form.password.label=Password
 form.password.forgot=Forgot your password?

--- a/application/src/main/resources/templates/login_local_es.properties
+++ b/application/src/main/resources/templates/login_local_es.properties
@@ -1,3 +1,4 @@
-form.username.label=Nombre de usuario o dirección de correo electrónico
+form.username.label=Nombre de usuario
+form.username.placeholder=Nombre de usuario o dirección de correo electrónico
 form.password.label=Contraseña
 form.password.forgot=¿Olvidaste tu contraseña?

--- a/application/src/main/resources/templates/login_local_zh_TW.properties
+++ b/application/src/main/resources/templates/login_local_zh_TW.properties
@@ -1,3 +1,4 @@
-form.username.label=使用者名稱或電子郵件地址
+form.username.label=使用者名稱
+form.username.placeholder=使用者名稱或電子郵件地址
 form.password.label=密碼
 form.password.forgot=忘記密碼？


### PR DESCRIPTION
#### What type of PR is this?

- [ ] Feature
- [ ] Bug fix
- [x] Improvement
- [ ] Cleanup
- [ ] Documentation

#### What this PR does / why we need it:

Updates the local login form so the username field label stays concise as `Username`, while the placeholder explains that either a username or email address can be used. This keeps the label from becoming too long as additional credential types may be supported later.

#### Which issue(s) this PR fixes:

N/A

#### Special notes for your reviewer:

Prepared with AI assistance and reviewed locally.

Validation:

- `./gradlew :application:processResources`

#### Does this PR introduce a user-facing change?

```release-note
Refined the login form username field label and placeholder text.
```