### PR TITLE
Fix ListResult hasNext description

### DIFF
--- a/api-docs/openapi/v3_0/aggregated.json
+++ b/api-docs/openapi/v3_0/aggregated.json
@@ -15629,7 +15629,7 @@
           },
           "hasNext": {
             "type": "boolean",
-            "description": "Indicates whether current page has previous page."
+            "description": "Indicates whether current page has next page."
           },
           "hasPrevious": {
             "type": "boolean",
@@ -15737,7 +15737,7 @@
           },
           "hasNext": {
             "type": "boolean",
-            "description": "Indicates whether current page has previous page."
+            "description": "Indicates whether current page has next page."
           },
           "hasPrevious": {
             "type": "boolean",
@@ -15916,7 +15916,7 @@
           },
           "hasNext": {
             "type": "boolean",
-            "description": "Indicates whether current page has previous page."
+            "description": "Indicates whether current page has next page."
           },
           "hasPrevious": {
             "type": "boolean",
@@ -16104,7 +16104,7 @@
           },
           "hasNext": {
             "type": "boolean",
-            "description": "Indicates whether current page has previous page."
+            "description": "Indicates whether current page has next page."
           },
           "hasPrevious": {
             "type": "boolean",
@@ -16248,7 +16248,7 @@
           },
           "hasNext": {
             "type": "boolean",
-            "description": "Indicates whether current page has previous page."
+            "description": "Indicates whether current page has next page."
           },
           "hasPrevious": {
             "type": "boolean",
@@ -16449,7 +16449,7 @@
           },
           "hasNext": {
             "type": "boolean",
-            "description": "Indicates whether current page has previous page."
+            "description": "Indicates whether current page has next page."
           },
           "hasPrevious": {
             "type": "boolean",
@@ -16593,7 +16593,7 @@
           },
           "hasNext": {
             "type": "boolean",
-            "description": "Indicates whether current page has previous page."
+            "description": "Indicates whether current page has next page."
           },
           "hasPrevious": {
             "type": "boolean",
@@ -16885,7 +16885,7 @@
           },
           "hasNext": {
             "type": "boolean",
-            "description": "Indicates whether current page has previous page."
+            "description": "Indicates whether current page has next page."
           },
           "hasPrevious": {
             "type": "boolean",
@@ -16974,7 +16974,7 @@
           },
           "hasNext": {
             "type": "boolean",
-            "description": "Indicates whether current page has previous page."
+            "description": "Indicates whether current page has next page."
           },
           "hasPrevious": {
             "type": "boolean",
@@ -17102,7 +17102,7 @@
           },
           "hasNext": {
             "type": "boolean",
-            "description": "Indicates whether current page has previous page."
+            "description": "Indicates whether current page has next page."
           },
           "hasPrevious": {
             "type": "boolean",
@@ -17378,7 +17378,7 @@
           },
           "hasNext": {
             "type": "boolean",
-            "description": "Indicates whether current page has previous page."
+            "description": "Indicates whether current page has next page."
           },
           "hasPrevious": {
             "type": "boolean",
@@ -17647,7 +17647,7 @@
           },
           "hasNext": {
             "type": "boolean",
-            "description": "Indicates whether current page has previous page."
+            "description": "Indicates whether current page has next page."
           },
           "hasPrevious": {
             "type": "boolean",
@@ -17874,7 +17874,7 @@
           },
           "hasNext": {
             "type": "boolean",
-            "description": "Indicates whether current page has previous page."
+            "description": "Indicates whether current page has next page."
           },
           "hasPrevious": {
             "type": "boolean",
@@ -17957,7 +17957,7 @@
           },
           "hasNext": {
             "type": "boolean",
-            "description": "Indicates whether current page has previous page."
+            "description": "Indicates whether current page has next page."
           },
           "hasPrevious": {
             "type": "boolean",
@@ -18152,7 +18152,7 @@
           },
           "hasNext": {
             "type": "boolean",
-            "description": "Indicates whether current page has previous page."
+            "description": "Indicates whether current page has next page."
           },
           "hasPrevious": {
             "type": "boolean",
@@ -18474,7 +18474,7 @@
           },
           "hasNext": {
             "type": "boolean",
-            "description": "Indicates whether current page has previous page."
+            "description": "Indicates whether current page has next page."
           },
           "hasPrevious": {
             "type": "boolean",
@@ -18616,7 +18616,7 @@
           },
           "hasNext": {
             "type": "boolean",
-            "description": "Indicates whether current page has previous page."
+            "description": "Indicates whether current page has next page."
           },
           "hasPrevious": {
             "type": "boolean",
@@ -18719,7 +18719,7 @@
           },
           "hasNext": {
             "type": "boolean",
-            "description": "Indicates whether current page has previous page."
+            "description": "Indicates whether current page has next page."
           },
           "hasPrevious": {
             "type": "boolean",
@@ -18820,7 +18820,7 @@
           },
           "hasNext": {
             "type": "boolean",
-            "description": "Indicates whether current page has previous page."
+            "description": "Indicates whether current page has next page."
           },
           "hasPrevious": {
             "type": "boolean",
@@ -18899,7 +18899,7 @@
           },
           "hasNext": {
             "type": "boolean",
-            "description": "Indicates whether current page has previous page."
+            "description": "Indicates whether current page has next page."
           },
           "hasPrevious": {
             "type": "boolean",
@@ -18986,7 +18986,7 @@
           },
           "hasNext": {
             "type": "boolean",
-            "description": "Indicates whether current page has previous page."
+            "description": "Indicates whether current page has next page."
           },
           "hasPrevious": {
             "type": "boolean",
@@ -19075,7 +19075,7 @@
           },
           "hasNext": {
             "type": "boolean",
-            "description": "Indicates whether current page has previous page."
+            "description": "Indicates whether current page has next page."
           },
           "hasPrevious": {
             "type": "boolean",
@@ -19254,7 +19254,7 @@
           },
           "hasNext": {
             "type": "boolean",
-            "description": "Indicates whether current page has previous page."
+            "description": "Indicates whether current page has next page."
           },
           "hasPrevious": {
             "type": "boolean",
@@ -19448,7 +19448,7 @@
           },
           "hasNext": {
             "type": "boolean",
-            "description": "Indicates whether current page has previous page."
+            "description": "Indicates whether current page has next page."
           },
           "hasPrevious": {
             "type": "boolean",
@@ -19672,7 +19672,7 @@
           },
           "hasNext": {
             "type": "boolean",
-            "description": "Indicates whether current page has previous page."
+            "description": "Indicates whether current page has next page."
           },
           "hasPrevious": {
             "type": "boolean",
@@ -19799,7 +19799,7 @@
           },
           "hasNext": {
             "type": "boolean",
-            "description": "Indicates whether current page has previous page."
+            "description": "Indicates whether current page has next page."
           },
           "hasPrevious": {
             "type": "boolean",
@@ -19893,7 +19893,7 @@
           },
           "hasNext": {
             "type": "boolean",
-            "description": "Indicates whether current page has previous page."
+            "description": "Indicates whether current page has next page."
           },
           "hasPrevious": {
             "type": "boolean",
@@ -20174,7 +20174,7 @@
           },
           "hasNext": {
             "type": "boolean",
-            "description": "Indicates whether current page has previous page."
+            "description": "Indicates whether current page has next page."
           },
           "hasPrevious": {
             "type": "boolean",
@@ -20302,7 +20302,7 @@
           },
           "hasNext": {
             "type": "boolean",
-            "description": "Indicates whether current page has previous page."
+            "description": "Indicates whether current page has next page."
           },
           "hasPrevious": {
             "type": "boolean",
@@ -20543,7 +20543,7 @@
           },
           "hasNext": {
             "type": "boolean",
-            "description": "Indicates whether current page has previous page."
+            "description": "Indicates whether current page has next page."
           },
           "hasPrevious": {
             "type": "boolean",
@@ -20688,7 +20688,7 @@
           },
           "hasNext": {
             "type": "boolean",
-            "description": "Indicates whether current page has previous page."
+            "description": "Indicates whether current page has next page."
           },
           "hasPrevious": {
             "type": "boolean",
@@ -20813,7 +20813,7 @@
           },
           "hasNext": {
             "type": "boolean",
-            "description": "Indicates whether current page has previous page."
+            "description": "Indicates whether current page has next page."
           },
           "hasPrevious": {
             "type": "boolean",
@@ -21143,7 +21143,7 @@
           },
           "hasNext": {
             "type": "boolean",
-            "description": "Indicates whether current page has previous page."
+            "description": "Indicates whether current page has next page."
           },
           "hasPrevious": {
             "type": "boolean",
@@ -21361,7 +21361,7 @@
           },
           "hasNext": {
             "type": "boolean",
-            "description": "Indicates whether current page has previous page."
+            "description": "Indicates whether current page has next page."
           },
           "hasPrevious": {
             "type": "boolean",
@@ -21570,7 +21570,7 @@
           },
           "hasNext": {
             "type": "boolean",
-            "description": "Indicates whether current page has previous page."
+            "description": "Indicates whether current page has next page."
           },
           "hasPrevious": {
             "type": "boolean",
@@ -21738,7 +21738,7 @@
           },
           "hasNext": {
             "type": "boolean",
-            "description": "Indicates whether current page has previous page."
+            "description": "Indicates whether current page has next page."
           },
           "hasPrevious": {
             "type": "boolean",
@@ -21952,7 +21952,7 @@
           },
           "hasNext": {
             "type": "boolean",
-            "description": "Indicates whether current page has previous page."
+            "description": "Indicates whether current page has next page."
           },
           "hasPrevious": {
             "type": "boolean",
@@ -22061,7 +22061,7 @@
           },
           "hasNext": {
             "type": "boolean",
-            "description": "Indicates whether current page has previous page."
+            "description": "Indicates whether current page has next page."
           },
           "hasPrevious": {
             "type": "boolean",
@@ -22218,7 +22218,7 @@
           },
           "hasNext": {
             "type": "boolean",
-            "description": "Indicates whether current page has previous page."
+            "description": "Indicates whether current page has next page."
           },
           "hasPrevious": {
             "type": "boolean",
@@ -22277,7 +22277,7 @@
           },
           "hasNext": {
             "type": "boolean",
-            "description": "Indicates whether current page has previous page."
+            "description": "Indicates whether current page has next page."
           },
           "hasPrevious": {
             "type": "boolean",
@@ -22495,7 +22495,7 @@
           },
           "hasNext": {
             "type": "boolean",
-            "description": "Indicates whether current page has previous page."
+            "description": "Indicates whether current page has next page."
           },
           "hasPrevious": {
             "type": "boolean",
@@ -22604,7 +22604,7 @@
           },
           "hasNext": {
             "type": "boolean",
-            "description": "Indicates whether current page has previous page."
+            "description": "Indicates whether current page has next page."
           },
           "hasPrevious": {
             "type": "boolean",
@@ -22766,7 +22766,7 @@
           },
           "hasNext": {
             "type": "boolean",
-            "description": "Indicates whether current page has previous page."
+            "description": "Indicates whether current page has next page."
           },
           "hasPrevious": {
             "type": "boolean",
@@ -23138,7 +23138,7 @@
           },
           "hasNext": {
             "type": "boolean",
-            "description": "Indicates whether current page has previous page."
+            "description": "Indicates whether current page has next page."
           },
           "hasPrevious": {
             "type": "boolean",
@@ -23282,7 +23282,7 @@
           },
           "hasNext": {
             "type": "boolean",
-            "description": "Indicates whether current page has previous page."
+            "description": "Indicates whether current page has next page."
           },
           "hasPrevious": {
             "type": "boolean",
@@ -23407,7 +23407,7 @@
           },
           "hasNext": {
             "type": "boolean",
-            "description": "Indicates whether current page has previous page."
+            "description": "Indicates whether current page has next page."
           },
           "hasPrevious": {
             "type": "boolean",
@@ -23546,7 +23546,7 @@
           },
           "hasNext": {
             "type": "boolean",
-            "description": "Indicates whether current page has previous page."
+            "description": "Indicates whether current page has next page."
           },
           "hasPrevious": {
             "type": "boolean",
@@ -23711,7 +23711,7 @@
           },
           "hasNext": {
             "type": "boolean",
-            "description": "Indicates whether current page has previous page."
+            "description": "Indicates whether current page has next page."
           },
           "hasPrevious": {
             "type": "boolean",
@@ -24100,7 +24100,7 @@
           },
           "hasNext": {
             "type": "boolean",
-            "description": "Indicates whether current page has previous page."
+            "description": "Indicates whether current page has next page."
           },
           "hasPrevious": {
             "type": "boolean",
@@ -24209,7 +24209,7 @@
           },
           "hasNext": {
             "type": "boolean",
-            "description": "Indicates whether current page has previous page."
+            "description": "Indicates whether current page has next page."
           },
           "hasPrevious": {
             "type": "boolean",
@@ -24268,7 +24268,7 @@
           },
           "hasNext": {
             "type": "boolean",
-            "description": "Indicates whether current page has previous page."
+            "description": "Indicates whether current page has next page."
           },
           "hasPrevious": {
             "type": "boolean",

--- a/api-docs/openapi/v3_0/apis_console.api_v1alpha1.json
+++ b/api-docs/openapi/v3_0/apis_console.api_v1alpha1.json
@@ -3834,7 +3834,7 @@
           },
           "hasNext": {
             "type": "boolean",
-            "description": "Indicates whether current page has previous page."
+            "description": "Indicates whether current page has next page."
           },
           "hasPrevious": {
             "type": "boolean",
@@ -5166,7 +5166,7 @@
           },
           "hasNext": {
             "type": "boolean",
-            "description": "Indicates whether current page has previous page."
+            "description": "Indicates whether current page has next page."
           },
           "hasPrevious": {
             "type": "boolean",
@@ -5269,7 +5269,7 @@
           },
           "hasNext": {
             "type": "boolean",
-            "description": "Indicates whether current page has previous page."
+            "description": "Indicates whether current page has next page."
           },
           "hasPrevious": {
             "type": "boolean",
@@ -5348,7 +5348,7 @@
           },
           "hasNext": {
             "type": "boolean",
-            "description": "Indicates whether current page has previous page."
+            "description": "Indicates whether current page has next page."
           },
           "hasPrevious": {
             "type": "boolean",
@@ -5435,7 +5435,7 @@
           },
           "hasNext": {
             "type": "boolean",
-            "description": "Indicates whether current page has previous page."
+            "description": "Indicates whether current page has next page."
           },
           "hasPrevious": {
             "type": "boolean",
@@ -5933,7 +5933,7 @@
           },
           "hasNext": {
             "type": "boolean",
-            "description": "Indicates whether current page has previous page."
+            "description": "Indicates whether current page has next page."
           },
           "hasPrevious": {
             "type": "boolean",
@@ -7070,7 +7070,7 @@
           },
           "hasNext": {
             "type": "boolean",
-            "description": "Indicates whether current page has previous page."
+            "description": "Indicates whether current page has next page."
           },
           "hasPrevious": {
             "type": "boolean",
@@ -7271,7 +7271,7 @@
           },
           "hasNext": {
             "type": "boolean",
-            "description": "Indicates whether current page has previous page."
+            "description": "Indicates whether current page has next page."
           },
           "hasPrevious": {
             "type": "boolean",
@@ -7544,7 +7544,7 @@
           },
           "hasNext": {
             "type": "boolean",
-            "description": "Indicates whether current page has previous page."
+            "description": "Indicates whether current page has next page."
           },
           "hasPrevious": {
             "type": "boolean",

--- a/api-docs/openapi/v3_0/apis_extension.api_v1alpha1.json
+++ b/api-docs/openapi/v3_0/apis_extension.api_v1alpha1.json
@@ -9095,7 +9095,7 @@
           },
           "hasNext": {
             "type": "boolean",
-            "description": "Indicates whether current page has previous page."
+            "description": "Indicates whether current page has next page."
           },
           "hasPrevious": {
             "type": "boolean",
@@ -9203,7 +9203,7 @@
           },
           "hasNext": {
             "type": "boolean",
-            "description": "Indicates whether current page has previous page."
+            "description": "Indicates whether current page has next page."
           },
           "hasPrevious": {
             "type": "boolean",
@@ -9343,7 +9343,7 @@
           },
           "hasNext": {
             "type": "boolean",
-            "description": "Indicates whether current page has previous page."
+            "description": "Indicates whether current page has next page."
           },
           "hasPrevious": {
             "type": "boolean",
@@ -9511,7 +9511,7 @@
           },
           "hasNext": {
             "type": "boolean",
-            "description": "Indicates whether current page has previous page."
+            "description": "Indicates whether current page has next page."
           },
           "hasPrevious": {
             "type": "boolean",
@@ -9655,7 +9655,7 @@
           },
           "hasNext": {
             "type": "boolean",
-            "description": "Indicates whether current page has previous page."
+            "description": "Indicates whether current page has next page."
           },
           "hasPrevious": {
             "type": "boolean",
@@ -9828,7 +9828,7 @@
           },
           "hasNext": {
             "type": "boolean",
-            "description": "Indicates whether current page has previous page."
+            "description": "Indicates whether current page has next page."
           },
           "hasPrevious": {
             "type": "boolean",
@@ -10104,7 +10104,7 @@
           },
           "hasNext": {
             "type": "boolean",
-            "description": "Indicates whether current page has previous page."
+            "description": "Indicates whether current page has next page."
           },
           "hasPrevious": {
             "type": "boolean",
@@ -10250,7 +10250,7 @@
           },
           "hasNext": {
             "type": "boolean",
-            "description": "Indicates whether current page has previous page."
+            "description": "Indicates whether current page has next page."
           },
           "hasPrevious": {
             "type": "boolean",
@@ -10364,7 +10364,7 @@
           },
           "hasNext": {
             "type": "boolean",
-            "description": "Indicates whether current page has previous page."
+            "description": "Indicates whether current page has next page."
           },
           "hasPrevious": {
             "type": "boolean",
@@ -10524,7 +10524,7 @@
           },
           "hasNext": {
             "type": "boolean",
-            "description": "Indicates whether current page has previous page."
+            "description": "Indicates whether current page has next page."
           },
           "hasPrevious": {
             "type": "boolean",
@@ -10607,7 +10607,7 @@
           },
           "hasNext": {
             "type": "boolean",
-            "description": "Indicates whether current page has previous page."
+            "description": "Indicates whether current page has next page."
           },
           "hasPrevious": {
             "type": "boolean",
@@ -10785,7 +10785,7 @@
           },
           "hasNext": {
             "type": "boolean",
-            "description": "Indicates whether current page has previous page."
+            "description": "Indicates whether current page has next page."
           },
           "hasPrevious": {
             "type": "boolean",
@@ -11010,7 +11010,7 @@
           },
           "hasNext": {
             "type": "boolean",
-            "description": "Indicates whether current page has previous page."
+            "description": "Indicates whether current page has next page."
           },
           "hasPrevious": {
             "type": "boolean",
@@ -11133,7 +11133,7 @@
           },
           "hasNext": {
             "type": "boolean",
-            "description": "Indicates whether current page has previous page."
+            "description": "Indicates whether current page has next page."
           },
           "hasPrevious": {
             "type": "boolean",
@@ -11324,7 +11324,7 @@
           },
           "hasNext": {
             "type": "boolean",
-            "description": "Indicates whether current page has previous page."
+            "description": "Indicates whether current page has next page."
           },
           "hasPrevious": {
             "type": "boolean",
@@ -11451,7 +11451,7 @@
           },
           "hasNext": {
             "type": "boolean",
-            "description": "Indicates whether current page has previous page."
+            "description": "Indicates whether current page has next page."
           },
           "hasPrevious": {
             "type": "boolean",
@@ -11545,7 +11545,7 @@
           },
           "hasNext": {
             "type": "boolean",
-            "description": "Indicates whether current page has previous page."
+            "description": "Indicates whether current page has next page."
           },
           "hasPrevious": {
             "type": "boolean",
@@ -11762,7 +11762,7 @@
           },
           "hasNext": {
             "type": "boolean",
-            "description": "Indicates whether current page has previous page."
+            "description": "Indicates whether current page has next page."
           },
           "hasPrevious": {
             "type": "boolean",
@@ -11866,7 +11866,7 @@
           },
           "hasNext": {
             "type": "boolean",
-            "description": "Indicates whether current page has previous page."
+            "description": "Indicates whether current page has next page."
           },
           "hasPrevious": {
             "type": "boolean",
@@ -12089,7 +12089,7 @@
           },
           "hasNext": {
             "type": "boolean",
-            "description": "Indicates whether current page has previous page."
+            "description": "Indicates whether current page has next page."
           },
           "hasPrevious": {
             "type": "boolean",
@@ -12234,7 +12234,7 @@
           },
           "hasNext": {
             "type": "boolean",
-            "description": "Indicates whether current page has previous page."
+            "description": "Indicates whether current page has next page."
           },
           "hasPrevious": {
             "type": "boolean",
@@ -12337,7 +12337,7 @@
           },
           "hasNext": {
             "type": "boolean",
-            "description": "Indicates whether current page has previous page."
+            "description": "Indicates whether current page has next page."
           },
           "hasPrevious": {
             "type": "boolean",
@@ -12606,7 +12606,7 @@
           },
           "hasNext": {
             "type": "boolean",
-            "description": "Indicates whether current page has previous page."
+            "description": "Indicates whether current page has next page."
           },
           "hasPrevious": {
             "type": "boolean",
@@ -12795,7 +12795,7 @@
           },
           "hasNext": {
             "type": "boolean",
-            "description": "Indicates whether current page has previous page."
+            "description": "Indicates whether current page has next page."
           },
           "hasPrevious": {
             "type": "boolean",
@@ -12932,7 +12932,7 @@
           },
           "hasNext": {
             "type": "boolean",
-            "description": "Indicates whether current page has previous page."
+            "description": "Indicates whether current page has next page."
           },
           "hasPrevious": {
             "type": "boolean",
@@ -13100,7 +13100,7 @@
           },
           "hasNext": {
             "type": "boolean",
-            "description": "Indicates whether current page has previous page."
+            "description": "Indicates whether current page has next page."
           },
           "hasPrevious": {
             "type": "boolean",
@@ -13280,7 +13280,7 @@
           },
           "hasNext": {
             "type": "boolean",
-            "description": "Indicates whether current page has previous page."
+            "description": "Indicates whether current page has next page."
           },
           "hasPrevious": {
             "type": "boolean",
@@ -13409,7 +13409,7 @@
           },
           "hasNext": {
             "type": "boolean",
-            "description": "Indicates whether current page has previous page."
+            "description": "Indicates whether current page has next page."
           },
           "hasPrevious": {
             "type": "boolean",
@@ -13468,7 +13468,7 @@
           },
           "hasNext": {
             "type": "boolean",
-            "description": "Indicates whether current page has previous page."
+            "description": "Indicates whether current page has next page."
           },
           "hasPrevious": {
             "type": "boolean",
@@ -13584,7 +13584,7 @@
           },
           "hasNext": {
             "type": "boolean",
-            "description": "Indicates whether current page has previous page."
+            "description": "Indicates whether current page has next page."
           },
           "hasPrevious": {
             "type": "boolean",
@@ -13693,7 +13693,7 @@
           },
           "hasNext": {
             "type": "boolean",
-            "description": "Indicates whether current page has previous page."
+            "description": "Indicates whether current page has next page."
           },
           "hasPrevious": {
             "type": "boolean",
@@ -13816,7 +13816,7 @@
           },
           "hasNext": {
             "type": "boolean",
-            "description": "Indicates whether current page has previous page."
+            "description": "Indicates whether current page has next page."
           },
           "hasPrevious": {
             "type": "boolean",
@@ -14113,7 +14113,7 @@
           },
           "hasNext": {
             "type": "boolean",
-            "description": "Indicates whether current page has previous page."
+            "description": "Indicates whether current page has next page."
           },
           "hasPrevious": {
             "type": "boolean",
@@ -14213,7 +14213,7 @@
           },
           "hasNext": {
             "type": "boolean",
-            "description": "Indicates whether current page has previous page."
+            "description": "Indicates whether current page has next page."
           },
           "hasPrevious": {
             "type": "boolean",
@@ -14338,7 +14338,7 @@
           },
           "hasNext": {
             "type": "boolean",
-            "description": "Indicates whether current page has previous page."
+            "description": "Indicates whether current page has next page."
           },
           "hasPrevious": {
             "type": "boolean",
@@ -14557,7 +14557,7 @@
           },
           "hasNext": {
             "type": "boolean",
-            "description": "Indicates whether current page has previous page."
+            "description": "Indicates whether current page has next page."
           },
           "hasPrevious": {
             "type": "boolean",
@@ -14781,7 +14781,7 @@
           },
           "hasNext": {
             "type": "boolean",
-            "description": "Indicates whether current page has previous page."
+            "description": "Indicates whether current page has next page."
           },
           "hasPrevious": {
             "type": "boolean",
@@ -14868,7 +14868,7 @@
           },
           "hasNext": {
             "type": "boolean",
-            "description": "Indicates whether current page has previous page."
+            "description": "Indicates whether current page has next page."
           },
           "hasPrevious": {
             "type": "boolean",

--- a/api-docs/openapi/v3_0/apis_public.api_v1alpha1.json
+++ b/api-docs/openapi/v3_0/apis_public.api_v1alpha1.json
@@ -1374,7 +1374,7 @@
           },
           "hasNext": {
             "type": "boolean",
-            "description": "Indicates whether current page has previous page."
+            "description": "Indicates whether current page has next page."
           },
           "hasPrevious": {
             "type": "boolean",
@@ -1707,7 +1707,7 @@
           },
           "hasNext": {
             "type": "boolean",
-            "description": "Indicates whether current page has previous page."
+            "description": "Indicates whether current page has next page."
           },
           "hasPrevious": {
             "type": "boolean",
@@ -1796,7 +1796,7 @@
           },
           "hasNext": {
             "type": "boolean",
-            "description": "Indicates whether current page has previous page."
+            "description": "Indicates whether current page has next page."
           },
           "hasPrevious": {
             "type": "boolean",
@@ -2145,7 +2145,7 @@
           },
           "hasNext": {
             "type": "boolean",
-            "description": "Indicates whether current page has previous page."
+            "description": "Indicates whether current page has next page."
           },
           "hasPrevious": {
             "type": "boolean",
@@ -2246,7 +2246,7 @@
           },
           "hasNext": {
             "type": "boolean",
-            "description": "Indicates whether current page has previous page."
+            "description": "Indicates whether current page has next page."
           },
           "hasPrevious": {
             "type": "boolean",
@@ -2335,7 +2335,7 @@
           },
           "hasNext": {
             "type": "boolean",
-            "description": "Indicates whether current page has previous page."
+            "description": "Indicates whether current page has next page."
           },
           "hasPrevious": {
             "type": "boolean",
@@ -3136,7 +3136,7 @@
           },
           "hasNext": {
             "type": "boolean",
-            "description": "Indicates whether current page has previous page."
+            "description": "Indicates whether current page has next page."
           },
           "hasPrevious": {
             "type": "boolean",
@@ -3618,7 +3618,7 @@
           },
           "hasNext": {
             "type": "boolean",
-            "description": "Indicates whether current page has previous page."
+            "description": "Indicates whether current page has next page."
           },
           "hasPrevious": {
             "type": "boolean",

--- a/api-docs/openapi/v3_0/apis_uc.api_v1alpha1.json
+++ b/api-docs/openapi/v3_0/apis_uc.api_v1alpha1.json
@@ -1686,7 +1686,7 @@
           },
           "hasNext": {
             "type": "boolean",
-            "description": "Indicates whether current page has previous page."
+            "description": "Indicates whether current page has next page."
           },
           "hasPrevious": {
             "type": "boolean",
@@ -2234,7 +2234,7 @@
           },
           "hasNext": {
             "type": "boolean",
-            "description": "Indicates whether current page has previous page."
+            "description": "Indicates whether current page has next page."
           },
           "hasPrevious": {
             "type": "boolean",
@@ -2418,7 +2418,7 @@
           },
           "hasNext": {
             "type": "boolean",
-            "description": "Indicates whether current page has previous page."
+            "description": "Indicates whether current page has next page."
           },
           "hasPrevious": {
             "type": "boolean",

--- a/api/src/main/java/run/halo/app/extension/ListResult.java
+++ b/api/src/main/java/run/halo/app/extension/ListResult.java
@@ -67,7 +67,7 @@ public class ListResult<T> implements Iterable<T>, Supplier<Stream<T>> {
         return !hasNext();
     }
 
-    @Schema(description = "Indicates whether current page has previous page.", requiredMode = REQUIRED)
+    @Schema(description = "Indicates whether current page has next page.", requiredMode = REQUIRED)
     @JsonProperty("hasNext")
     public boolean hasNext() {
         if (page <= 0) {

--- a/ui/packages/api-client/src/models/annotation-setting-list.ts
+++ b/ui/packages/api-client/src/models/annotation-setting-list.ts
@@ -23,7 +23,7 @@ export interface AnnotationSettingList {
      */
     'first': boolean;
     /**
-     * Indicates whether current page has previous page.
+     * Indicates whether current page has next page.
      */
     'hasNext': boolean;
     /**

--- a/ui/packages/api-client/src/models/attachment-list.ts
+++ b/ui/packages/api-client/src/models/attachment-list.ts
@@ -23,7 +23,7 @@ export interface AttachmentList {
      */
     'first': boolean;
     /**
-     * Indicates whether current page has previous page.
+     * Indicates whether current page has next page.
      */
     'hasNext': boolean;
     /**

--- a/ui/packages/api-client/src/models/auth-provider-list.ts
+++ b/ui/packages/api-client/src/models/auth-provider-list.ts
@@ -23,7 +23,7 @@ export interface AuthProviderList {
      */
     'first': boolean;
     /**
-     * Indicates whether current page has previous page.
+     * Indicates whether current page has next page.
      */
     'hasNext': boolean;
     /**

--- a/ui/packages/api-client/src/models/backup-list.ts
+++ b/ui/packages/api-client/src/models/backup-list.ts
@@ -23,7 +23,7 @@ export interface BackupList {
      */
     'first': boolean;
     /**
-     * Indicates whether current page has previous page.
+     * Indicates whether current page has next page.
      */
     'hasNext': boolean;
     /**

--- a/ui/packages/api-client/src/models/category-list.ts
+++ b/ui/packages/api-client/src/models/category-list.ts
@@ -23,7 +23,7 @@ export interface CategoryList {
      */
     'first': boolean;
     /**
-     * Indicates whether current page has previous page.
+     * Indicates whether current page has next page.
      */
     'hasNext': boolean;
     /**

--- a/ui/packages/api-client/src/models/category-vo-list.ts
+++ b/ui/packages/api-client/src/models/category-vo-list.ts
@@ -23,7 +23,7 @@ export interface CategoryVoList {
      */
     'first': boolean;
     /**
-     * Indicates whether current page has previous page.
+     * Indicates whether current page has next page.
      */
     'hasNext': boolean;
     /**

--- a/ui/packages/api-client/src/models/comment-list.ts
+++ b/ui/packages/api-client/src/models/comment-list.ts
@@ -23,7 +23,7 @@ export interface CommentList {
      */
     'first': boolean;
     /**
-     * Indicates whether current page has previous page.
+     * Indicates whether current page has next page.
      */
     'hasNext': boolean;
     /**

--- a/ui/packages/api-client/src/models/comment-vo-list.ts
+++ b/ui/packages/api-client/src/models/comment-vo-list.ts
@@ -23,7 +23,7 @@ export interface CommentVoList {
      */
     'first': boolean;
     /**
-     * Indicates whether current page has previous page.
+     * Indicates whether current page has next page.
      */
     'hasNext': boolean;
     /**

--- a/ui/packages/api-client/src/models/comment-with-reply-vo-list.ts
+++ b/ui/packages/api-client/src/models/comment-with-reply-vo-list.ts
@@ -23,7 +23,7 @@ export interface CommentWithReplyVoList {
      */
     'first': boolean;
     /**
-     * Indicates whether current page has previous page.
+     * Indicates whether current page has next page.
      */
     'hasNext': boolean;
     /**

--- a/ui/packages/api-client/src/models/config-map-list.ts
+++ b/ui/packages/api-client/src/models/config-map-list.ts
@@ -23,7 +23,7 @@ export interface ConfigMapList {
      */
     'first': boolean;
     /**
-     * Indicates whether current page has previous page.
+     * Indicates whether current page has next page.
      */
     'hasNext': boolean;
     /**

--- a/ui/packages/api-client/src/models/counter-list.ts
+++ b/ui/packages/api-client/src/models/counter-list.ts
@@ -23,7 +23,7 @@ export interface CounterList {
      */
     'first': boolean;
     /**
-     * Indicates whether current page has previous page.
+     * Indicates whether current page has next page.
      */
     'hasNext': boolean;
     /**

--- a/ui/packages/api-client/src/models/device-list.ts
+++ b/ui/packages/api-client/src/models/device-list.ts
@@ -23,7 +23,7 @@ export interface DeviceList {
      */
     'first': boolean;
     /**
-     * Indicates whether current page has previous page.
+     * Indicates whether current page has next page.
      */
     'hasNext': boolean;
     /**

--- a/ui/packages/api-client/src/models/extension-definition-list.ts
+++ b/ui/packages/api-client/src/models/extension-definition-list.ts
@@ -23,7 +23,7 @@ export interface ExtensionDefinitionList {
      */
     'first': boolean;
     /**
-     * Indicates whether current page has previous page.
+     * Indicates whether current page has next page.
      */
     'hasNext': boolean;
     /**

--- a/ui/packages/api-client/src/models/extension-point-definition-list.ts
+++ b/ui/packages/api-client/src/models/extension-point-definition-list.ts
@@ -23,7 +23,7 @@ export interface ExtensionPointDefinitionList {
      */
     'first': boolean;
     /**
-     * Indicates whether current page has previous page.
+     * Indicates whether current page has next page.
      */
     'hasNext': boolean;
     /**

--- a/ui/packages/api-client/src/models/group-list.ts
+++ b/ui/packages/api-client/src/models/group-list.ts
@@ -23,7 +23,7 @@ export interface GroupList {
      */
     'first': boolean;
     /**
-     * Indicates whether current page has previous page.
+     * Indicates whether current page has next page.
      */
     'hasNext': boolean;
     /**

--- a/ui/packages/api-client/src/models/list-result-reply-vo.ts
+++ b/ui/packages/api-client/src/models/list-result-reply-vo.ts
@@ -23,7 +23,7 @@ export interface ListResultReplyVo {
      */
     'first': boolean;
     /**
-     * Indicates whether current page has previous page.
+     * Indicates whether current page has next page.
      */
     'hasNext': boolean;
     /**

--- a/ui/packages/api-client/src/models/listed-comment-list.ts
+++ b/ui/packages/api-client/src/models/listed-comment-list.ts
@@ -23,7 +23,7 @@ export interface ListedCommentList {
      */
     'first': boolean;
     /**
-     * Indicates whether current page has previous page.
+     * Indicates whether current page has next page.
      */
     'hasNext': boolean;
     /**

--- a/ui/packages/api-client/src/models/listed-post-list.ts
+++ b/ui/packages/api-client/src/models/listed-post-list.ts
@@ -23,7 +23,7 @@ export interface ListedPostList {
      */
     'first': boolean;
     /**
-     * Indicates whether current page has previous page.
+     * Indicates whether current page has next page.
      */
     'hasNext': boolean;
     /**

--- a/ui/packages/api-client/src/models/listed-post-vo-list.ts
+++ b/ui/packages/api-client/src/models/listed-post-vo-list.ts
@@ -23,7 +23,7 @@ export interface ListedPostVoList {
      */
     'first': boolean;
     /**
-     * Indicates whether current page has previous page.
+     * Indicates whether current page has next page.
      */
     'hasNext': boolean;
     /**

--- a/ui/packages/api-client/src/models/listed-reply-list.ts
+++ b/ui/packages/api-client/src/models/listed-reply-list.ts
@@ -23,7 +23,7 @@ export interface ListedReplyList {
      */
     'first': boolean;
     /**
-     * Indicates whether current page has previous page.
+     * Indicates whether current page has next page.
      */
     'hasNext': boolean;
     /**

--- a/ui/packages/api-client/src/models/listed-single-page-list.ts
+++ b/ui/packages/api-client/src/models/listed-single-page-list.ts
@@ -23,7 +23,7 @@ export interface ListedSinglePageList {
      */
     'first': boolean;
     /**
-     * Indicates whether current page has previous page.
+     * Indicates whether current page has next page.
      */
     'hasNext': boolean;
     /**

--- a/ui/packages/api-client/src/models/listed-single-page-vo-list.ts
+++ b/ui/packages/api-client/src/models/listed-single-page-vo-list.ts
@@ -23,7 +23,7 @@ export interface ListedSinglePageVoList {
      */
     'first': boolean;
     /**
-     * Indicates whether current page has previous page.
+     * Indicates whether current page has next page.
      */
     'hasNext': boolean;
     /**

--- a/ui/packages/api-client/src/models/menu-item-list.ts
+++ b/ui/packages/api-client/src/models/menu-item-list.ts
@@ -23,7 +23,7 @@ export interface MenuItemList {
      */
     'first': boolean;
     /**
-     * Indicates whether current page has previous page.
+     * Indicates whether current page has next page.
      */
     'hasNext': boolean;
     /**

--- a/ui/packages/api-client/src/models/menu-list.ts
+++ b/ui/packages/api-client/src/models/menu-list.ts
@@ -23,7 +23,7 @@ export interface MenuList {
      */
     'first': boolean;
     /**
-     * Indicates whether current page has previous page.
+     * Indicates whether current page has next page.
      */
     'hasNext': boolean;
     /**

--- a/ui/packages/api-client/src/models/notification-list.ts
+++ b/ui/packages/api-client/src/models/notification-list.ts
@@ -23,7 +23,7 @@ export interface NotificationList {
      */
     'first': boolean;
     /**
-     * Indicates whether current page has previous page.
+     * Indicates whether current page has next page.
      */
     'hasNext': boolean;
     /**

--- a/ui/packages/api-client/src/models/notification-template-list.ts
+++ b/ui/packages/api-client/src/models/notification-template-list.ts
@@ -23,7 +23,7 @@ export interface NotificationTemplateList {
      */
     'first': boolean;
     /**
-     * Indicates whether current page has previous page.
+     * Indicates whether current page has next page.
      */
     'hasNext': boolean;
     /**

--- a/ui/packages/api-client/src/models/notifier-descriptor-list.ts
+++ b/ui/packages/api-client/src/models/notifier-descriptor-list.ts
@@ -23,7 +23,7 @@ export interface NotifierDescriptorList {
      */
     'first': boolean;
     /**
-     * Indicates whether current page has previous page.
+     * Indicates whether current page has next page.
      */
     'hasNext': boolean;
     /**

--- a/ui/packages/api-client/src/models/personal-access-token-list.ts
+++ b/ui/packages/api-client/src/models/personal-access-token-list.ts
@@ -23,7 +23,7 @@ export interface PersonalAccessTokenList {
      */
     'first': boolean;
     /**
-     * Indicates whether current page has previous page.
+     * Indicates whether current page has next page.
      */
     'hasNext': boolean;
     /**

--- a/ui/packages/api-client/src/models/plugin-list.ts
+++ b/ui/packages/api-client/src/models/plugin-list.ts
@@ -23,7 +23,7 @@ export interface PluginList {
      */
     'first': boolean;
     /**
-     * Indicates whether current page has previous page.
+     * Indicates whether current page has next page.
      */
     'hasNext': boolean;
     /**

--- a/ui/packages/api-client/src/models/policy-list.ts
+++ b/ui/packages/api-client/src/models/policy-list.ts
@@ -23,7 +23,7 @@ export interface PolicyList {
      */
     'first': boolean;
     /**
-     * Indicates whether current page has previous page.
+     * Indicates whether current page has next page.
      */
     'hasNext': boolean;
     /**

--- a/ui/packages/api-client/src/models/policy-template-list.ts
+++ b/ui/packages/api-client/src/models/policy-template-list.ts
@@ -23,7 +23,7 @@ export interface PolicyTemplateList {
      */
     'first': boolean;
     /**
-     * Indicates whether current page has previous page.
+     * Indicates whether current page has next page.
      */
     'hasNext': boolean;
     /**

--- a/ui/packages/api-client/src/models/post-list.ts
+++ b/ui/packages/api-client/src/models/post-list.ts
@@ -23,7 +23,7 @@ export interface PostList {
      */
     'first': boolean;
     /**
-     * Indicates whether current page has previous page.
+     * Indicates whether current page has next page.
      */
     'hasNext': boolean;
     /**

--- a/ui/packages/api-client/src/models/reason-list.ts
+++ b/ui/packages/api-client/src/models/reason-list.ts
@@ -23,7 +23,7 @@ export interface ReasonList {
      */
     'first': boolean;
     /**
-     * Indicates whether current page has previous page.
+     * Indicates whether current page has next page.
      */
     'hasNext': boolean;
     /**

--- a/ui/packages/api-client/src/models/reason-type-list.ts
+++ b/ui/packages/api-client/src/models/reason-type-list.ts
@@ -23,7 +23,7 @@ export interface ReasonTypeList {
      */
     'first': boolean;
     /**
-     * Indicates whether current page has previous page.
+     * Indicates whether current page has next page.
      */
     'hasNext': boolean;
     /**

--- a/ui/packages/api-client/src/models/remember-me-token-list.ts
+++ b/ui/packages/api-client/src/models/remember-me-token-list.ts
@@ -23,7 +23,7 @@ export interface RememberMeTokenList {
      */
     'first': boolean;
     /**
-     * Indicates whether current page has previous page.
+     * Indicates whether current page has next page.
      */
     'hasNext': boolean;
     /**

--- a/ui/packages/api-client/src/models/reply-list.ts
+++ b/ui/packages/api-client/src/models/reply-list.ts
@@ -23,7 +23,7 @@ export interface ReplyList {
      */
     'first': boolean;
     /**
-     * Indicates whether current page has previous page.
+     * Indicates whether current page has next page.
      */
     'hasNext': boolean;
     /**

--- a/ui/packages/api-client/src/models/reply-vo-list.ts
+++ b/ui/packages/api-client/src/models/reply-vo-list.ts
@@ -23,7 +23,7 @@ export interface ReplyVoList {
      */
     'first': boolean;
     /**
-     * Indicates whether current page has previous page.
+     * Indicates whether current page has next page.
      */
     'hasNext': boolean;
     /**

--- a/ui/packages/api-client/src/models/reverse-proxy-list.ts
+++ b/ui/packages/api-client/src/models/reverse-proxy-list.ts
@@ -23,7 +23,7 @@ export interface ReverseProxyList {
      */
     'first': boolean;
     /**
-     * Indicates whether current page has previous page.
+     * Indicates whether current page has next page.
      */
     'hasNext': boolean;
     /**

--- a/ui/packages/api-client/src/models/role-binding-list.ts
+++ b/ui/packages/api-client/src/models/role-binding-list.ts
@@ -23,7 +23,7 @@ export interface RoleBindingList {
      */
     'first': boolean;
     /**
-     * Indicates whether current page has previous page.
+     * Indicates whether current page has next page.
      */
     'hasNext': boolean;
     /**

--- a/ui/packages/api-client/src/models/role-list.ts
+++ b/ui/packages/api-client/src/models/role-list.ts
@@ -23,7 +23,7 @@ export interface RoleList {
      */
     'first': boolean;
     /**
-     * Indicates whether current page has previous page.
+     * Indicates whether current page has next page.
      */
     'hasNext': boolean;
     /**

--- a/ui/packages/api-client/src/models/secret-list.ts
+++ b/ui/packages/api-client/src/models/secret-list.ts
@@ -23,7 +23,7 @@ export interface SecretList {
      */
     'first': boolean;
     /**
-     * Indicates whether current page has previous page.
+     * Indicates whether current page has next page.
      */
     'hasNext': boolean;
     /**

--- a/ui/packages/api-client/src/models/setting-list.ts
+++ b/ui/packages/api-client/src/models/setting-list.ts
@@ -23,7 +23,7 @@ export interface SettingList {
      */
     'first': boolean;
     /**
-     * Indicates whether current page has previous page.
+     * Indicates whether current page has next page.
      */
     'hasNext': boolean;
     /**

--- a/ui/packages/api-client/src/models/single-page-list.ts
+++ b/ui/packages/api-client/src/models/single-page-list.ts
@@ -23,7 +23,7 @@ export interface SinglePageList {
      */
     'first': boolean;
     /**
-     * Indicates whether current page has previous page.
+     * Indicates whether current page has next page.
      */
     'hasNext': boolean;
     /**

--- a/ui/packages/api-client/src/models/snapshot-list.ts
+++ b/ui/packages/api-client/src/models/snapshot-list.ts
@@ -23,7 +23,7 @@ export interface SnapshotList {
      */
     'first': boolean;
     /**
-     * Indicates whether current page has previous page.
+     * Indicates whether current page has next page.
      */
     'hasNext': boolean;
     /**

--- a/ui/packages/api-client/src/models/subscription-list.ts
+++ b/ui/packages/api-client/src/models/subscription-list.ts
@@ -23,7 +23,7 @@ export interface SubscriptionList {
      */
     'first': boolean;
     /**
-     * Indicates whether current page has previous page.
+     * Indicates whether current page has next page.
      */
     'hasNext': boolean;
     /**

--- a/ui/packages/api-client/src/models/tag-list.ts
+++ b/ui/packages/api-client/src/models/tag-list.ts
@@ -23,7 +23,7 @@ export interface TagList {
      */
     'first': boolean;
     /**
-     * Indicates whether current page has previous page.
+     * Indicates whether current page has next page.
      */
     'hasNext': boolean;
     /**

--- a/ui/packages/api-client/src/models/tag-vo-list.ts
+++ b/ui/packages/api-client/src/models/tag-vo-list.ts
@@ -23,7 +23,7 @@ export interface TagVoList {
      */
     'first': boolean;
     /**
-     * Indicates whether current page has previous page.
+     * Indicates whether current page has next page.
      */
     'hasNext': boolean;
     /**

--- a/ui/packages/api-client/src/models/theme-list.ts
+++ b/ui/packages/api-client/src/models/theme-list.ts
@@ -23,7 +23,7 @@ export interface ThemeList {
      */
     'first': boolean;
     /**
-     * Indicates whether current page has previous page.
+     * Indicates whether current page has next page.
      */
     'hasNext': boolean;
     /**

--- a/ui/packages/api-client/src/models/user-connection-list.ts
+++ b/ui/packages/api-client/src/models/user-connection-list.ts
@@ -23,7 +23,7 @@ export interface UserConnectionList {
      */
     'first': boolean;
     /**
-     * Indicates whether current page has previous page.
+     * Indicates whether current page has next page.
      */
     'hasNext': boolean;
     /**

--- a/ui/packages/api-client/src/models/user-endpoint-listed-user-list.ts
+++ b/ui/packages/api-client/src/models/user-endpoint-listed-user-list.ts
@@ -23,7 +23,7 @@ export interface UserEndpointListedUserList {
      */
     'first': boolean;
     /**
-     * Indicates whether current page has previous page.
+     * Indicates whether current page has next page.
      */
     'hasNext': boolean;
     /**

--- a/ui/packages/api-client/src/models/user-list.ts
+++ b/ui/packages/api-client/src/models/user-list.ts
@@ -23,7 +23,7 @@ export interface UserList {
      */
     'first': boolean;
     /**
-     * Indicates whether current page has previous page.
+     * Indicates whether current page has next page.
      */
     'hasNext': boolean;
     /**


### PR DESCRIPTION
#### What type of PR is this?

- [ ] Feature
- [x] Bug fix
- [ ] Improvement
- [ ] Cleanup
- [ ] Documentation

#### What this PR does / why we need it:

Corrects the OpenAPI description for `ListResult.hasNext` so that it refers to the next page instead of the previous page.

The OpenAPI documents and TypeScript API client models are regenerated to keep generated artifacts in sync.

#### Which issue(s) this PR fixes:

N/A

#### Special notes for your reviewer:

The runtime pagination logic and serialized API shape are unchanged. This only corrects the schema description and generated documentation comments.

Validation:

- `./gradlew generateOpenApiDocs`
- `corepack pnpm api-client:gen`
- `./gradlew :api:test`
- `git diff --check`

This change was prepared with AI assistance and the generated diffs were reviewed.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
