### PR TITLE
fix: resolve login ambiguity when username matches another user's email

### DIFF
--- a/application/src/main/java/run/halo/app/infra/config/WebServerSecurityConfig.java
+++ b/application/src/main/java/run/halo/app/infra/config/WebServerSecurityConfig.java
@@ -128,12 +128,9 @@ public class WebServerSecurityConfig {
         // we can remove this code.
         var encodingId = "argon2@SpringSecurity_v5_8";
         var encoders = new HashMap<String, PasswordEncoder>();
-        var argon2Encoder = Argon2PasswordEncoder.defaultsForSpringSecurity_v5_8();
-        encoders.put(encodingId, argon2Encoder);
+        encoders.put(encodingId, Argon2PasswordEncoder.defaultsForSpringSecurity_v5_8());
         encoders.put("bcrypt", new BCryptPasswordEncoder());
-        var passwordEncoder = new DelegatingPasswordEncoder(encodingId, encoders);
-        passwordEncoder.setDefaultPasswordEncoderForMatches(argon2Encoder);
-        return passwordEncoder;
+        return new DelegatingPasswordEncoder(encodingId, encoders);
     }
 
     @Bean

--- a/application/src/main/java/run/halo/app/infra/config/WebServerSecurityConfig.java
+++ b/application/src/main/java/run/halo/app/infra/config/WebServerSecurityConfig.java
@@ -128,9 +128,12 @@ public class WebServerSecurityConfig {
         // we can remove this code.
         var encodingId = "argon2@SpringSecurity_v5_8";
         var encoders = new HashMap<String, PasswordEncoder>();
-        encoders.put(encodingId, Argon2PasswordEncoder.defaultsForSpringSecurity_v5_8());
+        var argon2Encoder = Argon2PasswordEncoder.defaultsForSpringSecurity_v5_8();
+        encoders.put(encodingId, argon2Encoder);
         encoders.put("bcrypt", new BCryptPasswordEncoder());
-        return new DelegatingPasswordEncoder(encodingId, encoders);
+        var passwordEncoder = new DelegatingPasswordEncoder(encodingId, encoders);
+        passwordEncoder.setDefaultPasswordEncoderForMatches(argon2Encoder);
+        return passwordEncoder;
     }
 
     @Bean

--- a/application/src/main/java/run/halo/app/security/DefaultUserDetailService.java
+++ b/application/src/main/java/run/halo/app/security/DefaultUserDetailService.java
@@ -41,16 +41,7 @@ public class DefaultUserDetailService implements ReactiveUserDetailsService, Rea
 
     @Override
     public Mono<UserDetails> findByUsername(String username) {
-        var getUser = Mono.defer(() -> {
-            var isEmail = username.contains("@");
-            if (isEmail) {
-                log.debug("Try to authenticate by email: {}", username);
-                return userService.findUserByVerifiedEmail(username);
-            } else {
-                log.debug("Try to authenticate by username: {}", username);
-                return userService.getUser(username);
-            }
-        });
+        var getUser = userService.getUser(username);
         return getUser.switchIfEmpty(Mono.error(() -> new UserNotFoundException(username)))
                 .onErrorMap(UserNotFoundException.class, ignored -> new BadCredentialsException("Invalid Credentials"))
                 .flatMap(user -> {

--- a/application/src/main/java/run/halo/app/security/authentication/login/LoginReactiveAuthenticationManager.java
+++ b/application/src/main/java/run/halo/app/security/authentication/login/LoginReactiveAuthenticationManager.java
@@ -13,6 +13,7 @@ import org.springframework.security.core.userdetails.ReactiveUserDetailsPassword
 import org.springframework.security.core.userdetails.ReactiveUserDetailsService;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.crypto.password.PasswordEncoder;
+import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import reactor.core.scheduler.Schedulers;
 import run.halo.app.core.user.service.UserService;
@@ -37,12 +38,12 @@ class LoginReactiveAuthenticationManager implements ReactiveAuthenticationManage
 
     @Override
     public Mono<Authentication> authenticate(Authentication authentication) {
-        var username = authentication.getName();
+        var loginId = authentication.getName();
         var credentials = authentication.getCredentials();
         var password = credentials != null ? credentials.toString() : null;
 
-        return tryByUsername(username, password)
-                .switchIfEmpty(Mono.defer(() -> tryByEmail(username, password)))
+        return Flux.concat(tryByUsername(loginId, password), tryByEmail(loginId, password))
+                .next()
                 .switchIfEmpty(Mono.error(() -> new BadCredentialsException("Invalid Credentials")))
                 .publishOn(Schedulers.boundedElastic())
                 .doOnNext(this::preAuthenticationChecks)
@@ -79,24 +80,29 @@ class LoginReactiveAuthenticationManager implements ReactiveAuthenticationManage
     }
 
     /**
-     * Attempts to authenticate by username: loads the user and checks the password. Returns empty Mono if the user is
-     * not found or the password does not match.
+     * Attempts to authenticate by username. Since usernames do not contain {@code @}, this method immediately returns
+     * empty for email-like login identifiers.
      */
-    Mono<UserDetails> tryByUsername(String username, String password) {
+    Mono<UserDetails> tryByUsername(String loginId, String password) {
+        if (loginId.contains("@")) {
+            return Mono.empty();
+        }
         return userDetailsService
-                .findByUsername(username)
+                .findByUsername(loginId)
                 .onErrorResume(BadCredentialsException.class, e -> Mono.empty())
                 .filter(userDetails ->
                         password != null && passwordEncoder.matches(password, userDetails.getPassword()));
     }
 
     /**
-     * Attempts to authenticate by email: looks up the verified email to find the actual username, then delegates to
-     * {@link #tryByUsername(String, String)}.
+     * Attempts to authenticate by verified email. Only executes when the login identifier looks like an email address.
      */
-    Mono<UserDetails> tryByEmail(String email, String password) {
+    Mono<UserDetails> tryByEmail(String loginId, String password) {
+        if (!loginId.contains("@")) {
+            return Mono.empty();
+        }
         return userService
-                .findUserByVerifiedEmail(email)
+                .findUserByVerifiedEmail(loginId)
                 .flatMap(user -> tryByUsername(user.getMetadata().getName(), password));
     }
 

--- a/application/src/main/java/run/halo/app/security/authentication/login/LoginReactiveAuthenticationManager.java
+++ b/application/src/main/java/run/halo/app/security/authentication/login/LoginReactiveAuthenticationManager.java
@@ -1,7 +1,11 @@
 package run.halo.app.security.authentication.login;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.AccountExpiredException;
 import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.security.authentication.CredentialsExpiredException;
+import org.springframework.security.authentication.DisabledException;
+import org.springframework.security.authentication.LockedException;
 import org.springframework.security.authentication.ReactiveAuthenticationManager;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
@@ -10,6 +14,7 @@ import org.springframework.security.core.userdetails.ReactiveUserDetailsService;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import reactor.core.publisher.Mono;
+import reactor.core.scheduler.Schedulers;
 import run.halo.app.core.user.service.UserService;
 
 /**
@@ -33,18 +38,44 @@ class LoginReactiveAuthenticationManager implements ReactiveAuthenticationManage
     @Override
     public Mono<Authentication> authenticate(Authentication authentication) {
         var username = authentication.getName();
-        var password = authentication.getCredentials().toString();
+        var credentials = authentication.getCredentials();
+        var password = credentials != null ? credentials.toString() : null;
 
         return tryByUsername(username, password)
                 .switchIfEmpty(Mono.defer(() -> tryByEmail(username, password)))
                 .switchIfEmpty(Mono.error(() -> new BadCredentialsException("Invalid Credentials")))
+                .publishOn(Schedulers.boundedElastic())
+                .doOnNext(this::preAuthenticationChecks)
                 .flatMap(userDetails -> upgradePasswordIfNeeded(userDetails, password))
-                .map(userDetails -> {
-                    var result = new UsernamePasswordAuthenticationToken(
-                            userDetails, authentication.getCredentials(), userDetails.getAuthorities());
-                    result.setDetails(authentication.getDetails());
-                    return result;
-                });
+                .doOnNext(this::postAuthenticationChecks)
+                .map(userDetails -> UsernamePasswordAuthenticationToken.authenticated(
+                        userDetails, userDetails.getPassword(), userDetails.getAuthorities()));
+    }
+
+    /**
+     * Default pre-authentication checks: account locked, disabled, and expired. Mirrors
+     * {@code AbstractUserDetailsReactiveAuthenticationManager.defaultPreAuthenticationChecks}.
+     */
+    private void preAuthenticationChecks(UserDetails user) {
+        if (!user.isAccountNonLocked()) {
+            throw new LockedException("User account is locked");
+        }
+        if (!user.isEnabled()) {
+            throw new DisabledException("User is disabled");
+        }
+        if (!user.isAccountNonExpired()) {
+            throw new AccountExpiredException("User account has expired");
+        }
+    }
+
+    /**
+     * Default post-authentication checks: credentials expired. Mirrors
+     * {@code AbstractUserDetailsReactiveAuthenticationManager.defaultPostAuthenticationChecks}.
+     */
+    private void postAuthenticationChecks(UserDetails user) {
+        if (!user.isCredentialsNonExpired()) {
+            throw new CredentialsExpiredException("User credentials have expired");
+        }
     }
 
     /**
@@ -55,7 +86,8 @@ class LoginReactiveAuthenticationManager implements ReactiveAuthenticationManage
         return userDetailsService
                 .findByUsername(username)
                 .onErrorResume(BadCredentialsException.class, e -> Mono.empty())
-                .filter(userDetails -> passwordEncoder.matches(password, userDetails.getPassword()));
+                .filter(userDetails ->
+                        password != null && passwordEncoder.matches(password, userDetails.getPassword()));
     }
 
     /**

--- a/application/src/main/java/run/halo/app/security/authentication/login/LoginReactiveAuthenticationManager.java
+++ b/application/src/main/java/run/halo/app/security/authentication/login/LoginReactiveAuthenticationManager.java
@@ -39,8 +39,12 @@ class LoginReactiveAuthenticationManager implements ReactiveAuthenticationManage
                 .switchIfEmpty(Mono.defer(() -> tryByEmail(username, password)))
                 .switchIfEmpty(Mono.error(() -> new BadCredentialsException("Invalid Credentials")))
                 .flatMap(userDetails -> upgradePasswordIfNeeded(userDetails, password))
-                .map(userDetails -> new UsernamePasswordAuthenticationToken(
-                        userDetails, userDetails.getPassword(), userDetails.getAuthorities()));
+                .map(userDetails -> {
+                    var result = new UsernamePasswordAuthenticationToken(
+                            userDetails, authentication.getCredentials(), userDetails.getAuthorities());
+                    result.setDetails(authentication.getDetails());
+                    return result;
+                });
     }
 
     /**

--- a/application/src/main/java/run/halo/app/security/authentication/login/LoginReactiveAuthenticationManager.java
+++ b/application/src/main/java/run/halo/app/security/authentication/login/LoginReactiveAuthenticationManager.java
@@ -89,6 +89,7 @@ class LoginReactiveAuthenticationManager implements ReactiveAuthenticationManage
         }
         return userDetailsService
                 .findByUsername(loginId)
+                .publishOn(Schedulers.boundedElastic())
                 .onErrorResume(BadCredentialsException.class, e -> Mono.empty())
                 .filter(userDetails ->
                         password != null && passwordEncoder.matches(password, userDetails.getPassword()));

--- a/application/src/main/java/run/halo/app/security/authentication/login/LoginReactiveAuthenticationManager.java
+++ b/application/src/main/java/run/halo/app/security/authentication/login/LoginReactiveAuthenticationManager.java
@@ -70,7 +70,12 @@ class LoginReactiveAuthenticationManager implements ReactiveAuthenticationManage
 
     private Mono<UserDetails> upgradePasswordIfNeeded(UserDetails userDetails, String password) {
         if (passwordService != null) {
-            return passwordService.updatePassword(userDetails, password);
+            var upgradeEncoding =
+                    userDetails.getPassword() != null && passwordEncoder.upgradeEncoding(userDetails.getPassword());
+            if (upgradeEncoding) {
+                var newPassword = passwordEncoder.encode(password);
+                return passwordService.updatePassword(userDetails, newPassword);
+            }
         }
         return Mono.just(userDetails);
     }

--- a/application/src/main/java/run/halo/app/security/authentication/login/LoginReactiveAuthenticationManager.java
+++ b/application/src/main/java/run/halo/app/security/authentication/login/LoginReactiveAuthenticationManager.java
@@ -1,0 +1,73 @@
+package run.halo.app.security.authentication.login;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.security.authentication.ReactiveAuthenticationManager;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.userdetails.ReactiveUserDetailsPasswordService;
+import org.springframework.security.core.userdetails.ReactiveUserDetailsService;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import reactor.core.publisher.Mono;
+import run.halo.app.core.user.service.UserService;
+
+/**
+ * A {@link ReactiveAuthenticationManager} that authenticates by trying username first, then falling back to verified
+ * email lookup if the username is not found or the password does not match.
+ *
+ * <p>This prevents ambiguous credential matching when a login identifier could be either a username or an email
+ * address.
+ */
+@RequiredArgsConstructor
+class LoginReactiveAuthenticationManager implements ReactiveAuthenticationManager {
+
+    private final ReactiveUserDetailsService userDetailsService;
+
+    private final UserService userService;
+
+    private final PasswordEncoder passwordEncoder;
+
+    private final ReactiveUserDetailsPasswordService passwordService;
+
+    @Override
+    public Mono<Authentication> authenticate(Authentication authentication) {
+        var username = authentication.getName();
+        var password = authentication.getCredentials().toString();
+
+        return tryByUsername(username, password)
+                .switchIfEmpty(Mono.defer(() -> tryByEmail(username, password)))
+                .switchIfEmpty(Mono.error(() -> new BadCredentialsException("Invalid Credentials")))
+                .flatMap(userDetails -> upgradePasswordIfNeeded(userDetails, password))
+                .map(userDetails -> new UsernamePasswordAuthenticationToken(
+                        userDetails, userDetails.getPassword(), userDetails.getAuthorities()));
+    }
+
+    /**
+     * Attempts to authenticate by username: loads the user and checks the password. Returns empty Mono if the user is
+     * not found or the password does not match.
+     */
+    Mono<UserDetails> tryByUsername(String username, String password) {
+        return userDetailsService
+                .findByUsername(username)
+                .onErrorResume(BadCredentialsException.class, e -> Mono.empty())
+                .filter(userDetails -> passwordEncoder.matches(password, userDetails.getPassword()));
+    }
+
+    /**
+     * Attempts to authenticate by email: looks up the verified email to find the actual username, then delegates to
+     * {@link #tryByUsername(String, String)}.
+     */
+    Mono<UserDetails> tryByEmail(String email, String password) {
+        return userService
+                .findUserByVerifiedEmail(email)
+                .flatMap(user -> tryByUsername(user.getMetadata().getName(), password));
+    }
+
+    private Mono<UserDetails> upgradePasswordIfNeeded(UserDetails userDetails, String password) {
+        if (passwordService != null) {
+            return passwordService.updatePassword(userDetails, password);
+        }
+        return Mono.just(userDetails);
+    }
+}

--- a/application/src/main/java/run/halo/app/security/authentication/login/LoginReactiveAuthenticationManager.java
+++ b/application/src/main/java/run/halo/app/security/authentication/login/LoginReactiveAuthenticationManager.java
@@ -19,11 +19,9 @@ import reactor.core.scheduler.Schedulers;
 import run.halo.app.core.user.service.UserService;
 
 /**
- * A {@link ReactiveAuthenticationManager} that authenticates by trying username first, then falling back to verified
- * email lookup if the username is not found or the password does not match.
- *
- * <p>This prevents ambiguous credential matching when a login identifier could be either a username or an email
- * address.
+ * A {@link ReactiveAuthenticationManager} that authenticates by trying multiple login strategies in order: username
+ * first, then verified email. Each strategy only executes when the login identifier matches its expected format (e.g.,
+ * email lookup only runs for identifiers containing {@code @}).
  */
 @RequiredArgsConstructor
 class LoginReactiveAuthenticationManager implements ReactiveAuthenticationManager {
@@ -42,69 +40,53 @@ class LoginReactiveAuthenticationManager implements ReactiveAuthenticationManage
         var credentials = authentication.getCredentials();
         var password = credentials != null ? credentials.toString() : null;
 
-        return Flux.concat(tryByUsername(loginId, password), tryByEmail(loginId, password))
+        return Flux.concat(lookupByUsername(loginId), lookupByEmail(loginId))
+                .publishOn(Schedulers.boundedElastic())
+                .filter(userDetails -> password != null && passwordEncoder.matches(password, userDetails.getPassword()))
                 .next()
                 .switchIfEmpty(Mono.error(() -> new BadCredentialsException("Invalid Credentials")))
-                .publishOn(Schedulers.boundedElastic())
-                .doOnNext(this::preAuthenticationChecks)
+                .delayUntil(this::checkAccountStatus)
                 .flatMap(userDetails -> upgradePasswordIfNeeded(userDetails, password))
-                .doOnNext(this::postAuthenticationChecks)
                 .map(userDetails -> UsernamePasswordAuthenticationToken.authenticated(
                         userDetails, userDetails.getPassword(), userDetails.getAuthorities()));
     }
 
-    /**
-     * Default pre-authentication checks: account locked, disabled, and expired. Mirrors
-     * {@code AbstractUserDetailsReactiveAuthenticationManager.defaultPreAuthenticationChecks}.
-     */
-    private void preAuthenticationChecks(UserDetails user) {
+    private Mono<Void> checkAccountStatus(UserDetails user) {
         if (!user.isAccountNonLocked()) {
-            throw new LockedException("User account is locked");
+            return Mono.error(new LockedException("User account is locked"));
         }
         if (!user.isEnabled()) {
-            throw new DisabledException("User is disabled");
+            return Mono.error(new DisabledException("User is disabled"));
         }
         if (!user.isAccountNonExpired()) {
-            throw new AccountExpiredException("User account has expired");
+            return Mono.error(new AccountExpiredException("User account has expired"));
         }
-    }
-
-    /**
-     * Default post-authentication checks: credentials expired. Mirrors
-     * {@code AbstractUserDetailsReactiveAuthenticationManager.defaultPostAuthenticationChecks}.
-     */
-    private void postAuthenticationChecks(UserDetails user) {
         if (!user.isCredentialsNonExpired()) {
-            throw new CredentialsExpiredException("User credentials have expired");
+            return Mono.error(new CredentialsExpiredException("User credentials have expired"));
         }
+        return Mono.empty();
     }
 
-    /**
-     * Attempts to authenticate by username. Since usernames do not contain {@code @}, this method immediately returns
-     * empty for email-like login identifiers.
-     */
-    Mono<UserDetails> tryByUsername(String loginId, String password) {
+    /** Looks up the user by username. Skips email-like identifiers since usernames never contain {@code @}. */
+    Mono<UserDetails> lookupByUsername(String loginId) {
         if (loginId.contains("@")) {
             return Mono.empty();
         }
         return userDetailsService
                 .findByUsername(loginId)
-                .publishOn(Schedulers.boundedElastic())
-                .onErrorResume(BadCredentialsException.class, e -> Mono.empty())
-                .filter(userDetails ->
-                        password != null && passwordEncoder.matches(password, userDetails.getPassword()));
+                .onErrorResume(BadCredentialsException.class, e -> Mono.empty());
     }
 
-    /**
-     * Attempts to authenticate by verified email. Only executes when the login identifier looks like an email address.
-     */
-    Mono<UserDetails> tryByEmail(String loginId, String password) {
+    /** Looks up the user by verified email. Skips identifiers that don't look like email addresses. */
+    Mono<UserDetails> lookupByEmail(String loginId) {
         if (!loginId.contains("@")) {
             return Mono.empty();
         }
         return userService
                 .findUserByVerifiedEmail(loginId)
-                .flatMap(user -> tryByUsername(user.getMetadata().getName(), password));
+                .flatMap(user -> userDetailsService
+                        .findByUsername(user.getMetadata().getName())
+                        .onErrorResume(BadCredentialsException.class, e -> Mono.empty()));
     }
 
     private Mono<UserDetails> upgradePasswordIfNeeded(UserDetails userDetails, String password) {

--- a/application/src/main/java/run/halo/app/security/authentication/login/LoginSecurityConfigurer.java
+++ b/application/src/main/java/run/halo/app/security/authentication/login/LoginSecurityConfigurer.java
@@ -8,7 +8,6 @@ import org.springframework.core.annotation.Order;
 import org.springframework.http.HttpMethod;
 import org.springframework.security.authentication.ObservationReactiveAuthenticationManager;
 import org.springframework.security.authentication.ReactiveAuthenticationManager;
-import org.springframework.security.authentication.UserDetailsRepositoryReactiveAuthenticationManager;
 import org.springframework.security.config.web.server.SecurityWebFiltersOrder;
 import org.springframework.security.config.web.server.ServerHttpSecurity;
 import org.springframework.security.core.Authentication;
@@ -22,6 +21,7 @@ import org.springframework.security.web.server.util.matcher.ServerWebExchangeMat
 import org.springframework.stereotype.Component;
 import org.springframework.web.reactive.function.server.ServerResponse;
 import reactor.core.publisher.Mono;
+import run.halo.app.core.user.service.UserService;
 import run.halo.app.plugin.extensionpoint.ExtensionGetter;
 import run.halo.app.security.HaloUserDetails;
 import run.halo.app.security.LoginHandlerEnhancer;
@@ -41,6 +41,8 @@ public class LoginSecurityConfigurer implements SecurityConfigurer {
     private final ReactiveUserDetailsService userDetailsService;
 
     private final ReactiveUserDetailsPasswordService passwordService;
+
+    private final UserService userService;
 
     private final PasswordEncoder passwordEncoder;
 
@@ -92,9 +94,7 @@ public class LoginSecurityConfigurer implements SecurityConfigurer {
     }
 
     ReactiveAuthenticationManager defaultAuthenticationManager() {
-        var manager = new UserDetailsRepositoryReactiveAuthenticationManager(userDetailsService);
-        manager.setPasswordEncoder(passwordEncoder);
-        manager.setUserDetailsPasswordService(passwordService);
-        return manager;
+        return new LoginReactiveAuthenticationManager(
+                userDetailsService, userService, passwordEncoder, passwordService);
     }
 }

--- a/application/src/test/java/run/halo/app/security/DefaultUserDetailServiceTest.java
+++ b/application/src/test/java/run/halo/app/security/DefaultUserDetailServiceTest.java
@@ -1,7 +1,6 @@
 package run.halo.app.security;
 
 import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.*;
 import static org.springframework.security.core.authority.AuthorityUtils.authorityListToSet;
@@ -12,7 +11,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.core.userdetails.User;
 import org.springframework.security.core.userdetails.UserDetails;
@@ -185,41 +183,6 @@ class DefaultUserDetailServiceTest {
 
         StepVerifier.create(userDetailsMono)
                 .expectError(AuthenticationException.class)
-                .verify();
-    }
-
-    @Test
-    void shouldFindUserDetailsByEmail() {
-        var foundUser = createFakeUser();
-
-        when(userService.findUserByVerifiedEmail("faker@halo.run")).thenReturn(Mono.just(foundUser));
-        when(roleService.getRolesByUsername("faker")).thenReturn(Flux.just("fake-role"));
-
-        var userDetailsMono = userDetailService.findByUsername("faker@halo.run");
-
-        StepVerifier.create(userDetailsMono)
-                .expectSubscription()
-                .assertNext(gotUser -> {
-                    assertEquals(foundUser.getMetadata().getName(), gotUser.getUsername());
-                    assertEquals(foundUser.getSpec().getPassword(), gotUser.getPassword());
-                    assertEquals(
-                            Set.of("ROLE_fake-role", "ROLE_authenticated", "ROLE_anonymous"),
-                            authorityListToSet(gotUser.getAuthorities()));
-                })
-                .verifyComplete();
-
-        verify(userService, never()).getUser(any());
-    }
-
-    @Test
-    void shouldReturnNotFoundWhenEmailNotExists() {
-        when(userService.findUserByVerifiedEmail("non-existing-email@halo.run"))
-                .thenReturn(Mono.error(new UserNotFoundException("non-existing-email@halo.run")));
-
-        var userDetailsMono = userDetailService.findByUsername("non-existing-email@halo.run");
-
-        StepVerifier.create(userDetailsMono)
-                .expectError(BadCredentialsException.class)
                 .verify();
     }
 

--- a/application/src/test/java/run/halo/app/security/authentication/login/LoginReactiveAuthenticationManagerTest.java
+++ b/application/src/test/java/run/halo/app/security/authentication/login/LoginReactiveAuthenticationManagerTest.java
@@ -1,0 +1,271 @@
+package run.halo.app.security.authentication.login;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.userdetails.ReactiveUserDetailsPasswordService;
+import org.springframework.security.core.userdetails.ReactiveUserDetailsService;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+import run.halo.app.core.user.service.UserService;
+import run.halo.app.extension.Metadata;
+
+@ExtendWith(MockitoExtension.class)
+class LoginReactiveAuthenticationManagerTest {
+
+    @Mock
+    ReactiveUserDetailsService userDetailsService;
+
+    @Mock
+    UserService userService;
+
+    @Mock
+    PasswordEncoder passwordEncoder;
+
+    @Mock
+    ReactiveUserDetailsPasswordService passwordService;
+
+    @Test
+    void shouldAuthenticateByUsernameWithCorrectPassword() {
+        var userDetails = createUserDetails("testuser", "encoded-password");
+        when(userDetailsService.findByUsername("testuser")).thenReturn(Mono.just(userDetails));
+        when(passwordEncoder.matches("password", "encoded-password")).thenReturn(true);
+        stubPasswordService();
+
+        var result = authenticate("testuser", "password");
+
+        StepVerifier.create(result)
+                .expectSubscription()
+                .assertNext(auth -> {
+                    assertEquals(userDetails, auth.getPrincipal());
+                    assertEquals("encoded-password", auth.getCredentials());
+                })
+                .verifyComplete();
+
+        verify(userService, never()).findUserByVerifiedEmail(anyString());
+    }
+
+    @Test
+    void shouldFallbackToEmailWhenPasswordWrong() {
+        var userByUsername = createUserDetails("testuser", "encoded-wrong");
+        when(userDetailsService.findByUsername("test@example.com")).thenReturn(Mono.just(userByUsername));
+        when(passwordEncoder.matches("password", "encoded-wrong")).thenReturn(false);
+
+        var emailUser = createUserExtension("actualuser");
+        when(userService.findUserByVerifiedEmail("test@example.com")).thenReturn(Mono.just(emailUser));
+
+        var userByEmail = createUserDetails("actualuser", "encoded-correct");
+        when(userDetailsService.findByUsername("actualuser")).thenReturn(Mono.just(userByEmail));
+        when(passwordEncoder.matches("password", "encoded-correct")).thenReturn(true);
+        stubPasswordService();
+
+        var result = authenticate("test@example.com", "password");
+
+        StepVerifier.create(result)
+                .expectSubscription()
+                .assertNext(auth -> {
+                    assertEquals(userByEmail, auth.getPrincipal());
+                })
+                .verifyComplete();
+    }
+
+    @Test
+    void shouldFallbackToEmailWhenUsernameNotFound() {
+        when(userDetailsService.findByUsername("test@example.com"))
+                .thenReturn(Mono.error(new BadCredentialsException("Invalid Credentials")));
+
+        var emailUser = createUserExtension("actualuser");
+        when(userService.findUserByVerifiedEmail("test@example.com")).thenReturn(Mono.just(emailUser));
+
+        var userByEmail = createUserDetails("actualuser", "encoded-password");
+        when(userDetailsService.findByUsername("actualuser")).thenReturn(Mono.just(userByEmail));
+        when(passwordEncoder.matches("password", "encoded-password")).thenReturn(true);
+        stubPasswordService();
+
+        var result = authenticate("test@example.com", "password");
+
+        StepVerifier.create(result)
+                .expectSubscription()
+                .assertNext(auth -> {
+                    assertEquals(userByEmail, auth.getPrincipal());
+                })
+                .verifyComplete();
+    }
+
+    @Test
+    void shouldFailWhenBothUsernameAndEmailPasswordWrong() {
+        var userByUsername = createUserDetails("testuser", "encoded-wrong1");
+        when(userDetailsService.findByUsername("test@example.com")).thenReturn(Mono.just(userByUsername));
+        when(passwordEncoder.matches("password", "encoded-wrong1")).thenReturn(false);
+
+        var emailUser = createUserExtension("actualuser");
+        when(userService.findUserByVerifiedEmail("test@example.com")).thenReturn(Mono.just(emailUser));
+
+        var userByEmail = createUserDetails("actualuser", "encoded-wrong2");
+        when(userDetailsService.findByUsername("actualuser")).thenReturn(Mono.just(userByEmail));
+        when(passwordEncoder.matches("password", "encoded-wrong2")).thenReturn(false);
+
+        var result = authenticate("test@example.com", "password");
+
+        StepVerifier.create(result).expectError(BadCredentialsException.class).verify();
+    }
+
+    @Test
+    void shouldFailWhenUsernameNotFoundAndEmailNotFound() {
+        when(userDetailsService.findByUsername("test@example.com"))
+                .thenReturn(Mono.error(new BadCredentialsException("Invalid Credentials")));
+
+        when(userService.findUserByVerifiedEmail("test@example.com")).thenReturn(Mono.empty());
+
+        var result = authenticate("test@example.com", "password");
+
+        StepVerifier.create(result).expectError(BadCredentialsException.class).verify();
+    }
+
+    @Test
+    void shouldFailWhenUsernameNotFoundAndEmailFoundButPasswordWrong() {
+        when(userDetailsService.findByUsername("test@example.com"))
+                .thenReturn(Mono.error(new BadCredentialsException("Invalid Credentials")));
+
+        var emailUser = createUserExtension("actualuser");
+        when(userService.findUserByVerifiedEmail("test@example.com")).thenReturn(Mono.just(emailUser));
+
+        var userByEmail = createUserDetails("actualuser", "encoded-wrong");
+        when(userDetailsService.findByUsername("actualuser")).thenReturn(Mono.just(userByEmail));
+        when(passwordEncoder.matches("password", "encoded-wrong")).thenReturn(false);
+
+        var result = authenticate("test@example.com", "password");
+
+        StepVerifier.create(result).expectError(BadCredentialsException.class).verify();
+    }
+
+    @Test
+    void shouldUpgradePasswordWhenNeeded() {
+        var userDetails = createUserDetails("testuser", "encoded-password");
+        when(userDetailsService.findByUsername("testuser")).thenReturn(Mono.just(userDetails));
+        when(passwordEncoder.matches("password", "encoded-password")).thenReturn(true);
+
+        var upgradedUser = createUserDetails("testuser", "new-encoded-password");
+        when(passwordService.updatePassword(eq(userDetails), eq("password"))).thenReturn(Mono.just(upgradedUser));
+
+        var result = authenticate("testuser", "password");
+
+        StepVerifier.create(result)
+                .expectSubscription()
+                .assertNext(auth -> {
+                    assertEquals(upgradedUser, auth.getPrincipal());
+                    assertEquals("new-encoded-password", auth.getCredentials());
+                })
+                .verifyComplete();
+
+        verify(passwordService).updatePassword(userDetails, "password");
+    }
+
+    @Test
+    void shouldAuthenticateByPureUsernameWithoutEmailLookup() {
+        var userDetails = createUserDetails("alice", "encoded-password");
+        when(userDetailsService.findByUsername("alice")).thenReturn(Mono.just(userDetails));
+        when(passwordEncoder.matches("password", "encoded-password")).thenReturn(true);
+        stubPasswordService();
+
+        var result = authenticate("alice", "password");
+
+        StepVerifier.create(result)
+                .assertNext(auth -> assertEquals(userDetails, auth.getPrincipal()))
+                .verifyComplete();
+
+        verify(userService, never()).findUserByVerifiedEmail(anyString());
+    }
+
+    @Test
+    void shouldFallbackToEmailForPlainUsernameWhenNotFound() {
+        when(userDetailsService.findByUsername("alice"))
+                .thenReturn(Mono.error(new BadCredentialsException("Invalid Credentials")));
+
+        var emailUser = createUserExtension("alice_real");
+        when(userService.findUserByVerifiedEmail("alice")).thenReturn(Mono.just(emailUser));
+
+        var userByEmail = createUserDetails("alice_real", "encoded-password");
+        when(userDetailsService.findByUsername("alice_real")).thenReturn(Mono.just(userByEmail));
+        when(passwordEncoder.matches("password", "encoded-password")).thenReturn(true);
+        stubPasswordService();
+
+        var result = authenticate("alice", "password");
+
+        StepVerifier.create(result)
+                .assertNext(auth -> assertEquals(userByEmail, auth.getPrincipal()))
+                .verifyComplete();
+    }
+
+    @Test
+    void shouldNotAttemptEmailFallbackOnNonAuthenticationException() {
+        when(userDetailsService.findByUsername("testuser"))
+                .thenReturn(Mono.error(new RuntimeException("Database error")));
+
+        var result = authenticate("testuser", "password");
+
+        StepVerifier.create(result).expectError(RuntimeException.class).verify();
+
+        verify(userService, never()).findUserByVerifiedEmail(anyString());
+    }
+
+    @Test
+    void shouldCreateUsernamePasswordAuthenticationToken() {
+        var userDetails = createUserDetails("testuser", "encoded-password");
+        when(userDetailsService.findByUsername("testuser")).thenReturn(Mono.just(userDetails));
+        when(passwordEncoder.matches("password", "encoded-password")).thenReturn(false);
+
+        when(userService.findUserByVerifiedEmail("testuser")).thenReturn(Mono.empty());
+
+        var result = authenticate("testuser", "password");
+
+        StepVerifier.create(result).expectError(BadCredentialsException.class).verify();
+    }
+
+    private Mono<Authentication> authenticate(String username, String password) {
+        var manager = new LoginReactiveAuthenticationManager(
+                userDetailsService, userService, passwordEncoder, passwordService);
+        var token = UsernamePasswordAuthenticationToken.unauthenticated(username, password);
+        return manager.authenticate(token);
+    }
+
+    /**
+     * Sets up a default stub for passwordService.updatePassword that returns the input user. Tests that need specific
+     * upgrade behavior (like shouldUpgradePasswordWhenNeeded) should set up their own stubs instead of calling this
+     * method.
+     */
+    private void stubPasswordService() {
+        when(passwordService.updatePassword(any(), anyString()))
+                .thenAnswer(invocation -> Mono.just(invocation.getArgument(0)));
+    }
+
+    private UserDetails createUserDetails(String username, String password) {
+        return User.withUsername(username)
+                .password(password)
+                .authorities("ROLE_test")
+                .build();
+    }
+
+    private run.halo.app.core.extension.User createUserExtension(String name) {
+        var metadata = new Metadata();
+        metadata.setName(name);
+        var user = new run.halo.app.core.extension.User();
+        user.setMetadata(metadata);
+        return user;
+    }
+}

--- a/application/src/test/java/run/halo/app/security/authentication/login/LoginReactiveAuthenticationManagerTest.java
+++ b/application/src/test/java/run/halo/app/security/authentication/login/LoginReactiveAuthenticationManagerTest.java
@@ -4,6 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -160,8 +161,12 @@ class LoginReactiveAuthenticationManagerTest {
         when(userDetailsService.findByUsername("testuser")).thenReturn(Mono.just(userDetails));
         when(passwordEncoder.matches("password", "encoded-password")).thenReturn(true);
 
+        when(passwordEncoder.upgradeEncoding("encoded-password")).thenReturn(true);
+        when(passwordEncoder.encode("password")).thenReturn("new-encoded-password");
+
         var upgradedUser = createUserDetails("testuser", "new-encoded-password");
-        when(passwordService.updatePassword(eq(userDetails), eq("password"))).thenReturn(Mono.just(upgradedUser));
+        when(passwordService.updatePassword(eq(userDetails), eq("new-encoded-password")))
+                .thenReturn(Mono.just(upgradedUser));
 
         var result = authenticate("testuser", "password");
 
@@ -173,7 +178,7 @@ class LoginReactiveAuthenticationManagerTest {
                 })
                 .verifyComplete();
 
-        verify(passwordService).updatePassword(userDetails, "password");
+        verify(passwordService).updatePassword(userDetails, "new-encoded-password");
     }
 
     @Test
@@ -250,7 +255,8 @@ class LoginReactiveAuthenticationManagerTest {
      * method.
      */
     private void stubPasswordService() {
-        when(passwordService.updatePassword(any(), anyString()))
+        lenient()
+                .when(passwordService.updatePassword(any(), anyString()))
                 .thenAnswer(invocation -> Mono.just(invocation.getArgument(0)));
     }
 

--- a/application/src/test/java/run/halo/app/security/authentication/login/LoginReactiveAuthenticationManagerTest.java
+++ b/application/src/test/java/run/halo/app/security/authentication/login/LoginReactiveAuthenticationManagerTest.java
@@ -41,6 +41,8 @@ class LoginReactiveAuthenticationManagerTest {
     @Mock
     ReactiveUserDetailsPasswordService passwordService;
 
+    // ── Plain username (no @) ──────────────────────────────────────
+
     @Test
     void shouldAuthenticateByUsernameWithCorrectPassword() {
         var userDetails = createUserDetails("testuser", "encoded-password");
@@ -62,75 +64,57 @@ class LoginReactiveAuthenticationManagerTest {
     }
 
     @Test
-    void shouldFallbackToEmailWhenPasswordWrong() {
-        var userByUsername = createUserDetails("testuser", "encoded-wrong");
-        when(userDetailsService.findByUsername("test@example.com")).thenReturn(Mono.just(userByUsername));
-        when(passwordEncoder.matches("password", "encoded-wrong")).thenReturn(false);
+    void shouldFailWhenUsernameNotFoundAndInputIsPlain() {
+        when(userDetailsService.findByUsername("alice"))
+                .thenReturn(Mono.error(new BadCredentialsException("Invalid Credentials")));
 
-        var emailUser = createUserExtension("actualuser");
-        when(userService.findUserByVerifiedEmail("test@example.com")).thenReturn(Mono.just(emailUser));
+        var result = authenticate("alice", "password");
 
-        var userByEmail = createUserDetails("actualuser", "encoded-correct");
-        when(userDetailsService.findByUsername("actualuser")).thenReturn(Mono.just(userByEmail));
-        when(passwordEncoder.matches("password", "encoded-correct")).thenReturn(true);
-        stubPasswordService();
+        StepVerifier.create(result).expectError(BadCredentialsException.class).verify();
 
-        var result = authenticate("test@example.com", "password");
-
-        StepVerifier.create(result)
-                .expectSubscription()
-                .assertNext(auth -> {
-                    assertEquals(userByEmail, auth.getPrincipal());
-                })
-                .verifyComplete();
+        // plain input does not trigger email lookup
+        verify(userService, never()).findUserByVerifiedEmail(anyString());
     }
 
     @Test
-    void shouldFallbackToEmailWhenUsernameNotFound() {
-        when(userDetailsService.findByUsername("test@example.com"))
-                .thenReturn(Mono.error(new BadCredentialsException("Invalid Credentials")));
+    void shouldFailWhenUsernameFoundButPasswordWrongAndInputIsPlain() {
+        var userDetails = createUserDetails("testuser", "encoded-password");
+        when(userDetailsService.findByUsername("testuser")).thenReturn(Mono.just(userDetails));
+        when(passwordEncoder.matches("password", "encoded-password")).thenReturn(false);
 
+        var result = authenticate("testuser", "password");
+
+        StepVerifier.create(result).expectError(BadCredentialsException.class).verify();
+
+        // plain input does not trigger email lookup
+        verify(userService, never()).findUserByVerifiedEmail(anyString());
+    }
+
+    // ── Email input (contains @) ───────────────────────────────────
+
+    @Test
+    void shouldAuthenticateByEmailWithCorrectPassword() {
+        // tryByUsername skips @ input, goes directly to tryByEmail
         var emailUser = createUserExtension("actualuser");
         when(userService.findUserByVerifiedEmail("test@example.com")).thenReturn(Mono.just(emailUser));
 
-        var userByEmail = createUserDetails("actualuser", "encoded-password");
-        when(userDetailsService.findByUsername("actualuser")).thenReturn(Mono.just(userByEmail));
+        var userDetails = createUserDetails("actualuser", "encoded-password");
+        when(userDetailsService.findByUsername("actualuser")).thenReturn(Mono.just(userDetails));
         when(passwordEncoder.matches("password", "encoded-password")).thenReturn(true);
         stubPasswordService();
 
         var result = authenticate("test@example.com", "password");
 
         StepVerifier.create(result)
-                .expectSubscription()
-                .assertNext(auth -> {
-                    assertEquals(userByEmail, auth.getPrincipal());
-                })
+                .assertNext(auth -> assertEquals(userDetails, auth.getPrincipal()))
                 .verifyComplete();
+
+        // @ input bypasses username lookup entirely
+        verify(userDetailsService, never()).findByUsername("test@example.com");
     }
 
     @Test
-    void shouldFailWhenBothUsernameAndEmailPasswordWrong() {
-        var userByUsername = createUserDetails("testuser", "encoded-wrong1");
-        when(userDetailsService.findByUsername("test@example.com")).thenReturn(Mono.just(userByUsername));
-        when(passwordEncoder.matches("password", "encoded-wrong1")).thenReturn(false);
-
-        var emailUser = createUserExtension("actualuser");
-        when(userService.findUserByVerifiedEmail("test@example.com")).thenReturn(Mono.just(emailUser));
-
-        var userByEmail = createUserDetails("actualuser", "encoded-wrong2");
-        when(userDetailsService.findByUsername("actualuser")).thenReturn(Mono.just(userByEmail));
-        when(passwordEncoder.matches("password", "encoded-wrong2")).thenReturn(false);
-
-        var result = authenticate("test@example.com", "password");
-
-        StepVerifier.create(result).expectError(BadCredentialsException.class).verify();
-    }
-
-    @Test
-    void shouldFailWhenUsernameNotFoundAndEmailNotFound() {
-        when(userDetailsService.findByUsername("test@example.com"))
-                .thenReturn(Mono.error(new BadCredentialsException("Invalid Credentials")));
-
+    void shouldFailWhenEmailNotFound() {
         when(userService.findUserByVerifiedEmail("test@example.com")).thenReturn(Mono.empty());
 
         var result = authenticate("test@example.com", "password");
@@ -139,21 +123,20 @@ class LoginReactiveAuthenticationManagerTest {
     }
 
     @Test
-    void shouldFailWhenUsernameNotFoundAndEmailFoundButPasswordWrong() {
-        when(userDetailsService.findByUsername("test@example.com"))
-                .thenReturn(Mono.error(new BadCredentialsException("Invalid Credentials")));
-
+    void shouldFailWhenEmailFoundButPasswordWrong() {
         var emailUser = createUserExtension("actualuser");
         when(userService.findUserByVerifiedEmail("test@example.com")).thenReturn(Mono.just(emailUser));
 
-        var userByEmail = createUserDetails("actualuser", "encoded-wrong");
-        when(userDetailsService.findByUsername("actualuser")).thenReturn(Mono.just(userByEmail));
-        when(passwordEncoder.matches("password", "encoded-wrong")).thenReturn(false);
+        var userDetails = createUserDetails("actualuser", "encoded-password");
+        when(userDetailsService.findByUsername("actualuser")).thenReturn(Mono.just(userDetails));
+        when(passwordEncoder.matches("password", "encoded-password")).thenReturn(false);
 
         var result = authenticate("test@example.com", "password");
 
         StepVerifier.create(result).expectError(BadCredentialsException.class).verify();
     }
+
+    // ── Password upgrade ───────────────────────────────────────────
 
     @Test
     void shouldUpgradePasswordWhenNeeded() {
@@ -182,43 +165,37 @@ class LoginReactiveAuthenticationManagerTest {
     }
 
     @Test
-    void shouldAuthenticateByPureUsernameWithoutEmailLookup() {
-        var userDetails = createUserDetails("alice", "encoded-password");
-        when(userDetailsService.findByUsername("alice")).thenReturn(Mono.just(userDetails));
-        when(passwordEncoder.matches("password", "encoded-password")).thenReturn(true);
-        stubPasswordService();
+    void shouldUpgradePasswordWhenAuthenticatedByEmail() {
+        var emailUser = createUserExtension("actualuser");
+        when(userService.findUserByVerifiedEmail("test@example.com")).thenReturn(Mono.just(emailUser));
 
-        var result = authenticate("alice", "password");
+        var userDetails = createUserDetails("actualuser", "encoded-password");
+        when(userDetailsService.findByUsername("actualuser")).thenReturn(Mono.just(userDetails));
+        when(passwordEncoder.matches("password", "encoded-password")).thenReturn(true);
+
+        when(passwordEncoder.upgradeEncoding("encoded-password")).thenReturn(true);
+        when(passwordEncoder.encode("password")).thenReturn("new-encoded-password");
+
+        var upgradedUser = createUserDetails("actualuser", "new-encoded-password");
+        when(passwordService.updatePassword(eq(userDetails), eq("new-encoded-password")))
+                .thenReturn(Mono.just(upgradedUser));
+
+        var result = authenticate("test@example.com", "password");
 
         StepVerifier.create(result)
-                .assertNext(auth -> assertEquals(userDetails, auth.getPrincipal()))
+                .assertNext(auth -> {
+                    assertEquals(upgradedUser, auth.getPrincipal());
+                    assertEquals("new-encoded-password", auth.getCredentials());
+                })
                 .verifyComplete();
 
-        verify(userService, never()).findUserByVerifiedEmail(anyString());
+        verify(passwordService).updatePassword(userDetails, "new-encoded-password");
     }
 
-    @Test
-    void shouldFallbackToEmailForPlainUsernameWhenNotFound() {
-        when(userDetailsService.findByUsername("alice"))
-                .thenReturn(Mono.error(new BadCredentialsException("Invalid Credentials")));
-
-        var emailUser = createUserExtension("alice_real");
-        when(userService.findUserByVerifiedEmail("alice")).thenReturn(Mono.just(emailUser));
-
-        var userByEmail = createUserDetails("alice_real", "encoded-password");
-        when(userDetailsService.findByUsername("alice_real")).thenReturn(Mono.just(userByEmail));
-        when(passwordEncoder.matches("password", "encoded-password")).thenReturn(true);
-        stubPasswordService();
-
-        var result = authenticate("alice", "password");
-
-        StepVerifier.create(result)
-                .assertNext(auth -> assertEquals(userByEmail, auth.getPrincipal()))
-                .verifyComplete();
-    }
+    // ── Exception handling ─────────────────────────────────────────
 
     @Test
-    void shouldNotAttemptEmailFallbackOnNonAuthenticationException() {
+    void shouldPropagateNonAuthenticationException() {
         when(userDetailsService.findByUsername("testuser"))
                 .thenReturn(Mono.error(new RuntimeException("Database error")));
 
@@ -230,17 +207,15 @@ class LoginReactiveAuthenticationManagerTest {
     }
 
     @Test
-    void shouldCreateUsernamePasswordAuthenticationToken() {
-        var userDetails = createUserDetails("testuser", "encoded-password");
-        when(userDetailsService.findByUsername("testuser")).thenReturn(Mono.just(userDetails));
-        when(passwordEncoder.matches("password", "encoded-password")).thenReturn(false);
+    void shouldFailWhenAllStrategiesExhaustedForEmail() {
+        when(userService.findUserByVerifiedEmail("unknown@example.com")).thenReturn(Mono.empty());
 
-        when(userService.findUserByVerifiedEmail("testuser")).thenReturn(Mono.empty());
-
-        var result = authenticate("testuser", "password");
+        var result = authenticate("unknown@example.com", "password");
 
         StepVerifier.create(result).expectError(BadCredentialsException.class).verify();
     }
+
+    // ── Helpers ────────────────────────────────────────────────────
 
     private Mono<Authentication> authenticate(String username, String password) {
         var manager = new LoginReactiveAuthenticationManager(
@@ -249,11 +224,6 @@ class LoginReactiveAuthenticationManagerTest {
         return manager.authenticate(token);
     }
 
-    /**
-     * Sets up a default stub for passwordService.updatePassword that returns the input user. Tests that need specific
-     * upgrade behavior (like shouldUpgradePasswordWhenNeeded) should set up their own stubs instead of calling this
-     * method.
-     */
     private void stubPasswordService() {
         lenient()
                 .when(passwordService.updatePassword(any(), anyString()))

--- a/application/src/test/java/run/halo/app/security/authentication/login/LoginReactiveAuthenticationManagerTest.java
+++ b/application/src/test/java/run/halo/app/security/authentication/login/LoginReactiveAuthenticationManagerTest.java
@@ -54,7 +54,7 @@ class LoginReactiveAuthenticationManagerTest {
                 .expectSubscription()
                 .assertNext(auth -> {
                     assertEquals(userDetails, auth.getPrincipal());
-                    assertEquals("password", auth.getCredentials());
+                    assertEquals("encoded-password", auth.getCredentials());
                 })
                 .verifyComplete();
 
@@ -174,7 +174,7 @@ class LoginReactiveAuthenticationManagerTest {
                 .expectSubscription()
                 .assertNext(auth -> {
                     assertEquals(upgradedUser, auth.getPrincipal());
-                    assertEquals("password", auth.getCredentials());
+                    assertEquals("new-encoded-password", auth.getCredentials());
                 })
                 .verifyComplete();
 

--- a/application/src/test/java/run/halo/app/security/authentication/login/LoginReactiveAuthenticationManagerTest.java
+++ b/application/src/test/java/run/halo/app/security/authentication/login/LoginReactiveAuthenticationManagerTest.java
@@ -53,7 +53,7 @@ class LoginReactiveAuthenticationManagerTest {
                 .expectSubscription()
                 .assertNext(auth -> {
                     assertEquals(userDetails, auth.getPrincipal());
-                    assertEquals("encoded-password", auth.getCredentials());
+                    assertEquals("password", auth.getCredentials());
                 })
                 .verifyComplete();
 
@@ -169,7 +169,7 @@ class LoginReactiveAuthenticationManagerTest {
                 .expectSubscription()
                 .assertNext(auth -> {
                     assertEquals(upgradedUser, auth.getPrincipal());
-                    assertEquals("new-encoded-password", auth.getCredentials());
+                    assertEquals("password", auth.getCredentials());
                 })
                 .verifyComplete();
 


### PR DESCRIPTION
## What

Move email-based login fallback from `DefaultUserDetailService.findByUsername()` into a dedicated `LoginReactiveAuthenticationManager`.

## Why

The current implementation uses `@` character detection in `findByUsername` to decide whether to look up by email or username. This has two problems:
1. If username lookup succeeds but password is wrong, it never falls back to email lookup — the user gets `BadCredentialsException` even if their email-password combo is correct
2. Email adaptation logic doesn't belong in the `ReactiveUserDetailsService` layer — it's a login concern

## How

- Simplified `findByUsername` to username-only lookup
- Created `LoginReactiveAuthenticationManager` with a chain approach: try username → try verified email
- Replaced `UserDetailsRepositoryReactiveAuthenticationManager` in `LoginSecurityConfigurer`
- Added comprehensive tests for the new chain-based authentication