### PR TITLE
Replace code block auto language option with none

### DIFF
--- a/ui/packages/editor/src/extensions/code-block/CodeBlockSelect.spec.ts
+++ b/ui/packages/editor/src/extensions/code-block/CodeBlockSelect.spec.ts
@@ -64,4 +64,15 @@ describe("CodeBlockSelect", () => {
     expect(setupState.selectedIndex).toBe(0);
     wrapper.unmount();
   });
+
+  it("displays an option whose value is empty", () => {
+    const wrapper = mount(CodeBlockSelect, {
+      props: {
+        options: [{ label: "None", value: "" }, ...options],
+        modelValue: "",
+      },
+    });
+
+    expect(wrapper.get(".text-ellipsis.text-sm").text()).toBe("None");
+  });
 });

--- a/ui/packages/editor/src/extensions/code-block/CodeBlockSelect.vue
+++ b/ui/packages/editor/src/extensions/code-block/CodeBlockSelect.vue
@@ -107,9 +107,8 @@ const handleOptionKeydown = (event: KeyboardEvent) => {
 watch(
   [value, filterOptions],
   ([newValue, options]) => {
-    selectedOption.value = newValue
-      ? props.options.find((option) => option.value === newValue) || null
-      : null;
+    selectedOption.value =
+      props.options.find((option) => option.value === newValue) || null;
 
     const currentIndex = options.findIndex(
       (option) => option.value === newValue

--- a/ui/packages/editor/src/extensions/code-block/CodeBlockViewRenderer.spec.ts
+++ b/ui/packages/editor/src/extensions/code-block/CodeBlockViewRenderer.spec.ts
@@ -1,0 +1,64 @@
+// @vitest-environment jsdom
+
+import { shallowMount } from "@vue/test-utils";
+import { describe, expect, it, vi } from "vitest";
+import type { NodeViewProps } from "@/tiptap/vue-3";
+import CodeBlockSelect from "./CodeBlockSelect.vue";
+import CodeBlockViewRenderer from "./CodeBlockViewRenderer.vue";
+
+describe("CodeBlockViewRenderer", () => {
+  it("removes the auto option without changing an existing value", async () => {
+    const updateAttributes = vi.fn();
+    const wrapper = shallowMount(CodeBlockViewRenderer, {
+      props: {
+        node: {
+          attrs: {
+            language: "auto",
+            collapsed: false,
+          },
+          textContent: "",
+        },
+        updateAttributes,
+        editor: {
+          state: {},
+          options: {
+            element: document.createElement("div"),
+          },
+          commands: {
+            focus: vi.fn(),
+          },
+        },
+        extension: {
+          options: {
+            languages: [
+              { label: "Auto", value: "auto" },
+              { label: "JavaScript", value: "javascript" },
+            ],
+            themes: [],
+          },
+        },
+        getPos: () => 0,
+        selected: false,
+      } as unknown as NodeViewProps,
+      global: {
+        stubs: {
+          NodeViewWrapper: { template: "<div><slot /></div>" },
+          NodeViewContent: true,
+        },
+        directives: {
+          tooltip: {},
+        },
+      },
+    });
+
+    const languageSelect = wrapper.findComponent(CodeBlockSelect);
+    expect(languageSelect.props("options")).toEqual([
+      { label: "None", value: "" },
+      { label: "JavaScript", value: "javascript" },
+    ]);
+    expect(languageSelect.props("modelValue")).toBe("auto");
+
+    await languageSelect.vm.$emit("update:modelValue", "");
+    expect(updateAttributes).toHaveBeenCalledWith({ language: null });
+  });
+});

--- a/ui/packages/editor/src/extensions/code-block/CodeBlockViewRenderer.spec.ts
+++ b/ui/packages/editor/src/extensions/code-block/CodeBlockViewRenderer.spec.ts
@@ -7,7 +7,7 @@ import CodeBlockSelect from "./CodeBlockSelect.vue";
 import CodeBlockViewRenderer from "./CodeBlockViewRenderer.vue";
 
 describe("CodeBlockViewRenderer", () => {
-  it("removes the auto option without changing an existing value", async () => {
+  it("keeps plugin-provided auto option without changing its value", async () => {
     const updateAttributes = vi.fn();
     const wrapper = shallowMount(CodeBlockViewRenderer, {
       props: {
@@ -54,6 +54,7 @@ describe("CodeBlockViewRenderer", () => {
     const languageSelect = wrapper.findComponent(CodeBlockSelect);
     expect(languageSelect.props("options")).toEqual([
       { label: "None", value: "" },
+      { label: "Auto", value: "auto" },
       { label: "JavaScript", value: "javascript" },
     ]);
     expect(languageSelect.props("modelValue")).toBe("auto");

--- a/ui/packages/editor/src/extensions/code-block/CodeBlockViewRenderer.vue
+++ b/ui/packages/editor/src/extensions/code-block/CodeBlockViewRenderer.vue
@@ -30,9 +30,7 @@ const languageOptions = computed(() => {
       label: i18n.global.t("editor.common.codeblock.language.none"),
       value: "",
     },
-    ...(languages || []).filter(
-      (language) => language.value !== "auto" && language.value !== ""
-    ),
+    ...(languages || []).filter((language) => language.value !== ""),
   ];
 });
 

--- a/ui/packages/editor/src/extensions/code-block/CodeBlockViewRenderer.vue
+++ b/ui/packages/editor/src/extensions/code-block/CodeBlockViewRenderer.vue
@@ -25,23 +25,23 @@ const languageOptions = computed(() => {
   } else {
     languages = lang;
   }
-  languages = languages || [];
-  const languageValues = languages.map((language) => language.value);
-  if (languageValues.indexOf("auto") === -1) {
-    languages.unshift({
-      label: "Auto",
-      value: "auto",
-    });
-  }
-  return languages;
+  return [
+    {
+      label: i18n.global.t("editor.common.codeblock.language.none"),
+      value: "",
+    },
+    ...(languages || []).filter(
+      (language) => language.value !== "auto" && language.value !== ""
+    ),
+  ];
 });
 
 const selectedLanguage = computed({
   get: () => {
-    return props.node?.attrs.language || "auto";
+    return props.node?.attrs.language || "";
   },
   set: (language: string) => {
-    props.updateAttributes({ language: language });
+    props.updateAttributes({ language: language || null });
   },
 });
 

--- a/ui/packages/editor/src/locales/en.json
+++ b/ui/packages/editor/src/locales/en.json
@@ -134,6 +134,7 @@
   "editor.common.superscript": "Superscript",
   "editor.common.subscript": "Subscript",
   "editor.common.codeblock.title": "Code block",
+  "editor.common.codeblock.language.none": "None",
   "editor.common.codeblock.copy_code": "Copy code",
   "editor.common.codeblock.copy_code_success": "Copy success",
   "editor.common.image": "Image",

--- a/ui/packages/editor/src/locales/es.json
+++ b/ui/packages/editor/src/locales/es.json
@@ -134,6 +134,7 @@
   "editor.common.superscript": "Superíndice",
   "editor.common.subscript": "Subíndice",
   "editor.common.codeblock.title": "Bloque de código",
+  "editor.common.codeblock.language.none": "Ninguno",
   "editor.common.codeblock.copy_code": "Copiar código",
   "editor.common.codeblock.copy_code_success": "Copiado con éxito",
   "editor.common.image": "Imagen",

--- a/ui/packages/editor/src/locales/zh-CN.json
+++ b/ui/packages/editor/src/locales/zh-CN.json
@@ -134,6 +134,7 @@
   "editor.common.superscript": "上角标",
   "editor.common.subscript": "下角标",
   "editor.common.codeblock.title": "代码块",
+  "editor.common.codeblock.language.none": "无",
   "editor.common.codeblock.copy_code": "复制代码",
   "editor.common.codeblock.copy_code_success": "复制成功",
   "editor.common.image": "图片",


### PR DESCRIPTION
#### What type of PR is this?

- [ ] Feature
- [ ] Bug fix
- [x] Improvement
- [ ] Cleanup
- [ ] Documentation

#### What this PR does / why we need it:

Replaces the code block language selector's core-provided `Auto` option with a localized `None` option.

Selecting `None` clears the language attribute instead of storing a synthetic language value. Halo no longer injects `Auto` by default, but language options explicitly registered by plugins, including `auto`, are preserved.

This also updates the language selector to correctly display options whose value is an empty string and adds regression coverage for both behaviors.

#### Which issue(s) this PR fixes:

N/A

#### Special notes for your reviewer:

- Existing code blocks with `language: "auto"` are intentionally left untouched.
- Plugins can continue to register an `auto` language option explicitly.
- This change was implemented with AI assistance and manually reviewed.

Validation:

- Focused code block tests: 4 passed
- Editor package typecheck
- ESLint for the changed editor files
- Editor package build
- `git diff --check`

#### Does this PR introduce a user-facing change?

```release-note
代码块语言选择器不再默认提供“自动”选项，并新增“无”选项。插件仍可提供“自动”等语言选项。
```
