### PR TITLE
Unify editor upload handling

### DIFF
--- a/ui/console-src/modules/contents/pages/SinglePageEditor.vue
+++ b/ui/console-src/modules/contents/pages/SinglePageEditor.vue
@@ -414,20 +414,25 @@ const canManageAttachments = computed(() =>
   utils.permission.has(["system:attachments:manage"])
 );
 
-// Upload image
-async function handleUploadImage(file: File, options?: AxiosRequestConfig) {
+async function handleUpload(
+  fileOrUrl: File | string,
+  options?: AxiosRequestConfig
+) {
   if (!canManageAttachments.value) {
     return;
   }
 
   const { data } =
     await consoleApiClient.storage.attachment.uploadAttachmentForConsole(
-      {
-        file,
-      },
+      typeof fileOrUrl === "string" ? { url: fileOrUrl } : { file: fileOrUrl },
       options
     );
   return data;
+}
+
+// Kept for third-party editor providers that still consume the legacy prop.
+function handleUploadImage(file: File, options?: AxiosRequestConfig) {
+  return handleUpload(file, options);
 }
 
 async function handleMatchAttachmentPermalinks(urls: string[]) {
@@ -448,22 +453,6 @@ async function handleMatchAttachmentPermalinks(urls: string[]) {
     url: item.url || "",
     matched: item.matched || false,
   }));
-}
-
-async function handleUploadExternalUrl(url: string) {
-  if (!canManageAttachments.value) {
-    return;
-  }
-
-  const { data } =
-    await consoleApiClient.storage.attachment.uploadAttachmentForConsole({
-      url,
-    });
-
-  return {
-    url: data.status?.permalink || "",
-    alt: data.spec.displayName,
-  };
 }
 </script>
 
@@ -560,12 +549,10 @@ async function handleUploadExternalUrl(url: string) {
       v-model:content="formState.content.content"
       v-model:title="formState.page.spec.title"
       v-model:cover="formState.page.spec.cover"
+      :upload="canManageAttachments ? handleUpload : undefined"
       :upload-image="handleUploadImage"
       :match-attachment-permalinks="
         canManageAttachments ? handleMatchAttachmentPermalinks : undefined
-      "
-      :upload-external-url="
-        canManageAttachments ? handleUploadExternalUrl : undefined
       "
       class="h-full"
       @update="handleSetContentCache"

--- a/ui/console-src/modules/contents/posts/PostEditor.vue
+++ b/ui/console-src/modules/contents/posts/PostEditor.vue
@@ -459,20 +459,25 @@ const canManageAttachments = computed(() =>
   utils.permission.has(["system:attachments:manage"])
 );
 
-// Upload image
-async function handleUploadImage(file: File, options?: AxiosRequestConfig) {
+async function handleUpload(
+  fileOrUrl: File | string,
+  options?: AxiosRequestConfig
+) {
   if (!canManageAttachments.value) {
     return;
   }
 
   const { data } =
     await consoleApiClient.storage.attachment.uploadAttachmentForConsole(
-      {
-        file,
-      },
+      typeof fileOrUrl === "string" ? { url: fileOrUrl } : { file: fileOrUrl },
       options
     );
   return data;
+}
+
+// Kept for third-party editor providers that still consume the legacy prop.
+function handleUploadImage(file: File, options?: AxiosRequestConfig) {
+  return handleUpload(file, options);
 }
 
 async function handleMatchAttachmentPermalinks(urls: string[]) {
@@ -493,22 +498,6 @@ async function handleMatchAttachmentPermalinks(urls: string[]) {
     url: item.url || "",
     matched: item.matched || false,
   }));
-}
-
-async function handleUploadExternalUrl(url: string) {
-  if (!canManageAttachments.value) {
-    return;
-  }
-
-  const { data } =
-    await consoleApiClient.storage.attachment.uploadAttachmentForConsole({
-      url,
-    });
-
-  return {
-    url: data.status?.permalink || "",
-    alt: data.spec.displayName,
-  };
 }
 </script>
 
@@ -600,12 +589,10 @@ async function handleUploadExternalUrl(url: string) {
       v-model:content="formState.content.content"
       v-model:title="formState.post.spec.title"
       v-model:cover="formState.post.spec.cover"
+      :upload="canManageAttachments ? handleUpload : undefined"
       :upload-image="handleUploadImage"
       :match-attachment-permalinks="
         canManageAttachments ? handleMatchAttachmentPermalinks : undefined
-      "
-      :upload-external-url="
-        canManageAttachments ? handleUploadExternalUrl : undefined
       "
       class="size-full"
       @update="handleSetContentCache"

--- a/ui/packages/editor/src/components/upload/EditorLinkObtain.vue
+++ b/ui/packages/editor/src/components/upload/EditorLinkObtain.vue
@@ -7,11 +7,10 @@ import {
   type AttachmentSimple,
 } from "@halo-dev/ui-shared";
 import { useFileDialog } from "@vueuse/core";
-import type { AxiosRequestConfig } from "axios";
 import { onUnmounted, ref, watch } from "vue";
 import { i18n } from "@/locales";
 import type { Editor } from "@/tiptap";
-import { uploadFile } from "@/utils/upload";
+import { uploadFile, type UploadFile } from "@/utils/upload";
 import Input from "../base/Input.vue";
 
 const props = withDefaults(
@@ -19,10 +18,7 @@ const props = withDefaults(
     editor: Editor;
     accept?: string;
     uploadedFile?: File;
-    uploadToAttachmentFile: (
-      file: File,
-      options?: AxiosRequestConfig
-    ) => Promise<Attachment>;
+    uploadToAttachmentFile: UploadFile;
   }>(),
   {
     accept: "*",

--- a/ui/packages/editor/src/components/upload/ResourceReplaceButton.vue
+++ b/ui/packages/editor/src/components/upload/ResourceReplaceButton.vue
@@ -1,5 +1,4 @@
 <script lang="ts" setup>
-import type { Attachment } from "@halo-dev/api-client";
 import { Toast, VButton, VDropdown, VDropdownItem } from "@halo-dev/components";
 import {
   utils,
@@ -7,15 +6,15 @@ import {
   type AttachmentSimple,
 } from "@halo-dev/ui-shared";
 import { useFileDialog } from "@vueuse/core";
-import type { AxiosRequestConfig } from "axios";
 import { ref } from "vue";
 import { i18n } from "@/locales";
+import type { UploadFile } from "@/utils/upload";
 import Input from "../base/Input.vue";
 
 const props = defineProps<{
   originalLink?: string;
   accept?: string;
-  upload: (file: File, options?: AxiosRequestConfig) => Promise<Attachment>;
+  upload: UploadFile;
 }>();
 
 const emit = defineEmits<{
@@ -49,6 +48,9 @@ onInputChange((files) => {
   props
     .upload?.(file)
     .then((attachment) => {
+      if (!attachment) {
+        return;
+      }
       emit("change", utils.attachment.convertToSimple(attachment));
     })
     .catch((e: Error) => {

--- a/ui/packages/editor/src/composables/use-attachment.ts
+++ b/ui/packages/editor/src/composables/use-attachment.ts
@@ -1,5 +1,5 @@
 import { Toast } from "@halo-dev/components";
-import { stores, type AttachmentSimple } from "@halo-dev/ui-shared";
+import { stores, utils, type AttachmentSimple } from "@halo-dev/ui-shared";
 import { computed, ref, watch, type Ref } from "vue";
 import type { ExtensionUploadStorage } from "@/extensions/upload";
 import { i18n } from "@/locales";
@@ -20,7 +20,7 @@ export function useExternalAssetsTransfer(
   watch(
     src,
     (value) => {
-      if (!value || !uploadStorage.value?.uploadExternalUrl) {
+      if (!value || !uploadStorage.value?.upload) {
         return;
       }
       if (
@@ -45,7 +45,7 @@ export function useExternalAssetsTransfer(
   const isExternalAsset = computed(() => {
     const storage = uploadStorage.value;
 
-    if (!src.value || !storage?.uploadExternalUrl) {
+    if (!src.value || !storage?.upload) {
       return false;
     }
 
@@ -66,7 +66,7 @@ export function useExternalAssetsTransfer(
 
   async function handleTransfer() {
     const storage = uploadStorage.value;
-    if (!src.value || !storage?.uploadExternalUrl) {
+    if (!src.value || !storage?.upload) {
       return;
     }
 
@@ -78,7 +78,12 @@ export function useExternalAssetsTransfer(
         return;
       }
 
-      const attachment = await storage.uploadExternalUrl(src.value);
+      const uploadedAttachment = await storage.upload(src.value);
+      if (!uploadedAttachment) {
+        return;
+      }
+
+      const attachment = utils.attachment.convertToSimple(uploadedAttachment);
       if (!attachment?.url) {
         return;
       }

--- a/ui/packages/editor/src/extensions/audio/index.ts
+++ b/ui/packages/editor/src/extensions/audio/index.ts
@@ -1,5 +1,3 @@
-import type { Attachment } from "@halo-dev/api-client";
-import type { AxiosRequestConfig } from "axios";
 import { isEmpty } from "es-toolkit/compat";
 import { markRaw } from "vue";
 import MdiMotionPlay from "~icons/mdi/motion-play";
@@ -27,6 +25,7 @@ import {
 import type { EditorState } from "@/tiptap/pm";
 import type { ExtensionOptions, NodeBubbleMenuType } from "@/types";
 import { deleteNode } from "@/utils";
+import type { UploadFile } from "@/utils/upload";
 import AudioView from "./AudioView.vue";
 import BubbleItemAudioLink from "./BubbleItemAudioLink.vue";
 import BubbleItemAudioPosition from "./BubbleItemAudioPosition.vue";
@@ -42,10 +41,7 @@ declare module "@/tiptap" {
 export const AUDIO_BUBBLE_MENU_KEY = new PluginKey("audioBubbleMenu");
 
 export interface ExtensionAudioOptions extends ExtensionOptions {
-  uploadAudio?: (
-    file: File,
-    options?: AxiosRequestConfig
-  ) => Promise<Attachment>;
+  uploadAudio?: UploadFile;
 }
 
 export const ExtensionAudio = Node.create<ExtensionAudioOptions>({

--- a/ui/packages/editor/src/extensions/gallery/gallery-bubble.ts
+++ b/ui/packages/editor/src/extensions/gallery/gallery-bubble.ts
@@ -1,18 +1,14 @@
-import type { Attachment } from "@halo-dev/api-client";
-import type { AxiosRequestConfig } from "axios";
 import { markRaw } from "vue";
 import MdiImagePlus from "~icons/mdi/image-plus";
 import { i18n } from "@/locales";
 import { Extension } from "@/tiptap";
 import type { ExtensionOptions } from "@/types";
+import type { UploadFile } from "@/utils/upload";
 import { GALLERY_BUBBLE_MENU_KEY } from ".";
 import BubbleItemAddImage from "./BubbleItemAddImage.vue";
 
 export type ExtensionGalleryBubbleOptions = ExtensionOptions & {
-  uploadImage?: (
-    file: File,
-    options?: AxiosRequestConfig
-  ) => Promise<Attachment>;
+  uploadImage?: UploadFile;
 };
 
 export const ExtensionGalleryBubble =

--- a/ui/packages/editor/src/extensions/gallery/index.ts
+++ b/ui/packages/editor/src/extensions/gallery/index.ts
@@ -1,5 +1,3 @@
-import type { Attachment } from "@halo-dev/api-client";
-import type { AxiosRequestConfig } from "axios";
 import { markRaw } from "vue";
 import MdiImagePlus from "~icons/mdi/image-plus";
 import MingcutePhotoAlbumLine from "~icons/mingcute/photo-album-line";
@@ -18,6 +16,7 @@ import {
 import type { EditorState } from "@/tiptap/pm";
 import type { ExtensionOptions, NodeBubbleMenuType } from "@/types";
 import { deleteNode } from "@/utils";
+import type { UploadFile } from "@/utils/upload";
 import BubbleItemAddImage from "./BubbleItemAddImage.vue";
 import BubbleItemGap from "./BubbleItemGap.vue";
 import BubbleItemGroupSize from "./BubbleItemGroupSize.vue";
@@ -45,10 +44,7 @@ export type ExtensionGalleryOptions = ExtensionOptions & {
   gap?: number;
   allowBase64: boolean;
   HTMLAttributes: Record<string, unknown>;
-  uploadImage?: (
-    file: File,
-    options?: AxiosRequestConfig
-  ) => Promise<Attachment>;
+  uploadImage?: UploadFile;
 };
 
 export const ExtensionGallery = Node.create<

--- a/ui/packages/editor/src/extensions/image/index.ts
+++ b/ui/packages/editor/src/extensions/image/index.ts
@@ -1,7 +1,5 @@
-import type { Attachment } from "@halo-dev/api-client";
 import type { ImageOptions } from "@tiptap/extension-image";
 import TiptapImage from "@tiptap/extension-image";
-import type { AxiosRequestConfig } from "axios";
 import { isEmpty } from "es-toolkit/compat";
 import { markRaw } from "vue";
 import MingcuteBookmarkEditLine from "~icons/mingcute/bookmark-edit-line";
@@ -32,6 +30,7 @@ import {
 } from "@/tiptap";
 import type { ExtensionOptions, NodeBubbleMenuType } from "@/types";
 import { deleteNode } from "@/utils";
+import type { UploadFile } from "@/utils/upload";
 import { ExtensionFigure } from "../figure";
 import { ExtensionFigureCaption } from "../figure/figure-caption";
 import { ExtensionParagraph } from "../paragraph";
@@ -46,10 +45,7 @@ export const IMAGE_BUBBLE_MENU_KEY = new PluginKey("imageBubbleMenu");
 
 export type ExtensionImageOptions = ExtensionOptions &
   Partial<ImageOptions> & {
-    uploadImage?: (
-      file: File,
-      options?: AxiosRequestConfig
-    ) => Promise<Attachment>;
+    uploadImage?: UploadFile;
   };
 
 export const ExtensionImage = TiptapImage.extend<ExtensionImageOptions>({

--- a/ui/packages/editor/src/extensions/upload/index.spec.ts
+++ b/ui/packages/editor/src/extensions/upload/index.spec.ts
@@ -1,8 +1,9 @@
+import type { Attachment } from "@halo-dev/api-client";
 import { Dialog } from "@halo-dev/components";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { ref } from "vue";
 import type { Editor, PMNode } from "@/tiptap";
-import type { MatchAttachmentPermalinks, UploadExternalUrl } from "@/utils";
+import type { MatchAttachmentPermalinks, Upload } from "@/utils";
 import {
   getUnmatchedExternalNodes,
   matchAttachmentPermalinks,
@@ -74,14 +75,14 @@ describe("ExtensionUpload external asset matching", () => {
   });
 
   it("shows the paste dialog for unmatched external resources without uploading immediately", async () => {
-    const uploadExternalUrl = vi.fn<UploadExternalUrl>();
+    const upload = vi.fn<Upload>();
     const storage = createStorage(
       async (urls) =>
         urls.map((url) => ({
           url,
           matched: false,
         })),
-      uploadExternalUrl
+      upload
     );
 
     await showExternalAssetTransferDialog(editorWithNodes([]), storage, [
@@ -89,7 +90,7 @@ describe("ExtensionUpload external asset matching", () => {
     ]);
 
     expect(Dialog.info).toHaveBeenCalledTimes(1);
-    expect(uploadExternalUrl).not.toHaveBeenCalled();
+    expect(upload).not.toHaveBeenCalled();
   });
 
   it("does not show the paste dialog for matched Attachment URLs", async () => {
@@ -110,9 +111,9 @@ describe("ExtensionUpload external asset matching", () => {
   });
 
   it("passes unmatched resources to the dialog confirmation transfer", async () => {
-    const uploadExternalUrl = vi.fn<UploadExternalUrl>(async (url) => ({
-      url: `/upload/${url.split("/").pop()}`,
-    }));
+    const upload = vi.fn<Upload>(async (url) =>
+      attachment(`/upload/${String(url).split("/").pop()}`, "Uploaded asset")
+    );
     const editor = editorWithNodes([
       assetNode("https://remote.example.com/new.png"),
     ]);
@@ -122,7 +123,7 @@ describe("ExtensionUpload external asset matching", () => {
           url,
           matched: false,
         })),
-      uploadExternalUrl
+      upload
     );
 
     await showExternalAssetTransferDialog(editor, storage, [
@@ -135,20 +136,23 @@ describe("ExtensionUpload external asset matching", () => {
     }
     await dialogOptions.onConfirm?.();
 
-    expect(uploadExternalUrl).toHaveBeenCalledWith(
-      "https://remote.example.com/new.png"
+    expect(upload).toHaveBeenCalledWith("https://remote.example.com/new.png");
+    expect(editor.view.state.tr.setNodeMarkup).toHaveBeenCalledWith(
+      0,
+      expect.anything(),
+      expect.objectContaining({
+        src: "/upload/new.png",
+        name: "Uploaded asset",
+      })
     );
   });
 });
 
-function createStorage(
-  matcher?: MatchAttachmentPermalinks,
-  uploadExternalUrl?: UploadExternalUrl
-) {
+function createStorage(matcher?: MatchAttachmentPermalinks, upload?: Upload) {
   const storage = {
     matchCache: new Map<string, boolean>(),
     cacheVersion: ref(0),
-    uploadExternalUrl,
+    upload,
     matchAttachmentPermalinks: async (urls: string[]) =>
       matchAttachmentPermalinks(matcher, storage, urls),
   } as ExtensionUploadStorage;
@@ -169,6 +173,22 @@ function assetNode(src: string): ExternalAssetNode {
     pos: 0,
     index: 0,
     parent: null,
+  };
+}
+
+function attachment(permalink: string, displayName: string): Attachment {
+  return {
+    apiVersion: "storage.halo.run/v1alpha1",
+    kind: "Attachment",
+    metadata: {
+      name: displayName,
+    },
+    spec: {
+      displayName,
+    },
+    status: {
+      permalink,
+    },
   };
 }
 

--- a/ui/packages/editor/src/extensions/upload/index.ts
+++ b/ui/packages/editor/src/extensions/upload/index.ts
@@ -8,7 +8,7 @@ import {
   handleFileEvent,
   isExternalAsset,
   type MatchAttachmentPermalinks,
-  type UploadExternalUrl,
+  type Upload,
 } from "@/utils/upload";
 import { ExtensionAudio } from "../audio";
 import { ExtensionImage } from "../image";
@@ -16,13 +16,13 @@ import { ExtensionVideo } from "../video";
 
 export interface ExtensionUploadOptions {
   matchAttachmentPermalinks?: MatchAttachmentPermalinks;
-  uploadExternalUrl?: UploadExternalUrl;
+  upload?: Upload;
 }
 
 export interface ExtensionUploadStorage {
   matchCache: Map<string, boolean>;
   cacheVersion: Ref<number>;
-  uploadExternalUrl?: UploadExternalUrl;
+  upload?: Upload;
   matchAttachmentPermalinks: (urls: string[]) => Promise<void>;
 }
 
@@ -42,7 +42,7 @@ export const ExtensionUpload = Extension.create<
   addOptions() {
     return {
       matchAttachmentPermalinks: undefined,
-      uploadExternalUrl: undefined,
+      upload: undefined,
     };
   },
 
@@ -50,7 +50,7 @@ export const ExtensionUpload = Extension.create<
     return {
       matchCache: new Map<string, boolean>(),
       cacheVersion: ref(0),
-      uploadExternalUrl: undefined,
+      upload: undefined,
       matchAttachmentPermalinks: async () => undefined,
     };
   },
@@ -59,7 +59,7 @@ export const ExtensionUpload = Extension.create<
     const { editor }: { editor: Editor } = this;
     const storage = this.storage;
 
-    storage.uploadExternalUrl = this.options.uploadExternalUrl;
+    storage.upload = this.options.upload;
     storage.matchAttachmentPermalinks = (urls) =>
       matchAttachmentPermalinks(
         this.options.matchAttachmentPermalinks,
@@ -205,12 +205,12 @@ export async function showExternalAssetTransferDialog(
   storage: ExtensionUploadStorage,
   nodes: ExternalAssetNode[]
 ) {
-  if (!storage.uploadExternalUrl || !nodes.length) {
+  if (!storage.upload || !nodes.length) {
     return;
   }
 
   try {
-    const uploadExternalUrl = storage.uploadExternalUrl;
+    const upload = storage.upload;
     const externalNodes = await getUnmatchedExternalNodes(storage, nodes);
     if (externalNodes.length) {
       Dialog.info({
@@ -222,11 +222,7 @@ export async function showExternalAssetTransferDialog(
         confirmText: i18n.global.t("editor.common.button.confirm"),
         cancelText: i18n.global.t("editor.common.button.cancel"),
         async onConfirm() {
-          await batchUploadExternalLink(
-            editor,
-            externalNodes,
-            uploadExternalUrl
-          );
+          await batchUploadExternalLink(editor, externalNodes, upload);
 
           Toast.success(i18n.global.t("editor.common.toast.save_success"));
         },

--- a/ui/packages/editor/src/extensions/video/index.ts
+++ b/ui/packages/editor/src/extensions/video/index.ts
@@ -1,5 +1,3 @@
-import type { Attachment } from "@halo-dev/api-client";
-import type { AxiosRequestConfig } from "axios";
 import { isEmpty } from "es-toolkit/compat";
 import { markRaw } from "vue";
 import LucideCaptions from "~icons/lucide/captions";
@@ -33,6 +31,7 @@ import {
 } from "@/tiptap";
 import type { ExtensionOptions, NodeBubbleMenuType } from "@/types";
 import { deleteNode } from "@/utils";
+import type { UploadFile } from "@/utils/upload";
 import { ExtensionFigure } from "../figure";
 import { ExtensionFigureCaption } from "../figure/figure-caption";
 import { ExtensionParagraph } from "../paragraph";
@@ -51,10 +50,7 @@ declare module "@/tiptap" {
 export const VIDEO_BUBBLE_MENU_KEY = new PluginKey("videoBubbleMenu");
 
 export type ExtensionVideoOptions = ExtensionOptions & {
-  uploadVideo?: (
-    file: File,
-    options?: AxiosRequestConfig
-  ) => Promise<Attachment>;
+  uploadVideo?: UploadFile;
 };
 
 export const ExtensionVideo = Node.create<ExtensionVideoOptions>({

--- a/ui/packages/editor/src/index.ts
+++ b/ui/packages/editor/src/index.ts
@@ -20,5 +20,6 @@ export {
   isNodeContentEmpty,
   getCursorCoords,
   type MatchAttachmentPermalinks,
-  type UploadExternalUrl,
+  type Upload,
+  type UploadFile,
 } from "./utils";

--- a/ui/packages/editor/src/utils/upload.ts
+++ b/ui/packages/editor/src/utils/upload.ts
@@ -12,18 +12,19 @@ export interface AttachmentPermalinkMatchResult {
   matched: boolean;
 }
 
-export interface ExternalAssetTransferResult {
-  url: string;
-  alt?: string;
-}
-
 export type MatchAttachmentPermalinks = (
   urls: string[]
 ) => Promise<AttachmentPermalinkMatchResult[]>;
 
-export type UploadExternalUrl = (
-  url: string
-) => Promise<ExternalAssetTransferResult | undefined>;
+export type Upload = (
+  fileOrUrl: File | string,
+  options?: AxiosRequestConfig
+) => Promise<Attachment | undefined>;
+
+export type UploadFile = (
+  file: File,
+  options?: AxiosRequestConfig
+) => Promise<Attachment | undefined>;
 
 export interface FileProps {
   file: File;
@@ -137,7 +138,7 @@ export interface UploadFetchResponse {
  */
 export const uploadFile = async (
   file: File,
-  upload: (file: File, options?: AxiosRequestConfig) => Promise<Attachment>,
+  upload: UploadFile,
   uploadResponse: UploadFetchResponse
 ) => {
   const { signal } = uploadResponse.controller;
@@ -191,9 +192,9 @@ export async function batchUploadExternalLink(
     index: number;
     parent: PMNode | null;
   }[],
-  uploadExternalUrl?: UploadExternalUrl
+  upload?: Upload
 ) {
-  if (!uploadExternalUrl) {
+  if (!upload) {
     return;
   }
 
@@ -201,9 +202,7 @@ export async function batchUploadExternalLink(
 
   for (const chunkNodes of chunks) {
     await Promise.all(
-      chunkNodes.map((node) =>
-        uploadExternalLink(editor, node, uploadExternalUrl)
-      )
+      chunkNodes.map((node) => uploadExternalLink(editor, node, upload))
     );
   }
 }
@@ -216,7 +215,7 @@ export async function uploadExternalLink(
     index: number;
     parent: PMNode | null;
   },
-  uploadExternalUrl: UploadExternalUrl
+  upload: Upload
 ) {
   const { node, pos } = nodeWithPos;
   const { src } = node.attrs;
@@ -226,8 +225,13 @@ export async function uploadExternalLink(
   }
 
   try {
-    const attachment = await uploadExternalUrl(src);
+    const uploadedAttachment = await upload(src);
 
+    if (!uploadedAttachment) {
+      return;
+    }
+
+    const attachment = utils.attachment.convertToSimple(uploadedAttachment);
     if (!attachment?.url) {
       return;
     }

--- a/ui/src/components/editor/DefaultEditor.vue
+++ b/ui/src/components/editor/DefaultEditor.vue
@@ -34,7 +34,8 @@ import {
   VueEditor,
   type Extensions,
   type MatchAttachmentPermalinks,
-  type UploadExternalUrl,
+  type Upload,
+  type UploadFile,
 } from "@halo-dev/richtext-editor";
 import { utils, type AttachmentLike } from "@halo-dev/ui-shared";
 import { useDebounceFn, useFileDialog, useLocalStorage } from "@vueuse/core";
@@ -76,8 +77,8 @@ const props = withDefaults(
       file: File,
       options?: AxiosRequestConfig
     ) => Promise<Attachment>;
+    upload?: Upload;
     matchAttachmentPermalinks?: MatchAttachmentPermalinks;
-    uploadExternalUrl?: UploadExternalUrl;
   }>(),
   {
     title: "",
@@ -85,8 +86,8 @@ const props = withDefaults(
     content: "",
     cover: undefined,
     uploadImage: undefined,
+    upload: undefined,
     matchAttachmentPermalinks: undefined,
-    uploadExternalUrl: undefined,
   }
 );
 
@@ -232,6 +233,17 @@ const customExtensions = [
 
 const isInitialized = ref(false);
 
+const uploadFile: UploadFile | undefined =
+  props.upload || props.uploadImage
+    ? async (file, options) => {
+        if (props.upload) {
+          return props.upload(file, options);
+        }
+
+        return props.uploadImage?.(file, options);
+      }
+    : undefined;
+
 onMounted(async () => {
   const extensionsFromPlugins: Extensions = [];
 
@@ -261,20 +273,20 @@ onMounted(async () => {
     extensions: [
       ExtensionsKit.configure({
         image: {
-          uploadImage: props.uploadImage,
+          uploadImage: uploadFile,
         },
         gallery: {
-          uploadImage: props.uploadImage,
+          uploadImage: uploadFile,
         },
         video: {
-          uploadVideo: props.uploadImage,
+          uploadVideo: uploadFile,
         },
         audio: {
-          uploadAudio: props.uploadImage,
+          uploadAudio: uploadFile,
         },
         upload: {
           matchAttachmentPermalinks: props.matchAttachmentPermalinks,
-          uploadExternalUrl: props.uploadExternalUrl,
+          upload: props.upload,
         },
         placeholder: {
           placeholder: t(
@@ -366,15 +378,20 @@ onCoverInputChange((files) => {
   if (!file) {
     return;
   }
-  props
-    .uploadImage?.(file, {
-      onUploadProgress: (progress) => {
-        uploadProgress.value = Math.round(
-          (progress.loaded * 100) / (progress.total || 1)
-        );
-      },
-    })
+  if (!uploadFile) {
+    return;
+  }
+  uploadFile(file, {
+    onUploadProgress: (progress) => {
+      uploadProgress.value = Math.round(
+        (progress.loaded * 100) / (progress.total || 1)
+      );
+    },
+  })
     .then((attachment) => {
+      if (!attachment) {
+        return;
+      }
       emit("update:cover", attachment.status?.permalink);
     })
     .catch((e: Error) => {

--- a/ui/uc-src/modules/contents/posts/PostEditor.vue
+++ b/ui/uc-src/modules/contents/posts/PostEditor.vue
@@ -468,19 +468,24 @@ const canManageAttachments = computed(() =>
   utils.permission.has(["uc:attachments:manage"])
 );
 
-// Upload image
-async function handleUploadImage(file: File, options?: AxiosRequestConfig) {
+async function handleUpload(
+  fileOrUrl: File | string,
+  options?: AxiosRequestConfig
+) {
   if (!canManageAttachments.value) {
     return;
   }
 
   const { data } = await ucApiClient.storage.attachment.uploadAttachmentForUc(
-    {
-      file,
-    },
+    typeof fileOrUrl === "string" ? { url: fileOrUrl } : { file: fileOrUrl },
     options
   );
   return data;
+}
+
+// Kept for third-party editor providers that still consume the legacy prop.
+function handleUploadImage(file: File, options?: AxiosRequestConfig) {
+  return handleUpload(file, options);
 }
 
 async function handleMatchAttachmentPermalinks(urls: string[]) {
@@ -499,21 +504,6 @@ async function handleMatchAttachmentPermalinks(urls: string[]) {
     url: item.url || "",
     matched: item.matched || false,
   }));
-}
-
-async function handleUploadExternalUrl(url: string) {
-  if (!canManageAttachments.value) {
-    return;
-  }
-
-  const { data } = await ucApiClient.storage.attachment.uploadAttachmentForUc({
-    url,
-  });
-
-  return {
-    url: data.status?.permalink || "",
-    alt: data.spec.displayName,
-  };
 }
 
 // Keep session alive
@@ -576,12 +566,10 @@ useSessionKeepAlive();
       v-model:content="content.content"
       v-model:title="formState.spec.title"
       v-model:cover="formState.spec.cover"
+      :upload="canManageAttachments ? handleUpload : undefined"
       :upload-image="handleUploadImage"
       :match-attachment-permalinks="
         canManageAttachments ? handleMatchAttachmentPermalinks : undefined
-      "
-      :upload-external-url="
-        canManageAttachments ? handleUploadExternalUrl : undefined
       "
       class="h-full"
       @update="handleSetContentCache"


### PR DESCRIPTION
#### What type of PR is this?

- [ ] Feature
- [ ] Bug fix
- [x] Improvement
- [ ] Cleanup
- [ ] Documentation

#### What this PR does / why we need it:

This PR unifies the default editor upload contract so file uploads and external URL transfers both use a single `upload` callback that returns an `Attachment`.

It also keeps the legacy `uploadImage` prop available for third-party editor providers that still consume it, while removing the unreleased `uploadExternalUrl` callback from the default editor and rich-text editor upload extension.

#### Which issue(s) this PR fixes:

N/A

#### Special notes for your reviewer:

The attachment permalink matching callback remains separate from upload handling.

The URL transfer path now calls `upload(url)` and maps the returned `Attachment` back to editor node attributes through `status.permalink` and `spec.displayName`.

This change was implemented with AI assistance and reviewed/validated locally.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
