### PR TITLE
Fix cropped attachment previews

### DIFF
--- a/ui/src/formkit/inputs/attachment/AttachmentPreview.vue
+++ b/ui/src/formkit/inputs/attachment/AttachmentPreview.vue
@@ -19,11 +19,11 @@ const mediaType = computed(() => {
   <img
     v-if="isImage(mediaType)"
     :src="utils.attachment.getThumbnailUrl(url, GetThumbnailByUriSizeEnum.S)"
-    class="size-full object-cover"
+    class="size-full object-contain"
   />
   <LazyVideo
     v-else-if="mediaType?.startsWith('video/')"
-    classes="size-full object-cover"
+    classes="size-full object-contain"
     :src="url"
   />
   <AttachmentFileTypeIcon v-else :file-name="url" />


### PR DESCRIPTION
#### What type of PR is this?

- [ ] Feature
- [x] Bug fix
- [ ] Improvement
- [ ] Cleanup
- [ ] Documentation

#### What this PR does / why we need it:

Changes attachment image and video previews from `object-cover` to
`object-contain` so media with varying aspect ratios remains fully visible
inside fixed preview containers.

before:

<img width="406" height="136" alt="image" src="https://github.com/user-attachments/assets/77319e59-0562-4392-8d4a-29c3c227f951" />

after:

<img width="335" height="133" alt="image" src="https://github.com/user-attachments/assets/d57bfe43-12ef-4c30-ac38-582fbdc18074" />

#### Which issue(s) this PR fixes:

N/A

#### Special notes for your reviewer:

The preview may contain empty space when the media aspect ratio differs from
the configured container. This is intentional to avoid cropping.

#### Does this PR introduce a user-facing change?

```release-note
优化附件预览显示，避免不同宽高比的图片和视频被裁剪。
```
