### PR TITLE
Respect disabled thumbnail configuration

### DIFF
--- a/application/src/main/java/run/halo/app/core/attachment/endpoint/LocalAttachmentUploadHandler.java
+++ b/application/src/main/java/run/halo/app/core/attachment/endpoint/LocalAttachmentUploadHandler.java
@@ -53,6 +53,7 @@ import run.halo.app.infra.FileCategoryMatcher;
 import run.halo.app.infra.exception.AttachmentAlreadyExistsException;
 import run.halo.app.infra.exception.FileSizeExceededException;
 import run.halo.app.infra.exception.FileTypeNotAllowedException;
+import run.halo.app.infra.properties.HaloProperties;
 import run.halo.app.infra.utils.FileNameUtils;
 import run.halo.app.infra.utils.FileTypeDetectUtils;
 import run.halo.app.infra.utils.HaloUtils;
@@ -68,6 +69,8 @@ class LocalAttachmentUploadHandler implements AttachmentHandler {
     private final AttachmentRootGetter attachmentDirGetter;
 
     private final LocalThumbnailService localThumbnailService;
+
+    private final HaloProperties haloProperties;
 
     private Clock clock = Clock.systemUTC();
 
@@ -275,6 +278,9 @@ class LocalAttachmentUploadHandler implements AttachmentHandler {
     }
 
     private Map<ThumbnailSize, URI> doGetThumbnailLinks(Attachment attachment) {
+        if (isThumbnailDisabled()) {
+            return Map.of();
+        }
         if (attachment.getStatus() == null
                 || !StringUtils.hasText(attachment.getStatus().getPermalink())) {
             return Map.of();
@@ -297,6 +303,10 @@ class LocalAttachmentUploadHandler implements AttachmentHandler {
         }
         var permalinkUri = URI.create(attachment.getStatus().getPermalink());
         return ThumbnailUtils.buildSrcsetMap(permalinkUri);
+    }
+
+    private boolean isThumbnailDisabled() {
+        return haloProperties.getAttachment().getThumbnail().isDisabled();
     }
 
     private void deleteAttachmentFile(Path attachmentPath) {

--- a/application/src/main/java/run/halo/app/core/attachment/reconciler/AttachmentReconciler.java
+++ b/application/src/main/java/run/halo/app/core/attachment/reconciler/AttachmentReconciler.java
@@ -66,6 +66,7 @@ class AttachmentReconciler implements Reconciler<Request> {
                             .map(map -> map.keySet().stream()
                                     .collect(Collectors.toMap(
                                             Enum::name, k -> map.get(k).toString())))
+                            .filter(map -> !map.isEmpty())
                             .blockOptional(Duration.ofSeconds(10))
                             .orElse(null);
                     attachment.getStatus().setThumbnails(thumbnails);

--- a/application/src/main/java/run/halo/app/core/attachment/thumbnail/DefaultThumbnailService.java
+++ b/application/src/main/java/run/halo/app/core/attachment/thumbnail/DefaultThumbnailService.java
@@ -22,6 +22,7 @@ import run.halo.app.extension.ListOptions;
 import run.halo.app.extension.ReactiveExtensionClient;
 import run.halo.app.extension.index.query.Queries;
 import run.halo.app.infra.ExternalUrlSupplier;
+import run.halo.app.infra.properties.HaloProperties;
 
 /**
  * Implementation of {@link ThumbnailService}.
@@ -43,9 +44,13 @@ class DefaultThumbnailService implements ThumbnailService {
 
     private final ExternalUrlSupplier externalUrlSupplier;
 
-    public DefaultThumbnailService(ReactiveExtensionClient client, ExternalUrlSupplier externalUrlSupplier) {
+    private final HaloProperties haloProperties;
+
+    public DefaultThumbnailService(
+            ReactiveExtensionClient client, ExternalUrlSupplier externalUrlSupplier, HaloProperties haloProperties) {
         this.client = client;
         this.externalUrlSupplier = externalUrlSupplier;
+        this.haloProperties = haloProperties;
         this.thumbnailCache = Caffeine.newBuilder()
                 // TODO make it configurable
                 .maximumSize(10_000)
@@ -95,6 +100,9 @@ class DefaultThumbnailService implements ThumbnailService {
 
     @Override
     public Mono<Map<ThumbnailSize, URI>> get(URI permalink) {
+        if (isThumbnailDisabled()) {
+            return Mono.just(EMPTY_THUMBNAILS);
+        }
         var encodedPermalink = URI.create(permalink.toASCIIString());
         if (!encodedPermalink.isAbsolute()) {
             // build permalinks
@@ -130,5 +138,9 @@ class DefaultThumbnailService implements ThumbnailService {
                         return EMPTY_THUMBNAILS;
                     }));
         });
+    }
+
+    private boolean isThumbnailDisabled() {
+        return haloProperties.getAttachment().getThumbnail().isDisabled();
     }
 }

--- a/application/src/test/java/run/halo/app/core/attachment/endpoint/LocalAttachmentUploadHandlerTest.java
+++ b/application/src/test/java/run/halo/app/core/attachment/endpoint/LocalAttachmentUploadHandlerTest.java
@@ -39,6 +39,8 @@ import run.halo.app.core.extension.attachment.endpoint.UploadOption;
 import run.halo.app.extension.ConfigMap;
 import run.halo.app.extension.Metadata;
 import run.halo.app.infra.ExternalUrlSupplier;
+import run.halo.app.infra.properties.AttachmentProperties;
+import run.halo.app.infra.properties.HaloProperties;
 
 @ExtendWith(MockitoExtension.class)
 class LocalAttachmentUploadHandlerTest {
@@ -55,8 +57,13 @@ class LocalAttachmentUploadHandlerTest {
     @Mock
     LocalThumbnailService localThumbnailService;
 
+    @Mock
+    HaloProperties haloProperties;
+
     @TempDir
     Path attachmentRoot;
+
+    AttachmentProperties attachmentProperties;
 
     static Clock clock = Clock.fixed(Instant.now(), ZoneId.systemDefault());
 
@@ -64,6 +71,8 @@ class LocalAttachmentUploadHandlerTest {
     void setUp() {
         uploadHandler.setClock(clock);
         lenient().when(externalUrlSupplier.get()).thenReturn(URI.create("/"));
+        attachmentProperties = new AttachmentProperties();
+        lenient().when(haloProperties.getAttachment()).thenReturn(attachmentProperties);
     }
 
     public static Stream<Arguments> testUploadWithRenameStrategy() {
@@ -192,6 +201,33 @@ class LocalAttachmentUploadHandlerTest {
                     assertion.accept(attachment);
                     assertNotNull(attachment.getStatus().getPermalink());
                     assertNotNull(attachment.getStatus().getThumbnails());
+                })
+                .verifyComplete();
+    }
+
+    @Test
+    void shouldNotSetThumbnailsIfThumbnailIsDisabled() {
+        attachmentProperties.getThumbnail().setDisabled(true);
+
+        var dataBufferFactory = new DefaultDataBufferFactory();
+        var dataBuffer = dataBufferFactory.allocateBuffer(1024);
+        dataBuffer.write("fake content".getBytes(StandardCharsets.UTF_8));
+        var content = Flux.<DataBuffer>just(dataBuffer);
+
+        var policy = new Policy();
+        var policySpec = new Policy.PolicySpec();
+        policy.setSpec(policySpec);
+        policySpec.setTemplateName("local");
+
+        var uploadOption = UploadOption.from("halo.png", content, MediaType.IMAGE_PNG, policy, null);
+
+        when(attachmentRootGetter.get()).thenReturn(attachmentRoot);
+        uploadHandler
+                .upload(uploadOption)
+                .as(StepVerifier::create)
+                .assertNext(attachment -> {
+                    assertNotNull(attachment.getStatus().getPermalink());
+                    assertNull(attachment.getStatus().getThumbnails());
                 })
                 .verifyComplete();
     }

--- a/application/src/test/java/run/halo/app/core/attachment/thumbnail/DefaultThumbnailServiceTest.java
+++ b/application/src/test/java/run/halo/app/core/attachment/thumbnail/DefaultThumbnailServiceTest.java
@@ -8,6 +8,7 @@ import static org.mockito.Mockito.when;
 import java.net.MalformedURLException;
 import java.net.URI;
 import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -23,6 +24,8 @@ import run.halo.app.extension.ListOptions;
 import run.halo.app.extension.Metadata;
 import run.halo.app.extension.ReactiveExtensionClient;
 import run.halo.app.infra.ExternalUrlSupplier;
+import run.halo.app.infra.properties.AttachmentProperties;
+import run.halo.app.infra.properties.HaloProperties;
 
 @ExtendWith(MockitoExtension.class)
 class DefaultThumbnailServiceTest {
@@ -33,8 +36,19 @@ class DefaultThumbnailServiceTest {
     @Mock
     ExternalUrlSupplier externalUrlSupplier;
 
+    @Mock
+    HaloProperties haloProperties;
+
     @InjectMocks
     DefaultThumbnailService thumbnailService;
+
+    AttachmentProperties attachmentProperties;
+
+    @BeforeEach
+    void setUp() {
+        attachmentProperties = new AttachmentProperties();
+        when(haloProperties.getAttachment()).thenReturn(attachmentProperties);
+    }
 
     @Test
     void shouldGetThumbnailDirectlyIfPermalinkIsRelative() {
@@ -42,6 +56,16 @@ class DefaultThumbnailServiceTest {
                 .get(URI.create("/images/fake.png"), ThumbnailSize.M)
                 .as(StepVerifier::create)
                 .expectNext(URI.create("/images/fake.png?width=800"))
+                .verifyComplete();
+    }
+
+    @Test
+    void shouldGetEmptyThumbnailIfThumbnailIsDisabled() {
+        attachmentProperties.getThumbnail().setDisabled(true);
+
+        thumbnailService
+                .get(URI.create("/images/fake.png"), ThumbnailSize.M)
+                .as(StepVerifier::create)
                 .verifyComplete();
     }
 

--- a/application/src/test/java/run/halo/app/theme/finders/impl/ThumbnailFinderImplTest.java
+++ b/application/src/test/java/run/halo/app/theme/finders/impl/ThumbnailFinderImplTest.java
@@ -52,4 +52,16 @@ class ThumbnailFinderImplTest {
 
         verify(thumbnailService).get(any(), any());
     }
+
+    @Test
+    void shouldReturnOriginalUriIfNoThumbnailFound() {
+        when(thumbnailService.get(any(), any())).thenReturn(Mono.empty());
+        thumbnailFinder
+                .gen("/test.jpg", "l")
+                .as(StepVerifier::create)
+                .expectNext("/test.jpg")
+                .verifyComplete();
+
+        verify(thumbnailService).get(any(), any());
+    }
 }


### PR DESCRIPTION
#### What type of PR is this?

- [ ] Feature
- [x] Bug fix
- [ ] Improvement
- [ ] Cleanup
- [ ] Documentation

#### What this PR does / why we need it:

When `halo.attachment.thumbnail.disabled` is enabled, Halo should disable thumbnail behavior consistently instead of only skipping local file generation.

This PR updates the attachment thumbnail flow to:

- avoid writing generated thumbnail links to local attachment status when thumbnail generation is disabled
- clear reconciled thumbnail status when thumbnail handlers return no links
- make `ThumbnailService` return no thumbnail links while the configuration is disabled, so automatic theme `srcset` generation is skipped
- keep existing fallback behavior for explicit thumbnail requests, so callers receive the original image URI rather than an error or empty response

AI assistance was used to inspect and implement this change; the generated changes were reviewed and tested.

#### Which issue(s) this PR fixes:

Fixes #

#### Special notes for your reviewer:

The static resource transformer still keeps its defensive fallback: if a `?width=` request reaches it while thumbnails are disabled, it serves the original image and does not generate a thumbnail file.

#### Does this PR introduce a user-facing change?

```release-note
Fixed an issue where `halo.attachment.thumbnail.disabled` only skipped thumbnail file generation but still exposed thumbnail links.
```