### PR TITLE
Fix editor list deletion after columns block

### DIFF
--- a/ui/packages/editor/src/extensions/gap-cursor/index.ts
+++ b/ui/packages/editor/src/extensions/gap-cursor/index.ts
@@ -114,6 +114,7 @@ export const ExtensionGapCursor = Extension.create({
               const { selection, tr } = state;
               if (
                 selection instanceof TextSelection &&
+                selection.$from.depth === 1 &&
                 isActive(state, "paragraph") &&
                 isEmpty(selection.$from.parent) &&
                 selection.empty
@@ -329,8 +330,12 @@ const arrowGapCursor = (
     if (!$found) {
       return;
     }
-    tr.setSelection(new GapCursorSelection($found));
-    return $found;
+    const $mapped = tr.doc.resolve(tr.mapping.map($found.pos, dir));
+    if (!GapCursorSelection.valid($mapped)) {
+      return;
+    }
+    tr.setSelection(new GapCursorSelection($mapped));
+    return $mapped;
   };
 };
 


### PR DESCRIPTION
#### What type of PR is this?

- [ ] Feature
- [x] Bug fix
- [ ] Improvement
- [ ] Cleanup
- [ ] Documentation

#### What this PR does / why we need it:

This PR fixes an editor Backspace crash when an empty list item follows a columns block.

The custom gap cursor handler deleted an empty paragraph/list textblock and then created a gap cursor selection from a position resolved against the old document. ProseMirror rejects that selection after the transaction document changes, which caused `Selection passed to setSelection must point at the current document`.

The fix keeps the empty-paragraph Backspace handling scoped to top-level paragraphs, and remaps the found gap cursor position through the current transaction before setting the selection.

#### Which issue(s) this PR fixes:

Fixes #6535

#### Special notes for your reviewer:

This change was generated with AI assistance and reviewed locally.

Validation:

- `git diff --check HEAD^..HEAD`
- `npx --yes pnpm@10.30.3 -C ui --filter @halo-dev/richtext-editor typecheck`
- `npx --yes pnpm@10.30.3 -C ui --filter @halo-dev/richtext-editor build`

#### Does this PR introduce a user-facing change?

```release-note
修复编辑器在分栏卡片之后的列表无法删除，或者抛出异常的问题
```
