### PR TITLE
fix: mark forkedSpringBoot tasks as incompatible with configuration cache

### DIFF
--- a/application/build.gradle
+++ b/application/build.gradle
@@ -230,6 +230,18 @@ tasks.named('generateOpenApiDocs') {
     }
 }
 
+tasks.named('forkedSpringBootRun') {
+    notCompatibleWithConfigurationCache(
+        'JavaExecFork holds references to Task objects (OpenApiGeneratorTask, BootRun), which are not serializable'
+    )
+}
+
+tasks.named('forkedSpringBootStop') {
+    notCompatibleWithConfigurationCache(
+        'ExecJoin holds a reference to JavaExecFork (a Task), which is not serializable'
+    )
+}
+
 def branchProvider = providers.exec { commandLine 'git', 'rev-parse', '--abbrev-ref', 'HEAD' }
 .standardOutput
 .asText


### PR DESCRIPTION
## What

Mark `forkedSpringBootRun` and `forkedSpringBootStop` as incompatible with the Gradle configuration cache, alongside the existing `generateOpenApiDocs` exclusion.

## Why

Running `./gradlew generateOpenApiDocs --configuration-cache` failed with:

```
3 problems were found storing the configuration cache.
- Task `:application:forkedSpringBootRun` (JavaExecFork): cannot serialize OpenApiGeneratorTask
- Task `:application:forkedSpringBootRun` (JavaExecFork): cannot serialize BootRun
- Task `:application:forkedSpringBootStop` (ExecJoin): cannot serialize JavaExecFork
```

The root cause is that `JavaExecFork` and `ExecJoin` (from `gradle-execfork-plugin`) hold internal references to `Task` objects, which Gradle cannot serialize for the configuration cache. Only `generateOpenApiDocs` was marked as incompatible — the forked lifecycle tasks that wrap the server start/stop were missed.

## Fix

Added `notCompatibleWithConfigurationCache` to both forked tasks. The OpenAPI doc generation workflow (boot server → fetch docs → stop server) now correctly bypasses the configuration cache, while normal build tasks continue to leverage it.

## Verification

```
# Before fix → BUILD FAILED
./gradlew generateOpenApiDocs --configuration-cache --dry-run  # FAILED

# After fix → BUILD SUCCESSFUL
./gradlew generateOpenApiDocs --configuration-cache --dry-run  # SUCCESS
./gradlew :application:compileJava --configuration-cache       # cache stored + reused ✓
```