### PR TITLE
Support editing post category parents

### DIFF
--- a/openspec/changes/support-category-parent-editing/.openspec.yaml
+++ b/openspec/changes/support-category-parent-editing/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-05

--- a/openspec/changes/support-category-parent-editing/design.md
+++ b/openspec/changes/support-category-parent-editing/design.md
@@ -1,0 +1,50 @@
+## Context
+
+Console category creation already lets administrators choose a parent category, but the edit modal hides that field in update mode. Category hierarchy is now represented by `Category.spec.parent`, and the Console backend already exposes canonical tree and position APIs that validate moves, prevent cycles, normalize priorities, and return the canonical tree.
+
+The change should stay UI-scoped. It should not introduce new backend routes, mutate hierarchy through frontend JSON patches, or change existing category selector behavior for callers that do not opt in to exclusion.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Let administrators change an existing category's parent from the edit modal.
+- Prevent selecting the current category or any of its descendants as the new parent.
+- Use the existing Console category position API for parent changes.
+- Keep parent-only edits simple by appending the moved category to the target sibling list.
+
+**Non-Goals:**
+
+- Add a sibling-order selector to the edit modal.
+- Add new category creation inside the parent selector.
+- Change backend category contracts, migration behavior, or public theme/plugin APIs.
+- Replace the existing drag-and-drop ordering workflow.
+
+## Decisions
+
+1. Reuse the shared tree-aware category selector with opt-in exclusion.
+
+   The parent control should continue to show the canonical category tree so administrators can see hierarchy while choosing a parent. The shared `categorySelect` input should accept `excludedNames` and filter those nodes from its tree, search results, keyboard navigation, and FormKit option labels. The category edit modal should pass the current category as the excluded subtree root and disable inline creation in update mode.
+
+   Alternative considered: use a plain FormKit `select`. That is simple but loses hierarchy context in the editing form. Adding opt-in props to `categorySelect` keeps existing callers unchanged while preserving the tree UI for this workflow.
+
+2. Move categories through `updateCategoryPosition` only when the parent changes.
+
+   Normal category fields should continue to save through the existing category update path. If the selected parent differs from the original parent, the modal should call the Console category position API with `parentName` set to the selected parent or unset for root, and `beforeName` unset.
+
+   Alternative considered: set `formState.spec.parent` before `updateCategory`. That would bypass backend move validation and priority normalization, and would not keep the original and target sibling lists canonical.
+
+3. Let backend append moved categories to the target sibling list.
+
+   The edit modal is a parent reassignment workflow, not a precise ordering workflow. Passing `beforeName` unset uses the existing backend contract to append the moved category to the target parent or root list. Administrators can still use drag-and-drop for exact ordering.
+
+4. Refresh the canonical category query after save.
+
+   The current category management page is driven by the `post-categories` query and canonical tree API. After a successful edit and any optional parent move, the UI should refresh or replace that query data so the tree reflects backend-confirmed hierarchy. On position update failure, it should surface the failure and reload the canonical tree instead of keeping a stale local hierarchy.
+
+## Risks / Trade-offs
+
+- Field update succeeds but parent move fails -> keep the successfully saved non-hierarchy fields, show a failure toast for the parent move, and refresh the canonical category tree.
+- Category tree data is stale while the modal is open -> backend validation remains authoritative; refreshing the query after save corrects the UI.
+- The edited category has invalid existing hierarchy data -> canonical tree rendering already treats invalid parent references as root; the parent candidate filter should still exclude the current node when present.
+- Shared selector changes could affect other forms -> keep exclusion and creation control opt-in, with existing defaults preserving current behavior.

--- a/openspec/changes/support-category-parent-editing/proposal.md
+++ b/openspec/changes/support-category-parent-editing/proposal.md
@@ -1,0 +1,28 @@
+## Why
+
+Post category creation already supports choosing a parent category, but editing an existing category does not expose the same hierarchy control. Now that Console category management is backed by `Category.spec.parent` and backend position APIs, administrators should be able to change a category's parent from the edit modal without relying on drag-and-drop.
+
+## What Changes
+
+- Show a parent category field when editing an existing post category.
+- Let administrators move an edited category to root or under an existing category.
+- Exclude the current category and its descendants from selectable parent candidates.
+- Use the existing Console category position API for parent changes so backend validation and priority normalization stay authoritative.
+- Keep precise sibling ordering as a drag-and-drop workflow; edit-form parent changes append the category to the target sibling list.
+
+## Capabilities
+
+### New Capabilities
+
+- None.
+
+### Modified Capabilities
+
+- `category-hierarchy`: Console category management will support parent changes from the category edit modal.
+
+## Impact
+
+- Affected UI: `ui/console-src/modules/contents/posts/categories/`
+- Affected APIs: existing Console `UpdateCategoryPosition` usage only; no new backend route or OpenAPI contract is expected.
+- Compatibility: no database, theme API, plugin API, or public REST contract changes.
+- i18n: reuse the existing parent category field label and existing common option wording where possible.

--- a/openspec/changes/support-category-parent-editing/specs/category-hierarchy/spec.md
+++ b/openspec/changes/support-category-parent-editing/specs/category-hierarchy/spec.md
@@ -1,0 +1,42 @@
+## ADDED Requirements
+
+### Requirement: Console edits category parents
+
+The Console SHALL allow administrators to change a Category's parent from the category edit modal using backend Console hierarchy APIs.
+
+#### Scenario: Category edit modal shows parent choices
+- **WHEN** an administrator opens the edit modal for an existing Category
+- **THEN** Console SHALL show a parent Category field
+- **AND** the field SHALL include an option for no parent
+- **AND** the field SHALL include existing Category candidates from the canonical Console Category tree
+- **AND** the field SHALL NOT offer inline Category creation
+
+#### Scenario: Category edit parent choices exclude invalid candidates
+- **WHEN** Console builds parent choices for an existing Category
+- **THEN** Console SHALL exclude the Category being edited
+- **AND** Console SHALL exclude all descendants of the Category being edited
+
+#### Scenario: Category edit changes parent
+- **WHEN** an administrator saves an edited Category with a different parent Category selected
+- **THEN** Console SHALL send a Category position update with `parentName` equal to the selected parent Category name
+- **AND** Console SHALL send the position update with `beforeName` unset or null
+- **AND** the moved Category SHALL be appended to the target parent's sibling list
+- **AND** Console SHALL refresh from the canonical Category tree after the save
+
+#### Scenario: Category edit moves category to root
+- **WHEN** an administrator saves an edited Category with no parent selected
+- **THEN** Console SHALL send a Category position update with `parentName` unset or null
+- **AND** Console SHALL send the position update with `beforeName` unset or null
+- **AND** the moved Category SHALL be appended to the root sibling list
+- **AND** Console SHALL refresh from the canonical Category tree after the save
+
+#### Scenario: Category edit keeps unchanged parent
+- **WHEN** an administrator saves an edited Category without changing its parent
+- **THEN** Console SHALL NOT send a Category position update
+- **AND** Console SHALL preserve the Category's existing hierarchy position
+
+#### Scenario: Category edit parent move fails
+- **WHEN** the edited Category fields save but the Category position update fails
+- **THEN** Console SHALL report the parent move failure
+- **AND** Console SHALL refresh from the canonical Category tree
+- **AND** Console SHALL NOT keep an unconfirmed local hierarchy state as persisted structure

--- a/openspec/changes/support-category-parent-editing/tasks.md
+++ b/openspec/changes/support-category-parent-editing/tasks.md
@@ -1,0 +1,22 @@
+## 1. Category Parent Utilities
+
+- [x] 1.1 Add category tree helpers to derive selectable parent candidates while excluding the current category and descendants.
+- [x] 1.2 Add a helper to build a parent move request only when the selected parent differs from the original parent.
+- [x] 1.3 Cover the helper behavior with focused unit tests for root moves, child moves, unchanged parents, and descendant exclusion.
+
+## 2. Edit Modal Integration
+
+- [x] 2.1 Show a tree-aware parent category selector in the category edit modal for both create and update modes.
+- [x] 2.2 Initialize the parent select from the category being edited.
+- [x] 2.3 Save normal category fields through the existing category update path.
+- [x] 2.4 When the parent changes, call `updateCategoryPosition` with the selected `parentName` and no `beforeName`.
+- [x] 2.5 Refresh the canonical `post-categories` query after successful saves and after parent move failures.
+- [x] 2.6 Report parent move failures without keeping unconfirmed local hierarchy state.
+
+## 3. Validation
+
+- [x] 3.1 Run the focused category utility unit test.
+- [x] 3.2 Run `pnpm -C ui format`.
+- [x] 3.3 Run `pnpm -C ui typecheck && pnpm -C ui lint`.
+- [x] 3.4 Run `openspec validate support-category-parent-editing --strict`.
+- [x] 3.5 Run `git diff --check`.

--- a/ui/console-src/modules/contents/posts/categories/CategoryList.vue
+++ b/ui/console-src/modules/contents/posts/categories/CategoryList.vue
@@ -139,11 +139,8 @@ async function handleUpdatePosition() {
           :indent="40"
           @after-drop="handleUpdatePosition"
         >
-          <template #default="{ node, stat }">
-            <CategoryListItem
-              :category-tree-node="node"
-              :is-child-level="stat.level > 1"
-            />
+          <template #default="{ node }">
+            <CategoryListItem :category-tree-node="node" />
           </template>
         </Draggable>
       </Transition>

--- a/ui/console-src/modules/contents/posts/categories/components/CategoryEditingModal.vue
+++ b/ui/console-src/modules/contents/posts/categories/components/CategoryEditingModal.vue
@@ -3,7 +3,7 @@ import useSlugify from "@console/composables/use-slugify";
 import { useThemeCustomTemplates } from "@console/modules/interface/themes/composables/use-theme";
 import { reset, submitForm, type FormKitNode } from "@formkit/core";
 import type { Category } from "@halo-dev/api-client";
-import { coreApiClient } from "@halo-dev/api-client";
+import { consoleApiClient, coreApiClient } from "@halo-dev/api-client";
 import {
   IconRefreshLine,
   Toast,
@@ -19,17 +19,16 @@ import { useI18n } from "vue-i18n";
 import SubmitButton from "@/components/button/SubmitButton.vue";
 import type AnnotationsForm from "@/components/form/AnnotationsForm.vue";
 import { setFocus } from "@/formkit/utils/focus";
+import { buildCategoryParentMovePosition } from "../utils";
 
 const props = withDefaults(
   defineProps<{
     category?: Category;
     parentCategory?: Category;
-    isChildLevelCategory?: boolean;
   }>(),
   {
     category: undefined,
     parentCategory: undefined,
-    isChildLevelCategory: false,
   }
 );
 
@@ -59,7 +58,10 @@ const formState = ref<Category>({
     generateName: "category-",
   },
 });
-const selectedParentCategory = ref<string>();
+const selectedParentCategory = ref<string>(
+  props.parentCategory?.metadata.name || props.category?.spec.parent || ""
+);
+const originalParentCategory = ref<string>(props.category?.spec.parent || "");
 const saving = ref(false);
 const modal = ref<InstanceType<typeof VModal> | null>(null);
 const keepAddingSubmit = ref(false);
@@ -71,6 +73,16 @@ const modalTitle = props.category
   : t("core.post_category.editing_modal.titles.create");
 
 const annotationsFormRef = ref<InstanceType<typeof AnnotationsForm>>();
+
+const excludedParentNames = computed(() => {
+  return props.category?.metadata.name ? [props.category.metadata.name] : [];
+});
+
+const isChildCategory = computed(() => !!selectedParentCategory.value);
+
+const refreshCategories = () => {
+  return queryClient.invalidateQueries({ queryKey: ["post-categories"] });
+};
 
 const handleSaveCategory = async () => {
   annotationsFormRef.value?.handleSubmit();
@@ -94,6 +106,29 @@ const handleSaveCategory = async () => {
         name: formState.value.metadata.name,
         category: formState.value,
       });
+
+      const positionRequest = buildCategoryParentMovePosition(
+        formState.value.metadata.name,
+        originalParentCategory.value,
+        selectedParentCategory.value
+      );
+
+      if (positionRequest) {
+        try {
+          await consoleApiClient.content.category.updateCategoryPosition({
+            name: positionRequest.name,
+            categoryPositionRequest: {
+              parentName: positionRequest.parentName,
+              beforeName: positionRequest.beforeName,
+            },
+          });
+        } catch (e) {
+          console.error("Failed to update category parent", e);
+          await refreshCategories();
+          Toast.error(t("core.common.toast.save_failed_and_retry"));
+          return;
+        }
+      }
     } else {
       const parentName = selectedParentCategory.value || undefined;
       if (parentName) {
@@ -109,17 +144,17 @@ const handleSaveCategory = async () => {
       });
     }
 
+    await refreshCategories();
+
     if (keepAddingSubmit.value) {
       reset("category-form");
     } else {
       modal.value?.close();
     }
 
-    queryClient.invalidateQueries({ queryKey: ["post-categories"] });
-
     Toast.success(t("core.common.toast.save_success"));
   } catch (e) {
-    console.error("Failed to create category", e);
+    console.error("Failed to save category", e);
   } finally {
     saving.value = false;
   }
@@ -148,7 +183,6 @@ onMounted(() => {
   if (props.category) {
     formState.value = cloneDeep(props.category);
   }
-  selectedParentCategory.value = props.parentCategory?.metadata.name;
   setFocus("displayNameInput");
 });
 
@@ -221,9 +255,10 @@ async function slugUniqueValidation(node: FormKitNode) {
           </div>
           <div class="mt-5 divide-y divide-gray-100 md:col-span-3 md:mt-0">
             <FormKit
-              v-if="!isUpdateMode"
               v-model="selectedParentCategory"
               type="categorySelect"
+              :excluded-names="excludedParentNames"
+              :allow-create="!isUpdateMode"
               :label="
                 $t('core.post_category.editing_modal.fields.parent.label')
               "
@@ -305,7 +340,7 @@ async function slugUniqueValidation(node: FormKitNode) {
             ></FormKit>
             <FormKit
               v-model="formState.spec.hideFromList"
-              :disabled="isChildLevelCategory"
+              :disabled="isChildCategory"
               :label="
                 $t(
                   'core.post_category.editing_modal.fields.hide_from_list.label'

--- a/ui/console-src/modules/contents/posts/categories/components/CategoryListItem.vue
+++ b/ui/console-src/modules/contents/posts/categories/components/CategoryListItem.vue
@@ -21,15 +21,9 @@ import CategoryEditingModal from "./CategoryEditingModal.vue";
 const { t } = useI18n();
 const queryClient = useQueryClient();
 
-const props = withDefaults(
-  defineProps<{
-    isChildLevel?: boolean;
-    categoryTreeNode: CategoryTreeNode;
-  }>(),
-  {
-    isChildLevel: false,
-  }
-);
+const props = defineProps<{
+  categoryTreeNode: CategoryTreeNode;
+}>();
 
 const category = computed(() => props.categoryTreeNode.category);
 
@@ -161,7 +155,6 @@ const handleOpenCreateByParentModal = () => {
 
     <CategoryEditingModal
       v-if="editingModal"
-      :is-child-level-category="isChildLevel || !!selectedParentCategory"
       :category="selectedCategory"
       :parent-category="selectedParentCategory"
       @close="onEditingModalClose"

--- a/ui/console-src/modules/contents/posts/categories/utils/__tests__/index.spec.ts
+++ b/ui/console-src/modules/contents/posts/categories/utils/__tests__/index.spec.ts
@@ -1,11 +1,14 @@
 import type { Category, CategoryTreeNode } from "@halo-dev/api-client";
 import { describe, expect, it } from "vitest";
 import {
+  buildCategoryParentMovePosition,
   buildCategoryPositionRequest,
   convertCategoryTreeToCategory,
+  filterCategoryTreeNodes,
   flattenCategoryTreeNodes,
   getCategoryFromNode,
   getCategoryPath,
+  getSelectableParentCategoryTreeNodes,
 } from "../index";
 
 describe("flattenCategoryTreeNodes", () => {
@@ -69,6 +72,73 @@ describe("getCategoryFromNode", () => {
 
     expect(getCategoryFromNode(category).metadata.name).toBe("plain");
     expect(getCategoryFromNode(treeNode).metadata.name).toBe("tree");
+  });
+});
+
+describe("getSelectableParentCategoryTreeNodes", () => {
+  it("should exclude the current category and its descendants", () => {
+    const tree = [
+      node("root", [node("child", [node("grandchild")])]),
+      node("sibling"),
+    ];
+
+    expect(
+      getSelectableParentCategoryTreeNodes(tree, "child").map(nodeName)
+    ).toEqual(["root", "sibling"]);
+  });
+
+  it("should include all categories when there is no current category", () => {
+    const tree = [node("root", [node("child")]), node("sibling")];
+
+    expect(getSelectableParentCategoryTreeNodes(tree).map(nodeName)).toEqual([
+      "root",
+      "child",
+      "sibling",
+    ]);
+  });
+});
+
+describe("filterCategoryTreeNodes", () => {
+  it("should exclude matching categories and their child subtrees", () => {
+    const tree = [
+      node("root", [node("child", [node("grandchild")])]),
+      node("sibling"),
+    ];
+
+    expect(
+      flattenCategoryTreeNodes(filterCategoryTreeNodes(tree, ["child"])).map(
+        categoryName
+      )
+    ).toEqual(["root", "sibling"]);
+  });
+});
+
+describe("buildCategoryParentMovePosition", () => {
+  it("should build a move request for moving a category under a parent", () => {
+    expect(buildCategoryParentMovePosition("child", undefined, "root")).toEqual(
+      {
+        name: "child",
+        parentName: "root",
+        beforeName: undefined,
+      }
+    );
+  });
+
+  it("should build a move request for moving a category to root", () => {
+    expect(buildCategoryParentMovePosition("child", "root", "")).toEqual({
+      name: "child",
+      parentName: undefined,
+      beforeName: undefined,
+    });
+  });
+
+  it("should return undefined when the parent is unchanged", () => {
+    expect(buildCategoryParentMovePosition("child", "root", "root")).toBe(
+      undefined
+    );
+    expect(buildCategoryParentMovePosition("root", undefined, "")).toBe(
+      undefined
+    );
   });
 });
 

--- a/ui/console-src/modules/contents/posts/categories/utils/index.ts
+++ b/ui/console-src/modules/contents/posts/categories/utils/index.ts
@@ -55,6 +55,61 @@ export function convertCategoryTreeToCategory(
   };
 }
 
+export function getSelectableParentCategoryTreeNodes(
+  tree: CategoryTreeNode[],
+  currentCategoryName?: string
+): CategoryTreeNode[] {
+  return flattenTreeNodes(
+    filterCategoryTreeNodes(
+      tree,
+      currentCategoryName ? [currentCategoryName] : []
+    )
+  );
+}
+
+export function filterCategoryTreeNodes(
+  tree: CategoryTreeNode[],
+  excludedNames: string[] = []
+): CategoryTreeNode[] {
+  const excludedNameSet = new Set(excludedNames.filter(Boolean));
+
+  function collect(nodes: CategoryTreeNode[]): CategoryTreeNode[] {
+    return nodes.flatMap((node) => {
+      if (excludedNameSet.has(node.category.metadata.name)) {
+        return [];
+      }
+
+      return [
+        {
+          ...node,
+          children: collect(node.children),
+        },
+      ];
+    });
+  }
+
+  return collect(tree);
+}
+
+export function buildCategoryParentMovePosition(
+  categoryName: string,
+  previousParentName?: string,
+  selectedParentName?: string
+): CategoryMovePosition | undefined {
+  const normalizedPreviousParentName = previousParentName || undefined;
+  const normalizedSelectedParentName = selectedParentName || undefined;
+
+  if (normalizedPreviousParentName === normalizedSelectedParentName) {
+    return undefined;
+  }
+
+  return {
+    name: categoryName,
+    parentName: normalizedSelectedParentName,
+    beforeName: undefined,
+  };
+}
+
 export function buildCategoryPositionRequest(
   previousTree: CategoryTreeNode[],
   currentTree: CategoryTreeNode[]
@@ -95,6 +150,20 @@ function flattenCategoryTreePositions(tree: CategoryTreeNode[]) {
 
   collect(tree);
   return positions;
+}
+
+function flattenTreeNodes(tree: CategoryTreeNode[]): CategoryTreeNode[] {
+  const nodes: CategoryTreeNode[] = [];
+
+  function collect(current: CategoryTreeNode[]) {
+    current.forEach((node) => {
+      nodes.push(node);
+      collect(node.children);
+    });
+  }
+
+  collect(tree);
+  return nodes;
 }
 
 function sameTreeAfterMove(

--- a/ui/src/formkit/inputs/category-select/CategorySelect.vue
+++ b/ui/src/formkit/inputs/category-select/CategorySelect.vue
@@ -1,6 +1,7 @@
 <script lang="ts" setup>
 import { usePostCategory } from "@console/modules/contents/posts/categories/composables/use-post-category";
 import {
+  filterCategoryTreeNodes,
   flattenCategoryTreeNodes,
   getCategoryFromNode,
   type CategoryTreeNode,
@@ -47,7 +48,41 @@ const multiple = computed(() => {
 
 const { categories, categoriesTree, handleFetchCategories } = usePostCategory();
 
-provide<Ref<CategoryTreeNode[]>>("categoriesTree", categoriesTree);
+const excludedNames = computed(() => {
+  const names = props.context.excludedNames;
+  if (Array.isArray(names)) {
+    return names;
+  }
+  if (typeof names === "string") {
+    return names.split(",").map((name) => name.trim());
+  }
+  return [];
+});
+
+const filteredCategoriesTree = computed(() => {
+  return filterCategoryTreeNodes(categoriesTree.value, excludedNames.value);
+});
+
+const filteredCategories = computed(() => {
+  return flattenCategoryTreeNodes(filteredCategoriesTree.value);
+});
+
+const excludedNameSet = computed(() => {
+  return new Set(excludedNames.value.filter(Boolean));
+});
+
+const allowCreate = computed(() => {
+  const { allowCreate } = props.context;
+  if (allowCreate === undefined) {
+    return true;
+  }
+  if (typeof allowCreate === "boolean") {
+    return allowCreate;
+  }
+  return allowCreate === "true";
+});
+
+provide<Ref<CategoryTreeNode[]>>("categoriesTree", filteredCategoriesTree);
 
 const selectedCategory = ref<Category | CategoryTreeNode>();
 
@@ -82,7 +117,7 @@ let fuse: Fuse<Category> | undefined = undefined;
 
 const searchResults = computed(() => {
   if (!text.value) {
-    return categories.value;
+    return filteredCategories.value;
   }
   return fuse?.search(text.value).map((item) => item.item) || [];
 });
@@ -100,9 +135,9 @@ watch(
 );
 
 watch(
-  () => categories.value,
+  () => filteredCategories.value,
   () => {
-    fuse = new Fuse(categories.value || [], {
+    fuse = new Fuse(filteredCategories.value || [], {
       keys: ["spec.displayName", "spec.slug"],
       useExtendedSearch: true,
       threshold: 0.2,
@@ -110,7 +145,7 @@ watch(
     if (props.context) {
       // eslint-disable-next-line vue/no-mutating-props
       props.context.options =
-        categories.value?.map((category) => {
+        filteredCategories.value?.map((category) => {
           return {
             label: category.spec.displayName,
             value: category.metadata.name,
@@ -156,6 +191,9 @@ provide<(category: CategoryTreeNode | Category) => boolean>(
 
 const handleSelect = (category: CategoryTreeNode | Category) => {
   const categoryName = getCategoryFromNode(category).metadata.name;
+  if (excludedNameSet.value.has(categoryName)) {
+    return;
+  }
   if (multiple.value) {
     const currentValue = props.context._value || [];
     if (currentValue.includes(categoryName)) {
@@ -182,7 +220,7 @@ const handleKeydown = (e: KeyboardEvent) => {
 
     const categoryIndices = text.value
       ? searchResults.value
-      : flattenCategoryTreeNodes(categoriesTree.value);
+      : flattenCategoryTreeNodes(filteredCategoriesTree.value);
 
     const index = categoryIndices.findIndex(
       (category) =>
@@ -192,7 +230,7 @@ const handleKeydown = (e: KeyboardEvent) => {
           : undefined)
     );
 
-    if (index < searchResults.value.length - 1) {
+    if (index < categoryIndices.length - 1) {
       selectedCategory.value = categoryIndices[index + 1];
     }
     scrollToSelected();
@@ -203,7 +241,7 @@ const handleKeydown = (e: KeyboardEvent) => {
 
     const categoryIndices = text.value
       ? searchResults.value
-      : flattenCategoryTreeNodes(categoriesTree.value);
+      : flattenCategoryTreeNodes(filteredCategoriesTree.value);
 
     const index = categoryIndices.findIndex(
       (category) =>
@@ -221,7 +259,7 @@ const handleKeydown = (e: KeyboardEvent) => {
   }
 
   if (e.key === "Enter") {
-    if (!selectedCategory.value && text.value) {
+    if (!selectedCategory.value && text.value && allowCreate.value) {
       handleCreateCategory();
       return;
     }
@@ -251,7 +289,7 @@ const scrollToSelected = () => {
 const uid = new ShortUniqueId();
 
 const handleCreateCategory = async () => {
-  if (!utils.permission.has(["system:posts:manage"])) {
+  if (!allowCreate.value || !utils.permission.has(["system:posts:manage"])) {
     return;
   }
 
@@ -355,7 +393,7 @@ const handleDelete = () => {
       <div ref="popperRef" :class="context.classes['dropdown-wrapper']">
         <ul class="p-1">
           <HasPermission
-            v-if="text.trim()"
+            v-if="allowCreate && text.trim()"
             :permissions="['system:posts:manage']"
           >
             <li
@@ -386,7 +424,7 @@ const handleDelete = () => {
           </template>
           <template v-else>
             <CategoryListItem
-              v-for="category in categoriesTree"
+              v-for="category in filteredCategoriesTree"
               :key="category.category.metadata.name"
               :category="category"
               @select="handleSelect"

--- a/ui/src/formkit/inputs/category-select/index.ts
+++ b/ui/src/formkit/inputs/category-select/index.ts
@@ -31,7 +31,7 @@ export const categorySelect: FormKitTypeDefinition = {
     messages(message("$message.value"))
   ),
   type: "input",
-  props: ["multiple"],
+  props: ["multiple", "excludedNames", "allowCreate"],
   library: {
     CategorySelect: defineAsyncComponent(() => import("./CategorySelect.vue")),
   },
@@ -43,6 +43,9 @@ declare module "@formkit/inputs" {
     categorySelect: {
       type: "categorySelect";
       value?: string | string[];
+      multiple?: boolean;
+      excludedNames?: string[];
+      allowCreate?: boolean;
     };
   }
 }


### PR DESCRIPTION
#### What type of PR is this?

- [x] Feature
- [ ] Bug fix
- [ ] Improvement
- [ ] Cleanup
- [ ] Documentation

#### What this PR does / why we need it:

This PR lets administrators change a post category's parent from the category editing modal.

It adds a tree-aware parent selector for category editing, excludes the current category subtree from selectable parents, and reuses the existing Console category position API for parent changes so backend validation and priority normalization remain authoritative. Parent changes from the modal append the category to the target sibling list; exact ordering remains handled by drag-and-drop.

#### Which issue(s) this PR fixes:

N/A

#### Special notes for your reviewer:

- The shared `categorySelect` input now supports opt-in `excludedNames` and `allowCreate` props. Existing callers keep the previous default behavior.
- The category edit modal disables inline category creation in update mode and excludes the category being edited from the selector while preserving hierarchy in the tree UI.
- AI assistance was used to prepare this PR; the generated changes were reviewed and validated locally.

Validation performed:

- `pnpm -C ui exec vp test --run console-src/modules/contents/posts/categories/utils/__tests__/index.spec.ts`
- `pnpm -C ui format`
- `pnpm -C ui typecheck && pnpm -C ui lint`
- `openspec validate support-category-parent-editing --strict`
- `git diff --check`

#### Does this PR introduce a user-facing change?

```release-note
支持在文章分类编辑页面中修改上级分类
```
