### PR TITLE
Fix duplicate menu items during hierarchy migration

### DIFF
--- a/application/src/main/java/run/halo/app/core/extension/migration/MenuItemHierarchyMigration.java
+++ b/application/src/main/java/run/halo/app/core/extension/migration/MenuItemHierarchyMigration.java
@@ -8,9 +8,11 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Comparator;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 import lombok.RequiredArgsConstructor;
 import lombok.Value;
 import lombok.extern.slf4j.Slf4j;
@@ -338,11 +340,58 @@ class MenuItemHierarchyMigration {
                 if (spec == null || spec.getMenuItems() == null) {
                     continue;
                 }
-                spec.getMenuItems().stream()
-                        .filter(Objects::nonNull)
+                legacyRootNames(spec.getMenuItems()).stream()
                         .forEach(itemName -> paths.add(new LegacyPath(menuName, null, itemName, List.of(itemName))));
             }
             return paths;
+        }
+
+        private List<String> legacyRootNames(Iterable<String> menuItemNames) {
+            var members = new ArrayList<String>();
+            menuItemNames.forEach(itemName -> {
+                if (itemName != null) {
+                    members.add(itemName);
+                }
+            });
+            var memberSet = new HashSet<>(members);
+            var descendants = new HashSet<String>();
+            // Legacy Console stored every menu member, not only roots, in Menu.spec.menuItems.
+            for (var member : members) {
+                var memberDescendants = new HashSet<String>();
+                collectLegacyDescendants(member, memberDescendants);
+                memberDescendants.remove(member);
+                memberDescendants.retainAll(memberSet);
+                descendants.addAll(memberDescendants);
+            }
+
+            var roots = new ArrayList<String>();
+            members.stream().filter(itemName -> !descendants.contains(itemName)).forEach(roots::add);
+            var covered = new HashSet<String>();
+            roots.forEach(root -> {
+                covered.add(root);
+                collectLegacyDescendants(root, covered);
+            });
+            // A cyclic or otherwise disconnected component has no natural root. Pick one entry so
+            // migration can still visit it, without treating every member in the component as a root.
+            for (var member : members) {
+                if (covered.add(member)) {
+                    roots.add(member);
+                    collectLegacyDescendants(member, covered);
+                }
+            }
+            return roots;
+        }
+
+        private void collectLegacyDescendants(String itemName, Set<String> descendants) {
+            var item = getItem(itemName);
+            if (item == null) {
+                return;
+            }
+            for (var childName : legacyChildren(item)) {
+                if (descendants.add(childName)) {
+                    collectLegacyDescendants(childName, descendants);
+                }
+            }
         }
 
         @Nullable

--- a/application/src/test/java/run/halo/app/core/extension/migration/MenuItemHierarchyMigrationTest.java
+++ b/application/src/test/java/run/halo/app/core/extension/migration/MenuItemHierarchyMigrationTest.java
@@ -73,6 +73,68 @@ class MenuItemHierarchyMigrationTest {
     }
 
     @Test
+    void shouldMigrateLegacyMembershipWithoutCloningDescendants() {
+        var root = menuItem("root", children("child"));
+        var child = menuItem("child", children("grandchild"));
+        var grandchild = menuItem("grandchild", null);
+
+        StepVerifier.create(migration.migrate(
+                        List.of(menu("primary", children("root", "child", "grandchild"))),
+                        List.of(root, child, grandchild)))
+                .assertNext(summary -> {
+                    assertThat(summary.getClonesCreated()).isZero();
+                    assertThat(createdItems).isEmpty();
+                    assertThat(root.getSpec().getParent()).isNull();
+                    assertThat(child.getSpec().getParent()).isEqualTo("root");
+                    assertThat(grandchild.getSpec().getParent()).isEqualTo("child");
+                })
+                .verifyComplete();
+    }
+
+    @Test
+    void shouldMigrateLegacyMembershipWhenParentWasAddedAfterChildren() {
+        var promotion = menuItem("promotion", null);
+        var app = menuItem("app", null);
+        var aiSite = menuItem("ai-site", null);
+        var community = menuItem("community", children("promotion", "app", "ai-site"));
+
+        StepVerifier.create(migration.migrate(
+                        List.of(menu("primary", children("promotion", "app", "ai-site", "community"))),
+                        List.of(promotion, app, aiSite, community)))
+                .assertNext(summary -> {
+                    assertThat(summary.getClonesCreated()).isZero();
+                    assertThat(createdItems).isEmpty();
+                    assertThat(community.getSpec().getParent()).isNull();
+                    assertThat(promotion.getSpec().getParent()).isEqualTo("community");
+                    assertThat(app.getSpec().getParent()).isEqualTo("community");
+                    assertThat(aiSite.getSpec().getParent()).isEqualTo("community");
+                })
+                .verifyComplete();
+    }
+
+    @Test
+    void shouldNotRecreateDeletedCloneForMigratedLegacyMembership() {
+        var root = menuItem("root", children("child"));
+        var child = menuItem("child", null);
+        root.getSpec().setMenuName("primary");
+        child.getSpec().setMenuName("primary");
+        child.getSpec().setParent("root");
+        root.getMetadata().setLabels(new HashMap<>());
+        root.getMetadata().getLabels().put(MenuItem.HIERARCHY_MIGRATED_LABEL, "true");
+        child.getMetadata().setLabels(new HashMap<>());
+        child.getMetadata().getLabels().put(MenuItem.HIERARCHY_MIGRATED_LABEL, "true");
+
+        StepVerifier.create(
+                        migration.migrate(List.of(menu("primary", children("root", "child"))), List.of(root, child)))
+                .assertNext(summary -> {
+                    assertThat(summary.getClonesCreated()).isZero();
+                    assertThat(createdItems).isEmpty();
+                    assertThat(child.getSpec().getParent()).isEqualTo("root");
+                })
+                .verifyComplete();
+    }
+
+    @Test
     void shouldNotOverwriteExistingNewFields() {
         var root = menuItem("root", null);
         root.getSpec().setMenuName("custom");
@@ -125,7 +187,8 @@ class MenuItemHierarchyMigrationTest {
         var leaf = menuItem("leaf", null);
 
         StepVerifier.create(migration.migrate(
-                        List.of(menu("primary", children("root-a", "root-b"))), List.of(rootA, rootB, shared, leaf)))
+                        List.of(menu("primary", children("root-a", "root-b", "shared", "leaf"))),
+                        List.of(rootA, rootB, shared, leaf)))
                 .assertNext(summary -> {
                     assertThat(summary.getClonesCreated()).isEqualTo(2);
                     assertThat(shared.getSpec().getParent()).isEqualTo("root-a");


### PR DESCRIPTION
#### What type of PR is this?

- [ ] Feature
- [x] Bug fix
- [ ] Improvement
- [ ] Cleanup
- [ ] Documentation

#### What this PR does / why we need it:

Legacy Console versions stored every menu member, including descendants, in `Menu.spec.menuItems`. The hierarchy migration treated every entry in that collection as a root path while also traversing `MenuItem.spec.children`.

Depending on the legacy member order, this could either:

- keep the original child items at the root and create clones below their parent; or
- keep the original child items below their parent and create clones at the root.

Because the legacy fields remain unchanged, deleting an erroneous clone caused it to be created again on the next startup.

This change derives the actual legacy roots by excluding menu members that are reachable through another member's legacy child hierarchy. It also selects a single entry for cyclic or otherwise disconnected components so they remain migratable without treating every member as a root.

The existing cloning behavior for items genuinely shared across menus or multiple parent paths is preserved.

Reproduction:

1. Create legacy menu data where `Menu.spec.menuItems` contains both a parent and its descendants.
2. Reference the descendants through the parent's `MenuItem.spec.children`.
3. Start Halo so the menu hierarchy migration runs.
4. Observe duplicate descendants at the root or below the parent, depending on member order.
5. Delete the generated duplicate and restart Halo; the duplicate is created again.

After this change, the migration assigns the original descendants directly to their parent without creating conflict clones, regardless of whether the parent appears before or after its children in the legacy member list. Deleted erroneous clones are not recreated after the fix is installed.

#### Which issue(s) this PR fixes:

None.

#### Special notes for your reviewer:

Existing erroneous clones are not deleted automatically to avoid destructive cleanup of persisted menu data. Affected users can delete the duplicate once after upgrading.

Regression coverage includes:

- parent-before-descendant legacy member ordering;
- descendant-before-parent ordering based on captured production data;
- restarting after an erroneous clone was deleted;
- preservation of legitimate multi-parent subtree cloning.

Validation:

- `./gradlew :application:test --tests '*Menu*'`
- `./gradlew :application:spotlessCheck`
- `openspec validate menu-hierarchy --strict`
- `git diff --check`

OpenAI Codex materially assisted with implementation and test generation. The resulting changes were validated using the commands listed above and against the provided migration data.

#### Does this PR introduce a user-facing change?

```release-note
修复升级后菜单层级迁移可能重复创建子菜单项的问题，删除已生成的重复菜单后重启也不会再次出现。
```
