### PR TITLE
Fix gallery layout recalculation on editor load

### DIFF
--- a/ui/packages/editor/src/extensions/gallery/GalleryView.spec.ts
+++ b/ui/packages/editor/src/extensions/gallery/GalleryView.spec.ts
@@ -52,6 +52,40 @@ describe("GalleryView", () => {
     expect(images).toEqual([{ src: "/image.jpg", aspectRatio: 2 }]);
   });
 
+  it("retains support for aspect ratios stored on image elements", () => {
+    const editor = createEditor(`
+      <div data-type="gallery">
+        <div>
+          <div>
+            <img src="/image.jpg" data-aspect-ratio="2" />
+          </div>
+        </div>
+      </div>
+    `);
+    const images = editor.state.doc.nodeAt(0)?.attrs
+      .images as ExtensionGalleryImageItem[];
+    editor.destroy();
+
+    expect(images).toEqual([{ src: "/image.jpg", aspectRatio: 2 }]);
+  });
+
+  it("prefers aspect ratios stored on image wrappers", () => {
+    const editor = createEditor(`
+      <div data-type="gallery">
+        <div>
+          <div data-aspect-ratio="2">
+            <img src="/image.jpg" data-aspect-ratio="1" />
+          </div>
+        </div>
+      </div>
+    `);
+    const images = editor.state.doc.nodeAt(0)?.attrs
+      .images as ExtensionGalleryImageItem[];
+    editor.destroy();
+
+    expect(images).toEqual([{ src: "/image.jpg", aspectRatio: 2 }]);
+  });
+
   it("does not update attributes when an existing image already has an aspect ratio", async () => {
     const { wrapper, updateAttributes } = mountGallery({
       src: "/image.jpg",

--- a/ui/packages/editor/src/extensions/gallery/GalleryView.spec.ts
+++ b/ui/packages/editor/src/extensions/gallery/GalleryView.spec.ts
@@ -1,0 +1,131 @@
+// @vitest-environment jsdom
+
+import { shallowMount, type VueWrapper } from "@vue/test-utils";
+import { describe, expect, it, vi } from "vitest";
+import { type Content, type NodeViewProps, VueEditor } from "@/tiptap";
+import { ExtensionDocument } from "../document";
+import { ExtensionText } from "../text";
+import GalleryView from "./GalleryView.vue";
+import { ExtensionGallery, type ExtensionGalleryImageItem } from "./index";
+
+vi.mock("@halo-dev/components", () => ({
+  VButton: { template: "<button><slot /></button>" },
+  VSpace: { template: "<div><slot /></div>" },
+}));
+
+vi.mock("@halo-dev/ui-shared", () => ({
+  utils: {
+    permission: { has: () => false },
+    attachment: { getUrl: () => undefined },
+  },
+}));
+
+vi.mock("./useGalleryImages", () => ({
+  useUploadGalleryImage: () => ({ openFileDialog: vi.fn() }),
+}));
+
+describe("GalleryView", () => {
+  it("preserves image aspect ratios across an HTML round trip", () => {
+    const sourceEditor = createEditor({
+      type: "doc",
+      content: [
+        {
+          type: "gallery",
+          attrs: {
+            images: [{ src: "/image.jpg", aspectRatio: 2 }],
+            groupSize: 3,
+            layout: "auto",
+            gap: 8,
+            file: null,
+          },
+        },
+      ],
+    });
+    const html = sourceEditor.getHTML();
+    sourceEditor.destroy();
+
+    const parsedEditor = createEditor(html);
+    const images = parsedEditor.state.doc.nodeAt(0)?.attrs
+      .images as ExtensionGalleryImageItem[];
+    parsedEditor.destroy();
+
+    expect(images).toEqual([{ src: "/image.jpg", aspectRatio: 2 }]);
+  });
+
+  it("does not update attributes when an existing image already has an aspect ratio", async () => {
+    const { wrapper, updateAttributes } = mountGallery({
+      src: "/image.jpg",
+      aspectRatio: 2,
+    });
+
+    await loadImage(wrapper, 200, 100);
+
+    expect(updateAttributes).not.toHaveBeenCalled();
+  });
+
+  it("fills a missing aspect ratio without rewriting the image source", async () => {
+    const { wrapper, updateAttributes } = mountGallery({
+      src: "/image.jpg",
+      aspectRatio: 0,
+    });
+
+    await loadImage(wrapper, 200, 100);
+
+    expect(updateAttributes).toHaveBeenCalledWith({
+      images: [{ src: "/image.jpg", aspectRatio: 2 }],
+    });
+  });
+});
+
+function createEditor(content: Content) {
+  return new VueEditor({
+    extensions: [ExtensionDocument, ExtensionText, ExtensionGallery],
+    content,
+  });
+}
+
+function mountGallery(image: ExtensionGalleryImageItem) {
+  const updateAttributes = vi.fn();
+  const wrapper = shallowMount(GalleryView, {
+    props: {
+      node: {
+        attrs: {
+          images: [image],
+          groupSize: 3,
+          layout: "auto",
+          gap: 8,
+        },
+      },
+      updateAttributes,
+      editor: {},
+      extension: { options: {} },
+      getPos: () => 0,
+      selected: false,
+    } as unknown as NodeViewProps,
+    global: {
+      stubs: {
+        NodeViewWrapper: { template: "<div><slot /></div>" },
+        AttachmentSelectorModal: true,
+        MingcuteDelete2Line: true,
+      },
+      directives: {
+        tooltip: {},
+      },
+    },
+  });
+
+  return { wrapper, updateAttributes };
+}
+
+async function loadImage(
+  wrapper: VueWrapper,
+  naturalWidth: number,
+  naturalHeight: number
+) {
+  const image = wrapper.get("img");
+  Object.defineProperties(image.element, {
+    naturalWidth: { value: naturalWidth },
+    naturalHeight: { value: naturalHeight },
+  });
+  await image.trigger("load");
+}

--- a/ui/packages/editor/src/extensions/gallery/GalleryView.vue
+++ b/ui/packages/editor/src/extensions/gallery/GalleryView.vue
@@ -34,15 +34,20 @@ function removeImage(index: number) {
 }
 
 function handleImageLoad(event: Event, index: number) {
+  const currentImage = images.value[index];
+  if (!currentImage || currentImage.aspectRatio > 0) {
+    return;
+  }
+
   const img = event.target as HTMLImageElement;
   if (img.naturalWidth && img.naturalHeight) {
     const ratio = img.naturalWidth / img.naturalHeight;
     const newImages = [...images.value];
     newImages[index] = {
-      src: img.src,
+      ...currentImage,
       aspectRatio: ratio,
     };
-    images.value = [...newImages];
+    images.value = newImages;
   }
 }
 

--- a/ui/packages/editor/src/extensions/gallery/index.ts
+++ b/ui/packages/editor/src/extensions/gallery/index.ts
@@ -71,9 +71,13 @@ export const ExtensionGallery = Node.create<
         default: [],
         parseHTML: (element) => {
           return Array.from(element.querySelectorAll("img")).map((img) => {
+            const aspectRatio = Number(
+              img.getAttribute("data-aspect-ratio") ??
+                img.parentElement?.getAttribute("data-aspect-ratio")
+            );
             return {
               src: img.getAttribute("src") || "",
-              aspectRatio: Number(img.getAttribute("data-aspect-ratio")) || 0,
+              aspectRatio: aspectRatio || 0,
             };
           });
         },

--- a/ui/packages/editor/src/extensions/gallery/index.ts
+++ b/ui/packages/editor/src/extensions/gallery/index.ts
@@ -72,8 +72,8 @@ export const ExtensionGallery = Node.create<
         parseHTML: (element) => {
           return Array.from(element.querySelectorAll("img")).map((img) => {
             const aspectRatio = Number(
-              img.getAttribute("data-aspect-ratio") ??
-                img.parentElement?.getAttribute("data-aspect-ratio")
+              img.parentElement?.getAttribute("data-aspect-ratio") ??
+                img.getAttribute("data-aspect-ratio")
             );
             return {
               src: img.getAttribute("src") || "",


### PR DESCRIPTION
#### What type of PR is this?

- [ ] Feature
- [x] Bug fix
- [ ] Improvement
- [ ] Cleanup
- [ ] Documentation

#### What this PR does / why we need it:

Gallery image aspect ratios are serialized on the image wrapper, but the parser only read the attribute from the `<img>` element. As a result, reopening saved gallery content reset its image aspect ratios to `0`. The editor then recalculated and wrote the ratios back as each image loaded, causing layout shifts and unnecessary content updates.

This change:

- restores aspect ratios from the existing gallery image wrapper while retaining support for attributes stored on the image element;
- skips load-time attribute updates when a valid aspect ratio is already available;
- preserves the stored image source when filling a missing aspect ratio;
- adds regression coverage for HTML round trips and image-load behavior.

Reproduction:

1. Serialize a gallery containing an image with a saved aspect ratio.
2. Parse the generated HTML as editor content.
3. Before this change, the parsed aspect ratio becomes `0`, and loading the image writes a recalculated ratio back into the document.

After this change, the serialized ratio survives the HTML round trip, and existing images no longer update the document while loading. Newly added images with a missing ratio are still populated after loading.

#### Which issue(s) this PR fixes:

None.

#### Special notes for your reviewer:

This change was developed with assistance from OpenAI Codex and reviewed through the validation listed below.

Validation:

- `npx --yes pnpm@10.30.3 -C ui/packages/editor exec vitest run src/extensions/gallery/GalleryView.spec.ts --reporter=verbose`
- `npx --yes pnpm@10.30.3 -C ui typecheck`
- `npx --yes pnpm@10.30.3 -C ui lint`
- `npx --yes pnpm@10.30.3 -C ui build:packages`
- `npx --yes pnpm@10.30.3 -C ui exec vp fmt --check packages/editor/src/extensions/gallery/GalleryView.vue packages/editor/src/extensions/gallery/index.ts packages/editor/src/extensions/gallery/GalleryView.spec.ts`
- `git diff --check`

#### Does this PR introduce a user-facing change?

```release-note
修复重新打开包含图库块的文章时图片布局跳动并产生未保存内容的问题。
```
