### PR TITLE
Fix table wheel scrolling at horizontal boundaries

### DIFF
--- a/ui/packages/editor/src/extensions/table/index.spec.ts
+++ b/ui/packages/editor/src/extensions/table/index.spec.ts
@@ -1,0 +1,80 @@
+// @vitest-environment jsdom
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { PMNode } from "@/tiptap";
+import type { EditorView } from "@/tiptap/pm";
+import { ExtensionTable } from "./index";
+
+describe("ExtensionTable horizontal wheel scrolling", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.runOnlyPendingTimers();
+    vi.useRealTimers();
+  });
+
+  it("uses vertical wheel input while the table can scroll horizontally", () => {
+    const { container, scrollBy } = createScrollableTable(200);
+    const event = createWheelEvent(100);
+
+    container.dispatchEvent(event);
+
+    expect(event.defaultPrevented).toBe(true);
+    expect(scrollBy).toHaveBeenCalledWith({ left: 100 });
+  });
+
+  it.each([
+    ["left", 0, -100],
+    ["right", 600, 100],
+  ])(
+    "lets the page consume wheel input at the %s boundary",
+    (_boundary, scrollLeft, deltaY) => {
+      const { container, scrollBy } = createScrollableTable(scrollLeft);
+      const event = createWheelEvent(deltaY);
+
+      container.dispatchEvent(event);
+
+      expect(event.defaultPrevented).toBe(false);
+      expect(scrollBy).not.toHaveBeenCalled();
+    }
+  );
+});
+
+function createScrollableTable(scrollLeft: number) {
+  const TableView = ExtensionTable.options.View;
+  if (!TableView) {
+    throw new Error("Table view is not configured");
+  }
+
+  const tableView = new TableView(
+    { firstChild: null } as unknown as PMNode,
+    25,
+    {} as EditorView
+  );
+  const container = (tableView.dom as HTMLElement).querySelector<HTMLElement>(
+    ".tableWrapper"
+  );
+  if (!container) {
+    throw new Error("Table scroll container was not rendered");
+  }
+
+  const scrollBy = vi.fn();
+  Object.defineProperties(container, {
+    scrollWidth: { configurable: true, value: 1000 },
+    clientWidth: { configurable: true, value: 400 },
+    scrollLeft: { configurable: true, value: scrollLeft },
+    scrollBy: { configurable: true, value: scrollBy },
+  });
+
+  return { container, scrollBy };
+}
+
+function createWheelEvent(deltaY: number) {
+  return new WheelEvent("wheel", {
+    bubbles: true,
+    cancelable: true,
+    deltaY,
+  });
+}

--- a/ui/packages/editor/src/extensions/table/index.ts
+++ b/ui/packages/editor/src/extensions/table/index.ts
@@ -200,9 +200,14 @@ class TableView implements NodeView {
   }
 
   handleHorizontalWheel(dom: HTMLElement, event: WheelEvent) {
-    const { scrollWidth, clientWidth } = dom;
+    const { scrollWidth, clientWidth, scrollLeft } = dom;
     const hasScrollWidth = scrollWidth > clientWidth;
-    if (hasScrollWidth) {
+    const maxScrollLeft = scrollWidth - clientWidth;
+    const canScrollHorizontally =
+      hasScrollWidth &&
+      ((event.deltaY < 0 && scrollLeft > 0) ||
+        (event.deltaY > 0 && scrollLeft < maxScrollLeft));
+    if (canScrollHorizontally) {
       event.stopPropagation();
       event.preventDefault();
       dom.scrollBy({ left: event.deltaY });


### PR DESCRIPTION
#### What type of PR is this?

- [ ] Feature
- [x] Bug fix
- [ ] Improvement
- [ ] Cleanup
- [ ] Documentation

#### What this PR does / why we need it:

Wide tables in the rich text editor currently consume vertical wheel input whenever they overflow horizontally. This also happens at the left and right horizontal boundaries, preventing the surrounding page from continuing to scroll vertically.

This change only prevents the default wheel behavior while the table can still scroll in the requested horizontal direction. Once the table reaches that boundary, the wheel event is left unhandled so normal page scrolling can continue.

It also adds regression coverage for horizontal scrolling within the table and event handoff at both boundaries.

#### Which issue(s) this PR fixes:

None.

#### Special notes for your reviewer:

Reproduction path:

1. Insert a table that is wider than the editor.
2. Hover over the table and scroll it to a horizontal boundary.
3. Continue scrolling in the same direction.
4. Before this change, the wheel event remains canceled and the page cannot continue scrolling vertically.

Verification:

- Wheel input is still converted to horizontal scrolling while movement is possible.
- At the left and right boundaries, the event is no longer canceled.
- Regression tests cover all three states.

This change was developed with AI assistance and reviewed through focused tests and local validation.

Tests:

- `pnpm -C ui/packages/editor exec vitest run src/extensions/table/index.spec.ts --reporter=verbose`
- `pnpm -C ui/packages/editor typecheck`
- `pnpm -C ui lint`
- `pnpm -C ui build:packages`
- `pnpm -C ui exec vp fmt --check packages/editor/src/extensions/table/index.ts packages/editor/src/extensions/table/index.spec.ts`
- `git diff --check`

The full `pnpm -C ui typecheck` command remains blocked by existing Uppy API and type mismatches in unrelated UI files.

#### Does this PR introduce a user-facing change?

```release-note
修复在富文本编辑器的宽表格横向滚动到边界后，页面无法继续上下滚动的问题。
```
