### PR TITLE
Optimize gallery preview image loading

### DIFF
--- a/ui/packages/editor/src/extensions/gallery/GalleryView.spec.ts
+++ b/ui/packages/editor/src/extensions/gallery/GalleryView.spec.ts
@@ -16,7 +16,11 @@ vi.mock("@halo-dev/components", () => ({
 vi.mock("@halo-dev/ui-shared", () => ({
   utils: {
     permission: { has: () => false },
-    attachment: { getUrl: () => undefined },
+    attachment: {
+      getUrl: () => undefined,
+      getThumbnailUrl: (url: string, size: string) =>
+        `${url}?thumbnail=${size}`,
+    },
   },
 }));
 
@@ -43,6 +47,9 @@ describe("GalleryView", () => {
     });
     const html = sourceEditor.getHTML();
     sourceEditor.destroy();
+
+    expect(html).toContain('src="/image.jpg"');
+    expect(html).not.toContain("thumbnail");
 
     const parsedEditor = createEditor(html);
     const images = parsedEditor.state.doc.nodeAt(0)?.attrs
@@ -109,6 +116,71 @@ describe("GalleryView", () => {
       images: [{ src: "/image.jpg", aspectRatio: 2 }],
     });
   });
+
+  it.each([
+    { count: 1, expectedSize: "XL" },
+    { count: 2, expectedSize: "M" },
+    { count: 3, expectedSize: "M" },
+    { count: 4, expectedSize: "S" },
+  ])(
+    "uses $expectedSize thumbnails for a row containing $count images",
+    ({ count, expectedSize }) => {
+      const images = Array.from({ length: count }, (_, index) => ({
+        src: `/image-${index + 1}.jpg`,
+        aspectRatio: 2,
+      }));
+      const { wrapper } = mountGallery(images, count);
+
+      expect(
+        wrapper.findAll("img").map((image) => image.attributes("src"))
+      ).toEqual(
+        images.map((image) => `${image.src}?thumbnail=${expectedSize}`)
+      );
+    }
+  );
+
+  it("recalculates thumbnail sizes from actual rows when group size changes", async () => {
+    const images = Array.from({ length: 4 }, (_, index) => ({
+      src: `/image-${index + 1}.jpg`,
+      aspectRatio: 2,
+    }));
+    const { wrapper } = mountGallery(images, 4);
+
+    expect(
+      wrapper.findAll("img").map((image) => image.attributes("src"))
+    ).toEqual(images.map((image) => `${image.src}?thumbnail=S`));
+
+    await wrapper.setProps({
+      node: {
+        attrs: {
+          images,
+          groupSize: 3,
+          layout: "auto",
+          gap: 8,
+        },
+      } as unknown as NodeViewProps["node"],
+    });
+
+    expect(
+      wrapper.findAll("img").map((image) => image.attributes("src"))
+    ).toEqual([
+      "/image-1.jpg?thumbnail=M",
+      "/image-2.jpg?thumbnail=M",
+      "/image-3.jpg?thumbnail=M",
+      "/image-4.jpg?thumbnail=XL",
+    ]);
+  });
+
+  it("eagerly loads images until their aspect ratio is known", () => {
+    const { wrapper } = mountGallery([
+      { src: "/known.jpg", aspectRatio: 2 },
+      { src: "/unknown.jpg", aspectRatio: 0 },
+    ]);
+
+    expect(
+      wrapper.findAll("img").map((image) => image.attributes("loading"))
+    ).toEqual(["lazy", "eager"]);
+  });
 });
 
 function createEditor(content: Content) {
@@ -118,14 +190,18 @@ function createEditor(content: Content) {
   });
 }
 
-function mountGallery(image: ExtensionGalleryImageItem) {
+function mountGallery(
+  image: ExtensionGalleryImageItem | ExtensionGalleryImageItem[],
+  groupSize = 3
+) {
+  const images = Array.isArray(image) ? image : [image];
   const updateAttributes = vi.fn();
   const wrapper = shallowMount(GalleryView, {
     props: {
       node: {
         attrs: {
-          images: [image],
-          groupSize: 3,
+          images,
+          groupSize,
           layout: "auto",
           gap: 8,
         },

--- a/ui/packages/editor/src/extensions/gallery/GalleryView.vue
+++ b/ui/packages/editor/src/extensions/gallery/GalleryView.vue
@@ -1,4 +1,5 @@
 <script lang="ts" setup>
+import { GetThumbnailByUriSizeEnum } from "@halo-dev/api-client";
 import { VButton, VSpace } from "@halo-dev/components";
 import { utils, type AttachmentLike } from "@halo-dev/ui-shared";
 import { computed, ref } from "vue";
@@ -78,6 +79,16 @@ const groups = computed<ExtensionGalleryImageItem[][]>(() => {
     []
   );
 });
+
+function getThumbnailSize(groupLength: number) {
+  if (groupLength === 1) {
+    return GetThumbnailByUriSizeEnum.Xl;
+  }
+  if (groupLength <= 3) {
+    return GetThumbnailByUriSizeEnum.M;
+  }
+  return GetThumbnailByUriSizeEnum.S;
+}
 
 const draggedIndex = ref<number | null>(null);
 const dragOverIndex = ref<number | null>(null);
@@ -225,8 +236,14 @@ function onAttachmentSelect(attachments: AttachmentLike[]) {
           @drop="handleDrop(groupIndex * groupSize + imgIndex, $event)"
         >
           <img
-            :src="image.src"
+            :src="
+              utils.attachment.getThumbnailUrl(
+                image.src,
+                getThumbnailSize(group.length)
+              )
+            "
             :alt="`Gallery image ${groupIndex * groupSize + imgIndex + 1}`"
+            :loading="image.aspectRatio > 0 ? 'lazy' : 'eager'"
             class="pointer-events-none block size-full object-cover"
             @load="handleImageLoad($event, groupIndex * groupSize + imgIndex)"
           />


### PR DESCRIPTION
#### What type of PR is this?

- [ ] Feature
- [ ] Bug fix
- [x] Improvement
- [ ] Cleanup
- [ ] Documentation

#### What this PR does / why we need it:

Gallery previews currently load original images in the editor, which can make galleries with many images slow to render.

This change:

- Uses attachment thumbnail URLs only for the editor preview.
- Selects the thumbnail size from the actual number of images in each row:
  - `XL` for one image.
  - `M` for two or three images.
  - `S` for four or more images.
- Recalculates thumbnail sizes when gallery rows are regrouped.
- Lazily loads images with a known aspect ratio while eagerly loading images whose aspect ratio still needs to be detected.
- Keeps original image URLs in the editor document and serialized HTML.

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

The Gallery node attributes and serialized HTML continue to use the original image URLs. Thumbnail URLs are limited to the Vue node view used for editor previews.

Validation performed:

- Gallery focused tests: 11 passed
- `corepack pnpm@10.30.3 -C ui typecheck`
- `corepack pnpm@10.30.3 -C ui lint`
- `corepack pnpm@10.30.3 -C ui build:packages`
- Formatting check
- `git diff --check`

This change was implemented with assistance from an LLM and reviewed against the existing Gallery behavior and regression tests.

#### Does this PR introduce a user-facing change?

```release-note
优化编辑器中图库图片的加载性能，图片较多时预览更加流畅。
```
