### PR TITLE
Add pinned filter to PostFinder list

### DIFF
--- a/application/src/main/java/run/halo/app/theme/finders/impl/PostFinderImpl.java
+++ b/application/src/main/java/run/halo/app/theme/finders/impl/PostFinderImpl.java
@@ -391,6 +391,7 @@ class PostFinderImpl implements PostFinder {
         private String categoryName;
         private String tagName;
         private String owner;
+        private Boolean pinned;
         private List<String> sort;
 
         public ListOptions toListOptions() {
@@ -402,6 +403,10 @@ class PostFinderImpl implements PostFinder {
             }
             if (StringUtils.isNotBlank(tagName)) {
                 builder.andQuery(equal("spec.tags", tagName));
+                hasQuery = true;
+            }
+            if (pinned != null) {
+                builder.andQuery(equal("spec.pinned", pinned));
                 hasQuery = true;
             }
             // Exclude hidden posts when no query

--- a/application/src/test/java/run/halo/app/theme/finders/impl/PostFinderImplIntegrationTest.java
+++ b/application/src/test/java/run/halo/app/theme/finders/impl/PostFinderImplIntegrationTest.java
@@ -2,7 +2,9 @@ package run.halo.app.theme.finders.impl;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.util.Map;
@@ -76,13 +78,15 @@ class PostFinderImplIntegrationTest {
         when(templateResourceComputer.compute(eq("post"))).thenReturn(new StringTemplateResource("""
             <span
               th:each="post : ${postFinder.list({page: 1, size: 10, tagName: 'fake-tag',
-               ownerName: 'fake-owner', sort: {'spec.publishTime,desc',
+               ownerName: 'fake-owner', pinned: true, sort: {'spec.publishTime,desc',
                 'metadata.creationTimestamp,asc'}})}"
             >
             </span>
             """));
         result = templateEngine.process("post", context);
         assertThat(result).isEqualToIgnoringWhitespace("");
+        verify(postPublicQueryService)
+                .list(argThat(options -> options.toCondition().toString().contains("spec.pinned = true")), any());
     }
 
     static class TestTemplateResolver extends StringTemplateResolver {

--- a/application/src/test/java/run/halo/app/theme/finders/impl/PostFinderImplTest.java
+++ b/application/src/test/java/run/halo/app/theme/finders/impl/PostFinderImplTest.java
@@ -231,6 +231,14 @@ class PostFinderImplTest {
             assertThat(result.getSort())
                     .isEqualTo(Sort.by(Sort.Order.desc("spec.publishTime")).and(PostFinderImpl.defaultSort()));
         }
+
+        @Test
+        void toListOptionsWithPinnedTest() {
+            var query = new PostFinderImpl.PostQuery();
+            query.setPinned(true);
+
+            assertThat(query.toListOptions().toCondition().toString()).isEqualTo("spec.pinned = true");
+        }
     }
 
     @Nested


### PR DESCRIPTION
#### What type of PR is this?

- [x] Feature
- [ ] Bug fix
- [ ] Improvement
- [ ] Cleanup
- [ ] Documentation

#### What this PR does / why we need it:

Adds an optional `pinned` parameter to `postFinder.list` so themes can query posts by pinned status. Existing calls without this parameter retain their current behavior.

Adds unit coverage for the generated list condition and integration coverage for Thymeleaf parameter binding.

#### Which issue(s) this PR fixes:

Fixes #1651

#### Special notes for your reviewer:

Example theme usage:

`${postFinder.list({pinned: true, page: 1, size: 10})}`

Validated with:

- `./gradlew :application:spotlessApply`
- `./gradlew :application:test --tests '*PostFinderImplTest' --tests '*PostFinderImplIntegrationTest'`
- `./gradlew :application:test`
- `git diff --check`

This change was implemented with assistance from OpenAI Codex and validated locally with the tests listed above.

#### Does this PR introduce a user-facing change?

```release-note
主题模板现可通过 `postFinder.list` 的 `pinned` 参数筛选置顶或非置顶文章。
```
