### PR TITLE
Fix Unicode truncation in generated excerpts

### DIFF
--- a/application/src/main/java/run/halo/app/core/reconciler/ExcerptUtils.java
+++ b/application/src/main/java/run/halo/app/core/reconciler/ExcerptUtils.java
@@ -1,0 +1,32 @@
+package run.halo.app.core.reconciler;
+
+final class ExcerptUtils {
+
+    private ExcerptUtils() {}
+
+    static String substringByCodePoints(String value, int maxLength) {
+        int endIndex = 0;
+        for (int i = 0; i < maxLength && endIndex < value.length(); i++) {
+            endIndex += Character.charCount(value.codePointAt(endIndex));
+        }
+        return value.substring(0, endIndex);
+    }
+
+    static boolean containsUnpairedSurrogate(String value) {
+        if (value == null) {
+            return false;
+        }
+        for (int i = 0; i < value.length(); i++) {
+            char current = value.charAt(i);
+            if (Character.isHighSurrogate(current)) {
+                if (i + 1 >= value.length() || !Character.isLowSurrogate(value.charAt(i + 1))) {
+                    return true;
+                }
+                i++;
+            } else if (Character.isLowSurrogate(current)) {
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/application/src/main/java/run/halo/app/core/reconciler/PostReconciler.java
+++ b/application/src/main/java/run/halo/app/core/reconciler/PostReconciler.java
@@ -375,8 +375,9 @@ public class PostReconciler implements Reconciler<Reconciler.Request> {
         var cacheKey = contentChecksum + ":" + isAutoGenerate;
         var annotations = MetadataUtil.nullSafeAnnotations(post);
         var oldCacheKey = annotations.get(Constant.CONTENT_CHECKSUM_ANNO);
-        if (Objects.equals(oldCacheKey, cacheKey)) {
-            return post.getStatusOrDefault().getExcerpt();
+        var cachedExcerpt = post.getStatusOrDefault().getExcerpt();
+        if (Objects.equals(oldCacheKey, cacheKey) && !ExcerptUtils.containsUnpairedSurrogate(cachedExcerpt)) {
+            return cachedExcerpt;
         }
         // update the checksum and generate new excerpt
         annotations.put(Constant.CONTENT_CHECKSUM_ANNO, cacheKey);
@@ -424,9 +425,9 @@ public class PostReconciler implements Reconciler<Reconciler.Request> {
     static class DefaultExcerptGenerator implements ExcerptGenerator {
         @Override
         public Mono<String> generate(Context context) {
-            String shortHtmlContent = StringUtils.substring(context.getContent(), 0, 500);
+            String shortHtmlContent = ExcerptUtils.substringByCodePoints(context.getContent(), 500);
             String text = Jsoup.parse(shortHtmlContent).text();
-            return Mono.just(StringUtils.substring(text, 0, 150));
+            return Mono.just(ExcerptUtils.substringByCodePoints(text, 150));
         }
     }
 

--- a/application/src/main/java/run/halo/app/core/reconciler/SinglePageReconciler.java
+++ b/application/src/main/java/run/halo/app/core/reconciler/SinglePageReconciler.java
@@ -376,8 +376,9 @@ public class SinglePageReconciler implements Reconciler<Reconciler.Request> {
         var cacheKey = contentChecksum + ":" + isAutoGenerate;
         var annotations = MetadataUtil.nullSafeAnnotations(singlePage);
         var oldCacheKey = annotations.get(Constant.CONTENT_CHECKSUM_ANNO);
-        if (Objects.equals(oldCacheKey, cacheKey)) {
-            return singlePage.getStatusOrDefault().getExcerpt();
+        var cachedExcerpt = singlePage.getStatusOrDefault().getExcerpt();
+        if (Objects.equals(oldCacheKey, cacheKey) && !ExcerptUtils.containsUnpairedSurrogate(cachedExcerpt)) {
+            return cachedExcerpt;
         }
         // update the checksum and generate new excerpt
         annotations.put(Constant.CONTENT_CHECKSUM_ANNO, cacheKey);
@@ -406,9 +407,9 @@ public class SinglePageReconciler implements Reconciler<Reconciler.Request> {
     static class DefaultExcerptGenerator implements ExcerptGenerator {
         @Override
         public Mono<String> generate(Context context) {
-            String shortHtmlContent = StringUtils.substring(context.getContent(), 0, 500);
+            String shortHtmlContent = ExcerptUtils.substringByCodePoints(context.getContent(), 500);
             String text = Jsoup.parse(shortHtmlContent).text();
-            return Mono.just(StringUtils.substring(text, 0, 150));
+            return Mono.just(ExcerptUtils.substringByCodePoints(text, 150));
         }
     }
 

--- a/application/src/test/java/run/halo/app/core/reconciler/PostReconcilerTest.java
+++ b/application/src/test/java/run/halo/app/core/reconciler/PostReconcilerTest.java
@@ -1,9 +1,11 @@
 package run.halo.app.core.reconciler;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 
+import com.google.common.hash.Hashing;
 import java.time.Instant;
 import java.util.HashMap;
 import java.util.List;
@@ -167,6 +169,52 @@ class PostReconcilerTest {
         verify(client, times(1)).update(captor.capture());
         Post value = captor.getValue();
         assertThat(value.getStatus().getExcerpt()).isEqualTo("hello world");
+    }
+
+    @Test
+    void shouldNotSplitSurrogatePairInGeneratedExcerpt() {
+        var prefix = "a".repeat(149);
+        var context = new ExcerptGenerator.Context().setContent(prefix + "📘remaining");
+
+        var excerpt =
+                new PostReconciler.DefaultExcerptGenerator().generate(context).block();
+
+        assertThat(excerpt).isEqualTo(prefix + "📘");
+    }
+
+    @Test
+    void shouldRegenerateMalformedCachedExcerpt() {
+        String name = "post-A";
+        var prefix = "a".repeat(149);
+        var content = "<p>" + prefix + "📘remaining</p>";
+        Post post = TestPost.postV1();
+        post.getSpec().setPublish(true);
+        post.getSpec().setHeadSnapshot("post-A-head-snapshot");
+        post.getSpec().setReleaseSnapshot("post-fake-released-snapshot");
+        post.getMetadata().setAnnotations(new HashMap<>());
+        post.getMetadata()
+                .getAnnotations()
+                .put(Constant.CONTENT_CHECKSUM_ANNO, Hashing.sha256().hashString(content, UTF_8) + ":true");
+        post.getStatusOrDefault().setExcerpt(prefix + "\uD83D");
+
+        when(client.fetch(eq(Post.class), eq(name))).thenReturn(Optional.of(post));
+        when(postService.getContent(
+                        eq(post.getSpec().getReleaseSnapshot()),
+                        eq(post.getSpec().getBaseSnapshot())))
+                .thenReturn(Mono.just(ContentWrapper.builder()
+                        .snapshotName(post.getSpec().getHeadSnapshot())
+                        .raw(prefix + "📘remaining")
+                        .content(content)
+                        .rawType("markdown")
+                        .build()));
+        when(extensionGetter.getEnabledExtension(eq(ExcerptGenerator.class))).thenReturn(Mono.empty());
+        when(client.listAll(eq(Snapshot.class), any(), any())).thenReturn(List.of());
+
+        ArgumentCaptor<Post> captor = ArgumentCaptor.forClass(Post.class);
+        postReconciler.reconcile(new Reconciler.Request(name));
+
+        verify(client).update(captor.capture());
+        assertThat(captor.getValue().getStatus().getExcerpt()).isEqualTo(prefix + "📘");
     }
 
     @Test

--- a/application/src/test/java/run/halo/app/core/reconciler/SinglePageReconcilerTest.java
+++ b/application/src/test/java/run/halo/app/core/reconciler/SinglePageReconcilerTest.java
@@ -164,6 +164,18 @@ class SinglePageReconcilerTest {
     }
 
     @Test
+    void shouldNotSplitSurrogatePairInGeneratedExcerpt() {
+        var prefix = "a".repeat(149);
+        var context = new ExcerptGenerator.Context().setContent(prefix + "📘remaining");
+
+        var excerpt = new SinglePageReconciler.DefaultExcerptGenerator()
+                .generate(context)
+                .block();
+
+        assertThat(excerpt).isEqualTo(prefix + "📘");
+    }
+
+    @Test
     void createPermalink() {
         SinglePage page = pageV1();
         page.getSpec().setSlug("page-slug");


### PR DESCRIPTION
#### What type of PR is this?

- [ ] Feature
- [x] Bug fix
- [ ] Improvement
- [ ] Cleanup
- [ ] Documentation

#### What this PR does / why we need it:

Auto-generated excerpts were truncated by UTF-16 code units. When a supplementary Unicode character, such as an emoji, crossed the truncation boundary, the resulting excerpt could contain an unpaired surrogate. Thymeleaf was then unable to encode the malformed string and returned a 500 response.

This PR:

- truncates generated post and single-page excerpts by Unicode code points;
- regenerates cached excerpts containing unpaired surrogate characters even when the content checksum is unchanged;
- adds regression tests for boundary emoji characters and malformed cached excerpts.

#### Which issue(s) this PR fixes:

None.

#### Special notes for your reviewer:

The existing excerpt limits remain unchanged: 500 code points before HTML-to-text conversion and 150 code points afterward.

Validation:

- `./gradlew :application:test --tests "run.halo.app.core.reconciler.PostReconcilerTest" --tests "run.halo.app.core.reconciler.SinglePageReconcilerTest"`
- `./gradlew :application:test`
- `./gradlew :application:spotlessCheck`
- `git diff --check`

AI assistance was used to diagnose and implement this change. The resulting diff and regression coverage were reviewed and validated with the checks above.

#### Does this PR introduce a user-facing change?

```release-note
修复自动生成摘要截断 Emoji 等 Unicode 字符时可能导致页面返回 500 的问题。
```