### PR TITLE
Fix Console access for users with multiple roles

### DIFF
--- a/ui/console-src/router/guards/permission.ts
+++ b/ui/console-src/router/guards/permission.ts
@@ -1,8 +1,6 @@
-import type { Role } from "@halo-dev/api-client";
 import { stores, utils } from "@halo-dev/ui-shared";
 import type { RouteLocationNormalized, Router } from "vue-router";
-import { rbacAnnotations } from "@/constants/annotations";
-import { SUPER_ROLE_NAME } from "@/constants/constants";
+import { isConsoleAccessDisallowed } from "@/utils/role";
 
 export function setupPermissionGuard(router: Router) {
   router.beforeEach(async (to, _, next) => {
@@ -24,20 +22,6 @@ export function setupPermissionGuard(router: Router) {
       next({ name: "Forbidden" });
     }
   });
-}
-
-function isConsoleAccessDisallowed(currentRoles?: Role[]): boolean {
-  if (currentRoles?.some((role) => role.metadata.name === SUPER_ROLE_NAME)) {
-    return false;
-  }
-
-  return (
-    currentRoles?.some(
-      (role) =>
-        role.metadata.annotations?.[rbacAnnotations.DISALLOW_ACCESS_CONSOLE] ===
-        "true"
-    ) || false
-  );
 }
 
 async function checkRoutePermissions(

--- a/ui/src/layouts/UserProfileBanner.vue
+++ b/ui/src/layouts/UserProfileBanner.vue
@@ -15,7 +15,7 @@ import { storeToRefs } from "pinia";
 import { computed } from "vue";
 import { useI18n } from "vue-i18n";
 import { rbacAnnotations } from "@/constants/annotations";
-import { SUPER_ROLE_NAME } from "@/constants/constants";
+import { isConsoleAccessDisallowed } from "@/utils/role";
 
 const props = defineProps<{
   platform?: "console" | "uc";
@@ -37,23 +37,9 @@ const handleLogout = () => {
   });
 };
 
-const disallowAccessConsole = computed(() => {
-  if (
-    currentUser.value?.roles.some(
-      (role) => role.metadata.name === SUPER_ROLE_NAME
-    )
-  ) {
-    return false;
-  }
-
-  const hasDisallowAccessConsoleRole = currentUser.value?.roles.some((role) => {
-    return (
-      role.metadata.annotations?.[rbacAnnotations.DISALLOW_ACCESS_CONSOLE] ===
-      "true"
-    );
-  });
-  return !!hasDisallowAccessConsoleRole;
-});
+const disallowAccessConsole = computed(() =>
+  isConsoleAccessDisallowed(currentUser.value?.roles)
+);
 
 const actions = computed(() => {
   const items = [

--- a/ui/src/utils/__tests__/role.spec.ts
+++ b/ui/src/utils/__tests__/role.spec.ts
@@ -1,0 +1,57 @@
+import type { Role } from "@halo-dev/api-client";
+import { describe, expect, it } from "vite-plus/test";
+import { rbacAnnotations } from "@/constants/annotations";
+import { SUPER_ROLE_NAME } from "@/constants/constants";
+import { isConsoleAccessDisallowed } from "../role";
+
+function createRole(name: string, disallowAccessConsole = false): Role {
+  return {
+    apiVersion: "v1alpha1",
+    kind: "Role",
+    metadata: {
+      name,
+      annotations: disallowAccessConsole
+        ? { [rbacAnnotations.DISALLOW_ACCESS_CONSOLE]: "true" }
+        : {},
+    },
+    rules: [],
+  };
+}
+
+describe("isConsoleAccessDisallowed", () => {
+  it("does not disallow access when roles are missing", () => {
+    expect(isConsoleAccessDisallowed()).toBe(false);
+    expect(isConsoleAccessDisallowed([])).toBe(false);
+  });
+
+  it("disallows access when every role disallows Console access", () => {
+    expect(isConsoleAccessDisallowed([createRole("post-author", true)])).toBe(
+      true
+    );
+    expect(
+      isConsoleAccessDisallowed([
+        createRole("post-author", true),
+        createRole("post-contributor", true),
+      ])
+    ).toBe(true);
+  });
+
+  it("allows access when any role allows Console access", () => {
+    expect(isConsoleAccessDisallowed([createRole("post-editor")])).toBe(false);
+    expect(
+      isConsoleAccessDisallowed([
+        createRole("post-editor"),
+        createRole("post-author", true),
+      ])
+    ).toBe(false);
+  });
+
+  it("allows access for the super role", () => {
+    expect(
+      isConsoleAccessDisallowed([
+        createRole(SUPER_ROLE_NAME),
+        createRole("post-author", true),
+      ])
+    ).toBe(false);
+  });
+});

--- a/ui/src/utils/role.ts
+++ b/ui/src/utils/role.ts
@@ -1,5 +1,21 @@
 import type { Role } from "@halo-dev/api-client";
 import { rbacAnnotations } from "@/constants/annotations";
+import { SUPER_ROLE_NAME } from "@/constants/constants";
+
+export function isConsoleAccessDisallowed(roles?: Role[]): boolean {
+  if (roles?.some((role) => role.metadata.name === SUPER_ROLE_NAME)) {
+    return false;
+  }
+
+  return (
+    !!roles?.length &&
+    roles.every(
+      (role) =>
+        role.metadata.annotations?.[rbacAnnotations.DISALLOW_ACCESS_CONSOLE] ===
+        "true"
+    )
+  );
+}
 
 export function resolveDeepDependencies(
   role: Role,


### PR DESCRIPTION
#### What type of PR is this?

- [ ] Feature
- [x] Bug fix
- [ ] Improvement
- [ ] Cleanup
- [ ] Documentation

#### What this PR does / why we need it:

Users can be assigned multiple roles, but the current Console access check denies access when any role explicitly disallows it, even if another assigned role allows Console access.

This change:

- denies Console access only when every assigned role explicitly disallows it;
- preserves the existing super-role override;
- shares the access decision between the Console route guard and the User Center entry;
- adds regression tests for single, mixed, empty, and super-role combinations.

#### Which issue(s) this PR fixes:

Fixes #10141

#### Special notes for your reviewer:

Route-level and API permission checks remain unchanged after Console access is granted.

AI assistance was used to implement this change. The resulting code and tests were reviewed and validated by the author.

#### Does this PR introduce a user-facing change?

```release-note
修复拥有多个角色的用户可能无法正常访问 Console 的问题。
```
