### PR TITLE
build: increase OpenAPI docs generation wait time to 60s

### DIFF
--- a/application/build.gradle
+++ b/application/build.gradle
@@ -201,6 +201,7 @@ tasks.register('downloadPluginPresets', Download) {
 
 openApi {
     outputDir = file("$rootDir/api-docs/openapi/v3_0")
+    waitTimeInSeconds = 60
     groupedApiMappings = [
         'http://localhost:8091/v3/api-docs/apis_aggregated.api_v1alpha1': 'aggregated.json',
         'http://localhost:8091/v3/api-docs/apis_public.api_v1alpha1'    : 'apis_public.api_v1alpha1.json',


### PR DESCRIPTION
将 `generateOpenApiDocs` 任务的 `waitTimeInSeconds` 从默认 30 秒增加到 60 秒。

## 动机

默认 30 秒在一些较慢的环境下不够用，导致 `generateOpenApiDocs` 在 server 启动完成前就超时失败了。

## 改动

`application/build.gradle` 中 `openApi` 扩展块新增一行:

```groovy
waitTimeInSeconds = 60
```