### PR TITLE
chore: upgrade r2dbc-migrate to 4.1.0

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -30,7 +30,7 @@ openapi-schema-validator = 'org.openapi4j:openapi-schema-validator:1.0.7'
 bouncycastle-bcpkix = 'org.bouncycastle:bcpkix-jdk18on:1.83'
 twofactor-auth = 'com.j256.two-factor-auth:two-factor-auth:1.3'
 thumbnailator = 'net.coobird:thumbnailator:0.4.21'
-r2dbc-migrate-starter = 'name.nkonev.r2dbc-migrate:r2dbc-migrate-spring-boot-starter:4.0.1'
+r2dbc-migrate-starter = 'name.nkonev.r2dbc-migrate:r2dbc-migrate-spring-boot-starter:4.1.0'
 ua-parser = 'com.github.ua-parser:uap-java:1.6.1'
 
 [bundles]


### PR DESCRIPTION
Upgrade `name.nkonev.r2dbc-migrate:r2dbc-migrate-spring-boot-starter` from 4.0.1 to 4.1.0.

No breaking changes in r2dbc-migrate itself — the only change is a Spring Boot version bump to 4.1.0, which this project already uses.

See: https://github.com/nkonev/r2dbc-migrate/compare/4.0.1...4.1.0