### PR TITLE
Fix pasted asset transfer positions

### DIFF
--- a/ui/packages/editor/src/extensions/upload/changed-assets.ts
+++ b/ui/packages/editor/src/extensions/upload/changed-assets.ts
@@ -1,0 +1,38 @@
+import { ExtensionAudio } from "@/extensions/audio";
+import { ExtensionImage } from "@/extensions/image";
+import { ExtensionVideo } from "@/extensions/video";
+import type { PMNode } from "@/tiptap";
+
+export function getChangedAssetNodes(
+  docBeforePaste: PMNode,
+  docAfterPaste: PMNode
+) {
+  const from = docBeforePaste.content.findDiffStart(docAfterPaste.content);
+  const diffEnd = docBeforePaste.content.findDiffEnd(docAfterPaste.content);
+  if (from === null || !diffEnd) {
+    return [];
+  }
+
+  const assetNodes: Array<{
+    node: PMNode;
+    pos: number;
+    index: number;
+    parent: PMNode | null;
+  }> = [];
+  docAfterPaste.nodesBetween(
+    from,
+    Math.max(from, diffEnd.b),
+    (node, pos, parent, index) => {
+      if (
+        [
+          ExtensionAudio.name,
+          ExtensionVideo.name,
+          ExtensionImage.name,
+        ].includes(node.type.name)
+      ) {
+        assetNodes.push({ node, pos, parent, index });
+      }
+    }
+  );
+  return assetNodes;
+}

--- a/ui/packages/editor/src/extensions/upload/index.spec.ts
+++ b/ui/packages/editor/src/extensions/upload/index.spec.ts
@@ -2,8 +2,9 @@ import type { Attachment } from "@halo-dev/api-client";
 import { Dialog } from "@halo-dev/components";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { ref } from "vue";
-import type { Editor, PMNode } from "@/tiptap";
+import { Schema, type Editor, type PMNode } from "@/tiptap";
 import type { MatchAttachmentPermalinks, Upload } from "@/utils";
+import { getChangedAssetNodes } from "./changed-assets";
 import {
   getUnmatchedExternalNodes,
   matchAttachmentPermalinks,
@@ -55,6 +56,32 @@ describe("ExtensionUpload external asset matching", () => {
     expect(storage.matchCache.get("https://remote.example.com/new.png")).toBe(
       false
     );
+  });
+
+  it("uses final document positions for assets inserted after existing content", () => {
+    const schema = new Schema({
+      nodes: {
+        doc: { content: "block+" },
+        paragraph: { content: "text*", group: "block" },
+        text: {},
+        image: {
+          group: "block",
+          attrs: { src: { default: null } },
+        },
+      },
+    });
+    const paragraph = schema.node("paragraph", null, [schema.text("before")]);
+    const beforePaste = schema.node("doc", null, [paragraph]);
+    const pastedImage = schema.node("image", {
+      src: "https://remote.example.com/new.png",
+    });
+    const afterPaste = schema.node("doc", null, [paragraph, pastedImage]);
+
+    const nodes = getChangedAssetNodes(beforePaste, afterPaste);
+
+    expect(nodes).toHaveLength(1);
+    expect(nodes[0]?.pos).toBe(paragraph.nodeSize);
+    expect(nodes[0]?.node.attrs.src).toBe("https://remote.example.com/new.png");
   });
 
   it("does not show a dialog when URL transfer is unavailable", async () => {

--- a/ui/packages/editor/src/extensions/upload/index.ts
+++ b/ui/packages/editor/src/extensions/upload/index.ts
@@ -13,6 +13,7 @@ import {
 import { ExtensionAudio } from "../audio";
 import { ExtensionImage } from "../image";
 import { ExtensionVideo } from "../video";
+import { getChangedAssetNodes } from "./changed-assets";
 
 export interface ExtensionUploadOptions {
   matchAttachmentPermalinks?: MatchAttachmentPermalinks;
@@ -80,11 +81,17 @@ export const ExtensionUpload = Extension.create<
               return false;
             }
 
-            void showExternalAssetTransferDialog(
-              editor,
-              storage,
-              getAllAssetNodes(slice)
-            );
+            const pastedAssetNodes = getAllAssetNodes(slice);
+            if (pastedAssetNodes.length) {
+              const docBeforePaste = view.state.doc;
+              queueMicrotask(() => {
+                void showExternalAssetTransferDialog(
+                  editor,
+                  storage,
+                  getChangedAssetNodes(docBeforePaste, editor.state.doc)
+                );
+              });
+            }
 
             const types = event.clipboardData.types;
             if (!containsFileClipboardIdentifier(types)) {


### PR DESCRIPTION
#### What type of PR is this?

- [ ] Feature
- [x] Bug fix
- [ ] Improvement
- [ ] Cleanup
- [ ] Documentation

#### What this PR does / why we need it:

External asset nodes collected from a pasted ProseMirror slice use positions relative to the slice. These positions were previously reused as document positions when transferring the pasted assets, which could update the wrong node when content was pasted after existing content.

This change waits for the paste operation and its synchronous document normalization to complete, compares the document before and after the paste, and collects media nodes from the actual changed document range. External asset transfers therefore use their final document positions.

A regression test covers pasting an external image after existing content.

#### Which issue(s) this PR fixes:

N/A

#### Special notes for your reviewer:

The implementation was developed with AI assistance and manually reviewed.

Validation performed:

- `pnpm -C ui/packages/editor exec vitest run src/extensions/upload/index.spec.ts --reporter=verbose`
- `pnpm -C ui/packages/editor typecheck`
- `pnpm -C ui build:packages`
- `pnpm -C ui lint`
- `git diff --check`

`build:packages` completed successfully while continuing to emit unrelated declaration diagnostics from the components package.

#### Does this PR introduce a user-facing change?

```release-note
修复在富文本编辑器中转存粘贴的外部资源时可能更新错误内容的问题。
```
