### PR TITLE
Fix theme message fallback for overridden templates

### DIFF
--- a/application/src/main/java/run/halo/app/theme/TemplateEngineManager.java
+++ b/application/src/main/java/run/halo/app/theme/TemplateEngineManager.java
@@ -3,6 +3,7 @@ package run.halo.app.theme;
 import org.pf4j.PluginManager;
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.boot.thymeleaf.autoconfigure.ThymeleafProperties;
+import org.springframework.core.io.ResourceLoader;
 import org.springframework.stereotype.Component;
 import org.springframework.util.ConcurrentLruCache;
 import org.thymeleaf.dialect.IDialect;
@@ -59,6 +60,8 @@ public class TemplateEngineManager {
 
     private final ThemeLayoutCompatibilityChecker themeLayoutCompatibilityChecker;
 
+    private final ResourceLoader resourceLoader;
+
     public TemplateEngineManager(
             ThymeleafProperties thymeleafProperties,
             ExternalUrlSupplier externalUrlSupplier,
@@ -67,7 +70,8 @@ public class TemplateEngineManager {
             ObjectProvider<IDialect> dialects,
             ThemeResolver themeResolver,
             SystemVersionSupplier systemVersionSupplier,
-            ThemeLayoutCompatibilityChecker themeLayoutCompatibilityChecker) {
+            ThemeLayoutCompatibilityChecker themeLayoutCompatibilityChecker,
+            ResourceLoader resourceLoader) {
         this.thymeleafProperties = thymeleafProperties;
         this.externalUrlSupplier = externalUrlSupplier;
         this.pluginManager = pluginManager;
@@ -76,6 +80,7 @@ public class TemplateEngineManager {
         this.themeResolver = themeResolver;
         this.systemVersionSupplier = systemVersionSupplier;
         this.themeLayoutCompatibilityChecker = themeLayoutCompatibilityChecker;
+        this.resourceLoader = resourceLoader;
         engineCache = new ConcurrentLruCache<>(CACHE_SIZE_LIMIT, this::templateEngineGenerator);
     }
 
@@ -106,7 +111,14 @@ public class TemplateEngineManager {
 
     private ISpringWebFluxTemplateEngine templateEngineGenerator(CacheKey cacheKey) {
 
-        var engine = new HaloTemplateEngine(new ThemeMessageResolver(cacheKey.context()));
+        var engine = new HaloTemplateEngine(new ThemeMessageResolver(
+                cacheKey.context(),
+                resourceLoader,
+                thymeleafProperties.getPrefix(),
+                thymeleafProperties.getSuffix(),
+                thymeleafProperties.getEncoding() == null
+                        ? null
+                        : thymeleafProperties.getEncoding().name()));
         engine.setEnableSpringELCompiler(thymeleafProperties.isEnableSpringElCompiler());
         engine.setLinkBuilder(new ThemeLinkBuilder(cacheKey.context(), externalUrlSupplier));
         engine.setRenderHiddenMarkersBeforeCheckboxes(thymeleafProperties.isRenderHiddenMarkersBeforeCheckboxes());

--- a/application/src/main/java/run/halo/app/theme/message/ThemeMessageResolver.java
+++ b/application/src/main/java/run/halo/app/theme/message/ThemeMessageResolver.java
@@ -1,11 +1,16 @@
 package run.halo.app.theme.message;
 
+import java.nio.file.Path;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
+import org.jspecify.annotations.Nullable;
+import org.springframework.core.io.ResourceLoader;
 import org.thymeleaf.messageresolver.StandardMessageResolver;
+import org.thymeleaf.spring6.templateresource.SpringResourceTemplateResource;
+import org.thymeleaf.templateresource.FileTemplateResource;
 import org.thymeleaf.templateresource.ITemplateResource;
 import run.halo.app.theme.ThemeContext;
 
@@ -17,8 +22,30 @@ public class ThemeMessageResolver extends StandardMessageResolver {
 
     private final ThemeContext theme;
 
-    public ThemeMessageResolver(ThemeContext theme) {
+    private final ResourceLoader resourceLoader;
+
+    private final String templatePrefix;
+
+    private final String templateSuffix;
+
+    @Nullable
+    private final String characterEncoding;
+
+    private final Path themeTemplatesPath;
+
+    public ThemeMessageResolver(
+            ThemeContext theme,
+            ResourceLoader resourceLoader,
+            String templatePrefix,
+            String templateSuffix,
+            @Nullable String characterEncoding) {
         this.theme = theme;
+        this.resourceLoader = resourceLoader;
+        this.templatePrefix = templatePrefix;
+        this.templateSuffix = templateSuffix;
+        this.characterEncoding = characterEncoding;
+        this.themeTemplatesPath =
+                theme.getPath().resolve("templates").toAbsolutePath().normalize();
     }
 
     @Override
@@ -27,8 +54,31 @@ public class ThemeMessageResolver extends StandardMessageResolver {
         var properties = new HashMap<String, String>();
         Optional.ofNullable(ThemeMessageResolutionUtils.resolveMessagesForTemplate(locale, theme))
                 .ifPresent(properties::putAll);
+        Optional.ofNullable(resolveHaloMessages(template, templateResource, locale))
+                .ifPresent(properties::putAll);
         Optional.ofNullable(super.resolveMessagesForTemplate(template, templateResource, locale))
                 .ifPresent(properties::putAll);
         return Collections.unmodifiableMap(properties);
+    }
+
+    @Nullable
+    private Map<String, String> resolveHaloMessages(
+            String template, ITemplateResource templateResource, Locale locale) {
+        if (!(templateResource instanceof FileTemplateResource)) {
+            return null;
+        }
+        var selectedTemplatePath =
+                Path.of(templateResource.getDescription()).toAbsolutePath().normalize();
+        if (!selectedTemplatePath.startsWith(themeTemplatesPath)) {
+            return null;
+        }
+
+        var suffix = template.endsWith(templateSuffix) ? "" : templateSuffix;
+        var resource = resourceLoader.getResource(templatePrefix + template + suffix);
+        if (!resource.exists()) {
+            return null;
+        }
+        var haloTemplateResource = new SpringResourceTemplateResource(resource, characterEncoding);
+        return super.resolveMessagesForTemplate(template, haloTemplateResource, locale);
     }
 }

--- a/application/src/test/java/run/halo/app/theme/message/ThemeMessageFallbackTest.java
+++ b/application/src/test/java/run/halo/app/theme/message/ThemeMessageFallbackTest.java
@@ -1,0 +1,188 @@
+package run.halo.app.theme.message;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Locale;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.springframework.core.io.DefaultResourceLoader;
+import org.thymeleaf.context.Context;
+import org.thymeleaf.templateresolver.ClassLoaderTemplateResolver;
+import org.thymeleaf.templateresolver.FileTemplateResolver;
+import run.halo.app.theme.ThemeContext;
+import run.halo.app.theme.engine.HaloTemplateEngine;
+
+class ThemeMessageFallbackTest {
+
+    @Test
+    void shouldFallBackToHaloMessagesWhenThemeOnlyOverridesTemplate(@TempDir Path themePath) throws Exception {
+        var templatesPath = Files.createDirectories(themePath.resolve("templates"));
+        Files.writeString(templatesPath.resolve("message-fallback.html"), "<p th:text=\"#{core.only}\"></p>");
+
+        var engine = templateEngine(themePath);
+
+        assertThat(engine.process("message-fallback", new Context(Locale.ENGLISH)))
+                .isEqualTo("<p>Halo fallback</p>");
+    }
+
+    @Test
+    void shouldMergeMessagesUsingSourcePrecedence(@TempDir Path themePath) throws Exception {
+        var templatesPath = Files.createDirectories(themePath.resolve("templates"));
+        Files.writeString(templatesPath.resolve("message-fallback.html"), """
+                <div>
+                  <span th:text="#{core.only}"></span>
+                  <span th:text="#{shared}"></span>
+                  <span th:text="#{global.conflict}"></span>
+                  <span th:text="#{locale.priority}"></span>
+                </div>
+                """);
+        Files.writeString(templatesPath.resolve("message-fallback.properties"), """
+                shared=Theme template
+                locale.priority=Theme default
+                """);
+        var i18nPath = Files.createDirectories(themePath.resolve("i18n"));
+        Files.writeString(i18nPath.resolve("default.properties"), """
+                shared=Theme global
+                global.conflict=Theme global
+                """);
+
+        var engine = templateEngine(themePath);
+
+        assertThat(engine.process("message-fallback", new Context(Locale.ENGLISH)))
+                .contains("<span>Halo fallback</span>")
+                .contains("<span>Theme template</span>")
+                .contains("<span>Halo template</span>")
+                .contains("<span>Theme default</span>");
+    }
+
+    @Test
+    void shouldFallBackForNestedThemeFragment(@TempDir Path themePath) throws Exception {
+        var fragmentPath =
+                Files.createDirectories(themePath.resolve("templates").resolve("fragments"));
+        Files.writeString(
+                fragmentPath.resolve("message.html"),
+                "<span th:fragment=\"content\" th:text=\"#{fragment.message}\"></span>");
+
+        var engine = templateEngine(themePath);
+
+        assertThat(engine.process("message-fallback-container", new Context(Locale.ENGLISH)))
+                .contains("<span>Halo fragment</span>");
+    }
+
+    @Test
+    void shouldKeepAbsentMessageWhenNoSourceDefinesKey(@TempDir Path themePath) throws Exception {
+        var templatesPath = Files.createDirectories(themePath.resolve("templates"));
+        Files.writeString(templatesPath.resolve("message-fallback.html"), "<p th:text=\"#{missing.message}\"></p>");
+
+        var engine = templateEngine(themePath);
+
+        assertThat(engine.process("message-fallback", new Context(Locale.ENGLISH)))
+                .isEqualTo("<p>??missing.message_en??</p>");
+    }
+
+    @Test
+    void shouldRequireCorrespondingHaloTemplate(@TempDir Path themePath) throws Exception {
+        var templatesPath = Files.createDirectories(themePath.resolve("templates"));
+        Files.writeString(templatesPath.resolve("properties-only.html"), "<p th:text=\"#{properties.only}\"></p>");
+
+        var engine = templateEngine(themePath);
+
+        assertThat(engine.process("properties-only", new Context(Locale.ENGLISH)))
+                .isEqualTo("<p>??properties.only_en??</p>");
+    }
+
+    @Test
+    void shouldNotFallBackForFileOutsideActiveTheme(@TempDir Path temporaryPath) throws Exception {
+        var themePath = Files.createDirectories(temporaryPath.resolve("theme"));
+        var externalTemplatesPath = Files.createDirectories(temporaryPath.resolve("external-templates"));
+        Files.writeString(externalTemplatesPath.resolve("message-fallback.html"), "<p th:text=\"#{core.only}\"></p>");
+
+        var engine = templateEngine(themePath, externalTemplatesPath);
+
+        assertThat(engine.process("message-fallback", new Context(Locale.ENGLISH)))
+                .isEqualTo("<p>??core.only_en??</p>");
+    }
+
+    @Test
+    void shouldPropagateHaloMessageParsingFailure(@TempDir Path themePath) throws Exception {
+        var templatesPath = Files.createDirectories(themePath.resolve("templates"));
+        Files.writeString(templatesPath.resolve("invalid-message.html"), "<p th:text=\"#{invalid.message}\"></p>");
+
+        var engine = templateEngine(themePath);
+
+        assertThatThrownBy(() -> engine.process("invalid-message", new Context(Locale.ENGLISH)))
+                .hasRootCauseInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void shouldUseConfiguredHaloTemplateSettings(@TempDir Path themePath) throws Exception {
+        var templatesPath = Files.createDirectories(themePath.resolve("templates"));
+        Files.writeString(templatesPath.resolve("configured-message.tpl"), "<p th:text=\"#{configured.message}\"></p>");
+
+        var engine = templateEngine(
+                themePath, null, "classpath:/configured-templates/", "configured-templates/", ".tpl", "UTF-8");
+
+        assertThat(engine.process("configured-message", new Context(Locale.ENGLISH)))
+                .isEqualTo("<p>Configured fallback</p>");
+    }
+
+    private static HaloTemplateEngine templateEngine(Path themePath) {
+        return templateEngine(themePath, null, "classpath:/templates/", "templates/", ".html", "UTF-8");
+    }
+
+    private static HaloTemplateEngine templateEngine(Path themePath, Path externalTemplatesPath) {
+        return templateEngine(
+                themePath, externalTemplatesPath, "classpath:/templates/", "templates/", ".html", "UTF-8");
+    }
+
+    private static HaloTemplateEngine templateEngine(
+            Path themePath,
+            Path externalTemplatesPath,
+            String haloResourcePrefix,
+            String haloResolverPrefix,
+            String templateSuffix,
+            String characterEncoding) {
+        var themeContext = ThemeContext.builder()
+                .name("test-theme")
+                .path(themePath)
+                .active(true)
+                .build();
+        var engine = new HaloTemplateEngine(new ThemeMessageResolver(
+                themeContext,
+                new DefaultResourceLoader(ThemeMessageFallbackTest.class.getClassLoader()),
+                haloResourcePrefix,
+                templateSuffix,
+                characterEncoding));
+
+        var themeResolver = new FileTemplateResolver();
+        themeResolver.setPrefix(themePath.resolve("templates") + "/");
+        themeResolver.setSuffix(templateSuffix);
+        themeResolver.setCheckExistence(true);
+        themeResolver.setCacheable(false);
+        themeResolver.setOrder(externalTemplatesPath == null ? 0 : 1);
+        engine.addTemplateResolver(themeResolver);
+
+        if (externalTemplatesPath != null) {
+            var externalResolver = new FileTemplateResolver();
+            externalResolver.setPrefix(externalTemplatesPath + "/");
+            externalResolver.setSuffix(templateSuffix);
+            externalResolver.setCheckExistence(true);
+            externalResolver.setCacheable(false);
+            externalResolver.setOrder(0);
+            engine.addTemplateResolver(externalResolver);
+        }
+
+        var haloResolver = new ClassLoaderTemplateResolver();
+        haloResolver.setPrefix(haloResolverPrefix);
+        haloResolver.setSuffix(templateSuffix);
+        haloResolver.setCheckExistence(true);
+        haloResolver.setCacheable(false);
+        haloResolver.setOrder(2);
+        engine.addTemplateResolver(haloResolver);
+
+        return engine;
+    }
+}

--- a/application/src/test/resources/configured-templates/configured-message.properties
+++ b/application/src/test/resources/configured-templates/configured-message.properties
@@ -1,0 +1,1 @@
+configured.message=Configured fallback

--- a/application/src/test/resources/configured-templates/configured-message.tpl
+++ b/application/src/test/resources/configured-templates/configured-message.tpl
@@ -1,0 +1,1 @@
+<p th:text="#{configured.message}"></p>

--- a/application/src/test/resources/templates/fragments/message.html
+++ b/application/src/test/resources/templates/fragments/message.html
@@ -1,0 +1,1 @@
+<span th:fragment="content" th:text="#{fragment.message}"></span>

--- a/application/src/test/resources/templates/fragments/message.properties
+++ b/application/src/test/resources/templates/fragments/message.properties
@@ -1,0 +1,1 @@
+fragment.message=Halo fragment

--- a/application/src/test/resources/templates/invalid-message.html
+++ b/application/src/test/resources/templates/invalid-message.html
@@ -1,0 +1,1 @@
+<p th:text="#{invalid.message}"></p>

--- a/application/src/test/resources/templates/invalid-message.properties
+++ b/application/src/test/resources/templates/invalid-message.properties
@@ -1,0 +1,1 @@
+invalid.message=\uZZZZ

--- a/application/src/test/resources/templates/message-fallback-container.html
+++ b/application/src/test/resources/templates/message-fallback-container.html
@@ -1,0 +1,3 @@
+<main>
+  <div th:replace="~{fragments/message :: content}"></div>
+</main>

--- a/application/src/test/resources/templates/message-fallback.html
+++ b/application/src/test/resources/templates/message-fallback.html
@@ -1,0 +1,1 @@
+<p th:text="#{core.only}"></p>

--- a/application/src/test/resources/templates/message-fallback.properties
+++ b/application/src/test/resources/templates/message-fallback.properties
@@ -1,0 +1,4 @@
+core.only=Halo fallback
+global.conflict=Halo template
+locale.priority=Halo default
+shared=Halo shared

--- a/application/src/test/resources/templates/message-fallback_en.properties
+++ b/application/src/test/resources/templates/message-fallback_en.properties
@@ -1,0 +1,1 @@
+locale.priority=Halo English

--- a/application/src/test/resources/templates/properties-only.properties
+++ b/application/src/test/resources/templates/properties-only.properties
@@ -1,0 +1,1 @@
+properties.only=Must not be loaded without a Halo template

--- a/openspec/changes/archive/2026-07-17-support-theme-message-fallback/.openspec.yaml
+++ b/openspec/changes/archive/2026-07-17-support-theme-message-fallback/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-17

--- a/openspec/changes/archive/2026-07-17-support-theme-message-fallback/design.md
+++ b/openspec/changes/archive/2026-07-17-support-theme-message-fallback/design.md
@@ -1,0 +1,89 @@
+## Context
+
+`TemplateEngineManager` creates one Thymeleaf engine per theme context. Its composite template resolver selects the first matching template resource, which lets an active theme override a Halo-provided template. `ThemeMessageResolver` then merges the theme-global `i18n` bundle with messages adjacent to that selected resource.
+
+Because `StandardMessageResolver` only derives message resources from the selected `ITemplateResource`, selecting a theme file prevents it from seeing messages adjacent to the corresponding Halo classpath template. Real themes consequently copy Halo message bundles alongside overridden login, signup, logout, password-reset, challenge, and error templates.
+
+Thymeleaf already invokes `resolveMessagesForTemplate` independently for each template in the template stack, including nested fragments, and caches messages according to template cacheability. The change should extend that existing seam without altering template selection.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Fill missing keys in a theme template bundle from the corresponding Halo template bundle.
+- Preserve theme ownership of explicitly supplied values, including values from a less-specific theme locale bundle.
+- Apply the behavior uniformly to top-level templates, fragments, and nested template paths.
+- Preserve current theme-global message precedence, absent-message rendering, parsing failures, and engine cache invalidation.
+- Keep the implementation local to application template-message resolution.
+
+**Non-Goals:**
+
+- Merging templates or changing the first-match behavior of `CompositeTemplateResolver`.
+- Falling back to plugin message bundles or defining a plugin/theme message override contract.
+- Adding theme metadata, feature flags, public APIs, dependencies, or frontend behavior.
+- Changing the locale naming and fallback rules implemented by Thymeleaf.
+
+## Decisions
+
+### Merge messages in `ThemeMessageResolver`
+
+`ThemeMessageResolver.resolveMessagesForTemplate` will remain the integration point. When the selected resource is an eligible active-theme template, it will resolve three maps in ascending precedence:
+
+1. Theme-global `i18n` messages.
+2. Messages adjacent to the corresponding Halo template resource.
+3. Messages adjacent to the selected theme template resource.
+
+Maps are merged by key, with later maps overwriting earlier maps. Both template-specific maps use `StandardMessageResolver` behavior, so each source independently resolves its base, language, country, and variant bundles before source precedence is applied.
+
+This means a value in a theme base bundle overrides a value in a more locale-specific Halo bundle. The theme base bundle is the theme author's declared default for unsupported locales.
+
+**Alternative considered:** Modify `CompositeTemplateResolver` to expose all matching template resources. This was rejected because templates still require first-match selection, plugins are explicitly out of scope, and only message resources need composition.
+
+### Identify active-theme resources by their concrete path
+
+Fallback is eligible only when the selected resource:
+
+- is a file-backed Thymeleaf template resource; and
+- has a normalized absolute path within the active theme's normalized `templates` directory.
+
+The implementation will use `Path.startsWith` rather than a raw string prefix. Plugin classloader resources and files outside the active theme directory therefore do not participate.
+
+**Alternative considered:** Introduce a theme-specific template resource type carrying an origin marker. This was rejected because it would expand a message-only change into the template-resolution layer.
+
+### Require a corresponding Halo template
+
+The resolver will construct the Halo template resource at the same logical template path using the configured Thymeleaf prefix, suffix, and encoding. It will merge Halo messages only if that template resource exists.
+
+A properties file without a corresponding Halo template is not a fallback source. Missing locale-specific properties continue to be ignored by standard Thymeleaf resolution, while malformed or unreadable existing bundles retain standard parsing-error behavior.
+
+**Alternative considered:** Read from a hard-coded `classpath:/templates/` path. This was rejected to avoid introducing a second source of truth for template prefix, suffix, and encoding.
+
+### Preserve Thymeleaf template-stack and cache behavior
+
+The resolver will continue returning one merged message map per logical template and locale. Thymeleaf remains responsible for visiting outer templates and nested fragments in template-stack order and caching messages only for cacheable templates.
+
+No cross-theme or global message cache will be added. Clearing or replacing a theme's cached template engine continues to invalidate the associated message resolver and its cached maps.
+
+### Test through a real template engine
+
+Focused tests will assemble the actual `HaloTemplateEngine`, `ThemeMessageResolver`, a temporary theme file resolver, and a Halo classpath resolver. They will render templates and assert resulting text rather than testing only a standalone map utility.
+
+Fixtures will cover full fallback, partial theme overrides, source-versus-locale precedence, nested fragments, ineligible resources, absent-message markers, and invalid message resources.
+
+## Risks / Trade-offs
+
+- [Theme templates with accidentally omitted keys will begin showing Halo text instead of missing-message markers] → This is the intended compatibility improvement; explicit theme values remain unchanged.
+- [Path-based origin detection depends on Thymeleaf's file-backed resource type] → Limit the check to the known `FileTemplateResolver` used for active themes and cover non-theme resources with regression tests.
+- [Constructing the Halo resource duplicates a small part of configured resource-name handling] → Centralize suffix and resource construction in a narrow helper and test nested paths plus configured resource attributes.
+- [Additional resource existence and bundle reads add work on the first render for each locale] → Reuse Thymeleaf's existing per-template message cache and avoid a separate cache layer.
+- [A malformed Halo bundle can now fail rendering a theme override that previously never read it] → Preserve fail-fast parsing because packaged Halo bundles are controlled build artifacts and should not fail silently.
+
+## Migration Plan
+
+No data or theme migration is required. Existing theme bundles keep their precedence. Theme authors may remove duplicated Halo keys after deploying a Halo version that contains this capability, but doing so is optional.
+
+Rollback consists of reverting the resolver change; themes that removed duplicated keys would again need to provide complete bundles on older Halo versions.
+
+## Open Questions
+
+None.

--- a/openspec/changes/archive/2026-07-17-support-theme-message-fallback/proposal.md
+++ b/openspec/changes/archive/2026-07-17-support-theme-message-fallback/proposal.md
@@ -1,0 +1,28 @@
+## Why
+
+Themes can override Halo-provided Thymeleaf templates, but message resolution only reads bundles adjacent to the selected theme resource. A theme must therefore copy every Halo-provided message bundle even when it changes only the markup or a single message, otherwise unresolved message expressions appear in the rendered page.
+
+## What Changes
+
+- Add key-level message fallback for active-theme templates that override a Halo-provided template at the same logical path.
+- Merge template messages so theme template bundles override Halo template bundles, while missing theme keys fall back to Halo.
+- Apply the behavior independently to page templates, fragments, and templates in nested directories.
+- Preserve existing theme-global message precedence, locale fallback behavior, absent-message markers, and template-engine cache lifecycle.
+- Exclude plugin templates and unrelated template resolvers from the fallback contract.
+
+## Capabilities
+
+### New Capabilities
+
+- `theme-message-fallback`: Defines message lookup and precedence when an active theme overrides a Halo-provided Thymeleaf template.
+
+### Modified Capabilities
+
+None.
+
+## Impact
+
+- Affects the application theme engine, primarily `ThemeMessageResolver` and its construction in `TemplateEngineManager`.
+- Adds focused template-engine tests and classpath template/message fixtures.
+- Does not change public APIs, theme metadata, plugin contracts, database schemas, security behavior, frontend code, or dependencies.
+- Existing themes remain compatible; duplicated message keys continue to win, while previously missing keys begin using Halo-provided values.

--- a/openspec/changes/archive/2026-07-17-support-theme-message-fallback/specs/theme-message-fallback/spec.md
+++ b/openspec/changes/archive/2026-07-17-support-theme-message-fallback/specs/theme-message-fallback/spec.md
@@ -1,0 +1,98 @@
+## ADDED Requirements
+
+### Requirement: Eligible theme templates use Halo message fallback
+When an active theme supplies a template at the same logical path as a Halo-provided template, the system SHALL use the Halo template's message bundles as fallback sources for that theme template.
+
+#### Scenario: Theme overrides a Halo template
+- **WHEN** the selected template resource is inside the active theme's `templates` directory and Halo provides a template at the same logical path
+- **THEN** the system includes messages adjacent to the Halo template in the selected template's message lookup
+
+#### Scenario: Halo has no corresponding template
+- **WHEN** a selected active-theme template has no Halo-provided template at the same logical path
+- **THEN** the system does not include any Halo message bundle solely because a similarly located properties file exists
+
+#### Scenario: Selected resource is not an active-theme template
+- **WHEN** a selected template resource comes from a plugin, Halo itself, or a file outside the active theme's `templates` directory
+- **THEN** the system does not add active-theme-to-Halo fallback processing for that resource
+
+### Requirement: Message fallback merges by key
+For each eligible theme template, the system SHALL merge message maps by key in ascending precedence order: theme-global messages, corresponding Halo template messages, and selected theme template messages.
+
+#### Scenario: Theme omits a Halo key
+- **WHEN** an eligible theme template bundle does not define a key that is defined by the corresponding Halo template bundle
+- **THEN** resolving that key returns the Halo-provided value
+
+#### Scenario: Theme overrides a Halo key
+- **WHEN** both the eligible theme template bundle and corresponding Halo template bundle define the same key
+- **THEN** resolving that key returns the theme-provided value
+
+#### Scenario: Halo template message conflicts with theme-global message
+- **WHEN** a corresponding Halo template bundle and the active theme's global `i18n` bundle define the same key and the selected theme template bundle does not
+- **THEN** resolving that key returns the Halo template bundle value
+
+#### Scenario: Theme template message conflicts with all lower-precedence sources
+- **WHEN** the selected theme template bundle, corresponding Halo template bundle, and theme-global `i18n` bundle define the same key
+- **THEN** resolving that key returns the selected theme template bundle value
+
+### Requirement: Each message source resolves locale fallback independently
+The system SHALL apply Thymeleaf locale fallback within each message source before applying source precedence.
+
+#### Scenario: Theme base bundle overrides a locale-specific Halo value
+- **WHEN** the requested locale has a value in a locale-specific Halo bundle, the theme has no matching locale-specific bundle, and the theme base bundle defines the same key
+- **THEN** resolving that key returns the theme base-bundle value
+
+#### Scenario: Theme locale bundle overrides its base bundle
+- **WHEN** the theme base bundle and a more locale-specific theme bundle define the same key
+- **THEN** resolving that key returns the value from the more locale-specific theme bundle
+
+#### Scenario: Theme has no value in any applicable locale bundle
+- **WHEN** no applicable theme bundle defines a key and an applicable Halo bundle defines it
+- **THEN** resolving that key returns the most locale-specific applicable Halo value
+
+### Requirement: Fallback applies per template in the template stack
+The system SHALL evaluate message fallback independently for every eligible template resource processed by Thymeleaf, including top-level templates, fragments, and templates in nested directories.
+
+#### Scenario: Theme overrides a nested fragment
+- **WHEN** an active theme overrides a Halo fragment in a nested template path and omits a message defined beside the Halo fragment
+- **THEN** resolving that message while processing the fragment returns the Halo fragment's value
+
+#### Scenario: Outer template and fragment use separate bundles
+- **WHEN** a rendered page and one of its fragments each have template-specific message bundles
+- **THEN** each template uses the fallback sources associated with its own logical path and resource origin
+
+### Requirement: Standard absent-message and error behavior is preserved
+The system SHALL preserve Thymeleaf's existing behavior when no source supplies a key or when an existing message resource cannot be parsed.
+
+#### Scenario: Key is absent from all message sources
+- **WHEN** a message key is absent from the theme template bundle, corresponding Halo template bundle, and theme-global bundle
+- **THEN** a normal Thymeleaf message expression produces the standard locale-qualified absent-message representation
+
+#### Scenario: Locale-specific bundle does not exist
+- **WHEN** an optional locale-specific message resource does not exist
+- **THEN** the system continues resolving less-specific resources without failing template rendering
+
+#### Scenario: Existing bundle cannot be parsed
+- **WHEN** an applicable existing theme or Halo message resource contains content that cannot be parsed as a properties bundle
+- **THEN** template rendering fails with the standard message-resource parsing error
+
+### Requirement: Fallback follows configured system template resource settings
+The system SHALL locate corresponding Halo templates using the configured Thymeleaf template prefix, suffix, and character encoding.
+
+#### Scenario: Default template settings are used
+- **WHEN** Halo uses its default Thymeleaf template resource settings
+- **THEN** the fallback resolves the corresponding packaged Halo template and adjacent messages
+
+#### Scenario: Template resource settings are configured
+- **WHEN** the Thymeleaf template prefix, suffix, or encoding is configured to a supported non-default value
+- **THEN** the fallback uses those configured values rather than hard-coded resource settings
+
+### Requirement: Message caching remains scoped to the theme template engine
+The system SHALL use Thymeleaf's existing template-message cache behavior and SHALL NOT introduce a message cache shared across theme template engines.
+
+#### Scenario: Theme engine cache is cleared
+- **WHEN** the cached template engine for a theme is cleared and recreated
+- **THEN** subsequent renders resolve theme and Halo fallback messages through the new engine and message resolver
+
+#### Scenario: Template is non-cacheable
+- **WHEN** Thymeleaf marks the selected template as non-cacheable
+- **THEN** the merged message map is resolved without adding a separate fallback cache

--- a/openspec/changes/archive/2026-07-17-support-theme-message-fallback/tasks.md
+++ b/openspec/changes/archive/2026-07-17-support-theme-message-fallback/tasks.md
@@ -1,0 +1,17 @@
+## 1. Regression Coverage
+
+- [x] 1.1 Add classpath Halo template/message fixtures and a focused `HaloTemplateEngine` test that reproduces the missing-message result when a temporary active theme overrides only the template.
+- [x] 1.2 Add engine-level cases for key-level merging, theme-template precedence, theme-global precedence, and theme-base-bundle precedence over a locale-specific Halo value.
+- [x] 1.3 Add engine-level cases for nested fragments, absent-message markers, missing Halo templates, non-theme resources, and malformed applicable message bundles.
+
+## 2. Theme Message Fallback
+
+- [x] 2.1 Pass the configured Thymeleaf template prefix, suffix, encoding, and resource-loading support from `TemplateEngineManager` into `ThemeMessageResolver`.
+- [x] 2.2 Add normalized file-resource boundary detection so only templates selected from the active theme's `templates` directory are eligible.
+- [x] 2.3 Resolve the same logical Halo template with the configured resource settings, require that template to exist, and load its template-adjacent locale bundles.
+- [x] 2.4 Merge theme-global, Halo template, and selected theme template message maps in the specified key-level precedence order without adding a separate cache.
+
+## 3. Verification
+
+- [x] 3.1 Run the focused theme message resolver and template-engine tests, including the existing `ThemeMessageResolverIntegrationTest`.
+- [x] 3.2 Run `./gradlew :application:spotlessCheck` and the relevant application test suite, then confirm `git diff --check` passes and only planned files changed.

--- a/openspec/specs/theme-message-fallback/spec.md
+++ b/openspec/specs/theme-message-fallback/spec.md
@@ -1,0 +1,104 @@
+# Theme Message Fallback
+
+## Purpose
+
+Define how active-theme templates reuse Halo-provided template messages while preserving theme overrides, locale fallback, and Thymeleaf's standard message-resolution behavior.
+
+## Requirements
+
+### Requirement: Eligible theme templates use Halo message fallback
+When an active theme supplies a template at the same logical path as a Halo-provided template, the system SHALL use the Halo template's message bundles as fallback sources for that theme template.
+
+#### Scenario: Theme overrides a Halo template
+- **WHEN** the selected template resource is inside the active theme's `templates` directory and Halo provides a template at the same logical path
+- **THEN** the system includes messages adjacent to the Halo template in the selected template's message lookup
+
+#### Scenario: Halo has no corresponding template
+- **WHEN** a selected active-theme template has no Halo-provided template at the same logical path
+- **THEN** the system does not include any Halo message bundle solely because a similarly located properties file exists
+
+#### Scenario: Selected resource is not an active-theme template
+- **WHEN** a selected template resource comes from a plugin, Halo itself, or a file outside the active theme's `templates` directory
+- **THEN** the system does not add active-theme-to-Halo fallback processing for that resource
+
+### Requirement: Message fallback merges by key
+For each eligible theme template, the system SHALL merge message maps by key in ascending precedence order: theme-global messages, corresponding Halo template messages, and selected theme template messages.
+
+#### Scenario: Theme omits a Halo key
+- **WHEN** an eligible theme template bundle does not define a key that is defined by the corresponding Halo template bundle
+- **THEN** resolving that key returns the Halo-provided value
+
+#### Scenario: Theme overrides a Halo key
+- **WHEN** both the eligible theme template bundle and corresponding Halo template bundle define the same key
+- **THEN** resolving that key returns the theme-provided value
+
+#### Scenario: Halo template message conflicts with theme-global message
+- **WHEN** a corresponding Halo template bundle and the active theme's global `i18n` bundle define the same key and the selected theme template bundle does not
+- **THEN** resolving that key returns the Halo template bundle value
+
+#### Scenario: Theme template message conflicts with all lower-precedence sources
+- **WHEN** the selected theme template bundle, corresponding Halo template bundle, and theme-global `i18n` bundle define the same key
+- **THEN** resolving that key returns the selected theme template bundle value
+
+### Requirement: Each message source resolves locale fallback independently
+The system SHALL apply Thymeleaf locale fallback within each message source before applying source precedence.
+
+#### Scenario: Theme base bundle overrides a locale-specific Halo value
+- **WHEN** the requested locale has a value in a locale-specific Halo bundle, the theme has no matching locale-specific bundle, and the theme base bundle defines the same key
+- **THEN** resolving that key returns the theme base-bundle value
+
+#### Scenario: Theme locale bundle overrides its base bundle
+- **WHEN** the theme base bundle and a more locale-specific theme bundle define the same key
+- **THEN** resolving that key returns the value from the more locale-specific theme bundle
+
+#### Scenario: Theme has no value in any applicable locale bundle
+- **WHEN** no applicable theme bundle defines a key and an applicable Halo bundle defines it
+- **THEN** resolving that key returns the most locale-specific applicable Halo value
+
+### Requirement: Fallback applies per template in the template stack
+The system SHALL evaluate message fallback independently for every eligible template resource processed by Thymeleaf, including top-level templates, fragments, and templates in nested directories.
+
+#### Scenario: Theme overrides a nested fragment
+- **WHEN** an active theme overrides a Halo fragment in a nested template path and omits a message defined beside the Halo fragment
+- **THEN** resolving that message while processing the fragment returns the Halo fragment's value
+
+#### Scenario: Outer template and fragment use separate bundles
+- **WHEN** a rendered page and one of its fragments each have template-specific message bundles
+- **THEN** each template uses the fallback sources associated with its own logical path and resource origin
+
+### Requirement: Standard absent-message and error behavior is preserved
+The system SHALL preserve Thymeleaf's existing behavior when no source supplies a key or when an existing message resource cannot be parsed.
+
+#### Scenario: Key is absent from all message sources
+- **WHEN** a message key is absent from the theme template bundle, corresponding Halo template bundle, and theme-global bundle
+- **THEN** a normal Thymeleaf message expression produces the standard locale-qualified absent-message representation
+
+#### Scenario: Locale-specific bundle does not exist
+- **WHEN** an optional locale-specific message resource does not exist
+- **THEN** the system continues resolving less-specific resources without failing template rendering
+
+#### Scenario: Existing bundle cannot be parsed
+- **WHEN** an applicable existing theme or Halo message resource contains content that cannot be parsed as a properties bundle
+- **THEN** template rendering fails with the standard message-resource parsing error
+
+### Requirement: Fallback follows configured system template resource settings
+The system SHALL locate corresponding Halo templates using the configured Thymeleaf template prefix, suffix, and character encoding.
+
+#### Scenario: Default template settings are used
+- **WHEN** Halo uses its default Thymeleaf template resource settings
+- **THEN** the fallback resolves the corresponding packaged Halo template and adjacent messages
+
+#### Scenario: Template resource settings are configured
+- **WHEN** the Thymeleaf template prefix, suffix, or encoding is configured to a supported non-default value
+- **THEN** the fallback uses those configured values rather than hard-coded resource settings
+
+### Requirement: Message caching remains scoped to the theme template engine
+The system SHALL use Thymeleaf's existing template-message cache behavior and SHALL NOT introduce a message cache shared across theme template engines.
+
+#### Scenario: Theme engine cache is cleared
+- **WHEN** the cached template engine for a theme is cleared and recreated
+- **THEN** subsequent renders resolve theme and Halo fallback messages through the new engine and message resolver
+
+#### Scenario: Template is non-cacheable
+- **WHEN** Thymeleaf marks the selected template as non-cacheable
+- **THEN** the merged message map is resolved without adding a separate fallback cache


### PR DESCRIPTION
#### What type of PR is this?

- [ ] Feature
- [x] Bug fix
- [ ] Improvement
- [ ] Cleanup
- [ ] Documentation

#### What this PR does / why we need it:

Themes can override Halo-provided Thymeleaf templates, but message resolution currently reads only bundles adjacent to the selected theme resource. As a result, a theme that overrides only the template must also copy the complete Halo message bundle, otherwise unresolved message markers are rendered.

This PR adds key-level message fallback for active-theme templates that override Halo templates at the same logical path.

Messages are merged in the following precedence order:

1. Theme-global messages
2. Messages adjacent to the corresponding Halo template
3. Messages adjacent to the selected theme template

The fallback applies independently to top-level templates and nested fragments. It is limited to file resources inside the active theme's `templates` directory, so plugin templates and unrelated file resolvers are unaffected.

The corresponding Halo template is resolved using the configured Thymeleaf prefix, suffix, and encoding. A properties file is not used as a fallback source unless the corresponding Halo template exists.

The regression is reproduced by rendering a theme override without an adjacent message bundle and referencing a key supplied by Halo. Before this change, Thymeleaf renders an unresolved-message marker. After this change, the Halo-provided value is rendered while explicit theme values retain precedence.

#### Which issue(s) this PR fixes:

None.

#### Special notes for your reviewer:

The implementation preserves Thymeleaf's standard locale fallback, absent-message, parsing-error, template-stack, and message-cache behavior.

Engine-level tests cover full and partial fallback, source precedence, locale precedence, nested fragments, configured template resource settings, missing Halo templates, non-theme resources, absent keys, and malformed bundles.

This change was developed with assistance from OpenAI Codex and reviewed through focused and full application test suites.

#### Does this PR introduce a user-facing change?

```release-note
主题覆盖 Halo 内置模板时，缺失的多语言文案现在会自动回退到 Halo 提供的语言包。
```
