### PR TITLE
Fix orphaned plugin JAR files after upgrades and uninstallations

### DIFF
--- a/application/src/main/java/run/halo/app/core/reconciler/PluginReconciler.java
+++ b/application/src/main/java/run/halo/app/core/reconciler/PluginReconciler.java
@@ -307,7 +307,7 @@ class PluginReconciler implements Reconciler<Request>, DisposableBean {
         }
         if (!isDevelopmentMode(plugin)) {
             deleteManagedPluginFile(pluginName, plugin.statusNonNull().getLoadLocation());
-            deleteManagedPluginFiles(pluginName, null);
+            deleteManagedPluginFiles(pluginName);
         }
         plugin.statusNonNull().setLastProbeState(null);
     }
@@ -342,8 +342,7 @@ class PluginReconciler implements Reconciler<Request>, DisposableBean {
         }
     }
 
-    private void deleteManagedPluginFiles(String pluginName, URI retainedLocation) {
-        var retainedPath = toNormalizedPath(retainedLocation);
+    private void deleteManagedPluginFiles(String pluginName) {
         var pluginFinder = new YamlPluginFinder();
         for (var pluginRoot : pluginManager.getPluginsRoots()) {
             if (!Files.isDirectory(pluginRoot)) {
@@ -352,7 +351,6 @@ class PluginReconciler implements Reconciler<Request>, DisposableBean {
             try (var paths = Files.list(pluginRoot)) {
                 paths.filter(path -> Files.isRegularFile(path, LinkOption.NOFOLLOW_LINKS))
                         .filter(path -> path.getFileName().toString().endsWith(".jar"))
-                        .filter(path -> !Objects.equals(path.toAbsolutePath().normalize(), retainedPath))
                         .filter(path -> isOwnedByPlugin(pluginFinder, path, pluginName))
                         .forEach(path -> deleteManagedPluginFile(pluginName, path.toUri()));
             } catch (IOException e) {
@@ -634,6 +632,8 @@ class PluginReconciler implements Reconciler<Request>, DisposableBean {
         var conditions = status.getConditions();
         var desiredLoadLocation = resolveDesiredLoadLocation(plugin);
         var currentPluginPath = p == null ? null : p.getPluginPath();
+        var previousPluginPath =
+                currentPluginPath == null ? toNormalizedPath(status.getLoadLocation()) : currentPluginPath;
 
         var requestToUnloadBy = requestToUnload(plugin);
         var requestToUnload = requestToUnloadBy != null;
@@ -693,16 +693,6 @@ class PluginReconciler implements Reconciler<Request>, DisposableBean {
                                 .build());
                 return Result.doNotRetry();
             }
-
-            if (shouldReload && !isDevelopmentMode(plugin)) {
-                if (!isSamePath(status.getLoadLocation(), desiredLoadLocation)) {
-                    deleteManagedPluginFile(pluginName, status.getLoadLocation());
-                }
-                if (currentPluginPath != null && !isSamePath(currentPluginPath.toUri(), desiredLoadLocation)) {
-                    deleteManagedPluginFile(pluginName, currentPluginPath.toUri());
-                }
-                deleteManagedPluginFiles(pluginName, desiredLoadLocation);
-            }
         }
 
         // check dependencies before loading
@@ -725,7 +715,20 @@ class PluginReconciler implements Reconciler<Request>, DisposableBean {
 
         if (p == null) {
             log.info("Loading plugin {} from {}", pluginName, desiredLoadLocation);
-            pluginManager.loadPlugin(Paths.get(desiredLoadLocation));
+            try {
+                pluginManager.loadPlugin(Paths.get(desiredLoadLocation));
+            } catch (RuntimeException loadError) {
+                restorePreviousPlugin(pluginName, previousPluginPath, desiredLoadLocation, loadError);
+                throw loadError;
+            }
+            if (shouldReload && !isDevelopmentMode(plugin)) {
+                if (!isSamePath(status.getLoadLocation(), desiredLoadLocation)) {
+                    deleteManagedPluginFile(pluginName, status.getLoadLocation());
+                }
+                if (currentPluginPath != null && !isSamePath(currentPluginPath.toUri(), desiredLoadLocation)) {
+                    deleteManagedPluginFile(pluginName, currentPluginPath.toUri());
+                }
+            }
             status.setLoadLocation(desiredLoadLocation);
             status.setPhase(Plugin.Phase.RESOLVED);
             if (shouldReload) {
@@ -741,6 +744,22 @@ class PluginReconciler implements Reconciler<Request>, DisposableBean {
         }
 
         return null;
+    }
+
+    private void restorePreviousPlugin(
+            String pluginName, Path previousPluginPath, URI desiredLoadLocation, RuntimeException loadError) {
+        if (previousPluginPath == null
+                || isSamePath(previousPluginPath.toUri(), desiredLoadLocation)
+                || Files.notExists(previousPluginPath)) {
+            return;
+        }
+        try {
+            pluginManager.loadPlugin(previousPluginPath);
+            log.info("Restored plugin {} from {} after replacement failed.", pluginName, previousPluginPath);
+        } catch (RuntimeException restoreError) {
+            loadError.addSuppressed(restoreError);
+            log.warn("Failed to restore plugin {} from {}.", pluginName, previousPluginPath, restoreError);
+        }
     }
 
     private URI resolveDesiredLoadLocation(Plugin plugin) {

--- a/application/src/main/java/run/halo/app/core/reconciler/PluginReconciler.java
+++ b/application/src/main/java/run/halo/app/core/reconciler/PluginReconciler.java
@@ -17,10 +17,12 @@ import java.io.IOException;
 import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.net.MalformedURLException;
+import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.nio.file.FileSystemNotFoundException;
 import java.nio.file.Files;
+import java.nio.file.LinkOption;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.time.Clock;
@@ -75,6 +77,7 @@ import run.halo.app.plugin.PluginConst;
 import run.halo.app.plugin.PluginProperties;
 import run.halo.app.plugin.PluginService;
 import run.halo.app.plugin.SpringPluginManager;
+import run.halo.app.plugin.YamlPluginFinder;
 import run.halo.app.plugin.resources.BundleResourceUtils;
 
 /**
@@ -143,10 +146,10 @@ class PluginReconciler implements Reconciler<Request>, DisposableBean {
                             // Check dependents every 10 seconds
                             return Result.requeue(Duration.ofSeconds(10));
                         }
-                        // CleanUp resources and remove finalizer.
-                        if (removeFinalizers(plugin.getMetadata(), Set.of(FINALIZER_NAME))) {
+                        var finalizers = plugin.getMetadata().getFinalizers();
+                        if (finalizers != null && finalizers.contains(FINALIZER_NAME)) {
                             cleanupResources(plugin);
-                            syncPluginState(plugin);
+                            removeFinalizers(plugin.getMetadata(), Set.of(FINALIZER_NAME));
                             client.update(plugin);
                         }
                         return Result.doNotRetry();
@@ -243,16 +246,6 @@ class PluginReconciler implements Reconciler<Request>, DisposableBean {
         return false;
     }
 
-    private void syncPluginState(Plugin plugin) {
-        var pluginName = plugin.getMetadata().getName();
-        var p = pluginManager.getPlugin(pluginName);
-        if (p != null) {
-            plugin.statusNonNull().setLastProbeState(p.getPluginState());
-        } else {
-            plugin.statusNonNull().setLastProbeState(null);
-        }
-    }
-
     private static String requestToUnload(Plugin plugin) {
         var labels = plugin.getMetadata().getLabels();
         if (labels == null) {
@@ -291,12 +284,104 @@ class PluginReconciler implements Reconciler<Request>, DisposableBean {
                         Waiting for setting %s to be deleted.""", settingName));
             });
         }
-        if (pluginManager.getPlugin(pluginName) != null) {
+        var pluginWrapper = pluginManager.getPlugin(pluginName);
+        RuntimeException deletionError = null;
+        if (pluginWrapper != null) {
             log.info("Deleting plugin {} in plugin manager.", pluginName);
-            var deleted = pluginManager.deletePlugin(pluginName);
-            if (!deleted) {
-                log.warn("Failed to delete plugin {}", pluginName);
+            try {
+                var deleted = pluginManager.deletePlugin(pluginName);
+                if (!deleted) {
+                    log.warn("Plugin manager did not delete plugin {}.", pluginName);
+                }
+            } catch (RuntimeException e) {
+                deletionError = e;
+                log.warn("Plugin manager failed to delete plugin {}.", pluginName, e);
             }
+        }
+        var remainingPlugin = pluginManager.getPlugin(pluginName);
+        if (remainingPlugin != null) {
+            throw new RequeueException(
+                    Result.requeue(null),
+                    "Waiting for plugin %s to be deleted from plugin manager.".formatted(pluginName),
+                    deletionError);
+        }
+        if (!isDevelopmentMode(plugin)) {
+            deleteManagedPluginFile(pluginName, plugin.statusNonNull().getLoadLocation());
+            deleteManagedPluginFiles(pluginName, null);
+        }
+        plugin.statusNonNull().setLastProbeState(null);
+    }
+
+    private void deleteManagedPluginFile(String pluginName, URI loadLocation) {
+        if (loadLocation == null) {
+            return;
+        }
+        final Path pluginPath;
+        try {
+            pluginPath = Path.of(loadLocation).toAbsolutePath().normalize();
+        } catch (IllegalArgumentException | FileSystemNotFoundException e) {
+            log.warn("Skip deleting unsupported plugin path {} for plugin {}.", loadLocation, pluginName);
+            return;
+        }
+        var managed = pluginManager.getPluginsRoots().stream()
+                .map(path -> path.toAbsolutePath().normalize())
+                .anyMatch(root -> Objects.equals(pluginPath.getParent(), root));
+        if (!managed || !pluginPath.getFileName().toString().endsWith(".jar") || Files.isDirectory(pluginPath)) {
+            log.warn("Skip deleting unmanaged plugin path {} for plugin {}.", pluginPath, pluginName);
+            return;
+        }
+        try {
+            if (Files.deleteIfExists(pluginPath)) {
+                log.info("Deleted plugin file {} for plugin {}.", pluginPath, pluginName);
+            }
+        } catch (IOException e) {
+            throw new RequeueException(
+                    Result.requeue(Duration.ofSeconds(1)),
+                    "Failed to delete plugin file %s for plugin %s.".formatted(pluginPath, pluginName),
+                    e);
+        }
+    }
+
+    private void deleteManagedPluginFiles(String pluginName, URI retainedLocation) {
+        var retainedPath = toNormalizedPath(retainedLocation);
+        var pluginFinder = new YamlPluginFinder();
+        for (var pluginRoot : pluginManager.getPluginsRoots()) {
+            if (!Files.isDirectory(pluginRoot)) {
+                continue;
+            }
+            try (var paths = Files.list(pluginRoot)) {
+                paths.filter(path -> Files.isRegularFile(path, LinkOption.NOFOLLOW_LINKS))
+                        .filter(path -> path.getFileName().toString().endsWith(".jar"))
+                        .filter(path -> !Objects.equals(path.toAbsolutePath().normalize(), retainedPath))
+                        .filter(path -> isOwnedByPlugin(pluginFinder, path, pluginName))
+                        .forEach(path -> deleteManagedPluginFile(pluginName, path.toUri()));
+            } catch (IOException e) {
+                throw new RequeueException(
+                        Result.requeue(Duration.ofSeconds(1)),
+                        "Failed to scan plugin files for plugin %s.".formatted(pluginName),
+                        e);
+            }
+        }
+    }
+
+    private boolean isOwnedByPlugin(YamlPluginFinder pluginFinder, Path pluginPath, String pluginName) {
+        try {
+            var plugin = pluginFinder.find(pluginPath);
+            return Objects.equals(pluginName, plugin.getMetadata().getName());
+        } catch (RuntimeException e) {
+            log.warn("Skip unrecognized plugin file {} while cleaning up plugin {}.", pluginPath, pluginName, e);
+            return false;
+        }
+    }
+
+    private static Path toNormalizedPath(URI location) {
+        if (location == null) {
+            return null;
+        }
+        try {
+            return Path.of(location).toAbsolutePath().normalize();
+        } catch (IllegalArgumentException | FileSystemNotFoundException e) {
+            return null;
         }
     }
 
@@ -545,16 +630,23 @@ class PluginReconciler implements Reconciler<Request>, DisposableBean {
     private Result loadOrReload(Plugin plugin) {
         var pluginName = plugin.getMetadata().getName();
         var p = pluginManager.getPlugin(pluginName);
-        var conditions = plugin.getStatus().getConditions();
+        var status = plugin.statusNonNull();
+        var conditions = status.getConditions();
+        var desiredLoadLocation = resolveDesiredLoadLocation(plugin);
+        var currentPluginPath = p == null ? null : p.getPluginPath();
 
         var requestToUnloadBy = requestToUnload(plugin);
         var requestToUnload = requestToUnloadBy != null;
         var notFullyLoaded = p != null && pluginManager.getUnresolvedPlugins().contains(p);
         var alreadyLoaded = p != null && pluginManager.getResolvedPlugins().contains(p);
 
-        var requestToReload = requestToReload(plugin);
-        // TODO Check load location
-        var shouldUnload = requestToUnload || requestToReload || notFullyLoaded;
+        var reloadRequested = requestToReload(plugin);
+        var statusLoadLocationChanged =
+                status.getLoadLocation() != null && !isSamePath(status.getLoadLocation(), desiredLoadLocation);
+        var actualLoadLocationChanged =
+                currentPluginPath != null && !isSamePath(currentPluginPath.toUri(), desiredLoadLocation);
+        var shouldReload = reloadRequested || statusLoadLocationChanged || actualLoadLocationChanged;
+        var shouldUnload = requestToUnload || shouldReload || notFullyLoaded;
         if (shouldUnload) {
             // check if the plugin is already loaded or not fully loaded.
             if (alreadyLoaded || notFullyLoaded) {
@@ -576,7 +668,10 @@ class PluginReconciler implements Reconciler<Request>, DisposableBean {
                 }
 
                 // unload the plugin exactly
-                pluginManager.unloadPlugin(pluginName);
+                if (!pluginManager.unloadPlugin(pluginName)) {
+                    log.warn("Failed to unload plugin {}, will retry.", pluginName);
+                    return Result.requeue(Duration.ofSeconds(1));
+                }
 
                 removeConditionBy(conditions, ConditionType.INITIALIZED);
                 removeConditionBy(conditions, ConditionType.PROGRESSING);
@@ -586,10 +681,8 @@ class PluginReconciler implements Reconciler<Request>, DisposableBean {
                 p = null;
             }
 
-            // ensure removing the reload annotation after the plugin is unloaded
             if (requestToUnload) {
                 // skip loading and wait for removing the annotation by other plugins.
-                var status = plugin.getStatus();
                 status.getConditions()
                         .addAndEvictFIFO(Condition.builder()
                                 .type(ConditionType.INITIALIZED)
@@ -601,8 +694,14 @@ class PluginReconciler implements Reconciler<Request>, DisposableBean {
                 return Result.doNotRetry();
             }
 
-            if (requestToReload) {
-                removeRequestToReload(plugin);
+            if (shouldReload && !isDevelopmentMode(plugin)) {
+                if (!isSamePath(status.getLoadLocation(), desiredLoadLocation)) {
+                    deleteManagedPluginFile(pluginName, status.getLoadLocation());
+                }
+                if (currentPluginPath != null && !isSamePath(currentPluginPath.toUri(), desiredLoadLocation)) {
+                    deleteManagedPluginFile(pluginName, currentPluginPath.toUri());
+                }
+                deleteManagedPluginFiles(pluginName, desiredLoadLocation);
             }
         }
 
@@ -625,11 +724,14 @@ class PluginReconciler implements Reconciler<Request>, DisposableBean {
         }
 
         if (p == null) {
-            var loadLocation = plugin.getStatus().getLoadLocation();
-            log.info("Loading plugin {} from {}", pluginName, loadLocation);
-            pluginManager.loadPlugin(Paths.get(loadLocation));
-            plugin.getStatus().setPhase(Plugin.Phase.RESOLVED);
-            log.info("Loaded plugin {} from {}", pluginName, loadLocation);
+            log.info("Loading plugin {} from {}", pluginName, desiredLoadLocation);
+            pluginManager.loadPlugin(Paths.get(desiredLoadLocation));
+            status.setLoadLocation(desiredLoadLocation);
+            status.setPhase(Plugin.Phase.RESOLVED);
+            if (shouldReload) {
+                removeRequestToReload(plugin);
+            }
+            log.info("Loaded plugin {} from {}", pluginName, desiredLoadLocation);
             conditions.addAndEvictFIFO(Condition.builder()
                     .type(ConditionType.INITIALIZED)
                     .status(ConditionStatus.TRUE)
@@ -639,6 +741,27 @@ class PluginReconciler implements Reconciler<Request>, DisposableBean {
         }
 
         return null;
+    }
+
+    private URI resolveDesiredLoadLocation(Plugin plugin) {
+        if (isDevelopmentMode(plugin)) {
+            return plugin.statusNonNull().getLoadLocation();
+        }
+        var pluginPath = resolveManagedPluginPath(plugin);
+        return pluginPath == null ? plugin.statusNonNull().getLoadLocation() : pluginPath.toUri();
+    }
+
+    private static boolean isSamePath(URI left, URI right) {
+        if (left == null || right == null) {
+            return Objects.equals(left, right);
+        }
+        try {
+            return Objects.equals(
+                    Path.of(left).toAbsolutePath().normalize(),
+                    Path.of(right).toAbsolutePath().normalize());
+        } catch (IllegalArgumentException | FileSystemNotFoundException e) {
+            return Objects.equals(left, right);
+        }
     }
 
     private Result createOrUpdateSetting(Plugin plugin) {
@@ -771,12 +894,9 @@ class PluginReconciler implements Reconciler<Request>, DisposableBean {
             }
         } else {
             // reset annotation PLUGIN_PATH in non-dev mode
-            var pluginFilename = generateFileName(plugin);
-            var pluginRoot = pluginManager.getPluginsRoots().stream()
-                    .filter(root -> Files.exists(root.resolve(pluginFilename)))
-                    .findFirst()
-                    .orElse(null);
-            if (pluginRoot == null) {
+            var pluginPath = resolveManagedPluginPath(plugin);
+            if (pluginPath == null) {
+                var pluginFilename = generateFileName(plugin);
                 var condition = Condition.builder()
                         .type(ConditionType.INITIALIZED)
                         .status(ConditionStatus.FALSE)
@@ -788,33 +908,12 @@ class PluginReconciler implements Reconciler<Request>, DisposableBean {
                 status.setPhase(Plugin.Phase.UNKNOWN);
                 return Result.doNotRetry();
             }
-            var pluginPath = pluginRoot.resolve(pluginFilename);
+            var pluginRoot = pluginPath.getParent();
             annotations.put(PLUGIN_PATH, pluginRoot.relativize(pluginPath).toString());
 
-            // delete old load location if changed.
-            var oldLoadLocation = status.getLoadLocation();
             var newLoadLocation = pluginPath.toUri();
-            if (oldLoadLocation != null && !Objects.equals(oldLoadLocation, newLoadLocation)) {
-                // delete the old load location
-                log.info(
-                        "Deleting old plugin file {} for plugin {}, and new load location is {}.",
-                        oldLoadLocation,
-                        pluginName,
-                        newLoadLocation);
-                try {
-                    var deleted = Files.deleteIfExists(Path.of(oldLoadLocation));
-                    if (deleted) {
-                        log.info("Deleted old plugin file {} for plugin {}.", oldLoadLocation, pluginName);
-                    }
-                } catch (IOException e) {
-                    log.warn("Failed to delete old plugin file {} for plugin {}", oldLoadLocation, pluginName, e);
-                } catch (FileSystemNotFoundException e) {
-                    log.warn(
-                            "Failed to delete old plugin file {} for plugin {}: File system not found.",
-                            oldLoadLocation,
-                            pluginName,
-                            e);
-                }
+            if (status.getLoadLocation() == null) {
+                status.setLoadLocation(newLoadLocation);
                 status.setPhase(Plugin.Phase.RESOLVED);
                 status.getConditions()
                         .addAndEvictFIFO(Condition.builder()
@@ -823,11 +922,19 @@ class PluginReconciler implements Reconciler<Request>, DisposableBean {
                                 .reason(ConditionReason.LOAD_LOCATION_RESOLVED)
                                 .lastTransitionTime(clock.instant())
                                 .build());
-                log.debug("Populated load location {} for plugin {}", status.getLoadLocation(), pluginName);
+                log.debug("Populated load location {} for plugin {}", newLoadLocation, pluginName);
             }
-            status.setLoadLocation(newLoadLocation);
         }
         return null;
+    }
+
+    private Path resolveManagedPluginPath(Plugin plugin) {
+        var pluginFilename = generateFileName(plugin);
+        return pluginManager.getPluginsRoots().stream()
+                .map(root -> root.resolve(pluginFilename))
+                .filter(Files::exists)
+                .findFirst()
+                .orElse(null);
     }
 
     @Override

--- a/application/src/main/java/run/halo/app/plugin/PluginServiceImpl.java
+++ b/application/src/main/java/run/halo/app/plugin/PluginServiceImpl.java
@@ -12,7 +12,9 @@ import com.google.common.hash.HashCode;
 import com.google.common.hash.Hashing;
 import io.swagger.v3.core.util.Json;
 import java.io.IOException;
+import java.net.URI;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.FileSystemNotFoundException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.Clock;
@@ -215,10 +217,46 @@ public class PluginServiceImpl implements PluginService, InitializingBean, Dispo
                             .switchIfEmpty(Mono.error(() -> new ServerWebInputException(
                                     "The given plugin with name " + name + " was not found.")))
                             // copy plugin into plugin home
-                            .flatMap(oldPlugin -> copyToPluginHome(pluginInPath).thenReturn(oldPlugin))
-                            .doOnNext(oldPlugin -> updatePlugin(oldPlugin, pluginInPath))
-                            .flatMap(client::update);
+                            .flatMap(oldPlugin -> copyToPluginHome(pluginInPath).flatMap(copiedPluginPath -> {
+                                updatePlugin(oldPlugin, pluginInPath);
+                                return client.update(oldPlugin)
+                                        .onErrorResume(error -> deleteCopiedPluginOnError(
+                                                        copiedPluginPath,
+                                                        oldPlugin
+                                                                .statusNonNull()
+                                                                .getLoadLocation())
+                                                .then(Mono.error(error)));
+                            }));
                 });
+    }
+
+    private Mono<Void> deleteCopiedPluginOnError(Path copiedPluginPath, URI activeLoadLocation) {
+        if (activeLoadLocation != null) {
+            try {
+                var activePluginPath =
+                        Path.of(activeLoadLocation).toAbsolutePath().normalize();
+                if (Objects.equals(
+                        activePluginPath, copiedPluginPath.toAbsolutePath().normalize())) {
+                    return Mono.empty();
+                }
+            } catch (IllegalArgumentException | FileSystemNotFoundException e) {
+                log.warn(
+                        "Skip deleting copied plugin {} because active load location {} cannot be resolved.",
+                        copiedPluginPath,
+                        activeLoadLocation,
+                        e);
+                return Mono.empty();
+            }
+        }
+        return Mono.fromRunnable(() -> {
+                    try {
+                        Files.deleteIfExists(copiedPluginPath);
+                    } catch (IOException | RuntimeException e) {
+                        log.warn("Failed to delete copied plugin {} after upgrade failure.", copiedPluginPath, e);
+                    }
+                })
+                .subscribeOn(Schedulers.boundedElastic())
+                .then();
     }
 
     @Override

--- a/application/src/main/java/run/halo/app/plugin/PluginServiceImpl.java
+++ b/application/src/main/java/run/halo/app/plugin/PluginServiceImpl.java
@@ -220,34 +220,27 @@ public class PluginServiceImpl implements PluginService, InitializingBean, Dispo
                             .flatMap(oldPlugin -> copyToPluginHome(pluginInPath).flatMap(copiedPluginPath -> {
                                 updatePlugin(oldPlugin, pluginInPath);
                                 return client.update(oldPlugin)
-                                        .onErrorResume(error -> deleteCopiedPluginOnError(
-                                                        copiedPluginPath,
-                                                        oldPlugin
-                                                                .statusNonNull()
-                                                                .getLoadLocation())
+                                        .onErrorResume(error -> deleteCopiedPluginOnError(name, copiedPluginPath)
                                                 .then(Mono.error(error)));
                             }));
                 });
     }
 
-    private Mono<Void> deleteCopiedPluginOnError(Path copiedPluginPath, URI activeLoadLocation) {
-        if (activeLoadLocation != null) {
-            try {
-                var activePluginPath =
-                        Path.of(activeLoadLocation).toAbsolutePath().normalize();
-                if (Objects.equals(
-                        activePluginPath, copiedPluginPath.toAbsolutePath().normalize())) {
+    private Mono<Void> deleteCopiedPluginOnError(String pluginName, Path copiedPluginPath) {
+        return client.fetch(Plugin.class, pluginName)
+                .map(plugin -> referencesPluginFile(plugin, copiedPluginPath))
+                .defaultIfEmpty(false)
+                .flatMap(referenced -> referenced ? Mono.empty() : deleteCopiedPlugin(copiedPluginPath))
+                .onErrorResume(error -> {
+                    log.warn(
+                            "Skip deleting copied plugin {} because its current owner cannot be determined.",
+                            copiedPluginPath,
+                            error);
                     return Mono.empty();
-                }
-            } catch (IllegalArgumentException | FileSystemNotFoundException e) {
-                log.warn(
-                        "Skip deleting copied plugin {} because active load location {} cannot be resolved.",
-                        copiedPluginPath,
-                        activeLoadLocation,
-                        e);
-                return Mono.empty();
-            }
-        }
+                });
+    }
+
+    private Mono<Void> deleteCopiedPlugin(Path copiedPluginPath) {
         return Mono.fromRunnable(() -> {
                     try {
                         Files.deleteIfExists(copiedPluginPath);
@@ -257,6 +250,36 @@ public class PluginServiceImpl implements PluginService, InitializingBean, Dispo
                 })
                 .subscribeOn(Schedulers.boundedElastic())
                 .then();
+    }
+
+    private boolean referencesPluginFile(Plugin plugin, Path pluginPath) {
+        var status = plugin.getStatus();
+        if (status != null && isSamePath(pluginPath, status.getLoadLocation())) {
+            return true;
+        }
+        var annotations = plugin.getMetadata().getAnnotations();
+        var reloadLocation = annotations == null ? null : annotations.get(RELOAD_ANNO);
+        if (StringUtils.isBlank(reloadLocation)) {
+            return false;
+        }
+        try {
+            return isSamePath(pluginPath, URI.create(reloadLocation));
+        } catch (IllegalArgumentException e) {
+            return false;
+        }
+    }
+
+    private boolean isSamePath(Path pluginPath, URI location) {
+        if (location == null) {
+            return false;
+        }
+        try {
+            return Objects.equals(
+                    pluginPath.toAbsolutePath().normalize(),
+                    Path.of(location).toAbsolutePath().normalize());
+        } catch (IllegalArgumentException | FileSystemNotFoundException e) {
+            return false;
+        }
     }
 
     @Override

--- a/application/src/test/java/run/halo/app/core/reconciler/PluginReconcilerTest.java
+++ b/application/src/test/java/run/halo/app/core/reconciler/PluginReconcilerTest.java
@@ -7,6 +7,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -59,6 +60,7 @@ import run.halo.app.extension.controller.Reconciler.Request;
 import run.halo.app.extension.controller.RequeueException;
 import run.halo.app.infra.Condition;
 import run.halo.app.infra.ConditionStatus;
+import run.halo.app.infra.utils.FileUtils;
 import run.halo.app.plugin.PluginProperties;
 import run.halo.app.plugin.PluginService;
 import run.halo.app.plugin.SpringPluginManager;
@@ -206,11 +208,46 @@ class PluginReconcilerTest {
         }
 
         @Test
-        void shouldReloadIfReloadAnnotationPresent() {
+        void shouldReloadIfReloadAnnotationPresent() throws IOException {
+            var oldPluginFile = Files.createFile(tempPath.resolve("fake-plugin-1.0.0.jar"));
+            var newPluginFile = tempPath.resolve("fake-plugin-1.2.3.jar");
             var fakePlugin = createPlugin(name, plugin -> {
                 var spec = plugin.getSpec();
                 spec.setVersion("1.2.3");
                 spec.setLogo("fake-logo.svg");
+                spec.setEnabled(true);
+                plugin.getStatus().setLoadLocation(oldPluginFile.toUri());
+                plugin.getMetadata()
+                        .setAnnotations(new HashMap<>(
+                                Map.of(RELOAD_ANNO, newPluginFile.toUri().toString())));
+            });
+
+            when(client.fetch(Plugin.class, name)).thenReturn(Optional.of(fakePlugin));
+            when(pluginManager.getPluginsRoots()).thenReturn(List.of(tempPath));
+            var pluginWrapper = mockPluginWrapper(PluginState.RESOLVED);
+            when(pluginWrapper.getPluginPath()).thenReturn(oldPluginFile);
+            when(pluginManager.getPlugin(name)).thenReturn(pluginWrapper);
+            when(pluginManager.startPlugin(name)).thenReturn(PluginState.STARTED);
+            when(pluginManager.getUnresolvedPlugins()).thenReturn(List.of(pluginWrapper));
+            when(pluginManager.getResolvedPlugins()).thenReturn(List.of());
+            when(pluginManager.unloadPlugin(name)).thenReturn(true);
+
+            var result = reconciler.reconcile(new Request(name));
+            assertTrue(result.reEnqueue());
+
+            verify(pluginManager).unloadPlugin(name);
+            var loadLocation = Paths.get(fakePlugin.getStatus().getLoadLocation());
+            verify(pluginManager).loadPlugin(loadLocation);
+            assertEquals(newPluginFile, loadLocation);
+            assertFalse(Files.exists(oldPluginFile));
+            assertFalse(fakePlugin.getMetadata().getAnnotations().containsKey(RELOAD_ANNO));
+        }
+
+        @Test
+        void shouldKeepReloadRequestWhenUnloadFails() {
+            var fakePlugin = createPlugin(name, plugin -> {
+                var spec = plugin.getSpec();
+                spec.setVersion("1.2.3");
                 spec.setEnabled(true);
                 plugin.getMetadata().setAnnotations(new HashMap<>(Map.of(RELOAD_ANNO, "true")));
             });
@@ -219,16 +256,74 @@ class PluginReconcilerTest {
             when(pluginManager.getPluginsRoots()).thenReturn(List.of(tempPath));
             var pluginWrapper = mockPluginWrapper(PluginState.RESOLVED);
             when(pluginManager.getPlugin(name)).thenReturn(pluginWrapper);
-            when(pluginManager.startPlugin(name)).thenReturn(PluginState.STARTED);
             when(pluginManager.getUnresolvedPlugins()).thenReturn(List.of(pluginWrapper));
             when(pluginManager.getResolvedPlugins()).thenReturn(List.of());
+            when(pluginManager.unloadPlugin(name)).thenReturn(false);
 
             var result = reconciler.reconcile(new Request(name));
+
             assertTrue(result.reEnqueue());
+            assertTrue(fakePlugin.getMetadata().getAnnotations().containsKey(RELOAD_ANNO));
+            verify(pluginManager, never()).loadPlugin(any(Path.class));
+        }
+
+        @Test
+        void shouldKeepPreviousLoadLocationAndReloadRequestWhenLoadingNewPluginFails() throws IOException {
+            var oldPluginFile = Files.createFile(tempPath.resolve("fake-plugin-1.0.0.jar"));
+            var newPluginFile = tempPath.resolve("fake-plugin-1.2.3.jar");
+            var fakePlugin = createPlugin(name, plugin -> {
+                var spec = plugin.getSpec();
+                spec.setVersion("1.2.3");
+                spec.setEnabled(true);
+                plugin.getStatus().setLoadLocation(oldPluginFile.toUri());
+                plugin.getMetadata()
+                        .setAnnotations(new HashMap<>(
+                                Map.of(RELOAD_ANNO, newPluginFile.toUri().toString())));
+            });
+            var pluginWrapper = mockPluginWrapper(PluginState.RESOLVED);
+            when(pluginWrapper.getPluginPath()).thenReturn(oldPluginFile);
+
+            when(client.fetch(Plugin.class, name)).thenReturn(Optional.of(fakePlugin));
+            when(pluginManager.getPluginsRoots()).thenReturn(List.of(tempPath));
+            when(pluginManager.getPlugin(name)).thenReturn(pluginWrapper);
+            when(pluginManager.getUnresolvedPlugins()).thenReturn(List.of(pluginWrapper));
+            when(pluginManager.getResolvedPlugins()).thenReturn(List.of());
+            when(pluginManager.unloadPlugin(name)).thenReturn(true);
+            doThrow(new IllegalStateException("Failed to load replacement"))
+                    .when(pluginManager)
+                    .loadPlugin(newPluginFile);
+
+            assertThrows(IllegalStateException.class, () -> reconciler.reconcile(new Request(name)));
+
+            assertEquals(oldPluginFile.toUri(), fakePlugin.getStatus().getLoadLocation());
+            assertTrue(fakePlugin.getMetadata().getAnnotations().containsKey(RELOAD_ANNO));
+        }
+
+        @Test
+        void shouldReloadWhenRuntimePathDiffersFromDesiredPath() throws IOException {
+            var oldPluginFile = Files.createFile(tempPath.resolve("fake-plugin-1.0.0.jar"));
+            var newPluginFile = tempPath.resolve("fake-plugin-1.2.3.jar");
+            var fakePlugin = createPlugin(name, plugin -> {
+                plugin.getSpec().setVersion("1.2.3");
+                plugin.getSpec().setEnabled(false);
+                plugin.getStatus().setLoadLocation(newPluginFile.toUri());
+            });
+            var pluginWrapper = mockPluginWrapper(PluginState.DISABLED);
+            when(pluginWrapper.getPluginPath()).thenReturn(oldPluginFile);
+            when(pluginWrapper.getPluginClassLoader()).thenReturn(mock(ClassLoader.class));
+
+            when(client.fetch(Plugin.class, name)).thenReturn(Optional.of(fakePlugin));
+            when(pluginManager.getPluginsRoots()).thenReturn(List.of(tempPath));
+            when(pluginManager.getPlugin(name)).thenReturn(pluginWrapper);
+            when(pluginManager.getUnresolvedPlugins()).thenReturn(List.of());
+            when(pluginManager.getResolvedPlugins()).thenReturn(List.of(pluginWrapper));
+            when(pluginManager.unloadPlugin(name)).thenReturn(true);
+
+            reconciler.reconcile(new Request(name));
 
             verify(pluginManager).unloadPlugin(name);
-            var loadLocation = Paths.get(fakePlugin.getStatus().getLoadLocation());
-            verify(pluginManager).loadPlugin(loadLocation);
+            verify(pluginManager).loadPlugin(newPluginFile);
+            assertFalse(Files.exists(oldPluginFile));
         }
 
         @Test
@@ -479,6 +574,9 @@ class PluginReconcilerTest {
     @Nested
     class WhenDeleting {
 
+        @TempDir
+        Path tempPath;
+
         @Test
         void shouldDoNothingWithoutFinalizer() {
             var fakePlugin = createPlugin(name, plugin -> {
@@ -518,7 +616,7 @@ class PluginReconcilerTest {
             var result = reconciler.reconcile(new Request(name));
 
             assertFalse(result.reEnqueue());
-            // make sure the finalizer is removed.
+            // Remove the finalizer after all plugin resources have been deleted.
             assertFalse(fakePlugin.getMetadata().getFinalizers().contains(finalizer));
             assertNull(fakePlugin.getStatus().getLastProbeState());
             verify(pluginManager, times(2)).getPlugin(name);
@@ -527,6 +625,86 @@ class PluginReconcilerTest {
             verify(client).fetch(Setting.class, "fake-setting");
             verify(client).fetch(ReverseProxy.class, reverseProxyName);
             verify(client).update(fakePlugin);
+        }
+
+        @Test
+        void shouldDeleteManagedPluginFileWhenPluginIsNotLoaded() throws IOException {
+            var pluginFile = Files.createFile(tempPath.resolve("fake-plugin-1.2.3.jar"));
+            var fakePlugin = createPlugin(name, plugin -> {
+                var metadata = plugin.getMetadata();
+                metadata.setDeletionTimestamp(clock.instant());
+                metadata.setFinalizers(new HashSet<>(Set.of(finalizer)));
+                plugin.getStatus().setLoadLocation(pluginFile.toUri());
+            });
+
+            when(client.fetch(Plugin.class, name)).thenReturn(Optional.of(fakePlugin));
+            when(client.fetch(ReverseProxy.class, reverseProxyName)).thenReturn(Optional.empty());
+            when(pluginManager.getPlugin(name)).thenReturn(null);
+            when(pluginManager.getPluginsRoots()).thenReturn(List.of(tempPath));
+
+            var result = reconciler.reconcile(new Request(name));
+
+            assertFalse(result.reEnqueue());
+            assertFalse(Files.exists(pluginFile));
+            assertFalse(fakePlugin.getMetadata().getFinalizers().contains(finalizer));
+            verify(client).update(fakePlugin);
+        }
+
+        @Test
+        void shouldKeepFinalizerWhenPluginManagerStillContainsPlugin() {
+            var fakePlugin = createPlugin(name, plugin -> {
+                var metadata = plugin.getMetadata();
+                metadata.setDeletionTimestamp(clock.instant());
+                metadata.setFinalizers(new HashSet<>(Set.of(finalizer)));
+            });
+            var pluginWrapper = mock(PluginWrapper.class);
+
+            when(client.fetch(Plugin.class, name)).thenReturn(Optional.of(fakePlugin));
+            when(client.fetch(ReverseProxy.class, reverseProxyName)).thenReturn(Optional.empty());
+            when(pluginManager.getPlugin(name)).thenReturn(pluginWrapper);
+            when(pluginManager.deletePlugin(name)).thenReturn(false);
+
+            var exception = assertThrows(RequeueException.class, () -> reconciler.reconcile(new Request(name)));
+
+            assertEquals(Reconciler.Result.requeue(null), exception.getResult());
+            assertTrue(fakePlugin.getMetadata().getFinalizers().contains(finalizer));
+            verify(client, never()).update(fakePlugin);
+        }
+
+        @Test
+        void shouldDeleteOnlyArtifactsOwnedByPlugin() throws Exception {
+            var fakePluginResource = Paths.get(getClass()
+                    .getClassLoader()
+                    .getResource("plugin/plugin-0.0.2")
+                    .toURI());
+            var unrelatedPluginResource = Paths.get(getClass()
+                    .getClassLoader()
+                    .getResource("plugin/plugin-0.0.1")
+                    .toURI());
+            var currentPluginFile = tempPath.resolve("fake-plugin-1.2.3.jar");
+            var stalePluginFile = tempPath.resolve("fake-plugin-1.0.0.jar");
+            var similarlyNamedPluginFile = tempPath.resolve("fake-plugin-extra-1.0.0.jar");
+            FileUtils.jar(fakePluginResource, currentPluginFile);
+            FileUtils.jar(fakePluginResource, stalePluginFile);
+            FileUtils.jar(unrelatedPluginResource, similarlyNamedPluginFile);
+
+            var fakePlugin = createPlugin(name, plugin -> {
+                var metadata = plugin.getMetadata();
+                metadata.setDeletionTimestamp(clock.instant());
+                metadata.setFinalizers(new HashSet<>(Set.of(finalizer)));
+                plugin.getStatus().setLoadLocation(currentPluginFile.toUri());
+            });
+
+            when(client.fetch(Plugin.class, name)).thenReturn(Optional.of(fakePlugin));
+            when(client.fetch(ReverseProxy.class, reverseProxyName)).thenReturn(Optional.empty());
+            when(pluginManager.getPlugin(name)).thenReturn(null);
+            when(pluginManager.getPluginsRoots()).thenReturn(List.of(tempPath));
+
+            reconciler.reconcile(new Request(name));
+
+            assertFalse(Files.exists(currentPluginFile));
+            assertFalse(Files.exists(stalePluginFile));
+            assertTrue(Files.exists(similarlyNamedPluginFile));
         }
 
         @Test
@@ -549,8 +727,8 @@ class PluginReconcilerTest {
             assertEquals(Reconciler.Result.requeue(null), exception.getResult());
             assertEquals("Waiting for setting fake-setting to be deleted.", exception.getMessage());
 
-            // make sure the finalizer is removed.
-            assertFalse(fakePlugin.getMetadata().getFinalizers().contains(finalizer));
+            // Keep the finalizer until all plugin resources have been deleted.
+            assertTrue(fakePlugin.getMetadata().getFinalizers().contains(finalizer));
             assertEquals(PluginState.STARTED, fakePlugin.getStatus().getLastProbeState());
             verify(pluginManager, never()).getPlugin(name);
             verify(pluginManager, never()).deletePlugin(name);
@@ -583,8 +761,8 @@ class PluginReconcilerTest {
             assertEquals(Reconciler.Result.requeue(null), exception.getResult());
             assertEquals("Waiting for reverse proxy " + reverseProxyName + " to be deleted.", exception.getMessage());
 
-            // make sure the finalizer is removed.
-            assertFalse(fakePlugin.getMetadata().getFinalizers().contains(finalizer));
+            // Keep the finalizer until all plugin resources have been deleted.
+            assertTrue(fakePlugin.getMetadata().getFinalizers().contains(finalizer));
             assertEquals(PluginState.STARTED, fakePlugin.getStatus().getLastProbeState());
             verify(pluginManager, never()).getPlugin(name);
             verify(pluginManager, never()).deletePlugin(name);

--- a/application/src/test/java/run/halo/app/core/reconciler/PluginReconcilerTest.java
+++ b/application/src/test/java/run/halo/app/core/reconciler/PluginReconcilerTest.java
@@ -10,6 +10,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -25,6 +26,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.time.Clock;
+import java.time.Duration;
 import java.time.Instant;
 import java.time.ZoneOffset;
 import java.util.HashMap;
@@ -297,6 +299,8 @@ class PluginReconcilerTest {
 
             assertEquals(oldPluginFile.toUri(), fakePlugin.getStatus().getLoadLocation());
             assertTrue(fakePlugin.getMetadata().getAnnotations().containsKey(RELOAD_ANNO));
+            assertTrue(Files.exists(oldPluginFile));
+            verify(pluginManager).loadPlugin(oldPluginFile);
         }
 
         @Test
@@ -324,6 +328,41 @@ class PluginReconcilerTest {
             verify(pluginManager).unloadPlugin(name);
             verify(pluginManager).loadPlugin(newPluginFile);
             assertFalse(Files.exists(oldPluginFile));
+        }
+
+        @Test
+        void shouldNotDeletePluginFileCopiedByConcurrentUpgrade() throws Exception {
+            var pluginResource = Paths.get(getClass()
+                    .getClassLoader()
+                    .getResource("plugin/plugin-0.0.2")
+                    .toURI());
+            var currentPluginFile = tempPath.resolve("fake-plugin-1.2.3.jar");
+            var upgradingPluginFile = tempPath.resolve("fake-plugin-1.3.0.jar");
+            FileUtils.jar(pluginResource, currentPluginFile);
+            FileUtils.jar(pluginResource, upgradingPluginFile);
+
+            var fakePlugin = createPlugin(name, plugin -> {
+                plugin.getSpec().setVersion("1.2.3");
+                plugin.getSpec().setEnabled(true);
+                plugin.getStatus().setLoadLocation(currentPluginFile.toUri());
+                plugin.getMetadata()
+                        .setAnnotations(new HashMap<>(
+                                Map.of(RELOAD_ANNO, currentPluginFile.toUri().toString())));
+            });
+            var pluginWrapper = mockPluginWrapper(PluginState.RESOLVED);
+            when(pluginWrapper.getPluginPath()).thenReturn(currentPluginFile);
+
+            when(client.fetch(Plugin.class, name)).thenReturn(Optional.of(fakePlugin));
+            when(pluginManager.getPluginsRoots()).thenReturn(List.of(tempPath));
+            when(pluginManager.getPlugin(name)).thenReturn(pluginWrapper);
+            when(pluginManager.getUnresolvedPlugins()).thenReturn(List.of(pluginWrapper));
+            when(pluginManager.getResolvedPlugins()).thenReturn(List.of());
+            when(pluginManager.unloadPlugin(name)).thenReturn(true);
+            when(pluginManager.startPlugin(name)).thenReturn(PluginState.STARTED);
+
+            reconciler.reconcile(new Request(name));
+
+            assertTrue(Files.exists(upgradingPluginFile));
         }
 
         @Test
@@ -648,6 +687,33 @@ class PluginReconcilerTest {
             assertFalse(Files.exists(pluginFile));
             assertFalse(fakePlugin.getMetadata().getFinalizers().contains(finalizer));
             verify(client).update(fakePlugin);
+        }
+
+        @Test
+        void shouldKeepFinalizerAndRequeueWhenPluginFileDeletionFails() throws IOException {
+            var pluginFile = Files.createFile(tempPath.resolve("fake-plugin-1.2.3.jar"));
+            var fakePlugin = createPlugin(name, plugin -> {
+                var metadata = plugin.getMetadata();
+                metadata.setDeletionTimestamp(clock.instant());
+                metadata.setFinalizers(new HashSet<>(Set.of(finalizer)));
+                plugin.getStatus().setLoadLocation(pluginFile.toUri());
+            });
+
+            when(client.fetch(Plugin.class, name)).thenReturn(Optional.of(fakePlugin));
+            when(client.fetch(ReverseProxy.class, reverseProxyName)).thenReturn(Optional.empty());
+            when(pluginManager.getPlugin(name)).thenReturn(null);
+            when(pluginManager.getPluginsRoots()).thenReturn(List.of(tempPath));
+
+            try (var files = mockStatic(Files.class)) {
+                files.when(() -> Files.deleteIfExists(pluginFile)).thenThrow(new IOException("Deletion failed"));
+
+                var exception = assertThrows(RequeueException.class, () -> reconciler.reconcile(new Request(name)));
+
+                assertEquals(Reconciler.Result.requeue(Duration.ofSeconds(1)), exception.getResult());
+            }
+            assertTrue(Files.exists(pluginFile));
+            assertTrue(fakePlugin.getMetadata().getFinalizers().contains(finalizer));
+            verify(client, never()).update(fakePlugin);
         }
 
         @Test

--- a/application/src/test/java/run/halo/app/plugin/PluginServiceImplTest.java
+++ b/application/src/test/java/run/halo/app/plugin/PluginServiceImplTest.java
@@ -30,6 +30,7 @@ import java.time.Instant;
 import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
@@ -196,7 +197,14 @@ class PluginServiceImplTest {
                 plugin.getSpec().setVersion("0.0.1");
                 plugin.getStatus().setLoadLocation(oldPluginFile.toUri());
             });
-            when(client.fetch(Plugin.class, "fake-plugin")).thenReturn(Mono.just(oldFakePlugin));
+            var persistedOldPlugin = createPlugin("fake-plugin", plugin -> {
+                plugin.getSpec().setEnabled(true);
+                plugin.getSpec().setVersion("0.0.1");
+                plugin.getStatus().setLoadLocation(oldPluginFile.toUri());
+            });
+            when(client.fetch(Plugin.class, "fake-plugin"))
+                    .thenReturn(Mono.just(oldFakePlugin))
+                    .thenReturn(Mono.just(persistedOldPlugin));
             when(client.update(oldFakePlugin)).thenReturn(Mono.error(new IllegalStateException("Update failed")));
 
             pluginService
@@ -207,6 +215,41 @@ class PluginServiceImplTest {
 
             assertTrue(Files.exists(oldPluginFile));
             assertFalse(Files.exists(newPluginFile));
+        }
+
+        @Test
+        void shouldKeepCopiedPluginWhenConcurrentUpgradeHasCommittedIt() throws IOException {
+            var pluginRoot = tempDirectory.resolve("plugins");
+            Files.createDirectories(pluginRoot);
+            var oldPluginFile = Files.createFile(pluginRoot.resolve("fake-plugin-0.0.1.jar"));
+            var newPluginFile = pluginRoot.resolve("fake-plugin-0.0.2.jar");
+            when(pluginsRootGetter.get()).thenReturn(pluginRoot);
+
+            var losingPlugin = createPlugin("fake-plugin", plugin -> {
+                plugin.getSpec().setEnabled(true);
+                plugin.getSpec().setVersion("0.0.1");
+                plugin.getStatus().setLoadLocation(oldPluginFile.toUri());
+            });
+            var persistedWinner = createPlugin("fake-plugin", plugin -> {
+                plugin.getSpec().setEnabled(true);
+                plugin.getSpec().setVersion("0.0.2");
+                plugin.getStatus().setLoadLocation(oldPluginFile.toUri());
+                plugin.getMetadata()
+                        .setAnnotations(Map.of(
+                                PluginConst.RELOAD_ANNO, newPluginFile.toUri().toString()));
+            });
+            when(client.fetch(Plugin.class, "fake-plugin"))
+                    .thenReturn(Mono.just(losingPlugin))
+                    .thenReturn(Mono.just(persistedWinner));
+            when(client.update(losingPlugin)).thenReturn(Mono.error(new IllegalStateException("Update failed")));
+
+            pluginService
+                    .upgrade("fake-plugin", fakePluginPath)
+                    .as(StepVerifier::create)
+                    .expectErrorMessage("Update failed")
+                    .verify();
+
+            assertTrue(Files.exists(newPluginFile));
         }
 
         @Test

--- a/application/src/test/java/run/halo/app/plugin/PluginServiceImplTest.java
+++ b/application/src/test/java/run/halo/app/plugin/PluginServiceImplTest.java
@@ -184,6 +184,32 @@ class PluginServiceImplTest {
         }
 
         @Test
+        void shouldDeleteCopiedPluginWhenUpgradeUpdateFails() throws IOException {
+            var pluginRoot = tempDirectory.resolve("plugins");
+            Files.createDirectories(pluginRoot);
+            var oldPluginFile = Files.createFile(pluginRoot.resolve("fake-plugin-0.0.1.jar"));
+            var newPluginFile = pluginRoot.resolve("fake-plugin-0.0.2.jar");
+            when(pluginsRootGetter.get()).thenReturn(pluginRoot);
+
+            var oldFakePlugin = createPlugin("fake-plugin", plugin -> {
+                plugin.getSpec().setEnabled(true);
+                plugin.getSpec().setVersion("0.0.1");
+                plugin.getStatus().setLoadLocation(oldPluginFile.toUri());
+            });
+            when(client.fetch(Plugin.class, "fake-plugin")).thenReturn(Mono.just(oldFakePlugin));
+            when(client.update(oldFakePlugin)).thenReturn(Mono.error(new IllegalStateException("Update failed")));
+
+            pluginService
+                    .upgrade("fake-plugin", fakePluginPath)
+                    .as(StepVerifier::create)
+                    .expectErrorMessage("Update failed")
+                    .verify();
+
+            assertTrue(Files.exists(oldPluginFile));
+            assertFalse(Files.exists(newPluginFile));
+        }
+
+        @Test
         void shouldNotReloadIfLoadLocationIsNotReady() {
             var pluginName = "test-plugin";
 


### PR DESCRIPTION
#### What type of PR is this?

- [ ] Feature
- [x] Bug fix
- [ ] Improvement
- [ ] Cleanup
- [ ] Documentation

#### What this PR does / why we need it:

Plugin upgrades and uninstallations could leave physical JAR files in the managed plugins directory.

During an upgrade, reconciliation advanced `status.loadLocation` even when deleting the previous JAR failed. This discarded the previous path and prevented subsequent cleanup attempts. During uninstallation, JAR cleanup was skipped when PF4J no longer contained the plugin, and the finalizer could be removed without confirming that runtime and filesystem cleanup had completed.

This change:

- keeps the previous load location and reload request until the replacement plugin loads successfully;
- retries reconciliation when unloading or deleting the current plugin is incomplete;
- compares the persisted load location with the actual PF4J wrapper path to recover from loading an outdated JAR after restart;
- removes the uninstall finalizer only after runtime resources and managed plugin artifacts have been cleaned up;
- cleans historical JARs by reading their plugin manifests and matching the exact plugin name;
- deletes a newly copied JAR when persisting the upgrade request fails;
- restricts direct deletion to JAR files located directly under managed plugin roots.

A focused regression test reproduces the uninstall issue by reconciling a deleted `Plugin` whose `status.loadLocation` points to an existing JAR while PF4J has no corresponding wrapper. Before this change, the finalizer was removed while the JAR remained. After this change, the managed JAR is removed before finalization.

Validation:

- `./gradlew :application:spotlessApply`
- `./gradlew :application:test --tests 'run.halo.app.core.reconciler.PluginReconcilerTest' --tests 'run.halo.app.plugin.PluginServiceImplTest'`
- `./gradlew :application:spotlessCheck :application:test`
- `git diff --check`

#### Which issue(s) this PR fixes:

Fixes #10174

#### Special notes for your reviewer:

This change was implemented with assistance from Codex. The resulting diff and regression tests were reviewed, and the full application test suite was run locally.

This PR intentionally does not introduce a staging or atomic activation protocol for same-version plugin replacement. That can be handled separately if stronger crash consistency is required.

#### Does this PR introduce a user-facing change?

```release-note
修复插件升级或卸载后旧版本 JAR 文件可能残留的问题。
```
