### PR TITLE
fix: resolve ClassCastException in MapOAuth2AuthenticationFilter during OAuth2 login

### DIFF
--- a/application/src/main/java/run/halo/app/security/authentication/oauth2/MapOAuth2AuthenticationFilter.java
+++ b/application/src/main/java/run/halo/app/security/authentication/oauth2/MapOAuth2AuthenticationFilter.java
@@ -87,7 +87,7 @@ class MapOAuth2AuthenticationFilter implements WebFilter {
                             return connectionService
                                     .updateUserConnectionIfPresent(registrationId, oauth2User)
                                     .switchIfEmpty(Mono.defer(
-                                            () -> Mono.justOrEmpty(exchange.getAttribute(PRE_AUTHENTICATION))
+                                            () -> Mono.justOrEmpty((Object) exchange.getAttribute(PRE_AUTHENTICATION))
                                                     .filter(Authentication.class::isInstance)
                                                     .cast(Authentication.class)
                                                     .filter(authenticationTrustResolver::isAuthenticated)


### PR DESCRIPTION
## What type of PR is this?

/kind bug

## What this PR does / why we need it:

Fixes a `ClassCastException` that occurs during OAuth2 login when the user is already authenticated (e.g., via username/password). The call `Mono.justOrEmpty(exchange.getAttribute(PRE_AUTHENTICATION))` triggers the `Optional` overload due to generic type inference on `ServerWebExchange.getAttribute()` (`<T> T`), causing a cast from `UsernamePasswordAuthenticationToken` to `Optional` at runtime.

Adding an explicit `(Object)` cast disambiguates the overload selection.

## Which issue(s) this PR fixes:

Fixes #10109

## Does this PR introduce a user-facing change?

```release-note
Fixed an issue where OAuth2 login (e.g., GitHub) would fail with a server error when the user was already authenticated.
```