### PR TITLE
feat: add AI metadata for editor extensions

### DIFF
--- a/openspec/changes/archive/2026-07-28-add-editor-extension-ai-metadata/.openspec.yaml
+++ b/openspec/changes/archive/2026-07-28-add-editor-extension-ai-metadata/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-27

--- a/openspec/changes/archive/2026-07-28-add-editor-extension-ai-metadata/design.md
+++ b/openspec/changes/archive/2026-07-28-add-editor-extension-ai-metadata/design.md
@@ -1,0 +1,194 @@
+## Context
+
+Halo assembles its editor from native Tiptap `Node`, `Mark`, and `Extension` instances, including extensions returned by third-party plugins through `default:editor:extension:create`. The final ProseMirror schema exposes component syntax, but it loses author-supplied semantics such as when to use a code block, how to fill a language attribute, or whether creating an image requires an attachment capability.
+
+`plugin-ai-assistant` currently reconstructs a compact schema description from the live `Editor` and hard-codes exceptional guidance such as `figureCaption` placement. This change moves the reusable declaration and Manifest generation contract into `@halo-dev/richtext-editor`; migrating that plugin remains a separate change.
+
+The metadata is untrusted, advisory input for AI consumers. It is not a runtime component protocol and must never alter Editor initialization, ProseMirror transactions, or document validation.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Preserve native Tiptap extension creation, configuration, inheritance, and plugin registration.
+- Let every Node or Mark describe its own AI usage and exceptional placement.
+- Let any final extension contribute metadata patches to explicitly named final Node or Mark components.
+- Resolve a deterministic, versioned Manifest from the final `Editor`, final extensions, and final schema.
+- Give every Halo default Node and Mark an explicit AI metadata or `ai: false` decision.
+- Keep built-in descriptions and examples aligned with the final runtime behavior, including editor-managed fields and normalization.
+- Provide a stable public contract and practical third-party plugin documentation.
+
+**Non-Goals:**
+
+- Enforce AI guidance or structure declarations against editor documents.
+- Add an AI write gateway, transaction interceptor, component-role protocol, or separate validation DSL.
+- Expose arbitrary prompt fields or allow extensions to inject system prompts.
+- Change the existing `AnyExtension[]` editor extension point.
+- Modify `plugin-ai-assistant` in this change.
+- Add i18n variants for metadata text.
+- Introduce general document enforcement or broad editor behavior changes; the only runtime adjustment is parsing Halo's existing serialized `columns` container.
+
+## Decisions
+
+### Public Tiptap hook and types
+
+TypeScript module augmentation will add `addHaloEditorMetadata()` to `NodeConfig`, `MarkConfig`, and `ExtensionConfig` in `@tiptap/core`. Public types and `createHaloEditorManifest(editor)` will be exported from `@halo-dev/richtext-editor`.
+
+The hook returns a local declaration patch. Native `Node.create()`, `Mark.create()`, and `.extend()` remain the only component construction APIs; no Halo-specific Node/Mark factory or extension wrapper will be added.
+
+Node and Mark hooks may return self metadata plus directed contributions. Plain Extension hooks return directed contributions because plain extensions are not Manifest components. A contribution explicitly names one or more `{ kind, name }` targets; wildcard targets are not supported.
+
+### Automatic parent-chain composition
+
+The resolver will walk each final extension's `.extend()` ancestry from parent to child and invoke each locally declared metadata hook using the final extension context. Developers do not call `this.parent` or a merge helper.
+
+Patches compose as follows:
+
+- object fields merge recursively;
+- arrays replace inherited arrays;
+- `undefined` inherits;
+- a higher-precedence `ai: false` disables AI metadata;
+- directed contributions accumulate across the parent chain.
+
+After self metadata is composed, directed contributions are applied from lower to higher Tiptap priority. At equal priority, later registration wins for fields it explicitly declares. The resolver emits a development warning when multiple sources overwrite the same final field.
+
+Schema-derived information remains authoritative. Metadata can describe semantics but cannot widen the final schema.
+
+### AI metadata model
+
+A final AI object has a required non-empty English `description` for Halo built-ins and supports:
+
+- `aliases`;
+- `exposure`, normalized to `recommended` or the default `available`;
+- `useWhen`;
+- `avoidWhen`;
+- `contentGuidelines`;
+- `attributeGuidance`;
+- `generation`;
+- `examples`.
+
+`attributeGuidance` keys must be attributes present on the final component. Declarations accept a string shorthand or an object with `description`, `format`, `allowedValues`, `examples`, `useWhen`, `omitWhen`, and `guidelines`. Manifest output always normalizes guidance to object form.
+
+`generation.mode` is `direct-html`, `requires-capability`, or `read-only`. Only `requires-capability` accepts a non-empty `requiredCapabilities` array. Capability identifiers are open, non-empty strings; Halo does not register, resolve, or execute them.
+
+Examples are HTML strings under `ai.examples`. When a final component has an AI object but no declared examples, the resolver may generate one from the final schema. No example is generated for `ai: false` or an extension without AI metadata. Declared examples need only parse with the final schema; validation does not require the parsed result to contain the declaring component.
+
+### Self-owned structure declaration
+
+`structure` describes only the current component:
+
+```ts
+interface HaloEditorStructureMetadata {
+  allowedParents: string[];
+  minPerParent?: number;
+  maxPerParent?: number;
+  description?: string;
+}
+```
+
+For example, `figureCaption` declares that it belongs under `figure`, is optional, and may occur once. `figure` does not declare or depend on `figureCaption` metadata. No `rules` array, `position`, `allowedChildren`, role system, or executable structure language is introduced.
+
+This information is advisory. Consumers may choose whether or how to use it.
+
+### Final Manifest
+
+`createHaloEditorManifest(editor)` is synchronous and returns a snapshot:
+
+```ts
+interface HaloEditorManifest {
+  version: 1;
+  signature: string;
+  components: HaloEditorComponent[];
+}
+```
+
+Components are unique by `kind + name` and include every final schema Node and Mark, even when no metadata was declared. Component fields are flat.
+
+The Node schema whitelist contains `content`, `group`, `inline`, `atom`, `leaf`, `code`, `whitespace`, `selectable`, `draggable`, `defining`, `isolating`, and attributes. The Mark whitelist contains `excludes`, `inclusive`, `spanning`, and attributes. Both may include serializable static HTML parse rule fields such as `tag`, `style`, and `priority`. Functions and custom NodeSpec fields such as `fakeSelection` and `allowGapCursor` are not emitted.
+
+The Manifest uses stable normalization:
+
+- components sort by kind and name;
+- attributes sort by name;
+- object keys serialize deterministically;
+- author-ordered guidance, example, and HTML parsing arrays preserve order.
+
+The synchronous signature uses Halo UI's existing `object-hash` dependency and covers the normalized complete Manifest except the signature field itself. It is an identity/change detector, not a security primitive.
+
+### Advisory validation and limits
+
+Metadata failures never affect Editor initialization. The resolver keeps valid fields, drops invalid fields or sections, and warns only in development. Unknown runtime keys are discarded through an output whitelist.
+
+Consistency checks include:
+
+- final AI objects require `description`;
+- attribute guidance names must exist on the final component;
+- contribution targets and structure parents must exist in the final schema;
+- HTML examples must parse with the final schema;
+- `generation` mode and capability fields must agree;
+- structure counts must be non-negative integers with `minPerParent <= maxPerParent`.
+
+Limits are:
+
+- 1,000 characters per guidance text;
+- 10 entries per guidance array;
+- 10 aliases of at most 100 characters;
+- 32 entries for allowed values or attribute-value examples;
+- three HTML examples of at most 4 KiB each;
+- 16 KiB of explicit AI metadata per component;
+- 128 KiB of explicit AI metadata per Manifest.
+
+Schema-derived data does not count against explicit AI metadata limits.
+
+### Built-in coverage
+
+Every Node and Mark in Halo's default `ExtensionsKit` must explicitly resolve to an AI object or `ai: false`; a test prevents accidental `undefined` coverage. Content-facing components receive English descriptions, usage guidance, relevant attribute guidance, generation guidance, and useful examples. Internal-only components may use `ai: false`.
+
+Built-in metadata is audited against the final schema rather than only against the most common toolbar path. When a component has materially different valid forms, its guidance or examples identify those alternatives without attempting a combinatorial example for every attribute. For example, `figure` covers image, video, and audio children; code blocks cover plain and configured forms; and galleries cover every editor-supported layout. Every final schema attribute is either explained for AI use or explicitly identified as editor-managed state that generated content should omit.
+
+Plain extensions that add global attributes, such as indentation or block position, contribute guidance to their explicitly configured target components. Nested `addExtensions()` results and duplicate component names resolve against the final schema identity.
+
+The final semantic audit also checks behavior that is not fully expressed by the schema:
+
+- descriptions distinguish inline nodes from block nodes and primary forms from legacy-normalized forms;
+- editor-maintained values such as heading anchors and figure-caption width are identified as values generated content should omit;
+- contributed attribute guidance describes the actual rendered CSS effect;
+- every built-in direct-HTML example parses to the intended component, and representative examples preserve the attributes that materially distinguish their forms.
+
+The `columns` node already serializes a `div.columns` container with `cols` and `style`, but previously declared no matching container parse rule. It will recognize that existing HTML shape so three-column content remains a three-column layout after import. This is a compatibility correction for an existing format, not a new metadata enforcement mechanism.
+
+### Documentation and downstream use
+
+Public documentation will show:
+
+- a third-party math Node or Mark declaring its own metadata;
+- a plugin extending `codeBlock` and returning only its local patch;
+- a plain Extension contributing guidance for global attributes;
+- `ai: false`, schema-only fallback, limits, and fail-soft behavior;
+- synchronous Manifest generation from a live Editor.
+
+Downstream consumers decide how to place the Manifest into model context and whether to enforce any declaration. `plugin-ai-assistant` can later replace its local schema description and hard-coded figure policy with this API.
+
+## Risks / Trade-offs
+
+- **Metadata can still contain misleading prose** → Treat all metadata as untrusted data, whitelist fields, bound sizes, and prohibit prompt-injection fields.
+- **Automatic parent traversal may diverge from Tiptap inheritance semantics** → Test `.extend()`, `.configure()`, dynamic options, and nested extension cases against the installed Tiptap version.
+- **A complete built-in Manifest consumes model context** → Keep schema fields compact and metadata bounded; catalog/detail splitting remains a future optimization.
+- **A deterministic signature can theoretically collide** → Use the existing full-width object hash and document that it is only a cache/change identity.
+- **Schema-valid HTML may normalize unexpectedly** → Validation is advisory and fail-soft; consumers still parse edits through the active Editor schema.
+- **A container parse rule may match unrelated HTML** → Match the existing `div.columns` class used by Halo serialization rather than arbitrary `div` elements.
+- **Public metadata types become plugin-facing API** → Export a versioned Manifest, preserve native Tiptap compatibility, and include third-party examples and regression tests.
+
+## Migration Plan
+
+1. Add public declarations, resolver, Manifest types, and tests without changing existing extension registration.
+2. Add explicit metadata decisions to all Halo default Nodes and Marks plus directed contributions from relevant plain extensions.
+3. Audit descriptions and examples against runtime parsing, serialization, normalization, and editor-managed fields.
+4. Publish plugin author documentation.
+5. Let downstream AI plugins adopt `createHaloEditorManifest(editor)` independently while retaining their current fallback on older Halo versions.
+
+Rollback removes the new public exports and declarations; editor content and runtime schemas are unaffected because metadata is advisory.
+
+## Open Questions
+
+None. The public contract and first-version scope were confirmed before implementation.

--- a/openspec/changes/archive/2026-07-28-add-editor-extension-ai-metadata/proposal.md
+++ b/openspec/changes/archive/2026-07-28-add-editor-extension-ai-metadata/proposal.md
@@ -1,0 +1,33 @@
+## Why
+
+Halo's active Tiptap schema exposes the syntax of registered editor components but not enough semantic guidance for an AI agent to reliably choose and construct components such as code blocks, tables, media, or plugin-provided nodes. The editor needs a public, plugin-extensible metadata contract that describes how each final component should be used without changing Tiptap runtime behavior.
+
+## What Changes
+
+- Add a public `addHaloEditorMetadata()` hook for Tiptap Node, Mark, and Extension configurations.
+- Add public metadata and Manifest types plus a synchronous `createHaloEditorManifest(editor)` API in `@halo-dev/richtext-editor`.
+- Resolve metadata from the final configured extension set, automatically merge `.extend()` parent chains, and merge directed contributions from Node, Mark, and plain Extension instances.
+- Combine declared AI guidance with a whitelisted description of the final ProseMirror schema, static HTML parsing rules, and stable Manifest identity.
+- Keep all metadata advisory: invalid declarations never block Editor initialization, and Halo does not enforce the guidance against editor documents.
+- Add explicit English AI metadata or `ai: false` decisions for every Node and Mark in Halo's default `ExtensionsKit`, including practical creation guidance and HTML examples.
+- Align built-in guidance with actual editor-managed fields, nesting, normalization, and inline or block behavior.
+- Preserve the existing `columns` container attributes when its serialized HTML is parsed so the built-in direct-HTML examples round-trip correctly.
+- Document how third-party plugins can describe new components and extend existing components.
+
+## Capabilities
+
+### New Capabilities
+
+- `editor-extension-ai-metadata`: Public editor-extension metadata declarations and deterministic AI capability Manifest generation.
+
+### Modified Capabilities
+
+None.
+
+## Impact
+
+- Affects the public TypeScript API and exports of `ui/packages/editor`.
+- Adds metadata declarations to Halo's built-in Tiptap extensions without changing their runtime schema.
+- Adds an HTML parse rule for the existing `columns` serialization format so `cols` and container styles are not lost on import.
+- Enables downstream AI plugins to replace local schema-description and hard-coded component guidance with Halo-provided data in a separate follow-up change.
+- Adds no backend API, dependency, database, security, or generated-client changes.

--- a/openspec/changes/archive/2026-07-28-add-editor-extension-ai-metadata/specs/editor-extension-ai-metadata/spec.md
+++ b/openspec/changes/archive/2026-07-28-add-editor-extension-ai-metadata/specs/editor-extension-ai-metadata/spec.md
@@ -1,0 +1,187 @@
+## ADDED Requirements
+
+### Requirement: Native Tiptap metadata declaration
+The rich-text editor package SHALL expose a public `addHaloEditorMetadata()` declaration hook on native Tiptap Node, Mark, and Extension configurations without replacing their construction or registration APIs.
+
+#### Scenario: Third-party Node declaration
+- **WHEN** a plugin creates a Node with native `Node.create()` and declares `addHaloEditorMetadata()`
+- **THEN** the Node SHALL remain a native Tiptap extension and its metadata SHALL be available to Manifest generation
+
+#### Scenario: Legacy extension without metadata
+- **WHEN** a registered extension does not declare `addHaloEditorMetadata()`
+- **THEN** the Editor SHALL continue to initialize and the final Node or Mark SHALL be represented using schema-derived information only
+
+#### Scenario: AI-disabled component
+- **WHEN** a Node or Mark resolves to `ai: false`
+- **THEN** its schema description SHALL remain in the Manifest and the explicit disabled decision SHALL be preserved
+
+### Requirement: Self-owned component guidance
+Each Node or Mark metadata declaration SHALL describe only that component's AI usage and optional placement constraints.
+
+#### Scenario: Figure caption declaration
+- **WHEN** `figureCaption` declares `allowedParents: ["figure"]`, `minPerParent: 0`, and `maxPerParent: 1`
+- **THEN** the Manifest SHALL associate those advisory constraints with `figureCaption`
+- **AND** the `figure` metadata SHALL NOT be required to declare or register `figureCaption`
+
+#### Scenario: Unregistered component
+- **WHEN** a component is not present in the final schema
+- **THEN** no Manifest component or dangling self metadata SHALL be emitted for it
+
+### Requirement: AI usage metadata
+A final AI metadata object SHALL contain a non-empty description and MAY contain aliases, exposure, usage guidance, attribute guidance, generation guidance, and HTML examples.
+
+#### Scenario: Default exposure
+- **WHEN** a valid AI object omits `exposure`
+- **THEN** the Manifest SHALL emit `exposure: "available"`
+
+#### Scenario: Attribute guidance shorthand
+- **WHEN** a declaration uses a string as an attribute guidance value
+- **THEN** the Manifest SHALL normalize it to an object containing that string as `description`
+
+#### Scenario: Enumerated attribute values
+- **WHEN** an attribute accepts a known finite set of values
+- **THEN** its guidance SHALL be able to declare scalar `allowedValues`
+
+#### Scenario: Capability-dependent generation
+- **WHEN** generation mode is `requires-capability`
+- **THEN** the declaration SHALL include at least one open string identifier in `requiredCapabilities`
+- **AND** Halo SHALL NOT resolve the identifier to a tool or execute it
+
+#### Scenario: Automatic example
+- **WHEN** a final component has a valid AI object and no declared examples
+- **THEN** the resolver MAY add one schema-generated HTML example to `ai.examples`
+
+#### Scenario: Schema-only component example
+- **WHEN** a component has no AI object or declares `ai: false`
+- **THEN** the resolver SHALL NOT synthesize an AI object or AI example
+
+### Requirement: Automatic inheritance and contributions
+The resolver SHALL automatically compose metadata from the final extension ancestry and directed contributions without requiring a plugin to call a parent metadata hook.
+
+#### Scenario: Extended code block
+- **WHEN** a plugin extends a Halo code block and locally declares guidance only for a new `highlightTheme` attribute
+- **THEN** the final code block SHALL retain inherited AI metadata and add the new attribute guidance
+
+#### Scenario: Configured extension
+- **WHEN** `.configure()` changes the final options used by a metadata hook
+- **THEN** Manifest generation SHALL invoke the hook with the final configured options
+
+#### Scenario: Plain Extension contribution
+- **WHEN** a plain Extension adds a global attribute to explicitly named final Node or Mark targets and contributes guidance
+- **THEN** the guidance SHALL be merged independently into each valid target component
+
+#### Scenario: Contribution precedence
+- **WHEN** multiple contributions declare the same final field
+- **THEN** higher Tiptap priority SHALL win
+- **AND** later registration SHALL win at equal priority
+
+#### Scenario: Array patch
+- **WHEN** a child or higher-precedence patch explicitly declares an array field
+- **THEN** that array SHALL replace the inherited array rather than append implicitly
+
+### Requirement: Final Editor Manifest
+The package SHALL synchronously derive a complete, deterministic Manifest from the live Editor's final extension set and final schema.
+
+#### Scenario: Complete final component catalog
+- **WHEN** the Manifest is generated
+- **THEN** every final schema Node and Mark SHALL appear exactly once using `kind + name` identity
+- **AND** nested or duplicate extension declarations SHALL NOT create duplicate Manifest components
+
+#### Scenario: Schema field whitelist
+- **WHEN** schema information is added to a component
+- **THEN** only the documented Node or Mark schema fields, attributes, and serializable static HTML parsing rule fields SHALL be emitted
+- **AND** functions and unknown custom NodeSpec fields SHALL be omitted
+
+#### Scenario: Stable normalization
+- **WHEN** two Editors have equivalent final schema and metadata but irrelevant extension registration ordering differs
+- **THEN** their normalized Manifest content and signature SHALL be equal
+
+#### Scenario: Meaningful change
+- **WHEN** final schema or valid AI metadata changes
+- **THEN** the Manifest signature SHALL change
+
+#### Scenario: Versioned format
+- **WHEN** a Manifest is generated by this contract
+- **THEN** it SHALL contain numeric `version: 1`, a synchronous deterministic `signature`, and flat component records
+
+### Requirement: Advisory fail-soft processing
+Metadata declarations SHALL be treated as untrusted advisory data and SHALL NOT affect Editor runtime behavior.
+
+#### Scenario: Throwing metadata hook
+- **WHEN** a metadata hook throws
+- **THEN** the Editor SHALL remain usable
+- **AND** Manifest generation SHALL omit the affected declaration and warn in development
+
+#### Scenario: Unknown metadata field
+- **WHEN** a runtime declaration contains a field outside the public metadata contract
+- **THEN** the unknown field SHALL be omitted from the Manifest
+
+#### Scenario: Invalid attribute guidance
+- **WHEN** guidance references an attribute not present on a target component
+- **THEN** that invalid guidance SHALL be omitted while other valid metadata remains
+
+#### Scenario: Invalid structure declaration
+- **WHEN** structure references a missing parent or has inconsistent cardinality
+- **THEN** the structure section SHALL be omitted while the AI and schema sections remain
+
+#### Scenario: HTML example validation
+- **WHEN** a declared HTML example cannot be parsed with the final schema
+- **THEN** the example SHALL be omitted
+- **AND** validation SHALL NOT require a parseable example to contain the declaring component
+
+#### Scenario: No document enforcement
+- **WHEN** metadata declares AI usage, structure, attribute values, or generation guidance
+- **THEN** Halo SHALL NOT validate an editor document, intercept a transaction, or enforce an AI edit based on that metadata
+
+### Requirement: Bounded metadata
+Manifest generation SHALL bound explicit third-party AI metadata before exposing it to consumers.
+
+#### Scenario: Field and component limits
+- **WHEN** text, arrays, allowed values, examples, or component metadata exceed their documented limits
+- **THEN** the excess invalid content SHALL be omitted without affecting Editor initialization
+
+#### Scenario: Manifest metadata limit
+- **WHEN** explicit AI metadata would exceed 128 KiB for one Manifest
+- **THEN** Manifest generation SHALL keep schema-derived component information and deterministically omit excess explicit metadata
+
+### Requirement: Halo built-in metadata coverage
+Every Node and Mark in Halo's default `ExtensionsKit` SHALL explicitly resolve to a complete AI object or `ai: false`.
+
+#### Scenario: Content-facing default component
+- **WHEN** a default content-facing component such as a code block, table, media node, list, or link is included
+- **THEN** it SHALL provide English guidance sufficient for an AI consumer to identify and use the component
+
+#### Scenario: Internal default component
+- **WHEN** a default Node or Mark is not suitable for direct AI creation or modification
+- **THEN** it MAY explicitly declare `ai: false`
+- **AND** it SHALL NOT remain accidentally undecided
+
+#### Scenario: Global attribute extension
+- **WHEN** a Halo plain Extension adds a user-facing global attribute
+- **THEN** it SHALL contribute relevant attribute guidance to its explicitly configured target components
+
+#### Scenario: Materially distinct built-in forms
+- **WHEN** a default component has materially distinct valid forms
+- **THEN** its guidance or examples SHALL identify those alternatives without requiring every attribute combination
+- **AND** `figure` SHALL identify image, video, and audio children as supported forms
+
+#### Scenario: Complete built-in attribute guidance
+- **WHEN** a default content-facing Node or Mark exposes an attribute in the final schema
+- **THEN** its AI metadata SHALL explain how to use that attribute or explicitly advise that generated persisted content omit the editor-managed attribute
+
+#### Scenario: Runtime-aligned built-in guidance
+- **WHEN** a built-in component is inline, is normally nested by editor commands, normalizes a legacy form, or maintains an attribute automatically
+- **THEN** its description and guidance SHALL reflect that runtime behavior
+- **AND** generated content SHALL be advised to omit editor-managed values
+
+#### Scenario: Representative direct-HTML round trip
+- **WHEN** a built-in example uses attributes that materially distinguish a supported form
+- **THEN** parsing that HTML with the final editor schema SHALL preserve the intended component and those distinguishing attributes
+- **AND** the existing three-column HTML form SHALL preserve `cols: 3`
+
+### Requirement: Third-party integration documentation
+The public editor package SHALL document how plugins declare and consume editor AI metadata.
+
+#### Scenario: Plugin author examples
+- **WHEN** a plugin developer reads the documentation
+- **THEN** examples SHALL cover a new mathematical component, extension of an existing code block, a plain Extension contribution, `ai: false`, schema fallback, fail-soft limits, and Manifest generation

--- a/openspec/changes/archive/2026-07-28-add-editor-extension-ai-metadata/tasks.md
+++ b/openspec/changes/archive/2026-07-28-add-editor-extension-ai-metadata/tasks.md
@@ -1,0 +1,38 @@
+## 1. Public Metadata Contract
+
+- [x] 1.1 Add public metadata declaration, normalized Manifest, contribution, and module-augmentation types to the editor package
+- [x] 1.2 Export the public metadata types and synchronous `createHaloEditorManifest(editor)` API from `@halo-dev/richtext-editor`
+
+## 2. Manifest Resolution
+
+- [x] 2.1 Implement final Node and Mark schema extraction with the approved field and HTML parse-rule whitelist
+- [x] 2.2 Implement automatic parent-chain metadata patch composition and explicit Node, Mark, and plain Extension contributions
+- [x] 2.3 Implement fail-soft normalization, consistency checks, field whitelisting, size limits, development diagnostics, and automatic AI examples
+- [x] 2.4 Implement deterministic component ordering, serialization, and synchronous Manifest signatures
+
+## 3. Halo Built-in Metadata
+
+- [x] 3.1 Add explicit English AI metadata or `ai: false` to every default `ExtensionsKit` Node and Mark
+- [x] 3.2 Add self-owned `figureCaption` structure metadata and generation guidance for code, media, table, list, link, and other content-facing components
+- [x] 3.3 Add directed metadata contributions for user-facing global attributes from plain Extensions
+- [x] 3.4 Audit every default component against its final schema and cover materially distinct forms plus editor-managed attributes
+- [x] 3.5 Correct final semantic-audit findings and preserve serialized `columns` container attributes on HTML import
+
+## 4. Tests
+
+- [x] 4.1 Add resolver tests for final schema coverage, nested extensions, duplicate identities, configuration, inheritance, contributions, and precedence
+- [x] 4.2 Add normalization and resilience tests for invalid hooks, unknown fields, limits, examples, structure, attributes, and stable signatures
+- [x] 4.3 Add a regression test requiring every default Node and Mark to explicitly resolve to AI metadata or `ai: false`
+- [x] 4.4 Add a regression audit for complete built-in usage, generation, examples, attribute guidance, and representative variants
+- [x] 4.5 Add regression coverage for runtime-aligned guidance and representative built-in HTML round trips
+
+## 5. Documentation
+
+- [x] 5.1 Document new component declarations, existing-component extensions, plain Extension contributions, fallback behavior, limits, and Manifest consumption
+
+## 6. Validation
+
+- [x] 6.1 Run OpenSpec validation and editor-focused unit tests
+- [x] 6.2 Run UI formatting, typecheck, lint, and workspace package build
+- [x] 6.3 Re-run OpenSpec and UI validation after the built-in metadata audit
+- [x] 6.4 Re-run OpenSpec and UI validation after the final semantic corrections

--- a/openspec/specs/editor-extension-ai-metadata/spec.md
+++ b/openspec/specs/editor-extension-ai-metadata/spec.md
@@ -1,7 +1,7 @@
 # editor-extension-ai-metadata Specification
 
 ## Purpose
-Define how Halo editor extensions expose advisory metadata so AI consumers can understand the final editor schema, component usage, placement constraints, attributes, generation capabilities, and representative HTML without changing editor runtime behavior.
+Define how Halo editor extensions expose runtime advisory metadata that describes the final editor schema, component usage, placement constraints, attributes, generation capabilities, and representative HTML to consumers such as AI agents without changing editor behavior.
 
 ## Requirements
 ### Requirement: Native Tiptap metadata declaration
@@ -184,7 +184,7 @@ Every Node and Mark in Halo's default `ExtensionsKit` SHALL explicitly resolve t
 - **AND** the existing three-column HTML form SHALL preserve `cols: 3`
 
 ### Requirement: Third-party integration documentation
-The public editor package SHALL document how plugins declare and consume editor AI metadata.
+The public editor package SHALL document how plugins declare and consume editor runtime metadata, including its AI-specific usage guidance.
 
 #### Scenario: Plugin author examples
 - **WHEN** a plugin developer reads the documentation

--- a/openspec/specs/editor-extension-ai-metadata/spec.md
+++ b/openspec/specs/editor-extension-ai-metadata/spec.md
@@ -1,0 +1,191 @@
+# editor-extension-ai-metadata Specification
+
+## Purpose
+Define how Halo editor extensions expose advisory metadata so AI consumers can understand the final editor schema, component usage, placement constraints, attributes, generation capabilities, and representative HTML without changing editor runtime behavior.
+
+## Requirements
+### Requirement: Native Tiptap metadata declaration
+The rich-text editor package SHALL expose a public `addHaloEditorMetadata()` declaration hook on native Tiptap Node, Mark, and Extension configurations without replacing their construction or registration APIs.
+
+#### Scenario: Third-party Node declaration
+- **WHEN** a plugin creates a Node with native `Node.create()` and declares `addHaloEditorMetadata()`
+- **THEN** the Node SHALL remain a native Tiptap extension and its metadata SHALL be available to Manifest generation
+
+#### Scenario: Legacy extension without metadata
+- **WHEN** a registered extension does not declare `addHaloEditorMetadata()`
+- **THEN** the Editor SHALL continue to initialize and the final Node or Mark SHALL be represented using schema-derived information only
+
+#### Scenario: AI-disabled component
+- **WHEN** a Node or Mark resolves to `ai: false`
+- **THEN** its schema description SHALL remain in the Manifest and the explicit disabled decision SHALL be preserved
+
+### Requirement: Self-owned component guidance
+Each Node or Mark metadata declaration SHALL describe only that component's AI usage and optional placement constraints.
+
+#### Scenario: Figure caption declaration
+- **WHEN** `figureCaption` declares `allowedParents: ["figure"]`, `minPerParent: 0`, and `maxPerParent: 1`
+- **THEN** the Manifest SHALL associate those advisory constraints with `figureCaption`
+- **AND** the `figure` metadata SHALL NOT be required to declare or register `figureCaption`
+
+#### Scenario: Unregistered component
+- **WHEN** a component is not present in the final schema
+- **THEN** no Manifest component or dangling self metadata SHALL be emitted for it
+
+### Requirement: AI usage metadata
+A final AI metadata object SHALL contain a non-empty description and MAY contain aliases, exposure, usage guidance, attribute guidance, generation guidance, and HTML examples.
+
+#### Scenario: Default exposure
+- **WHEN** a valid AI object omits `exposure`
+- **THEN** the Manifest SHALL emit `exposure: "available"`
+
+#### Scenario: Attribute guidance shorthand
+- **WHEN** a declaration uses a string as an attribute guidance value
+- **THEN** the Manifest SHALL normalize it to an object containing that string as `description`
+
+#### Scenario: Enumerated attribute values
+- **WHEN** an attribute accepts a known finite set of values
+- **THEN** its guidance SHALL be able to declare scalar `allowedValues`
+
+#### Scenario: Capability-dependent generation
+- **WHEN** generation mode is `requires-capability`
+- **THEN** the declaration SHALL include at least one open string identifier in `requiredCapabilities`
+- **AND** Halo SHALL NOT resolve the identifier to a tool or execute it
+
+#### Scenario: Automatic example
+- **WHEN** a final component has a valid AI object and no declared examples
+- **THEN** the resolver MAY add one schema-generated HTML example to `ai.examples`
+
+#### Scenario: Schema-only component example
+- **WHEN** a component has no AI object or declares `ai: false`
+- **THEN** the resolver SHALL NOT synthesize an AI object or AI example
+
+### Requirement: Automatic inheritance and contributions
+The resolver SHALL automatically compose metadata from the final extension ancestry and directed contributions without requiring a plugin to call a parent metadata hook.
+
+#### Scenario: Extended code block
+- **WHEN** a plugin extends a Halo code block and locally declares guidance only for a new `highlightTheme` attribute
+- **THEN** the final code block SHALL retain inherited AI metadata and add the new attribute guidance
+
+#### Scenario: Configured extension
+- **WHEN** `.configure()` changes the final options used by a metadata hook
+- **THEN** Manifest generation SHALL invoke the hook with the final configured options
+
+#### Scenario: Plain Extension contribution
+- **WHEN** a plain Extension adds a global attribute to explicitly named final Node or Mark targets and contributes guidance
+- **THEN** the guidance SHALL be merged independently into each valid target component
+
+#### Scenario: Contribution precedence
+- **WHEN** multiple contributions declare the same final field
+- **THEN** higher Tiptap priority SHALL win
+- **AND** later registration SHALL win at equal priority
+
+#### Scenario: Array patch
+- **WHEN** a child or higher-precedence patch explicitly declares an array field
+- **THEN** that array SHALL replace the inherited array rather than append implicitly
+
+### Requirement: Final Editor Manifest
+The package SHALL synchronously derive a complete, deterministic Manifest from the live Editor's final extension set and final schema.
+
+#### Scenario: Complete final component catalog
+- **WHEN** the Manifest is generated
+- **THEN** every final schema Node and Mark SHALL appear exactly once using `kind + name` identity
+- **AND** nested or duplicate extension declarations SHALL NOT create duplicate Manifest components
+
+#### Scenario: Schema field whitelist
+- **WHEN** schema information is added to a component
+- **THEN** only the documented Node or Mark schema fields, attributes, and serializable static HTML parsing rule fields SHALL be emitted
+- **AND** functions and unknown custom NodeSpec fields SHALL be omitted
+
+#### Scenario: Stable normalization
+- **WHEN** two Editors have equivalent final schema and metadata but irrelevant extension registration ordering differs
+- **THEN** their normalized Manifest content and signature SHALL be equal
+
+#### Scenario: Meaningful change
+- **WHEN** final schema or valid AI metadata changes
+- **THEN** the Manifest signature SHALL change
+
+#### Scenario: Versioned format
+- **WHEN** a Manifest is generated by this contract
+- **THEN** it SHALL contain numeric `version: 1`, a synchronous deterministic `signature`, and flat component records
+
+### Requirement: Advisory fail-soft processing
+Metadata declarations SHALL be treated as untrusted advisory data and SHALL NOT affect Editor runtime behavior.
+
+#### Scenario: Throwing metadata hook
+- **WHEN** a metadata hook throws
+- **THEN** the Editor SHALL remain usable
+- **AND** Manifest generation SHALL omit the affected declaration and warn in development
+
+#### Scenario: Unknown metadata field
+- **WHEN** a runtime declaration contains a field outside the public metadata contract
+- **THEN** the unknown field SHALL be omitted from the Manifest
+
+#### Scenario: Invalid attribute guidance
+- **WHEN** guidance references an attribute not present on a target component
+- **THEN** that invalid guidance SHALL be omitted while other valid metadata remains
+
+#### Scenario: Invalid structure declaration
+- **WHEN** structure references a missing parent or has inconsistent cardinality
+- **THEN** the structure section SHALL be omitted while the AI and schema sections remain
+
+#### Scenario: HTML example validation
+- **WHEN** a declared HTML example cannot be parsed with the final schema
+- **THEN** the example SHALL be omitted
+- **AND** validation SHALL NOT require a parseable example to contain the declaring component
+
+#### Scenario: No document enforcement
+- **WHEN** metadata declares AI usage, structure, attribute values, or generation guidance
+- **THEN** Halo SHALL NOT validate an editor document, intercept a transaction, or enforce an AI edit based on that metadata
+
+### Requirement: Bounded metadata
+Manifest generation SHALL bound explicit third-party AI metadata before exposing it to consumers.
+
+#### Scenario: Field and component limits
+- **WHEN** text, arrays, allowed values, examples, or component metadata exceed their documented limits
+- **THEN** the excess invalid content SHALL be omitted without affecting Editor initialization
+
+#### Scenario: Manifest metadata limit
+- **WHEN** explicit AI metadata would exceed 128 KiB for one Manifest
+- **THEN** Manifest generation SHALL keep schema-derived component information and deterministically omit excess explicit metadata
+
+### Requirement: Halo built-in metadata coverage
+Every Node and Mark in Halo's default `ExtensionsKit` SHALL explicitly resolve to a complete AI object or `ai: false`.
+
+#### Scenario: Content-facing default component
+- **WHEN** a default content-facing component such as a code block, table, media node, list, or link is included
+- **THEN** it SHALL provide English guidance sufficient for an AI consumer to identify and use the component
+
+#### Scenario: Internal default component
+- **WHEN** a default Node or Mark is not suitable for direct AI creation or modification
+- **THEN** it MAY explicitly declare `ai: false`
+- **AND** it SHALL NOT remain accidentally undecided
+
+#### Scenario: Global attribute extension
+- **WHEN** a Halo plain Extension adds a user-facing global attribute
+- **THEN** it SHALL contribute relevant attribute guidance to its explicitly configured target components
+
+#### Scenario: Materially distinct built-in forms
+- **WHEN** a default component has materially distinct valid forms
+- **THEN** its guidance or examples SHALL identify those alternatives without requiring every attribute combination
+- **AND** `figure` SHALL identify image, video, and audio children as supported forms
+
+#### Scenario: Complete built-in attribute guidance
+- **WHEN** a default content-facing Node or Mark exposes an attribute in the final schema
+- **THEN** its AI metadata SHALL explain how to use that attribute or explicitly advise that generated persisted content omit the editor-managed attribute
+
+#### Scenario: Runtime-aligned built-in guidance
+- **WHEN** a built-in component is inline, is normally nested by editor commands, normalizes a legacy form, or maintains an attribute automatically
+- **THEN** its description and guidance SHALL reflect that runtime behavior
+- **AND** generated content SHALL be advised to omit editor-managed values
+
+#### Scenario: Representative direct-HTML round trip
+- **WHEN** a built-in example uses attributes that materially distinguish a supported form
+- **THEN** parsing that HTML with the final editor schema SHALL preserve the intended component and those distinguishing attributes
+- **AND** the existing three-column HTML form SHALL preserve `cols: 3`
+
+### Requirement: Third-party integration documentation
+The public editor package SHALL document how plugins declare and consume editor AI metadata.
+
+#### Scenario: Plugin author examples
+- **WHEN** a plugin developer reads the documentation
+- **THEN** examples SHALL cover a new mathematical component, extension of an existing code block, a plain Extension contribution, `ai: false`, schema fallback, fail-soft limits, and Manifest generation

--- a/ui/packages/editor/README.md
+++ b/ui/packages/editor/README.md
@@ -50,6 +50,10 @@ onMounted(() => {
 - Vue 3.5.x or higher
 - Halo plugin environment
 
+## Extension development
+
+- [Editor extension AI metadata](./docs/ai-metadata.md)
+
 ## Links
 
 - [Halo](https://github.com/halo-dev/halo)

--- a/ui/packages/editor/README.md
+++ b/ui/packages/editor/README.md
@@ -52,7 +52,7 @@ onMounted(() => {
 
 ## Extension development
 
-- [Editor extension AI metadata](./docs/ai-metadata.md)
+- [Editor extension runtime metadata](./docs/runtime-metadata.md)
 
 ## Links
 

--- a/ui/packages/editor/docs/ai-metadata.md
+++ b/ui/packages/editor/docs/ai-metadata.md
@@ -1,0 +1,203 @@
+# 编辑器扩展的 AI 元数据
+
+`@halo-dev/richtext-editor` 允许 Tiptap 的 Node、Mark 和 Extension
+声明供 AI 消费的组件说明。元数据只描述最终编辑器中已有组件的用法，不会对组件功能有任何影响。
+
+## 声明新组件
+
+下面的数学公式节点说明了适用场景、属性和生成所需的外部能力：
+
+```ts
+import { Node } from "@halo-dev/richtext-editor";
+
+export const MathBlock = Node.create({
+  name: "mathBlock",
+  group: "block",
+  atom: true,
+
+  addAttributes() {
+    return {
+      formula: {
+        default: "",
+      },
+    };
+  },
+
+  parseHTML() {
+    return [{ tag: 'div[data-type="math-block"]' }];
+  },
+
+  renderHTML({ HTMLAttributes }) {
+    return ["div", { ...HTMLAttributes, "data-type": "math-block" }];
+  },
+
+  // 添加供 AI 理解能力的 元数据
+  addHaloEditorMetadata() {
+    return {
+      ai: {
+        description: "A display mathematical formula.",
+        exposure: "available",
+        useWhen: ["Presenting a standalone mathematical expression."],
+        attributeGuidance: {
+          formula: {
+            description: "Formula source written in LaTeX.",
+            format: "LaTeX",
+            examples: ["E = mc^2"],
+          },
+        },
+        generation: {
+          mode: "requires-capability",
+          requiredCapabilities: ["math-to-html"],
+        },
+        examples: [
+          '<div data-type="math-block" formula="E = mc^2"></div>',
+        ],
+      },
+    };
+  },
+});
+```
+
+Capability 名称是开放字符串。Halo 只把它放入 Manifest，不负责查找或执行对应工具，由最终使用者扩展工具。
+
+## 扩展现有组件
+
+元数据与 Tiptap 的 `.extend()` 继承链一起自动合并。插件只需返回自己的局部补丁，
+不需要调用 `this.parent`，也不需要手动合并 Halo 已有说明：
+
+```ts
+import { ExtensionCodeBlock } from "@halo-dev/richtext-editor";
+
+export const HighlightedCodeBlock = ExtensionCodeBlock.extend({
+  addAttributes() {
+    return {
+      ...this.parent?.(),
+      highlightTheme: {
+        default: null,
+      },
+    };
+  },
+
+  addHaloEditorMetadata() {
+    return {
+      ai: {
+        attributeGuidance: {
+          highlightTheme: {
+            description: "Syntax-highlighting theme.",
+            allowedValues: ["github-light", "github-dark"],
+            omitWhen: ["The editor default theme should be used."],
+          },
+        },
+      },
+    };
+  },
+});
+```
+
+最终 Manifest 会同时包含原 code block 的描述和 `highlightTheme`。
+
+## 为全局属性贡献说明
+
+Plain Extension 不会成为 Manifest 组件，但可向明确命名的 Node 或 Mark
+贡献元数据。这适合 `addGlobalAttributes()`：
+
+```ts
+import { Extension } from "@halo-dev/richtext-editor";
+
+export const Tone = Extension.create({
+  name: "tone",
+
+  addGlobalAttributes() {
+    return [
+      {
+        types: ["paragraph", "heading"],
+        attributes: {
+          tone: {
+            default: null,
+          },
+        },
+      },
+    ];
+  },
+
+  addHaloEditorMetadata() {
+    return {
+      contributions: [
+        {
+          targets: [
+            { kind: "node", name: "paragraph" },
+            { kind: "node", name: "heading" },
+          ],
+          metadata: {
+            ai: {
+              attributeGuidance: {
+                tone: {
+                  description: "Writing tone for this block.",
+                  allowedValues: ["neutral", "friendly", "formal"],
+                },
+              },
+            },
+          },
+        },
+      ],
+    };
+  },
+});
+```
+
+贡献只应用于最终 schema 中存在的目标。多个贡献冲突时，根据组件定义中的 priority 决定，
+较高者优先；priority 相同时，后注册者优先。
+
+## 组件自身的结构说明
+
+组件只声明自己的父级和数量关系，不跨组件声明子节点：
+
+```ts
+addHaloEditorMetadata() {
+  return {
+    ai: {
+      description: "An optional caption belonging to a figure.",
+    },
+    structure: {
+      allowedParents: ["figure"],
+      minPerParent: 0,
+      maxPerParent: 1,
+    },
+  };
+}
+```
+
+这表示当前组件只能位于 `figure` 下，在每个 `figure` 中可省略且最多出现一次。
+
+## 禁用与兼容
+
+- `ai: false` 明确建议 AI 不主动使用该组件，但组件的 schema 信息仍会出现在
+  Manifest 中供 AI 理解。
+- 声明抛错、字段无效、属性或父节点不存在时，生成器保留其他有效数据；
+  开发环境给出警告，生产环境不会因元数据阻止编辑器运行。
+- 未知字段会被丢弃。请勿把 system prompt、可执行回调或敏感信息放入元数据。
+
+每段文本最多 1,000 个字符；说明数组和 aliases 最多 10 项；
+`allowedValues` 和属性示例最多 32 项；组件 HTML 示例最多 3 个且每个不超过
+4 KiB；单组件 AI 元数据最多 16 KiB；单个 Manifest 的 AI 元数据最多
+128 KiB。
+
+## 生成 Manifest
+
+在 Editor 创建完成后同步生成最终快照：
+
+```ts
+import {
+  createHaloEditorManifest,
+  type HaloEditorManifest,
+  type VueEditor,
+} from "@halo-dev/richtext-editor";
+
+function editorManifest(editor: VueEditor): HaloEditorManifest {
+  return createHaloEditorManifest(editor);
+}
+```
+
+Manifest 包含编辑器中全部的 Node 和 Mark、规范化元数据、`version: 1`
+以及稳定的 `signature`。AI 插件自行决定怎样把它加入模型上下文，以及是否根据
+其中的建议进行额外校验。

--- a/ui/packages/editor/docs/runtime-metadata.md
+++ b/ui/packages/editor/docs/runtime-metadata.md
@@ -1,7 +1,9 @@
-# 编辑器扩展的 AI 元数据
+# 编辑器扩展的运行期元数据
 
 `@halo-dev/richtext-editor` 允许 Tiptap 的 Node、Mark 和 Extension
-声明供 AI 消费的组件说明。元数据只描述最终编辑器中已有组件的用法，不会对组件功能有任何影响。
+声明运行期组件元数据，用于描述最终 Editor 实例中的 schema、组件用法、结构关系、
+属性和示例。这些信息从 Editor 当前注册的扩展及最终 schema 中同步解析；AI Agent
+是目前的主要消费者，但元数据本身是对运行期组件能力的描述，不会改变或约束组件行为。
 
 ## 声明新组件
 
@@ -31,7 +33,7 @@ export const MathBlock = Node.create({
     return ["div", { ...HTMLAttributes, "data-type": "math-block" }];
   },
 
-  // 添加供 AI 理解能力的 元数据
+  // 声明运行期元数据中的 AI 使用说明
   addHaloEditorMetadata() {
     return {
       ai: {
@@ -182,7 +184,7 @@ addHaloEditorMetadata() {
 4 KiB；单组件 AI 元数据最多 16 KiB；单个 Manifest 的 AI 元数据最多
 128 KiB。
 
-## 生成 Manifest
+## 读取运行期 Manifest
 
 在 Editor 创建完成后同步生成最终快照：
 
@@ -198,6 +200,6 @@ function editorManifest(editor: VueEditor): HaloEditorManifest {
 }
 ```
 
-Manifest 包含编辑器中全部的 Node 和 Mark、规范化元数据、`version: 1`
-以及稳定的 `signature`。AI 插件自行决定怎样把它加入模型上下文，以及是否根据
-其中的建议进行额外校验。
+Manifest 是当前 Editor 实例的运行期快照，包含全部 Node 和 Mark、规范化元数据、
+`version: 1` 以及稳定的 `signature`。AI 插件可以把它加入模型上下文，其他消费者
+也可以用它了解当前编辑器实际注册的组件；消费者自行决定是否根据其中的建议进行额外校验。

--- a/ui/packages/editor/src/editor-metadata/index.ts
+++ b/ui/packages/editor/src/editor-metadata/index.ts
@@ -1,0 +1,2 @@
+export * from "./manifest";
+export * from "./types";

--- a/ui/packages/editor/src/editor-metadata/manifest.spec.ts
+++ b/ui/packages/editor/src/editor-metadata/manifest.spec.ts
@@ -1,0 +1,646 @@
+// @vitest-environment jsdom
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { ExtensionsKit } from "@/extensions";
+import { Editor, Extension, Node, type Extensions } from "@/tiptap";
+import { createHaloEditorManifest } from "./manifest";
+
+const Document = Node.create({
+  name: "doc",
+  topNode: true,
+  content: "block+",
+  addHaloEditorMetadata() {
+    return { ai: false };
+  },
+});
+
+const Text = Node.create({
+  name: "text",
+  group: "inline",
+  addHaloEditorMetadata() {
+    return {
+      ai: {
+        description: "Text",
+      },
+    };
+  },
+});
+
+function createEditor(extensions: Extensions) {
+  return new Editor({
+    element: null,
+    extensions,
+  });
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("createHaloEditorManifest", () => {
+  it("uses the final configured schema and includes nested components", () => {
+    const Nested = Node.create({
+      name: "nested",
+      group: "block",
+      content: "text*",
+      addAttributes() {
+        return {
+          tone: {
+            default: this.options.tone,
+          },
+        };
+      },
+      addOptions() {
+        return {
+          tone: "neutral",
+        };
+      },
+      addHaloEditorMetadata() {
+        return {
+          ai: {
+            description: `Nested ${this.options.tone}`,
+            attributeGuidance: {
+              tone: "Configured tone",
+            },
+          },
+        };
+      },
+    });
+    const Bundle = Extension.create({
+      name: "bundle",
+      addExtensions() {
+        return [Nested.configure({ tone: "warm" })];
+      },
+    });
+    const editor = createEditor([Document, Text, Bundle]);
+
+    const manifest = createHaloEditorManifest(editor);
+    const nested = manifest.components.find(
+      (component) => component.name === "nested"
+    );
+
+    expect(manifest.components.map(({ name }) => name)).toEqual([
+      "doc",
+      "nested",
+      "text",
+    ]);
+    expect(nested?.attributes).toContainEqual({
+      name: "tone",
+      required: false,
+      defaultValue: "warm",
+    });
+    expect(nested?.ai).toMatchObject({
+      description: "Nested warm",
+      exposure: "available",
+      attributeGuidance: {
+        tone: {
+          description: "Configured tone",
+        },
+      },
+    });
+    editor.destroy();
+  });
+
+  it("composes parent hooks once and lets child arrays replace parent arrays", () => {
+    const Base = Node.create({
+      name: "paragraph",
+      group: "block",
+      content: "text*",
+      addHaloEditorMetadata() {
+        return {
+          ai: {
+            description: "Base paragraph",
+            aliases: ["base"],
+            useWhen: ["Base use"],
+          },
+        };
+      },
+    });
+    const Child = Base.extend({
+      addHaloEditorMetadata() {
+        return {
+          ai: {
+            description: "Child paragraph",
+            aliases: ["child"],
+          },
+        };
+      },
+    }).configure({});
+    const editor = createEditor([Document, Text, Child]);
+
+    const paragraph = createHaloEditorManifest(editor).components.find(
+      (component) => component.name === "paragraph"
+    );
+
+    expect(paragraph?.ai).toMatchObject({
+      description: "Child paragraph",
+      aliases: ["child"],
+      useWhen: ["Base use"],
+    });
+    editor.destroy();
+  });
+
+  it("merges directed contributions by priority and registration order", () => {
+    const Paragraph = Node.create({
+      name: "paragraph",
+      group: "block",
+      content: "text*",
+      addHaloEditorMetadata() {
+        return {
+          ai: {
+            description: "Paragraph",
+            attributeGuidance: {
+              tone: "Original tone",
+            },
+          },
+        };
+      },
+      addAttributes() {
+        return {
+          tone: {
+            default: null,
+          },
+        };
+      },
+    });
+    const contribution = (
+      name: string,
+      priority: number,
+      description: string
+    ) =>
+      Extension.create({
+        name,
+        priority,
+        addHaloEditorMetadata() {
+          return {
+            contributions: [
+              {
+                targets: [{ kind: "node", name: "paragraph" }],
+                metadata: {
+                  ai: {
+                    attributeGuidance: {
+                      tone: description,
+                    },
+                  },
+                },
+              },
+            ],
+          };
+        },
+      });
+    const editor = createEditor([
+      Document,
+      Text,
+      Paragraph,
+      contribution("high-first", 200, "High first"),
+      contribution("low", 50, "Low"),
+      contribution("high-last", 200, "High last"),
+    ]);
+
+    const paragraph = createHaloEditorManifest(editor).components.find(
+      (component) => component.name === "paragraph"
+    );
+
+    expect(
+      paragraph?.ai && paragraph.ai.attributeGuidance?.tone.description
+    ).toBe("High last");
+    editor.destroy();
+  });
+
+  it("keeps only the extension that defines the final duplicate identity", () => {
+    vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    const first = Node.create({
+      name: "paragraph",
+      group: "block",
+      content: "text*",
+      addHaloEditorMetadata() {
+        return { ai: { description: "First" } };
+      },
+    });
+    const second = first.extend({
+      addHaloEditorMetadata() {
+        return { ai: { description: "Second" } };
+      },
+    });
+    const editor = createEditor([Document, Text, first, second]);
+
+    const paragraph = createHaloEditorManifest(editor).components.find(
+      (component) => component.name === "paragraph"
+    );
+
+    expect(paragraph?.ai).toMatchObject({ description: "Second" });
+    editor.destroy();
+  });
+
+  it("fails soft and drops unknown, invalid, and oversized metadata", () => {
+    vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    const Invalid = Node.create({
+      name: "invalid",
+      group: "block",
+      content: "text*",
+      addAttributes() {
+        return {
+          valid: {
+            default: null,
+          },
+        };
+      },
+      parseHTML() {
+        return [
+          {
+            tag: "invalid-example",
+            getAttrs() {
+              throw new Error("cannot parse example");
+            },
+          },
+        ];
+      },
+      renderHTML() {
+        return ["invalid-example", 0];
+      },
+      addHaloEditorMetadata() {
+        return {
+          ai: {
+            description: "Valid description",
+            aliases: Array.from({ length: 12 }, (_, index) => `alias-${index}`),
+            attributeGuidance: {
+              valid: {
+                description: "Valid attribute",
+                allowedValues: Array.from({ length: 40 }, (_, index) => index),
+              },
+              missing: "Missing attribute",
+            },
+            generation: {
+              mode: "requires-capability",
+            },
+            examples: [
+              "<invalid-example>Example</invalid-example>",
+              "x".repeat(4097),
+            ],
+            systemPrompt: "ignored",
+          },
+          structure: {
+            allowedParents: ["missing-parent"],
+          },
+          unknown: true,
+        } as never;
+      },
+    });
+    const Throwing = Node.create({
+      name: "throwing",
+      group: "block",
+      content: "text*",
+      addHaloEditorMetadata() {
+        throw new Error("metadata failure");
+      },
+    });
+    const editor = createEditor([Document, Text, Invalid, Throwing]);
+
+    const manifest = createHaloEditorManifest(editor);
+    const invalid = manifest.components.find(
+      (component) => component.name === "invalid"
+    );
+    const throwing = manifest.components.find(
+      (component) => component.name === "throwing"
+    );
+
+    expect(invalid?.ai).toMatchObject({
+      description: "Valid description",
+      aliases: Array.from({ length: 10 }, (_, index) => `alias-${index}`),
+      attributeGuidance: {
+        valid: {
+          description: "Valid attribute",
+          allowedValues: Array.from({ length: 32 }, (_, index) => index),
+        },
+      },
+      examples: [],
+    });
+    expect(invalid).not.toHaveProperty("structure");
+    expect(invalid?.ai).not.toHaveProperty("systemPrompt");
+    expect(invalid?.ai).not.toHaveProperty("generation");
+    expect(throwing).not.toHaveProperty("ai");
+    editor.destroy();
+  });
+
+  it("normalizes figureCaption structure and produces stable signatures", () => {
+    const Figure = Node.create({
+      name: "figure",
+      group: "block",
+      content: "figureCaption?",
+      addHaloEditorMetadata() {
+        return {
+          ai: {
+            description: "Figure",
+          },
+        };
+      },
+    });
+    const FigureCaption = Node.create({
+      name: "figureCaption",
+      group: "block",
+      content: "text*",
+      addHaloEditorMetadata() {
+        return {
+          ai: {
+            description: "Figure caption",
+          },
+          structure: {
+            allowedParents: ["figure"],
+            minPerParent: 0,
+            maxPerParent: 1,
+          },
+        };
+      },
+    });
+    const editor = createEditor([Document, Text, Figure, FigureCaption]);
+
+    const first = createHaloEditorManifest(editor);
+    const second = createHaloEditorManifest(editor);
+    const caption = first.components.find(
+      (component) => component.name === "figureCaption"
+    );
+
+    expect(first.signature).toBe(second.signature);
+    expect(caption?.structure).toEqual({
+      allowedParents: ["figure"],
+      minPerParent: 0,
+      maxPerParent: 1,
+    });
+    editor.destroy();
+  });
+
+  it("changes the signature only when normalized schema or metadata changes", () => {
+    const paragraph = (description: string) =>
+      Node.create({
+        name: "paragraph",
+        group: "block",
+        content: "text*",
+        addHaloEditorMetadata() {
+          return {
+            ai: {
+              description,
+            },
+          };
+        },
+      });
+    const UnrelatedOne = Extension.create({ name: "unrelated-one" });
+    const UnrelatedTwo = Extension.create({ name: "unrelated-two" });
+    const firstEditor = createEditor([
+      Document,
+      Text,
+      paragraph("Paragraph"),
+      UnrelatedOne,
+      UnrelatedTwo,
+    ]);
+    const reorderedEditor = createEditor([
+      Document,
+      Text,
+      paragraph("Paragraph"),
+      UnrelatedTwo,
+      UnrelatedOne,
+    ]);
+    const changedEditor = createEditor([
+      Document,
+      Text,
+      paragraph("Changed paragraph"),
+    ]);
+
+    const first = createHaloEditorManifest(firstEditor);
+    const reordered = createHaloEditorManifest(reorderedEditor);
+    const changed = createHaloEditorManifest(changedEditor);
+
+    expect(first).toEqual(reordered);
+    expect(changed.signature).not.toBe(first.signature);
+    firstEditor.destroy();
+    reorderedEditor.destroy();
+    changedEditor.destroy();
+  });
+
+  it("keeps schema components when component or Manifest AI limits are exceeded", () => {
+    vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    const oversizedComponent = Node.create({
+      name: "oversized",
+      group: "block",
+      content: "text*",
+      addHaloEditorMetadata() {
+        return {
+          ai: {
+            description: "Oversized component",
+            useWhen: Array.from({ length: 10 }, () => "u".repeat(1000)),
+            avoidWhen: Array.from({ length: 10 }, () => "a".repeat(1000)),
+          },
+        };
+      },
+    });
+    const bulkComponents = Array.from({ length: 14 }, (_, index) =>
+      Node.create({
+        name: `bulk-${index}`,
+        group: "block",
+        content: "text*",
+        addHaloEditorMetadata() {
+          return {
+            ai: {
+              description: `Bulk ${index}`,
+              contentGuidelines: Array.from({ length: 10 }, () =>
+                "g".repeat(950)
+              ),
+            },
+          };
+        },
+      })
+    );
+    const editor = createEditor([
+      Document,
+      Text,
+      oversizedComponent,
+      ...bulkComponents,
+    ]);
+
+    const manifest = createHaloEditorManifest(editor);
+    const oversized = manifest.components.find(
+      (component) => component.name === "oversized"
+    );
+    const bulk = manifest.components.filter(({ name }) =>
+      name.startsWith("bulk-")
+    );
+
+    expect(oversized).toBeDefined();
+    expect(oversized).not.toHaveProperty("ai");
+    expect(bulk).toHaveLength(14);
+    expect(bulk.some((component) => component.ai === undefined)).toBe(true);
+    editor.destroy();
+  });
+
+  it("gives every default schema component an explicit AI declaration", () => {
+    const warning = vi
+      .spyOn(console, "warn")
+      .mockImplementation(() => undefined);
+    const editor = createEditor([ExtensionsKit]);
+
+    const manifest = createHaloEditorManifest(editor);
+    const missing = manifest.components
+      .filter((component) => component.ai === undefined)
+      .map(({ kind, name }) => `${kind}:${name}`);
+
+    expect(missing).toEqual([]);
+    expect(
+      warning.mock.calls.filter(([message]) =>
+        String(message).startsWith("[halo-editor-metadata]")
+      )
+    ).toEqual([]);
+    editor.destroy();
+  });
+
+  it("keeps every active default component useful and covers representative variants", () => {
+    vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    const editor = createEditor([ExtensionsKit]);
+    const manifest = createHaloEditorManifest(editor);
+
+    for (const component of manifest.components) {
+      if (component.ai === false) {
+        continue;
+      }
+      expect(component.ai, `${component.kind}:${component.name}`).toBeDefined();
+      if (!component.ai) {
+        continue;
+      }
+      expect(
+        component.ai.useWhen?.length,
+        `${component.kind}:${component.name} useWhen`
+      ).toBeGreaterThan(0);
+      expect(
+        component.ai.generation,
+        `${component.kind}:${component.name} generation`
+      ).toBeDefined();
+      expect(
+        component.ai.examples?.length,
+        `${component.kind}:${component.name} examples`
+      ).toBeGreaterThan(0);
+      expect(
+        Object.keys(component.ai.attributeGuidance ?? {}).sort(),
+        `${component.kind}:${component.name} attributeGuidance`
+      ).toEqual(component.attributes.map(({ name }) => name).sort());
+    }
+
+    const examples = (name: string) => {
+      const component = manifest.components.find(
+        (component) => component.name === name
+      );
+      if (!component?.ai) {
+        throw new Error(`Missing AI metadata for ${name}`);
+      }
+      return component.ai.examples?.join("\n") ?? "";
+    };
+
+    expect(examples("figure")).toContain("<img");
+    expect(examples("figure")).toContain("<video");
+    expect(examples("figure")).toContain("<audio");
+    expect(examples("codeBlock")).toContain("theme=");
+    expect(examples("codeBlock")).toContain("collapsed=");
+    expect(examples("columns")).toContain('cols="2"');
+    expect(examples("columns")).toContain('cols="3"');
+    expect(examples("details")).toContain("<details>");
+    expect(examples("details")).toContain("<details open>");
+    expect(examples("gallery")).toContain('data-layout="auto"');
+    expect(examples("gallery")).toContain('data-layout="square"');
+    expect(examples("heading")).toContain("<h1");
+    expect(examples("heading")).toContain("<h2");
+    expect(examples("heading")).toContain("<h3");
+    expect(examples("link")).toContain('target="_blank"');
+    expect(examples("link")).toContain('title="External report"');
+    expect(examples("listItem")).toContain("<ul>");
+    expect(examples("listItem")).toContain("<ol>");
+    expect(examples("listItem")).toContain("<blockquote>");
+    expect(examples("orderedList")).toContain('start="3"');
+    expect(examples("orderedList")).toContain('type="I"');
+    expect(examples("taskItem")).toContain('data-checked="true"');
+    expect(examples("taskItem")).toContain('data-checked="false"');
+    expect(examples("table")).toContain("colspan=");
+    expect(examples("table")).toContain("rowspan=");
+    expect(examples("highlight")).toContain("<mark>");
+    expect(examples("highlight")).toContain("data-color=");
+    expect(examples("textStyle")).toContain("background-color:");
+    expect(examples("textStyle")).toContain("font-family:");
+    expect(examples("textStyle")).toContain("line-height:");
+    expect(examples("audio")).toContain("loop");
+    expect(examples("video")).toContain('height="360px"');
+    expect(examples("image")).toContain('width="640px"');
+
+    editor.destroy();
+  });
+
+  it("keeps built-in guidance aligned with editor-managed and normalized behavior", () => {
+    vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    const editor = createEditor([ExtensionsKit]);
+    const manifest = createHaloEditorManifest(editor);
+    const component = (name: string) => {
+      const value = manifest.components.find(
+        (component) => component.name === name
+      );
+      const ai = value?.ai;
+      if (!value || !ai) {
+        throw new Error(`Missing AI metadata for ${name}`);
+      }
+      return { component: value, ai };
+    };
+
+    expect(
+      component("figure").ai.attributeGuidance?.alignItems.description
+    ).toBe("Cross-axis alignment of this container's child content.");
+    expect(component("heading").ai.attributeGuidance?.id.omitWhen).toContain(
+      "Generating or editing article content; the editor maintains this value."
+    );
+    expect(
+      component("figureCaption").ai.attributeGuidance?.width.omitWhen
+    ).toContain(
+      "Generating or editing article content; the editor maintains this value."
+    );
+
+    const iframe = component("iframe");
+    expect(iframe.component.kind).toBe("node");
+    expect(iframe.component.kind === "node" && iframe.component.inline).toBe(
+      true
+    );
+    expect(iframe.ai.description).toContain("inline iframe");
+    expect(iframe.ai.examples?.[0]).toContain("<p><iframe");
+
+    for (const name of ["image", "video"]) {
+      const media = component(name);
+      expect(media.ai.description).toContain(
+        "normally used as the media child of a figure"
+      );
+      expect(
+        media.ai.examples?.every((example) => example.startsWith("<figure"))
+      ).toBe(true);
+    }
+
+    editor.destroy();
+  });
+
+  it("round-trips distinguishing columns attributes from serialized HTML", () => {
+    vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    const editor = createEditor([ExtensionsKit]);
+
+    editor.commands.setContent(
+      '<div class="columns" cols="3" style="display: flex; gap: 2em;"><div class="column" index="0"><p>First</p></div><div class="column" index="1"><p>Second</p></div><div class="column" index="2"><p>Third</p></div></div>'
+    );
+
+    const columns = editor.state.doc.firstChild;
+    expect(columns?.type.name).toBe("columns");
+    expect(columns?.attrs.cols).toBe(3);
+    expect(columns?.attrs.style).toContain("gap: 2em");
+    expect(
+      columns?.content.content.map((column) => column.attrs.index)
+    ).toEqual([0, 1, 2]);
+
+    const manifestColumns = createHaloEditorManifest(editor).components.find(
+      (component) => component.name === "columns"
+    );
+    expect(manifestColumns?.htmlParseRules).toContainEqual({
+      tag: "div.columns",
+    });
+    expect(editor.getHTML()).toContain('cols="3"');
+
+    editor.destroy();
+  });
+});

--- a/ui/packages/editor/src/editor-metadata/manifest.ts
+++ b/ui/packages/editor/src/editor-metadata/manifest.ts
@@ -1,4 +1,3 @@
-import { utf8ByteLength } from "@halo-dev/ui-shared";
 import type { AnyExtension, Editor } from "@tiptap/core";
 import {
   DOMParser as ProseMirrorDOMParser,
@@ -35,6 +34,11 @@ const MAX_HTML_EXAMPLES = 3;
 const MAX_HTML_EXAMPLE_BYTES = 4 * 1024;
 const MAX_COMPONENT_AI_BYTES = 16 * 1024;
 const MAX_MANIFEST_AI_BYTES = 128 * 1024;
+const textEncoder = new TextEncoder();
+
+function utf8ByteLength(value: string) {
+  return textEncoder.encode(value).byteLength;
+}
 
 interface ResolvedDeclaration {
   self: HaloEditorComponentMetadataPatch;

--- a/ui/packages/editor/src/editor-metadata/manifest.ts
+++ b/ui/packages/editor/src/editor-metadata/manifest.ts
@@ -1,0 +1,942 @@
+import { utf8ByteLength } from "@halo-dev/ui-shared";
+import type { AnyExtension, Editor } from "@tiptap/core";
+import {
+  DOMParser as ProseMirrorDOMParser,
+  DOMSerializer,
+  Fragment,
+  type MarkType,
+  type NodeType,
+  type Schema,
+} from "@tiptap/pm/model";
+import { isPlainObject, mergeWith, sortBy, uniqBy } from "es-toolkit";
+import objectHash from "object-hash";
+import type {
+  HaloEditorAIAttributeGuidance,
+  HaloEditorAIAttributeGuidanceDeclaration,
+  HaloEditorAIGeneration,
+  HaloEditorAIMetadata,
+  HaloEditorAIMetadataPatch,
+  HaloEditorAIAttributeValue,
+  HaloEditorComponent,
+  HaloEditorComponentMetadataPatch,
+  HaloEditorHTMLParseRule,
+  HaloEditorManifest,
+  HaloEditorMetadataContribution,
+  HaloEditorStructureMetadata,
+  HaloEditorStructureMetadataPatch,
+} from "./types";
+
+const DEFAULT_PRIORITY = 100;
+const MAX_TEXT_LENGTH = 1_000;
+const MAX_GUIDANCE_ITEMS = 10;
+const MAX_ALIAS_LENGTH = 100;
+const MAX_ATTRIBUTE_VALUES = 32;
+const MAX_HTML_EXAMPLES = 3;
+const MAX_HTML_EXAMPLE_BYTES = 4 * 1024;
+const MAX_COMPONENT_AI_BYTES = 16 * 1024;
+const MAX_MANIFEST_AI_BYTES = 128 * 1024;
+
+interface ResolvedDeclaration {
+  self: HaloEditorComponentMetadataPatch;
+  contributions: HaloEditorMetadataContribution[];
+}
+
+interface ContributionEntry {
+  contribution: HaloEditorMetadataContribution;
+  priority: number;
+  registrationIndex: number;
+  sequence: number;
+}
+
+type MetadataExtension = AnyExtension & {
+  parent: MetadataExtension | null;
+  config: AnyExtension["config"] & {
+    addHaloEditorMetadata?: (this: Record<string, unknown>) => unknown;
+  };
+};
+
+export function createHaloEditorManifest(editor: Editor): HaloEditorManifest {
+  const extensions = editor.extensionManager.extensions;
+  const declarationCache = new Map<AnyExtension, ResolvedDeclaration>();
+  const finalExtensions = finalComponentExtensions(extensions, editor.schema);
+  const metadata = new Map<string, HaloEditorComponentMetadataPatch>();
+
+  for (const [key, extension] of finalExtensions) {
+    metadata.set(
+      key,
+      resolveDeclaration(extension, editor, declarationCache).self
+    );
+  }
+
+  const contributions = extensions
+    .flatMap((extension, registrationIndex) => {
+      const resolved = resolveDeclaration(extension, editor, declarationCache);
+      return resolved.contributions.map(
+        (contribution, sequence): ContributionEntry => ({
+          contribution,
+          priority: extensionPriority(extension),
+          registrationIndex,
+          sequence,
+        })
+      );
+    })
+    .sort(
+      (left, right) =>
+        left.priority - right.priority ||
+        left.registrationIndex - right.registrationIndex ||
+        left.sequence - right.sequence
+    );
+
+  for (const { contribution } of contributions) {
+    for (const target of contribution.targets) {
+      const key = componentKey(target.kind, target.name);
+      if (!componentExists(editor.schema, target.kind, target.name)) {
+        warn(
+          `Ignored metadata contribution for missing ${target.kind} "${target.name}".`
+        );
+        continue;
+      }
+      metadata.set(
+        key,
+        mergeMetadataPatch(metadata.get(key) ?? {}, contribution.metadata)
+      );
+    }
+  }
+
+  const components = sortBy(
+    [
+      ...Object.entries(editor.schema.nodes).map(([name, type]) =>
+        nodeComponent(editor, type, metadata.get(componentKey("node", name)))
+      ),
+      ...Object.entries(editor.schema.marks).map(([name, type]) =>
+        markComponent(editor, type, metadata.get(componentKey("mark", name)))
+      ),
+    ],
+    ["kind", "name"]
+  );
+
+  enforceManifestMetadataLimit(components);
+
+  const unsigned = {
+    version: 1 as const,
+    components,
+  };
+
+  return {
+    ...unsigned,
+    signature: objectHash(unsigned, {
+      unorderedArrays: false,
+      unorderedObjects: true,
+      unorderedSets: false,
+    }),
+  };
+}
+
+function finalComponentExtensions(extensions: AnyExtension[], schema: Schema) {
+  const result = new Map<string, AnyExtension>();
+  for (const extension of extensions) {
+    if (extension.type !== "node" && extension.type !== "mark") {
+      continue;
+    }
+    if (!componentExists(schema, extension.type, extension.name)) {
+      continue;
+    }
+    result.set(componentKey(extension.type, extension.name), extension);
+  }
+  return result;
+}
+
+function resolveDeclaration(
+  extension: AnyExtension,
+  editor: Editor,
+  cache: Map<AnyExtension, ResolvedDeclaration>
+): ResolvedDeclaration {
+  const cached = cache.get(extension);
+  if (cached) {
+    return cached;
+  }
+
+  let self: HaloEditorComponentMetadataPatch = {};
+  const contributions: HaloEditorMetadataContribution[] = [];
+  let previousHook: unknown;
+
+  for (const current of extensionChain(extension)) {
+    const hook = current.config.addHaloEditorMetadata;
+    if (typeof hook !== "function" || hook === previousHook) {
+      previousHook = hook;
+      continue;
+    }
+    previousHook = hook;
+    try {
+      const declaration = sanitizeDeclaration(
+        hook.call(metadataContext(extension, editor)),
+        extension.name
+      );
+      self = mergeMetadataPatch(self, declaration.self);
+      contributions.push(...declaration.contributions);
+    } catch (error) {
+      warn(
+        `Ignored metadata hook from extension "${extension.name}" because it threw.`,
+        error
+      );
+    }
+  }
+
+  const resolved = { self, contributions };
+  cache.set(extension, resolved);
+  return resolved;
+}
+
+function extensionChain(extension: AnyExtension) {
+  const chain: MetadataExtension[] = [];
+  let current: MetadataExtension | null = extension as MetadataExtension;
+  while (current) {
+    chain.unshift(current);
+    current = current.parent;
+  }
+  return chain;
+}
+
+function metadataContext(extension: AnyExtension, editor: Editor) {
+  const type =
+    extension.type === "node"
+      ? editor.schema.nodes[extension.name]
+      : extension.type === "mark"
+        ? editor.schema.marks[extension.name]
+        : null;
+  return {
+    name: extension.name,
+    options: extension.options,
+    storage:
+      (editor.extensionStorage as unknown as Record<string, unknown>)[
+        extension.name
+      ] ?? extension.storage,
+    editor,
+    type,
+  };
+}
+
+function sanitizeDeclaration(
+  value: unknown,
+  extensionName: string
+): ResolvedDeclaration {
+  if (!isPlainObject(value)) {
+    if (value !== undefined) {
+      warn(`Ignored non-object metadata from extension "${extensionName}".`);
+    }
+    return { self: {}, contributions: [] };
+  }
+
+  const contributions: HaloEditorMetadataContribution[] = [];
+  if (Array.isArray(value.contributions)) {
+    for (const candidate of value.contributions) {
+      const contribution = sanitizeContribution(candidate, extensionName);
+      if (contribution) {
+        contributions.push(contribution);
+      }
+    }
+  } else if (value.contributions !== undefined) {
+    warn(`Ignored non-array contributions from extension "${extensionName}".`);
+  }
+
+  return {
+    self: sanitizeMetadataPatch(value, extensionName),
+    contributions,
+  };
+}
+
+function sanitizeContribution(
+  value: unknown,
+  extensionName: string
+): HaloEditorMetadataContribution | undefined {
+  if (!isPlainObject(value) || !Array.isArray(value.targets)) {
+    warn(`Ignored invalid metadata contribution from "${extensionName}".`);
+    return undefined;
+  }
+
+  const targets: HaloEditorMetadataContribution["targets"] =
+    value.targets.flatMap((target) => {
+      if (
+        !isPlainObject(target) ||
+        (target.kind !== "node" && target.kind !== "mark") ||
+        !validName(target.name)
+      ) {
+        return [];
+      }
+      return [{ kind: target.kind, name: target.name }];
+    });
+
+  if (!targets.length || !isPlainObject(value.metadata)) {
+    warn(`Ignored incomplete metadata contribution from "${extensionName}".`);
+    return undefined;
+  }
+
+  return {
+    targets: uniqueTargets(targets),
+    metadata: sanitizeMetadataPatch(value.metadata, extensionName),
+  };
+}
+
+function sanitizeMetadataPatch(
+  value: Record<string, unknown>,
+  source: string
+): HaloEditorComponentMetadataPatch {
+  const result: HaloEditorComponentMetadataPatch = {};
+  if (value.ai === false) {
+    result.ai = false;
+  } else if (isPlainObject(value.ai)) {
+    result.ai = sanitizeAIPatch(value.ai, source);
+  } else if (value.ai !== undefined) {
+    warn(`Ignored invalid AI metadata from "${source}".`);
+  }
+
+  if (isPlainObject(value.structure)) {
+    result.structure = sanitizeStructurePatch(value.structure, source);
+  } else if (value.structure !== undefined) {
+    warn(`Ignored invalid structure metadata from "${source}".`);
+  }
+  return result;
+}
+
+function sanitizeAIPatch(
+  value: Record<string, unknown>,
+  source: string
+): HaloEditorAIMetadataPatch {
+  const result: HaloEditorAIMetadataPatch = {};
+  assignText(result, "description", value.description, source);
+  assignStringArray(result, "aliases", value.aliases, source, {
+    itemLimit: MAX_ALIAS_LENGTH,
+  });
+  if (value.exposure === "recommended" || value.exposure === "available") {
+    result.exposure = value.exposure;
+  } else if (value.exposure !== undefined) {
+    warn(`Ignored invalid exposure from "${source}".`);
+  }
+  assignStringArray(result, "useWhen", value.useWhen, source);
+  assignStringArray(result, "avoidWhen", value.avoidWhen, source);
+  assignStringArray(
+    result,
+    "contentGuidelines",
+    value.contentGuidelines,
+    source
+  );
+
+  if (isPlainObject(value.attributeGuidance)) {
+    result.attributeGuidance = Object.fromEntries(
+      Object.entries(value.attributeGuidance).flatMap(([name, guidance]) => {
+        if (!validName(name)) {
+          return [];
+        }
+        const normalized = sanitizeAttributeGuidance(guidance, source);
+        return normalized ? [[name, normalized]] : [];
+      })
+    );
+  } else if (value.attributeGuidance !== undefined) {
+    warn(`Ignored invalid attribute guidance from "${source}".`);
+  }
+
+  if (isPlainObject(value.generation)) {
+    result.generation = sanitizeGenerationPatch(value.generation, source);
+  } else if (value.generation !== undefined) {
+    warn(`Ignored invalid generation metadata from "${source}".`);
+  }
+
+  if (Array.isArray(value.examples)) {
+    result.examples = sanitizeExamples(value.examples, source);
+  } else if (value.examples !== undefined) {
+    warn(`Ignored invalid HTML examples from "${source}".`);
+  }
+  return result;
+}
+
+function sanitizeAttributeGuidance(
+  value: unknown,
+  source: string
+): HaloEditorAIAttributeGuidanceDeclaration | undefined {
+  if (typeof value === "string") {
+    return validText(value, MAX_TEXT_LENGTH, source, "attribute description");
+  }
+  if (!isPlainObject(value)) {
+    warn(`Ignored invalid attribute guidance from "${source}".`);
+    return undefined;
+  }
+  const result: Partial<HaloEditorAIAttributeGuidance> = {};
+  assignText(result, "description", value.description, source);
+  assignText(result, "format", value.format, source);
+  assignAttributeValues(result, "allowedValues", value.allowedValues, source);
+  assignAttributeValues(result, "examples", value.examples, source);
+  assignStringArray(result, "useWhen", value.useWhen, source);
+  assignStringArray(result, "omitWhen", value.omitWhen, source);
+  assignStringArray(result, "guidelines", value.guidelines, source);
+  return result;
+}
+
+function sanitizeGenerationPatch(
+  value: Record<string, unknown>,
+  source: string
+): Partial<HaloEditorAIGeneration> {
+  const result: Partial<HaloEditorAIGeneration> = {};
+  if (
+    value.mode === "direct-html" ||
+    value.mode === "requires-capability" ||
+    value.mode === "read-only"
+  ) {
+    result.mode = value.mode;
+  } else if (value.mode !== undefined) {
+    warn(`Ignored invalid generation mode from "${source}".`);
+  }
+  assignStringArray(
+    result,
+    "requiredCapabilities",
+    value.requiredCapabilities,
+    source
+  );
+  assignStringArray(result, "guidelines", value.guidelines, source);
+  return result;
+}
+
+function sanitizeStructurePatch(
+  value: Record<string, unknown>,
+  source: string
+): HaloEditorStructureMetadataPatch {
+  const result: HaloEditorStructureMetadataPatch = {};
+  assignStringArray(result, "allowedParents", value.allowedParents, source);
+  if (value.minPerParent !== undefined) {
+    result.minPerParent = value.minPerParent as number;
+  }
+  if (value.maxPerParent !== undefined) {
+    result.maxPerParent = value.maxPerParent as number;
+  }
+  assignText(result, "description", value.description, source);
+  return result;
+}
+
+function mergeMetadataPatch(
+  base: HaloEditorComponentMetadataPatch,
+  patch: HaloEditorComponentMetadataPatch
+): HaloEditorComponentMetadataPatch {
+  return mergeWith(
+    mergeWith({}, base, replaceArrays),
+    patch,
+    replaceArrays
+  ) as HaloEditorComponentMetadataPatch;
+}
+
+function replaceArrays(targetValue: unknown, sourceValue: unknown) {
+  if (sourceValue === undefined) {
+    return targetValue;
+  }
+  return Array.isArray(sourceValue) ? [...sourceValue] : undefined;
+}
+
+function nodeComponent(
+  editor: Editor,
+  type: NodeType,
+  patch: HaloEditorComponentMetadataPatch | undefined
+): HaloEditorComponent {
+  const component: HaloEditorComponent = {
+    kind: "node",
+    name: type.name,
+    content: type.spec.content ?? "",
+    group: type.spec.group ?? "",
+    inline: type.isInline,
+    atom: type.isAtom,
+    leaf: type.isLeaf,
+    code: Boolean(type.spec.code),
+    whitespace: type.spec.whitespace ?? (type.spec.code ? "pre" : "normal"),
+    selectable: type.spec.selectable !== false,
+    draggable: Boolean(type.spec.draggable),
+    defining: Boolean(type.spec.defining),
+    isolating: Boolean(type.spec.isolating),
+    attributes: attributes(type.spec.attrs),
+    htmlParseRules: htmlParseRules(type.spec.parseDOM),
+  };
+  return applyMetadata(editor, component, patch, type);
+}
+
+function markComponent(
+  editor: Editor,
+  type: MarkType,
+  patch: HaloEditorComponentMetadataPatch | undefined
+): HaloEditorComponent {
+  const component: HaloEditorComponent = {
+    kind: "mark",
+    name: type.name,
+    excludes: type.spec.excludes ?? "",
+    inclusive: type.spec.inclusive !== false,
+    spanning: type.spec.spanning !== false,
+    attributes: attributes(type.spec.attrs),
+    htmlParseRules: htmlParseRules(type.spec.parseDOM),
+  };
+  return applyMetadata(editor, component, patch, type);
+}
+
+function applyMetadata(
+  editor: Editor,
+  component: HaloEditorComponent,
+  patch: HaloEditorComponentMetadataPatch | undefined,
+  type: NodeType | MarkType
+) {
+  if (!patch) {
+    return component;
+  }
+  const ai = normalizeAI(editor, component, patch.ai, type);
+  if (ai !== undefined) {
+    if (utf8ByteLength(JSON.stringify(ai)) <= MAX_COMPONENT_AI_BYTES) {
+      component.ai = ai;
+    } else {
+      warn(`Ignored oversized AI metadata for "${component.name}".`);
+    }
+  }
+  const structure = normalizeStructure(
+    editor.schema,
+    component.name,
+    patch.structure
+  );
+  if (structure) {
+    component.structure = structure;
+  }
+  return component;
+}
+
+function normalizeAI(
+  editor: Editor,
+  component: HaloEditorComponent,
+  patch: HaloEditorComponentMetadataPatch["ai"],
+  type: NodeType | MarkType
+): false | HaloEditorAIMetadata | undefined {
+  if (patch === false) {
+    return false;
+  }
+  const description =
+    patch &&
+    validText(
+      patch.description,
+      MAX_TEXT_LENGTH,
+      component.name,
+      "description"
+    );
+  if (!patch || !description) {
+    if (patch) {
+      warn(
+        `Ignored AI metadata without a description for "${component.name}".`
+      );
+    }
+    return undefined;
+  }
+
+  const result: HaloEditorAIMetadata = {
+    description,
+    exposure: patch.exposure ?? "available",
+  };
+  copyDefined(result, patch, [
+    "aliases",
+    "useWhen",
+    "avoidWhen",
+    "contentGuidelines",
+  ]);
+
+  const attributeNames = new Set(
+    component.attributes.map((attribute) => attribute.name)
+  );
+  if (patch.attributeGuidance) {
+    const guidance = Object.fromEntries(
+      Object.entries(patch.attributeGuidance).flatMap(([name, value]) => {
+        if (!attributeNames.has(name)) {
+          warn(
+            `Ignored guidance for missing attribute "${component.name}.${name}".`
+          );
+          return [];
+        }
+        const normalized = normalizeAttributeGuidance(value, component.name);
+        return normalized ? [[name, normalized]] : [];
+      })
+    );
+    if (Object.keys(guidance).length) {
+      result.attributeGuidance = guidance;
+    }
+  }
+
+  const generation = normalizeGeneration(patch.generation, component.name);
+  if (generation) {
+    result.generation = generation;
+  }
+
+  if (patch.examples !== undefined) {
+    result.examples = patch.examples.filter((example) =>
+      validHTMLExample(editor.schema, example, component.name)
+    );
+  } else {
+    const example = automaticExample(editor.schema, type);
+    if (example) {
+      result.examples = [example];
+    }
+  }
+  return result;
+}
+
+function normalizeAttributeGuidance(
+  value: HaloEditorAIAttributeGuidanceDeclaration,
+  source: string
+): HaloEditorAIAttributeGuidance | undefined {
+  const patch = typeof value === "string" ? { description: value } : value;
+  const description = validText(
+    patch.description,
+    MAX_TEXT_LENGTH,
+    source,
+    "attribute description"
+  );
+  if (!description) {
+    warn(`Ignored attribute guidance without a description for "${source}".`);
+    return undefined;
+  }
+  const result: HaloEditorAIAttributeGuidance = { description };
+  copyDefined(result, patch, [
+    "format",
+    "allowedValues",
+    "examples",
+    "useWhen",
+    "omitWhen",
+    "guidelines",
+  ]);
+  return result;
+}
+
+function normalizeGeneration(
+  patch: Partial<HaloEditorAIGeneration> | undefined,
+  source: string
+): HaloEditorAIGeneration | undefined {
+  if (!patch?.mode) {
+    if (patch) {
+      warn(`Ignored generation metadata without a mode for "${source}".`);
+    }
+    return undefined;
+  }
+  if (
+    patch.mode === "requires-capability" &&
+    !patch.requiredCapabilities?.length
+  ) {
+    warn(`Ignored generation metadata without capabilities for "${source}".`);
+    return undefined;
+  }
+  if (
+    patch.mode !== "requires-capability" &&
+    patch.requiredCapabilities !== undefined
+  ) {
+    warn(`Ignored inconsistent generation metadata for "${source}".`);
+    return undefined;
+  }
+  const result: HaloEditorAIGeneration = { mode: patch.mode };
+  copyDefined(result, patch, ["requiredCapabilities", "guidelines"]);
+  return result;
+}
+
+function normalizeStructure(
+  schema: Schema,
+  source: string,
+  patch: HaloEditorStructureMetadataPatch | undefined
+): HaloEditorStructureMetadata | undefined {
+  if (!patch) {
+    return undefined;
+  }
+  if (
+    !patch.allowedParents?.length ||
+    patch.allowedParents.some((parent) => !schema.nodes[parent]) ||
+    !validCount(patch.minPerParent) ||
+    !validCount(patch.maxPerParent) ||
+    (patch.minPerParent !== undefined &&
+      patch.maxPerParent !== undefined &&
+      patch.minPerParent > patch.maxPerParent)
+  ) {
+    warn(`Ignored invalid structure metadata for "${source}".`);
+    return undefined;
+  }
+  return {
+    allowedParents: [...patch.allowedParents],
+    ...(patch.minPerParent === undefined
+      ? {}
+      : { minPerParent: patch.minPerParent }),
+    ...(patch.maxPerParent === undefined
+      ? {}
+      : { maxPerParent: patch.maxPerParent }),
+    ...(patch.description === undefined
+      ? {}
+      : { description: patch.description }),
+  };
+}
+
+function attributes(specs: NodeType["spec"]["attrs"]) {
+  return Object.entries(specs ?? {})
+    .map(([name, spec]) => {
+      const required = !("default" in spec);
+      const defaultValue = required ? undefined : jsonValue(spec.default);
+      return {
+        name,
+        required,
+        ...(defaultValue === undefined ? {} : { defaultValue }),
+      };
+    })
+    .sort((left, right) => left.name.localeCompare(right.name));
+}
+
+function htmlParseRules(rules: readonly unknown[] | undefined) {
+  return (rules ?? []).flatMap((rule): HaloEditorHTMLParseRule[] => {
+    if (!isPlainObject(rule)) {
+      return [];
+    }
+    const result: HaloEditorHTMLParseRule = {};
+    if (typeof rule.tag === "string") {
+      result.tag = rule.tag;
+    }
+    if (typeof rule.style === "string") {
+      result.style = rule.style;
+    }
+    if (typeof rule.priority === "number" && Number.isFinite(rule.priority)) {
+      result.priority = rule.priority;
+    }
+    return Object.keys(result).length ? [result] : [];
+  });
+}
+
+function validHTMLExample(schema: Schema, html: string, source: string) {
+  if (typeof document === "undefined") {
+    warn(`Ignored HTML example without a DOM for "${source}".`);
+    return false;
+  }
+  try {
+    const container = document.createElement("div");
+    container.innerHTML = html;
+    ProseMirrorDOMParser.fromSchema(schema).parseSlice(container);
+    return true;
+  } catch (error) {
+    warn(`Ignored unparseable HTML example for "${source}".`, error);
+    return false;
+  }
+}
+
+function automaticExample(schema: Schema, type: NodeType | MarkType) {
+  if (typeof document === "undefined") {
+    return undefined;
+  }
+  try {
+    const serializer = DOMSerializer.fromSchema(schema);
+    const container = document.createElement("div");
+    if ("isText" in type) {
+      if (type.isText || type === schema.topNodeType) {
+        return undefined;
+      }
+      const content = type.isTextblock ? schema.text("Example") : undefined;
+      const node = type.createAndFill(null, content) ?? type.createAndFill();
+      if (!node) {
+        return undefined;
+      }
+      container.append(serializer.serializeNode(node));
+    } else {
+      const mark = type.create();
+      const text = schema.text("Example", [mark]);
+      container.append(serializer.serializeFragment(Fragment.from(text)));
+    }
+    const html = container.innerHTML;
+    return html && utf8ByteLength(html) <= MAX_HTML_EXAMPLE_BYTES
+      ? html
+      : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function enforceManifestMetadataLimit(components: HaloEditorComponent[]) {
+  let total = 0;
+  for (const component of components) {
+    if (component.ai === undefined) {
+      continue;
+    }
+    const size = utf8ByteLength(JSON.stringify(component.ai));
+    if (total + size > MAX_MANIFEST_AI_BYTES) {
+      delete component.ai;
+      warn(
+        `Ignored AI metadata for "${component.name}" due to Manifest limits.`
+      );
+      continue;
+    }
+    total += size;
+  }
+}
+
+function assignText<T extends object, K extends keyof T>(
+  target: T,
+  key: K,
+  value: unknown,
+  source: string
+) {
+  if (value === undefined) {
+    return;
+  }
+  const normalized = validText(value, MAX_TEXT_LENGTH, source, String(key));
+  if (normalized !== undefined) {
+    target[key] = normalized as T[K];
+  }
+}
+
+function assignStringArray<T extends object, K extends keyof T>(
+  target: T,
+  key: K,
+  value: unknown,
+  source: string,
+  options: { itemLimit?: number } = {}
+) {
+  if (value === undefined) {
+    return;
+  }
+  if (!Array.isArray(value)) {
+    warn(`Ignored invalid ${String(key)} from "${source}".`);
+    return;
+  }
+  if (value.length > MAX_GUIDANCE_ITEMS) {
+    warn(`Limited ${String(key)} from "${source}".`);
+  }
+  const result = value.slice(0, MAX_GUIDANCE_ITEMS).flatMap((item) => {
+    const normalized = validText(
+      item,
+      options.itemLimit ?? MAX_TEXT_LENGTH,
+      source,
+      String(key)
+    );
+    return normalized === undefined ? [] : [normalized];
+  });
+  target[key] = result as T[K];
+}
+
+function assignAttributeValues<T extends object, K extends keyof T>(
+  target: T,
+  key: K,
+  value: unknown,
+  source: string
+) {
+  if (value === undefined) {
+    return;
+  }
+  if (!Array.isArray(value)) {
+    warn(`Ignored invalid ${String(key)} from "${source}".`);
+    return;
+  }
+  if (value.length > MAX_ATTRIBUTE_VALUES) {
+    warn(`Limited ${String(key)} from "${source}".`);
+  }
+  target[key] = value
+    .slice(0, MAX_ATTRIBUTE_VALUES)
+    .filter(isAttributeValue) as T[K];
+}
+
+function sanitizeExamples(value: unknown[], source: string) {
+  if (value.length > MAX_HTML_EXAMPLES) {
+    warn(`Limited HTML examples from "${source}".`);
+  }
+  return value.slice(0, MAX_HTML_EXAMPLES).flatMap((example) => {
+    if (
+      typeof example !== "string" ||
+      !example.trim() ||
+      utf8ByteLength(example) > MAX_HTML_EXAMPLE_BYTES
+    ) {
+      warn(`Ignored invalid HTML example from "${source}".`);
+      return [];
+    }
+    return [example];
+  });
+}
+
+function validText(
+  value: unknown,
+  maximum: number,
+  source: string,
+  field: string
+) {
+  if (typeof value !== "string" || !value.trim() || value.length > maximum) {
+    if (value !== undefined) {
+      warn(`Ignored invalid ${field} from "${source}".`);
+    }
+    return undefined;
+  }
+  return value;
+}
+
+function validCount(value: unknown) {
+  return value === undefined || (Number.isInteger(value) && Number(value) >= 0);
+}
+
+function validName(value: unknown): value is string {
+  return (
+    typeof value === "string" && Boolean(value.trim()) && value.length <= 100
+  );
+}
+
+function isAttributeValue(value: unknown): value is HaloEditorAIAttributeValue {
+  return (
+    value === null ||
+    typeof value === "string" ||
+    (typeof value === "number" && Number.isFinite(value)) ||
+    typeof value === "boolean"
+  );
+}
+
+function uniqueTargets(targets: HaloEditorMetadataContribution["targets"]) {
+  return uniqBy(targets, (target) => componentKey(target.kind, target.name));
+}
+
+function componentExists(schema: Schema, kind: "node" | "mark", name: string) {
+  return kind === "node"
+    ? Boolean(schema.nodes[name])
+    : Boolean(schema.marks[name]);
+}
+
+function componentKey(kind: "node" | "mark", name: string) {
+  return `${kind}:${name}`;
+}
+
+function extensionPriority(extension: AnyExtension) {
+  const priority = extension.config.priority;
+  return typeof priority === "number" ? priority : DEFAULT_PRIORITY;
+}
+
+function copyDefined<T extends object, U extends object>(
+  target: T,
+  source: U,
+  keys: Array<keyof U>
+) {
+  for (const key of keys) {
+    if (source[key] !== undefined) {
+      (target as Record<keyof U, unknown>)[key] = source[key];
+    }
+  }
+}
+
+function jsonValue(value: unknown): unknown {
+  if (
+    value === null ||
+    typeof value === "string" ||
+    typeof value === "boolean"
+  ) {
+    return value;
+  }
+  if (typeof value === "number") {
+    return Number.isFinite(value) ? value : undefined;
+  }
+  if (Array.isArray(value)) {
+    return value.map(jsonValue).filter((item) => item !== undefined);
+  }
+  if (isPlainObject(value)) {
+    return Object.fromEntries(
+      Object.entries(value).flatMap(([key, item]) => {
+        const normalized = jsonValue(item);
+        return normalized === undefined ? [] : [[key, normalized]];
+      })
+    );
+  }
+  return undefined;
+}
+
+function warn(message: string, error?: unknown) {
+  if (import.meta.env.DEV) {
+    console.warn(`[halo-editor-metadata] ${message}`, error ?? "");
+  }
+}

--- a/ui/packages/editor/src/editor-metadata/types.ts
+++ b/ui/packages/editor/src/editor-metadata/types.ts
@@ -1,0 +1,168 @@
+import type { Editor } from "@tiptap/core";
+import type { MarkType, NodeType } from "@tiptap/pm/model";
+
+export type HaloEditorAIAttributeValue = string | number | boolean | null;
+
+export interface HaloEditorAIAttributeGuidance {
+  description: string;
+  format?: string;
+  allowedValues?: HaloEditorAIAttributeValue[];
+  examples?: HaloEditorAIAttributeValue[];
+  useWhen?: string[];
+  omitWhen?: string[];
+  guidelines?: string[];
+}
+
+export type HaloEditorAIAttributeGuidanceDeclaration =
+  | string
+  | Partial<HaloEditorAIAttributeGuidance>;
+
+export interface HaloEditorAIGeneration {
+  mode: "direct-html" | "requires-capability" | "read-only";
+  requiredCapabilities?: string[];
+  guidelines?: string[];
+}
+
+export interface HaloEditorAIMetadata {
+  description: string;
+  aliases?: string[];
+  exposure: "recommended" | "available";
+  useWhen?: string[];
+  avoidWhen?: string[];
+  contentGuidelines?: string[];
+  attributeGuidance?: Record<string, HaloEditorAIAttributeGuidance>;
+  generation?: HaloEditorAIGeneration;
+  examples?: string[];
+}
+
+export interface HaloEditorAIMetadataPatch {
+  description?: string;
+  aliases?: string[];
+  exposure?: "recommended" | "available";
+  useWhen?: string[];
+  avoidWhen?: string[];
+  contentGuidelines?: string[];
+  attributeGuidance?: Record<string, HaloEditorAIAttributeGuidanceDeclaration>;
+  generation?: Partial<HaloEditorAIGeneration>;
+  examples?: string[];
+}
+
+export interface HaloEditorStructureMetadata {
+  allowedParents: string[];
+  minPerParent?: number;
+  maxPerParent?: number;
+  description?: string;
+}
+
+export type HaloEditorStructureMetadataPatch =
+  Partial<HaloEditorStructureMetadata>;
+
+export interface HaloEditorComponentMetadataPatch {
+  ai?: false | HaloEditorAIMetadataPatch;
+  structure?: HaloEditorStructureMetadataPatch;
+}
+
+export interface HaloEditorComponentTarget {
+  kind: "node" | "mark";
+  name: string;
+}
+
+export interface HaloEditorMetadataContribution {
+  targets: HaloEditorComponentTarget[];
+  metadata: HaloEditorComponentMetadataPatch;
+}
+
+export interface HaloEditorMetadataDeclaration extends HaloEditorComponentMetadataPatch {
+  contributions?: HaloEditorMetadataContribution[];
+}
+
+export interface HaloEditorExtensionMetadataDeclaration {
+  contributions?: HaloEditorMetadataContribution[];
+}
+
+export interface HaloEditorAttribute {
+  name: string;
+  required: boolean;
+  defaultValue?: unknown;
+}
+
+export interface HaloEditorHTMLParseRule {
+  tag?: string;
+  style?: string;
+  priority?: number;
+}
+
+interface HaloEditorComponentBase {
+  name: string;
+  attributes: HaloEditorAttribute[];
+  htmlParseRules: HaloEditorHTMLParseRule[];
+  ai?: false | HaloEditorAIMetadata;
+  structure?: HaloEditorStructureMetadata;
+}
+
+export interface HaloEditorNodeComponent extends HaloEditorComponentBase {
+  kind: "node";
+  content: string;
+  group: string;
+  inline: boolean;
+  atom: boolean;
+  leaf: boolean;
+  code: boolean;
+  whitespace: "normal" | "pre";
+  selectable: boolean;
+  draggable: boolean;
+  defining: boolean;
+  isolating: boolean;
+}
+
+export interface HaloEditorMarkComponent extends HaloEditorComponentBase {
+  kind: "mark";
+  excludes: string;
+  inclusive: boolean;
+  spanning: boolean;
+}
+
+export type HaloEditorComponent =
+  | HaloEditorNodeComponent
+  | HaloEditorMarkComponent;
+
+export interface HaloEditorManifest {
+  version: 1;
+  signature: string;
+  components: HaloEditorComponent[];
+}
+
+export interface HaloEditorMetadataContext<
+  Options = unknown,
+  Storage = unknown,
+  Type = NodeType | MarkType | null,
+> {
+  name: string;
+  options: Options;
+  storage: Storage;
+  editor: Editor;
+  type: Type;
+}
+
+declare module "@tiptap/core" {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  interface NodeConfig<Options = any, Storage = any> {
+    addHaloEditorMetadata?: (
+      this: HaloEditorMetadataContext<Options, Storage, NodeType>
+    ) => HaloEditorMetadataDeclaration | undefined;
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  interface MarkConfig<Options = any, Storage = any> {
+    addHaloEditorMetadata?: (
+      this: HaloEditorMetadataContext<Options, Storage, MarkType>
+    ) => HaloEditorMetadataDeclaration | undefined;
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  interface ExtensionConfig<Options = any, Storage = any> {
+    addHaloEditorMetadata?: (
+      this: HaloEditorMetadataContext<Options, Storage, null>
+    ) => HaloEditorExtensionMetadataDeclaration | undefined;
+  }
+}

--- a/ui/packages/editor/src/extensions/audio/index.ts
+++ b/ui/packages/editor/src/extensions/audio/index.ts
@@ -38,6 +38,79 @@ export interface ExtensionAudioOptions extends AudioOptions, ExtensionOptions {
 export const ExtensionAudio = Audio.extend<ExtensionAudioOptions>({
   fakeSelection: true,
 
+  addHaloEditorMetadata() {
+    return {
+      ai: {
+        description:
+          "An audio player for a referenced audio resource, used directly as a block or as the media child of a figure.",
+        exposure: "available",
+        useWhen: ["Embedding a relevant audio recording with a known URL."],
+        avoidWhen: ["No accessible audio source is available."],
+        attributeGuidance: {
+          src: {
+            description: "URL of the audio resource.",
+            format: "absolute or site-relative URL",
+          },
+          autoplay: {
+            description: "Whether playback starts automatically.",
+            allowedValues: [true, false],
+            omitWhen: ["User-initiated playback is preferred."],
+          },
+          controls: {
+            description: "Whether native playback controls are visible.",
+            allowedValues: [true, false],
+          },
+          loop: {
+            description: "Whether playback restarts after reaching the end.",
+            allowedValues: [true, false],
+            omitWhen: ["The audio should play once."],
+          },
+          muted: {
+            description: "Whether audio output is initially muted.",
+            allowedValues: [true, false],
+            omitWhen: ["The audio should start with normal volume."],
+          },
+          preload: {
+            description: "Browser preload strategy for the audio resource.",
+            allowedValues: ["auto", "metadata", "none", null],
+          },
+          controlslist: {
+            description:
+              "Space-separated browser controls restrictions such as nodownload.",
+            examples: ["nodownload", "nodownload noplaybackrate"],
+            omitWhen: ["No native control restrictions are needed."],
+          },
+          crossorigin: {
+            description: "CORS mode used when fetching the audio resource.",
+            allowedValues: ["", "anonymous", "use-credentials"],
+            omitWhen: ["The audio does not require a CORS request."],
+          },
+          disableremoteplayback: {
+            description:
+              "Whether browsers should prevent remote playback of the audio.",
+            allowedValues: [true, false],
+            omitWhen: ["Remote playback may remain available."],
+          },
+          file: {
+            description:
+              "Editor-only upload state that is not part of persisted article HTML.",
+            omitWhen: ["Generating or editing persisted article content."],
+          },
+        },
+        generation: {
+          mode: "direct-html",
+          guidelines: [
+            "Use a stable accessible URL; uploading a local file requires a separate plugin capability.",
+          ],
+        },
+        examples: [
+          '<audio src="https://example.com/audio.mp3" controls></audio>',
+          '<audio src="https://example.com/ambient.ogg" controls loop></audio>',
+        ],
+      },
+    };
+  },
+
   addAttributes() {
     return {
       ...this.parent?.(),

--- a/ui/packages/editor/src/extensions/block-position/index.ts
+++ b/ui/packages/editor/src/extensions/block-position/index.ts
@@ -54,6 +54,26 @@ export const ExtensionBlockPosition =
   Extension.create<ExtensionBlockPositionOptions>({
     name: "blockPosition",
 
+    addHaloEditorMetadata() {
+      return {
+        contributions: this.options.types.map((name) => ({
+          targets: [{ kind: "node" as const, name }],
+          metadata: {
+            ai: {
+              attributeGuidance: {
+                alignItems: {
+                  description:
+                    "Cross-axis alignment of this container's child content.",
+                  allowedValues: this.options.positions,
+                  omitWhen: ["The default child alignment is appropriate."],
+                },
+              },
+            },
+          },
+        })),
+      };
+    },
+
     addOptions() {
       return {
         types: [],

--- a/ui/packages/editor/src/extensions/blockquote/index.ts
+++ b/ui/packages/editor/src/extensions/blockquote/index.ts
@@ -12,6 +12,25 @@ export type ExtensionBlockquoteOptions = Partial<BlockquoteOptions> &
 
 export const ExtensionBlockquote =
   TiptapBlockquote.extend<ExtensionBlockquoteOptions>({
+    addHaloEditorMetadata() {
+      return {
+        ai: {
+          description:
+            "A block quotation containing one or more block-level elements.",
+          exposure: "recommended",
+          useWhen: ["Quoting a source or visually separating quoted material."],
+          avoidWhen: ["Applying indentation to non-quoted prose."],
+          generation: {
+            mode: "direct-html",
+          },
+          examples: [
+            "<blockquote><p>Quoted material with its original meaning preserved.</p></blockquote>",
+            "<blockquote><p>Quoted introduction.</p><ul><li><p>A quoted list item</p></li></ul></blockquote>",
+          ],
+        },
+      };
+    },
+
     addOptions() {
       return {
         ...this.parent?.(),

--- a/ui/packages/editor/src/extensions/bold/index.ts
+++ b/ui/packages/editor/src/extensions/bold/index.ts
@@ -9,6 +9,21 @@ import type { ExtensionOptions } from "@/types";
 export type ExtensionBoldOptions = Partial<BoldOptions> & ExtensionOptions;
 
 export const ExtensionBold = TiptapBold.extend<ExtensionBoldOptions>({
+  addHaloEditorMetadata() {
+    return {
+      ai: {
+        description: "Strong emphasis for important inline text.",
+        exposure: "recommended",
+        useWhen: ["Emphasizing a key term or important phrase."],
+        avoidWhen: ["Styling long passages or headings solely for appearance."],
+        generation: {
+          mode: "direct-html",
+        },
+        examples: ["<p>This is <strong>important</strong>.</p>"],
+      },
+    };
+  },
+
   addOptions() {
     return {
       ...this.parent?.(),

--- a/ui/packages/editor/src/extensions/bullet-list/index.ts
+++ b/ui/packages/editor/src/extensions/bullet-list/index.ts
@@ -1,5 +1,4 @@
 import {
-  ListItem,
   BulletList as TiptapBulletList,
   type BulletListOptions,
 } from "@tiptap/extension-list";
@@ -7,11 +6,31 @@ import { markRaw } from "vue";
 import MingcuteListCheckLine from "~icons/mingcute/list-check-line";
 import type { Editor, Range } from "@/tiptap";
 import type { ExtensionOptions } from "@/types";
+import { ExtensionListItem } from "../list-item";
 
 export type ExtensionBulletListOptions = Partial<BulletListOptions> &
   ExtensionOptions;
 
 export const ExtensionBulletList = TiptapBulletList.extend<ExtensionOptions>({
+  addHaloEditorMetadata() {
+    return {
+      ai: {
+        description: "An unordered list of related items.",
+        aliases: ["unordered list"],
+        exposure: "recommended",
+        useWhen: ["Item order is not significant."],
+        avoidWhen: ["The sequence or ranking of items matters."],
+        generation: {
+          mode: "direct-html",
+        },
+        examples: [
+          "<ul><li><p>First point</p></li><li><p>Second point</p></li></ul>",
+          "<ul><li><p>Parent point</p><ul><li><p>Nested point</p></li></ul></li></ul>",
+        ],
+      },
+    };
+  },
+
   addOptions() {
     return {
       ...this.parent?.(),
@@ -29,6 +48,6 @@ export const ExtensionBulletList = TiptapBulletList.extend<ExtensionOptions>({
     };
   },
   addExtensions() {
-    return [ListItem];
+    return [ExtensionListItem];
   },
 });

--- a/ui/packages/editor/src/extensions/code-block/code-block.ts
+++ b/ui/packages/editor/src/extensions/code-block/code-block.ts
@@ -156,6 +156,61 @@ export const ExtensionCodeBlock = TiptapCodeBlock.extend<
 
   fakeSelection: true,
 
+  addHaloEditorMetadata() {
+    const languages = Array.isArray(this.options.languages)
+      ? this.options.languages.map(({ value }) => value)
+      : undefined;
+    const themes = Array.isArray(this.options.themes)
+      ? this.options.themes.map(({ value }) => value)
+      : undefined;
+    return {
+      ai: {
+        description:
+          "A multi-line code block with optional language, syntax theme, and collapsed presentation.",
+        aliases: ["fenced code block"],
+        exposure: "recommended",
+        useWhen: [
+          "Presenting source code, configuration, terminal commands, or other preformatted text.",
+        ],
+        avoidWhen: ["The code fragment is short enough to remain inline."],
+        contentGuidelines: [
+          "Keep the code text verbatim and do not encode it as nested HTML.",
+          "Set the language when it is known so a highlighting extension can render it correctly.",
+        ],
+        attributeGuidance: {
+          language: {
+            description:
+              "Language identifier used for syntax highlighting and labeling.",
+            ...(languages?.length ? { allowedValues: languages } : {}),
+            examples: ["javascript", "java", "yaml", "bash"],
+            omitWhen: ["The language cannot be determined reliably."],
+          },
+          collapsed: {
+            description:
+              "Whether the editor initially displays the code block in a collapsed state.",
+            allowedValues: [true, false],
+            omitWhen: ["The code should be visible by default."],
+          },
+          theme: {
+            description:
+              "Syntax-highlighting theme identifier. Plugins may extend the available themes.",
+            ...(themes?.length ? { allowedValues: themes } : {}),
+            examples: ["github-dark", "github-light"],
+            omitWhen: ["The editor default theme should be used."],
+          },
+        },
+        generation: {
+          mode: "direct-html",
+        },
+        examples: [
+          "<pre><code>Plain preformatted text</code></pre>",
+          '<pre><code class="language-javascript">const greeting = "Hello";</code></pre>',
+          '<pre theme="github-dark" collapsed="true"><code class="language-typescript">const enabled: boolean = true;</code></pre>',
+        ],
+      },
+    };
+  },
+
   addAttributes() {
     return {
       ...this.parent?.(),

--- a/ui/packages/editor/src/extensions/code/index.ts
+++ b/ui/packages/editor/src/extensions/code/index.ts
@@ -11,6 +11,22 @@ export type ExtensionCodeOptions = Partial<CodeOptions> & ExtensionOptions;
 
 export const ExtensionCode = TiptapCode.extend<ExtensionCodeOptions>({
   exitable: true,
+  addHaloEditorMetadata() {
+    return {
+      ai: {
+        description:
+          "Inline code for identifiers, commands, short expressions, and file names.",
+        exposure: "recommended",
+        useWhen: ["Including a short code fragment within prose."],
+        avoidWhen: ["Presenting a multi-line code sample."],
+        generation: {
+          mode: "direct-html",
+        },
+        examples: ["<p>Run <code>pnpm install</code> first.</p>"],
+      },
+    };
+  },
+
   addOptions() {
     return {
       ...this.parent?.(),

--- a/ui/packages/editor/src/extensions/color/index.ts
+++ b/ui/packages/editor/src/extensions/color/index.ts
@@ -11,6 +11,27 @@ import ColorToolbarItem from "./ColorToolbarItem.vue";
 export type ExtensionColorOptions = Partial<ColorOptions> & ExtensionOptions;
 
 export const ExtensionColor = TiptapColor.extend<ExtensionColorOptions>({
+  addHaloEditorMetadata() {
+    return {
+      contributions: (this.options.types ?? []).map((name) => ({
+        targets: [{ kind: "mark" as const, name }],
+        metadata: {
+          ai: {
+            attributeGuidance: {
+              color: {
+                description:
+                  "CSS foreground color. Use a value from the active editor palette when one is known.",
+                format: "CSS color",
+                examples: ["#1f2937", "#2563eb"],
+                omitWhen: ["The inherited text color is appropriate."],
+              },
+            },
+          },
+        },
+      })),
+    };
+  },
+
   addOptions() {
     return {
       ...this.parent?.(),

--- a/ui/packages/editor/src/extensions/columns/column.ts
+++ b/ui/packages/editor/src/extensions/columns/column.ts
@@ -12,6 +12,42 @@ export const ExtensionColumn = Node.create<ExtensionColumnOptions>({
   isolating: true,
   fakeSelection: true,
 
+  addHaloEditorMetadata() {
+    return {
+      ai: {
+        description:
+          "One block-content column inside a columns layout. It is not a top-level content block.",
+        exposure: "available",
+        useWhen: ["Adding a column to a multi-column layout."],
+        avoidWhen: ["There is no containing columns layout."],
+        attributeGuidance: {
+          index: {
+            description:
+              "Sequential zero-based position of this column in its layout.",
+            examples: [0, 1, 2],
+          },
+          style: {
+            description:
+              "Layout styles used to size the column within its container.",
+            format: "CSS declarations",
+          },
+        },
+        generation: {
+          mode: "direct-html",
+        },
+        examples: [
+          '<div class="columns" cols="1"><div class="column" index="0"><p>Column content</p></div></div>',
+        ],
+      },
+      structure: {
+        allowedParents: ["columns"],
+        minPerParent: 1,
+        description:
+          "column may appear only inside columns, and each columns layout contains at least one column.",
+      },
+    };
+  },
+
   addOptions() {
     return {
       HTMLAttributes: {
@@ -24,7 +60,10 @@ export const ExtensionColumn = Node.create<ExtensionColumnOptions>({
     return {
       index: {
         default: 0,
-        parseHTML: (element) => element.getAttribute("index"),
+        parseHTML: (element) => {
+          const index = Number(element.getAttribute("index"));
+          return Number.isInteger(index) && index >= 0 ? index : 0;
+        },
       },
       style: {
         default: "min-width: 0;flex: 1 1;box-sizing: border-box;",

--- a/ui/packages/editor/src/extensions/columns/columns.ts
+++ b/ui/packages/editor/src/extensions/columns/columns.ts
@@ -195,6 +195,41 @@ export const ExtensionColumns = Node.create<ExtensionColumnsOptions>({
   content: "column{1,}",
   fakeSelection: false,
 
+  addHaloEditorMetadata() {
+    return {
+      ai: {
+        description: "A multi-column layout containing one or more columns.",
+        exposure: "available",
+        useWhen: ["Related block content benefits from a side-by-side layout."],
+        avoidWhen: [
+          "The content must remain easy to read on narrow screens or has a natural linear order.",
+        ],
+        attributeGuidance: {
+          cols: {
+            description:
+              "Number of column children in the layout; it must match the actual child count.",
+            examples: [2, 3],
+          },
+          style: {
+            description: "CSS declarations controlling the columns container.",
+            format: "CSS declarations",
+          },
+        },
+        contentGuidelines: [
+          "Keep cols equal to the number of column children.",
+          "Order column children by sequential zero-based index.",
+        ],
+        generation: {
+          mode: "direct-html",
+        },
+        examples: [
+          '<div class="columns" cols="2"><div class="column" index="0"><p>Left column</p></div><div class="column" index="1"><p>Right column</p></div></div>',
+          '<div class="columns" cols="3"><div class="column" index="0"><p>First column</p></div><div class="column" index="1"><p>Second column</p></div><div class="column" index="2"><p>Third column</p></div></div>',
+        ],
+      },
+    };
+  },
+
   addOptions() {
     return {
       HTMLAttributes: {
@@ -329,13 +364,24 @@ export const ExtensionColumns = Node.create<ExtensionColumnsOptions>({
     return {
       cols: {
         default: 2,
-        parseHTML: (element) => element.getAttribute("cols"),
+        parseHTML: (element) => {
+          const cols = Number(element.getAttribute("cols"));
+          return Number.isInteger(cols) && cols > 0 ? cols : 2;
+        },
       },
       style: {
         default: "display: flex;width: 100%;gap: 1em;",
         parseHTML: (element) => element.getAttribute("style"),
       },
     };
+  },
+
+  parseHTML() {
+    return [
+      {
+        tag: "div.columns",
+      },
+    ];
   },
 
   renderHTML({ HTMLAttributes }) {

--- a/ui/packages/editor/src/extensions/details/index.ts
+++ b/ui/packages/editor/src/extensions/details/index.ts
@@ -25,7 +25,89 @@ export const DETAILS_BUBBLE_MENU_KEY = new PluginKey("detailsBubbleMenu");
 export type ExtensionDetailsOptions = Partial<DetailsOptions> &
   ExtensionOptions;
 
+const ExtensionDetailsSummary = DetailsSummary.extend({
+  addHaloEditorMetadata() {
+    return {
+      ai: {
+        description:
+          "The visible summary label for a details disclosure. It is not a top-level content block.",
+        exposure: "recommended",
+        useWhen: ["Labeling the content hidden or shown by a details element."],
+        avoidWhen: ["There is no containing details element."],
+        contentGuidelines: ["Keep the summary short and descriptive."],
+        generation: {
+          mode: "direct-html",
+        },
+        examples: [
+          '<details><summary>More information</summary><div data-type="detailsContent"><p>Additional details.</p></div></details>',
+        ],
+      },
+      structure: {
+        allowedParents: ["details"],
+        minPerParent: 1,
+        maxPerParent: 1,
+        description:
+          "detailsSummary may appear only inside details, exactly once per details element.",
+      },
+    };
+  },
+});
+
+const ExtensionDetailsContent = DetailsContent.extend({
+  addHaloEditorMetadata() {
+    return {
+      ai: {
+        description:
+          "The expandable block content of a details disclosure. It is not a top-level content block.",
+        exposure: "recommended",
+        useWhen: ["Providing the body controlled by a details summary."],
+        avoidWhen: ["There is no containing details element."],
+        generation: {
+          mode: "direct-html",
+        },
+        examples: [
+          '<details><summary>More information</summary><div data-type="detailsContent"><p>Additional details.</p></div></details>',
+        ],
+      },
+      structure: {
+        allowedParents: ["details"],
+        minPerParent: 1,
+        maxPerParent: 1,
+        description:
+          "detailsContent may appear only inside details, exactly once per details element.",
+      },
+    };
+  },
+});
+
 export const ExtensionDetails = TiptapDetails.extend<ExtensionDetailsOptions>({
+  addHaloEditorMetadata() {
+    return {
+      ai: {
+        description:
+          "A collapsible disclosure with a summary and block-level details content.",
+        exposure: "available",
+        useWhen: ["Secondary information should be expandable on demand."],
+        avoidWhen: [
+          "The content is essential and should always remain visible.",
+        ],
+        attributeGuidance: {
+          open: {
+            description: "Whether the details content is initially expanded.",
+            allowedValues: [true, false],
+          },
+        },
+        generation: {
+          mode: "direct-html",
+        },
+        examples: [
+          '<details><summary>More information</summary><div data-type="detailsContent"><p>Initially collapsed details.</p></div></details>',
+          '<details open><summary>More information</summary><div data-type="detailsContent"><p>Additional details.</p></div></details>',
+        ],
+      },
+    };
+  },
+
   addOptions() {
     return {
       ...this.parent?.(),
@@ -119,7 +201,7 @@ export const ExtensionDetails = TiptapDetails.extend<ExtensionDetailsOptions>({
     };
   },
   addExtensions() {
-    return [DetailsSummary, DetailsContent];
+    return [ExtensionDetailsSummary, ExtensionDetailsContent];
   },
 }).configure({
   persist: true,

--- a/ui/packages/editor/src/extensions/document/index.ts
+++ b/ui/packages/editor/src/extensions/document/index.ts
@@ -1,3 +1,9 @@
-import { Document as ExtensionDocument } from "@tiptap/extension-document";
+import { Document as TiptapDocument } from "@tiptap/extension-document";
 
-export { ExtensionDocument };
+export const ExtensionDocument = TiptapDocument.extend({
+  addHaloEditorMetadata() {
+    return {
+      ai: false,
+    };
+  },
+});

--- a/ui/packages/editor/src/extensions/figure/figure-caption.ts
+++ b/ui/packages/editor/src/extensions/figure/figure-caption.ts
@@ -16,6 +16,49 @@ export const ExtensionFigureCaption = Node.create({
   inline: false,
   group: "block",
 
+  addHaloEditorMetadata() {
+    return {
+      ai: {
+        description:
+          "An optional text caption belonging to a figure. It is not a top-level content block.",
+        aliases: ["figcaption"],
+        exposure: "recommended",
+        useWhen: ["A figure needs a concise explanatory caption."],
+        avoidWhen: ["There is no associated figure."],
+        contentGuidelines: [
+          "Keep the caption concise and directly related to the figure.",
+        ],
+        attributeGuidance: {
+          width: {
+            description:
+              "Editor-managed caption width synchronized with the associated media size.",
+            omitWhen: [
+              "Generating or editing article content; the editor maintains this value.",
+            ],
+          },
+          "data-placeholder": {
+            description:
+              "Editor placeholder text; omit it from generated article content.",
+            omitWhen: ["Generating article content."],
+          },
+        },
+        generation: {
+          mode: "direct-html",
+        },
+        examples: [
+          "<figure><figcaption>System architecture</figcaption></figure>",
+        ],
+      },
+      structure: {
+        allowedParents: ["figure"],
+        minPerParent: 0,
+        maxPerParent: 1,
+        description:
+          "figureCaption may appear only inside figure, is optional, and may occur at most once per figure.",
+      },
+    };
+  },
+
   addAttributes() {
     return {
       "data-placeholder": {

--- a/ui/packages/editor/src/extensions/figure/index.ts
+++ b/ui/packages/editor/src/extensions/figure/index.ts
@@ -12,6 +12,8 @@ import { ExtensionParagraph } from "../paragraph";
 import { RangeSelection } from "../range-selection";
 import { ExtensionFigureCaption } from "./figure-caption";
 
+const FIGURE_MEDIA_TYPES = ["image", "video", "audio"] as const;
+
 declare module "@/tiptap" {
   interface Commands<ReturnType> {
     figure: {
@@ -29,7 +31,7 @@ export interface ExtensionFigureOptions extends ExtensionOptions {
 export const ExtensionFigure = Node.create<ExtensionFigureOptions>({
   name: "figure",
   group: "block",
-  content: "(image|video|audio)? figureCaption?",
+  content: `(${FIGURE_MEDIA_TYPES.join("|")})? figureCaption?`,
   isolating: true,
   // Priority must be higher than paragraph (1000) and code-block to ensure
   // the Backspace shortcut handles figure selection correctly.
@@ -53,7 +55,7 @@ export const ExtensionFigure = Node.create<ExtensionFigureOptions>({
         attributeGuidance: {
           contentType: {
             description: "The kind of media represented by this figure.",
-            allowedValues: ["image", "video", "audio", null],
+            allowedValues: [...FIGURE_MEDIA_TYPES, null],
             omitWhen: ["The figure contains no media item."],
           },
         },

--- a/ui/packages/editor/src/extensions/figure/index.ts
+++ b/ui/packages/editor/src/extensions/figure/index.ts
@@ -34,6 +34,41 @@ export const ExtensionFigure = Node.create<ExtensionFigureOptions>({
   // Priority must be higher than paragraph (1000) and code-block to ensure
   // the Backspace shortcut handles figure selection correctly.
 
+  addHaloEditorMetadata() {
+    return {
+      ai: {
+        description:
+          "A semantic figure container for an optional single image, video, or audio item and an optional caption.",
+        exposure: "recommended",
+        useWhen: [
+          "An image, video, or audio item and its optional caption should form one semantic unit.",
+        ],
+        avoidWhen: ["The content is not media-related."],
+        contentGuidelines: [
+          "Use at most one media child, and use only image, video, or audio.",
+          "If present, place figureCaption after the media child.",
+          "Keep contentType consistent with the actual media child.",
+          "Do not generate an empty figure without media or a caption.",
+        ],
+        attributeGuidance: {
+          contentType: {
+            description: "The kind of media represented by this figure.",
+            allowedValues: ["image", "video", "audio", null],
+            omitWhen: ["The figure contains no media item."],
+          },
+        },
+        generation: {
+          mode: "direct-html",
+        },
+        examples: [
+          '<figure data-content-type="image"><img src="https://example.com/diagram.png" alt="Architecture diagram"><figcaption>System architecture</figcaption></figure>',
+          '<figure data-content-type="video"><video src="https://example.com/demo.mp4" width="100%" controls></video><figcaption>Product demonstration</figcaption></figure>',
+          '<figure data-content-type="audio"><audio src="https://example.com/interview.mp3" controls></audio><figcaption>Interview recording</figcaption></figure>',
+        ],
+      },
+    };
+  },
+
   addOptions() {
     return {
       HTMLAttributes: {},

--- a/ui/packages/editor/src/extensions/font-size/index.ts
+++ b/ui/packages/editor/src/extensions/font-size/index.ts
@@ -16,6 +16,40 @@ export const ExtensionFontSize =
   TiptapFontSize.extend<ExtensionFontSizeOptions>({
     name: "fontSize",
 
+    addHaloEditorMetadata() {
+      return {
+        contributions: (this.options.types ?? []).map((name) => ({
+          targets: [{ kind: "mark" as const, name }],
+          metadata: {
+            ai: {
+              attributeGuidance: {
+                fontSize: {
+                  description: "CSS font size for the inline text.",
+                  format: "CSS length",
+                  allowedValues: [
+                    "8px",
+                    "10px",
+                    "12px",
+                    "14px",
+                    "16px",
+                    "18px",
+                    "20px",
+                    "24px",
+                    "30px",
+                    "36px",
+                    "48px",
+                    "60px",
+                    "72px",
+                  ],
+                  omitWhen: ["The inherited font size is appropriate."],
+                },
+              },
+            },
+          },
+        })),
+      };
+    },
+
     addOptions() {
       return {
         ...this.parent?.(),

--- a/ui/packages/editor/src/extensions/font-size/index.ts
+++ b/ui/packages/editor/src/extensions/font-size/index.ts
@@ -9,6 +9,8 @@ import { i18n } from "@/locales";
 import { type Editor } from "@/tiptap";
 import type { ExtensionOptions } from "@/types";
 
+const FONT_SIZES = [8, 10, 12, 14, 16, 18, 20, 24, 30, 36, 48, 60, 72] as const;
+
 export type ExtensionFontSizeOptions = Partial<FontSizeOptions> &
   ExtensionOptions;
 
@@ -26,21 +28,7 @@ export const ExtensionFontSize =
                 fontSize: {
                   description: "CSS font size for the inline text.",
                   format: "CSS length",
-                  allowedValues: [
-                    "8px",
-                    "10px",
-                    "12px",
-                    "14px",
-                    "16px",
-                    "18px",
-                    "20px",
-                    "24px",
-                    "30px",
-                    "36px",
-                    "48px",
-                    "60px",
-                    "72px",
-                  ],
+                  allowedValues: FONT_SIZES.map((size) => `${size}px`),
                   omitWhen: ["The inherited font size is appropriate."],
                 },
               },
@@ -75,26 +63,24 @@ export const ExtensionFontSize =
                   action: () => editor.chain().focus().unsetFontSize().run(),
                 },
               },
-              ...[8, 10, 12, 14, 16, 18, 20, 24, 30, 36, 48, 60, 72].map(
-                (size) => {
-                  return {
-                    priority: size,
-                    component: markRaw(ToolbarSubItem),
-                    props: {
-                      editor,
-                      isActive: false,
-                      title: `${size} px`,
-                      action: () => {
-                        return editor
-                          .chain()
-                          .focus()
-                          .setFontSize(`${size}px`)
-                          .run();
-                      },
+              ...FONT_SIZES.map((size) => {
+                return {
+                  priority: size,
+                  component: markRaw(ToolbarSubItem),
+                  props: {
+                    editor,
+                    isActive: false,
+                    title: `${size} px`,
+                    action: () => {
+                      return editor
+                        .chain()
+                        .focus()
+                        .setFontSize(`${size}px`)
+                        .run();
                     },
-                  };
-                }
-              ),
+                  },
+                };
+              }),
             ],
           };
         },

--- a/ui/packages/editor/src/extensions/gallery/BubbleItemGroupSize.vue
+++ b/ui/packages/editor/src/extensions/gallery/BubbleItemGroupSize.vue
@@ -7,6 +7,7 @@ import DropdownItem from "@/components/base/DropdownItem.vue";
 import BubbleButton from "@/components/bubble/BubbleButton.vue";
 import { i18n } from "@/locales";
 import type { BubbleItemComponentProps } from "@/types";
+import { DEFAULT_GALLERY_GROUP_SIZE } from "./constants";
 import { ExtensionGallery } from "./index";
 
 const props = defineProps<BubbleItemComponentProps>();
@@ -14,7 +15,10 @@ const props = defineProps<BubbleItemComponentProps>();
 const dropdownRef = ref();
 
 const groupSize = computed(() => {
-  return props.editor.getAttributes(ExtensionGallery.name).groupSize || 3;
+  return (
+    props.editor.getAttributes(ExtensionGallery.name).groupSize ||
+    DEFAULT_GALLERY_GROUP_SIZE
+  );
 });
 
 function handleSetGroupSize(size: number) {

--- a/ui/packages/editor/src/extensions/gallery/BubbleItemLayout.vue
+++ b/ui/packages/editor/src/extensions/gallery/BubbleItemLayout.vue
@@ -8,6 +8,7 @@ import DropdownItem from "@/components/base/DropdownItem.vue";
 import BubbleButton from "@/components/bubble/BubbleButton.vue";
 import { i18n } from "@/locales";
 import type { BubbleItemComponentProps } from "@/types";
+import { DEFAULT_GALLERY_LAYOUT, GALLERY_LAYOUT_SQUARE } from "./constants";
 import { ExtensionGallery } from "./index";
 
 const props = defineProps<BubbleItemComponentProps>();
@@ -15,18 +16,21 @@ const props = defineProps<BubbleItemComponentProps>();
 const dropdownRef = ref();
 
 const layout = computed(() => {
-  return props.editor.getAttributes(ExtensionGallery.name).layout || "auto";
+  return (
+    props.editor.getAttributes(ExtensionGallery.name).layout ||
+    DEFAULT_GALLERY_LAYOUT
+  );
 });
 
 const options = [
   {
     label: i18n.global.t("editor.extensions.gallery.layout.auto"),
-    value: "auto",
+    value: DEFAULT_GALLERY_LAYOUT,
     icon: MingcuteLayout10Line,
   },
   {
     label: i18n.global.t("editor.extensions.gallery.layout.square"),
-    value: "square",
+    value: GALLERY_LAYOUT_SQUARE,
     icon: MingcuteLayoutGridLine,
   },
 ];

--- a/ui/packages/editor/src/extensions/gallery/GalleryView.vue
+++ b/ui/packages/editor/src/extensions/gallery/GalleryView.vue
@@ -6,6 +6,11 @@ import { computed, ref } from "vue";
 import MingcuteDelete2Line from "@/components/icon/MingcuteDelete2Line.vue";
 import { i18n } from "@/locales";
 import { NodeViewWrapper, type NodeViewProps } from "@/tiptap";
+import {
+  DEFAULT_GALLERY_GROUP_SIZE,
+  DEFAULT_GALLERY_LAYOUT,
+  GALLERY_LAYOUT_SQUARE,
+} from "./constants";
 import type { ExtensionGalleryImageItem } from "./index";
 import { useUploadGalleryImage } from "./useGalleryImages";
 
@@ -53,11 +58,15 @@ function handleImageLoad(event: Event, index: number) {
 }
 
 const groupSize = computed<number>(() => {
-  return props.node?.attrs.groupSize || props.extension.options?.groupSize || 3;
+  return (
+    props.node?.attrs.groupSize ||
+    props.extension.options?.groupSize ||
+    DEFAULT_GALLERY_GROUP_SIZE
+  );
 });
 
 const layout = computed<string>(() => {
-  return props.node?.attrs.layout || "auto";
+  return props.node?.attrs.layout || DEFAULT_GALLERY_LAYOUT;
 });
 
 const gap = computed<number>(() => {
@@ -219,10 +228,10 @@ function onAttachmentSelect(attachments: AttachmentLike[]) {
           draggable="true"
           class="group/image relative cursor-grab transition-all active:cursor-grabbing"
           :class="{
-            'aspect-1': layout === 'square',
+            'aspect-1': layout === GALLERY_LAYOUT_SQUARE,
           }"
           :style="{
-            flex: `${layout === 'square' ? '1' : image.aspectRatio} 1 0%`,
+            flex: `${layout === GALLERY_LAYOUT_SQUARE ? '1' : image.aspectRatio} 1 0%`,
           }"
           @dragstart="
             handleDragStart(groupIndex * groupSize + imgIndex, $event)

--- a/ui/packages/editor/src/extensions/gallery/constants.ts
+++ b/ui/packages/editor/src/extensions/gallery/constants.ts
@@ -1,0 +1,8 @@
+export const DEFAULT_GALLERY_GROUP_SIZE = 3;
+export const DEFAULT_GALLERY_GAP = 8;
+export const DEFAULT_GALLERY_LAYOUT = "auto";
+export const GALLERY_LAYOUT_SQUARE = "square";
+export const GALLERY_LAYOUTS = [
+  DEFAULT_GALLERY_LAYOUT,
+  GALLERY_LAYOUT_SQUARE,
+] as const;

--- a/ui/packages/editor/src/extensions/gallery/index.ts
+++ b/ui/packages/editor/src/extensions/gallery/index.ts
@@ -21,6 +21,13 @@ import BubbleItemAddImage from "./BubbleItemAddImage.vue";
 import BubbleItemGap from "./BubbleItemGap.vue";
 import BubbleItemGroupSize from "./BubbleItemGroupSize.vue";
 import BubbleItemLayout from "./BubbleItemLayout.vue";
+import {
+  DEFAULT_GALLERY_GAP,
+  DEFAULT_GALLERY_GROUP_SIZE,
+  DEFAULT_GALLERY_LAYOUT,
+  GALLERY_LAYOUT_SQUARE,
+  GALLERY_LAYOUTS,
+} from "./constants";
 import { ExtensionGalleryBubble } from "./gallery-bubble";
 import GalleryView from "./GalleryView.vue";
 
@@ -83,15 +90,15 @@ export const ExtensionGallery = Node.create<
           },
           groupSize: {
             description: "Maximum number of images in each visual group.",
-            examples: [2, 3, 4],
+            examples: [2, DEFAULT_GALLERY_GROUP_SIZE, 4],
           },
           layout: {
             description: "Gallery layout strategy.",
-            allowedValues: ["auto", "square"],
+            allowedValues: [...GALLERY_LAYOUTS],
           },
           gap: {
             description: "Gap between gallery images in pixels.",
-            examples: [0, 8, 16],
+            examples: [0, DEFAULT_GALLERY_GAP, 16],
           },
           file: {
             description:
@@ -106,8 +113,8 @@ export const ExtensionGallery = Node.create<
           ],
         },
         examples: [
-          '<div data-type="gallery" data-group-size="2" data-layout="auto" data-gap="8"><div data-type="gallery-group"><div data-aspect-ratio="1.5"><img src="https://example.com/one.jpg"></div><div data-aspect-ratio="1.5"><img src="https://example.com/two.jpg"></div></div></div>',
-          '<div data-type="gallery" data-group-size="3" data-layout="square" data-gap="12"><div data-type="gallery-group"><div data-aspect-ratio="1"><img src="https://example.com/one.jpg"></div><div data-aspect-ratio="1.5"><img src="https://example.com/two.jpg"></div><div data-aspect-ratio="0.75"><img src="https://example.com/three.jpg"></div></div></div>',
+          `<div data-type="gallery" data-group-size="2" data-layout="${DEFAULT_GALLERY_LAYOUT}" data-gap="${DEFAULT_GALLERY_GAP}"><div data-type="gallery-group"><div data-aspect-ratio="1.5"><img src="https://example.com/one.jpg"></div><div data-aspect-ratio="1.5"><img src="https://example.com/two.jpg"></div></div></div>`,
+          `<div data-type="gallery" data-group-size="${DEFAULT_GALLERY_GROUP_SIZE}" data-layout="${GALLERY_LAYOUT_SQUARE}" data-gap="12"><div data-type="gallery-group"><div data-aspect-ratio="1"><img src="https://example.com/one.jpg"></div><div data-aspect-ratio="1.5"><img src="https://example.com/two.jpg"></div><div data-aspect-ratio="0.75"><img src="https://example.com/three.jpg"></div></div></div>`,
         ],
       },
     };
@@ -131,19 +138,22 @@ export const ExtensionGallery = Node.create<
         },
       },
       groupSize: {
-        default: 3,
+        default: DEFAULT_GALLERY_GROUP_SIZE,
         parseHTML: (element) => {
-          return Number(element.getAttribute("data-group-size")) || 3;
+          return (
+            Number(element.getAttribute("data-group-size")) ||
+            DEFAULT_GALLERY_GROUP_SIZE
+          );
         },
       },
       layout: {
-        default: "auto",
+        default: DEFAULT_GALLERY_LAYOUT,
         parseHTML: (element) => {
-          return element.getAttribute("data-layout") || "auto";
+          return element.getAttribute("data-layout") || DEFAULT_GALLERY_LAYOUT;
         },
       },
       gap: {
-        default: 8,
+        default: DEFAULT_GALLERY_GAP,
         parseHTML: (element) => {
           const gap = Number(element.getAttribute("data-gap"));
           if (isNaN(gap) || gap < 0) {
@@ -174,8 +184,11 @@ export const ExtensionGallery = Node.create<
 
   renderHTML({ node }) {
     const images: ExtensionGalleryImageItem[] = node.attrs.images || [];
-    const groupSize = node.attrs.groupSize || this.options?.groupSize || 3;
-    const layout = node.attrs.layout || "auto";
+    const groupSize =
+      node.attrs.groupSize ||
+      this.options?.groupSize ||
+      DEFAULT_GALLERY_GROUP_SIZE;
+    const layout = node.attrs.layout || DEFAULT_GALLERY_LAYOUT;
     const gap = node.attrs.gap || this.options?.gap || 0;
     const imageGroups: ExtensionGalleryImageItem[][] = images.reduce(
       (
@@ -201,7 +214,7 @@ export const ExtensionGallery = Node.create<
           return [
             "div",
             {
-              style: `flex: ${layout === "square" ? "1" : image.aspectRatio} 1 0%;${layout === "square" ? "aspect-ratio: 1/1;" : ""}`,
+              style: `flex: ${layout === GALLERY_LAYOUT_SQUARE ? "1" : image.aspectRatio} 1 0%;${layout === GALLERY_LAYOUT_SQUARE ? "aspect-ratio: 1/1;" : ""}`,
               "data-aspect-ratio": image.aspectRatio.toString(),
             },
             [

--- a/ui/packages/editor/src/extensions/gallery/index.ts
+++ b/ui/packages/editor/src/extensions/gallery/index.ts
@@ -65,6 +65,54 @@ export const ExtensionGallery = Node.create<
 
   allowGapCursor: true,
 
+  addHaloEditorMetadata() {
+    return {
+      ai: {
+        description:
+          "A gallery that presents multiple images in configurable groups.",
+        exposure: "available",
+        useWhen: [
+          "Several related images should be presented as one visual set.",
+        ],
+        avoidWhen: ["Only one image is needed."],
+        attributeGuidance: {
+          images: {
+            description:
+              "Ordered gallery items, each containing a source URL and aspect ratio.",
+            format: "array of { src: string, aspectRatio: number }",
+          },
+          groupSize: {
+            description: "Maximum number of images in each visual group.",
+            examples: [2, 3, 4],
+          },
+          layout: {
+            description: "Gallery layout strategy.",
+            allowedValues: ["auto", "square"],
+          },
+          gap: {
+            description: "Gap between gallery images in pixels.",
+            examples: [0, 8, 16],
+          },
+          file: {
+            description:
+              "Editor-only upload state that is not part of persisted article HTML.",
+            omitWhen: ["Generating or editing persisted article content."],
+          },
+        },
+        generation: {
+          mode: "direct-html",
+          guidelines: [
+            "Use stable accessible image URLs; uploading local files requires a separate plugin capability.",
+          ],
+        },
+        examples: [
+          '<div data-type="gallery" data-group-size="2" data-layout="auto" data-gap="8"><div data-type="gallery-group"><div data-aspect-ratio="1.5"><img src="https://example.com/one.jpg"></div><div data-aspect-ratio="1.5"><img src="https://example.com/two.jpg"></div></div></div>',
+          '<div data-type="gallery" data-group-size="3" data-layout="square" data-gap="12"><div data-type="gallery-group"><div data-aspect-ratio="1"><img src="https://example.com/one.jpg"></div><div data-aspect-ratio="1.5"><img src="https://example.com/two.jpg"></div><div data-aspect-ratio="0.75"><img src="https://example.com/three.jpg"></div></div></div>',
+        ],
+      },
+    };
+  },
+
   addAttributes() {
     return {
       images: {

--- a/ui/packages/editor/src/extensions/hard-break/index.ts
+++ b/ui/packages/editor/src/extensions/hard-break/index.ts
@@ -1,1 +1,19 @@
-export { HardBreak as ExtensionHardBreak } from "@tiptap/extension-hard-break";
+import { HardBreak as TiptapHardBreak } from "@tiptap/extension-hard-break";
+
+export const ExtensionHardBreak = TiptapHardBreak.extend({
+  addHaloEditorMetadata() {
+    return {
+      ai: {
+        description:
+          "A line break inside the current text block without starting a new paragraph.",
+        exposure: "available",
+        useWhen: ["A semantic line break is required within one block."],
+        avoidWhen: ["A new paragraph better represents the separation."],
+        generation: {
+          mode: "direct-html",
+        },
+        examples: ["<p>First line<br>Second line</p>"],
+      },
+    };
+  },
+});

--- a/ui/packages/editor/src/extensions/heading/index.ts
+++ b/ui/packages/editor/src/extensions/heading/index.ts
@@ -26,6 +26,44 @@ import { generateAnchorId } from "@/utils";
 export type ExtensionHeadingOptions = ExtensionOptions & HeadingOptions;
 
 export const ExtensionHeading = TiptapHeading.extend<ExtensionHeadingOptions>({
+  addHaloEditorMetadata() {
+    return {
+      ai: {
+        description:
+          "A section heading whose level communicates document hierarchy.",
+        exposure: "recommended",
+        useWhen: ["Introducing a titled section or subsection."],
+        avoidWhen: ["Styling ordinary body text without creating a section."],
+        contentGuidelines: [
+          "Keep heading levels hierarchical and avoid skipping levels without a structural reason.",
+          "Keep the heading text concise.",
+        ],
+        attributeGuidance: {
+          level: {
+            description: "Heading level rendered as h1 through h6.",
+            allowedValues: this.options.levels,
+          },
+          id: {
+            description:
+              "Editor-managed anchor identifier regenerated from the heading text.",
+            format: "HTML id",
+            omitWhen: [
+              "Generating or editing article content; the editor maintains this value.",
+            ],
+          },
+        },
+        generation: {
+          mode: "direct-html",
+        },
+        examples: [
+          "<h1>Guide</h1>",
+          "<h2>Installation</h2>",
+          "<h3>Configuration options</h3>",
+        ],
+      },
+    };
+  },
+
   renderHTML({ node, HTMLAttributes }) {
     const hasLevel = this.options.levels.includes(node.attrs.level);
     const level = hasLevel ? node.attrs.level : this.options.levels[0];

--- a/ui/packages/editor/src/extensions/highlight/index.ts
+++ b/ui/packages/editor/src/extensions/highlight/index.ts
@@ -12,6 +12,33 @@ export type ExtensionHighlightOptions = ExtensionOptions &
 
 export const ExtensionHighlight =
   TiptapHighlight.extend<ExtensionHighlightOptions>({
+    addHaloEditorMetadata() {
+      return {
+        ai: {
+          description:
+            "Highlighted inline text with an optional background color.",
+          exposure: "available",
+          useWhen: ["Drawing attention to a short, especially notable phrase."],
+          avoidWhen: ["Highlighting large sections of text."],
+          attributeGuidance: {
+            color: {
+              description: "CSS color used as the highlight background.",
+              format: "CSS color",
+              examples: ["#fff3a3", "yellow"],
+              omitWhen: ["The default highlight color is appropriate."],
+            },
+          },
+          generation: {
+            mode: "direct-html",
+          },
+          examples: [
+            "<p>This is <mark>highlighted with the default color</mark>.</p>",
+            '<p>This is <mark data-color="#fff3a3" style="background-color: #fff3a3">notable</mark>.</p>',
+          ],
+        },
+      };
+    },
+
     addOptions() {
       return {
         ...this.parent?.(),

--- a/ui/packages/editor/src/extensions/horizontal-rule/index.ts
+++ b/ui/packages/editor/src/extensions/horizontal-rule/index.ts
@@ -1,1 +1,18 @@
-export { HorizontalRule as ExtensionHorizontalRule } from "@tiptap/extension-horizontal-rule";
+import { HorizontalRule as TiptapHorizontalRule } from "@tiptap/extension-horizontal-rule";
+
+export const ExtensionHorizontalRule = TiptapHorizontalRule.extend({
+  addHaloEditorMetadata() {
+    return {
+      ai: {
+        description: "A thematic break between sections of content.",
+        exposure: "available",
+        useWhen: ["Separating major shifts in topic or scene."],
+        avoidWhen: ["A heading or paragraph break already provides structure."],
+        generation: {
+          mode: "direct-html",
+        },
+        examples: ["<hr>"],
+      },
+    };
+  },
+});

--- a/ui/packages/editor/src/extensions/iframe/index.ts
+++ b/ui/packages/editor/src/extensions/iframe/index.ts
@@ -51,6 +51,70 @@ export const ExtensionIframe = Node.create<ExtensionOptions>({
     return "inline";
   },
 
+  addHaloEditorMetadata() {
+    return {
+      ai: {
+        description:
+          "An inline iframe embed for a trusted external page or application inside a text block.",
+        aliases: ["embed"],
+        exposure: "available",
+        useWhen: [
+          "Embedding a trusted page that cannot be represented natively.",
+        ],
+        avoidWhen: [
+          "The source is untrusted or a native link or media component is sufficient.",
+        ],
+        attributeGuidance: {
+          src: {
+            description: "Trusted URL loaded by the iframe.",
+            format: "allowed absolute URL",
+          },
+          width: {
+            description: "Rendered iframe width.",
+            format: "HTML dimension or CSS length",
+            examples: ["100%", "720px"],
+          },
+          height: {
+            description: "Rendered iframe height.",
+            format: "HTML dimension or CSS length",
+            examples: ["300px", "480px"],
+          },
+          scrolling: {
+            description: "Legacy iframe scrolling behavior.",
+            allowedValues: ["yes", "no", "auto", null],
+            omitWhen: ["Browser defaults are appropriate."],
+          },
+          frameborder: {
+            description: "Legacy iframe border setting.",
+            allowedValues: ["0", "1"],
+          },
+          allowfullscreen: {
+            description: "Whether embedded content may enter fullscreen.",
+            allowedValues: [true, false],
+          },
+          framespacing: {
+            description: "Legacy spacing around the iframe in pixels.",
+            examples: [0],
+            omitWhen: ["Modern CSS layout controls spacing."],
+          },
+          style: {
+            description: "Editor-managed display style for the iframe element.",
+            omitWhen: ["Generating or editing persisted article content."],
+          },
+        },
+        generation: {
+          mode: "direct-html",
+          guidelines: [
+            "Only use a trusted URL accepted by the editor's URI policy.",
+          ],
+        },
+        examples: [
+          '<p><iframe src="https://example.com/embed" width="100%" height="300px" frameborder="0" allowfullscreen></iframe></p>',
+        ],
+      },
+    };
+  },
+
   addAttributes() {
     return {
       ...this.parent?.(),

--- a/ui/packages/editor/src/extensions/image/BubbleItemImageHref.vue
+++ b/ui/packages/editor/src/extensions/image/BubbleItemImageHref.vue
@@ -5,6 +5,7 @@ import { ExtensionImage, ExtensionLink } from "@/extensions";
 import { i18n } from "@/locales";
 import type { BubbleItemComponentProps } from "@/types";
 import { isAllowedUri } from "@/utils/is-allowed-uri";
+import { IMAGE_LINK_TARGET_BLANK, IMAGE_LINK_TARGET_SELF } from "./constants";
 
 const props = defineProps<BubbleItemComponentProps>();
 
@@ -38,20 +39,20 @@ const href = computed({
     updateImageLinkAttributes({
       href,
       target: currentAttributes.href
-        ? currentAttributes.target || "_self"
-        : "_blank",
+        ? currentAttributes.target || IMAGE_LINK_TARGET_SELF
+        : IMAGE_LINK_TARGET_BLANK,
     });
   },
 });
 
 const target = computed({
   get() {
-    return getImageLinkAttributes().target === "_blank";
+    return getImageLinkAttributes().target === IMAGE_LINK_TARGET_BLANK;
   },
   set(value) {
     updateImageLinkAttributes({
       href: href.value,
-      target: value ? "_blank" : "_self",
+      target: value ? IMAGE_LINK_TARGET_BLANK : IMAGE_LINK_TARGET_SELF,
     });
   },
 });

--- a/ui/packages/editor/src/extensions/image/constants.ts
+++ b/ui/packages/editor/src/extensions/image/constants.ts
@@ -1,0 +1,6 @@
+export const IMAGE_LINK_TARGET_SELF = "_self";
+export const IMAGE_LINK_TARGET_BLANK = "_blank";
+export const IMAGE_LINK_TARGETS = [
+  IMAGE_LINK_TARGET_SELF,
+  IMAGE_LINK_TARGET_BLANK,
+] as const;

--- a/ui/packages/editor/src/extensions/image/index.ts
+++ b/ui/packages/editor/src/extensions/image/index.ts
@@ -39,6 +39,7 @@ import BubbleItemImageHref from "./BubbleItemImageHref.vue";
 import BubbleItemImageLink from "./BubbleItemImageLink.vue";
 import BubbleItemImagePosition from "./BubbleItemImagePosition.vue";
 import BubbleItemImageSize from "./BubbleItemImageSize.vue";
+import { IMAGE_LINK_TARGET_BLANK, IMAGE_LINK_TARGETS } from "./constants";
 import ImageView from "./ImageView.vue";
 
 export const IMAGE_BUBBLE_MENU_KEY = new PluginKey("imageBubbleMenu");
@@ -96,6 +97,12 @@ export const ExtensionImage = TiptapImage.extend<ExtensionImageOptions>({
           href: {
             description: "Optional URL opened when the image is activated.",
             format: "absolute or site-relative URL",
+            omitWhen: ["The image should not act as a link."],
+          },
+          target: {
+            description:
+              "Browsing context used when the linked image is activated.",
+            allowedValues: [...IMAGE_LINK_TARGETS, null],
             omitWhen: ["The image should not act as a link."],
           },
           file: {
@@ -481,7 +488,7 @@ export const ExtensionImage = TiptapImage.extend<ExtensionImageOptions>({
                 action: () => {
                   window.open(
                     editor.getAttributes(ExtensionImage.name).src,
-                    "_blank"
+                    IMAGE_LINK_TARGET_BLANK
                   );
                 },
               },

--- a/ui/packages/editor/src/extensions/image/index.ts
+++ b/ui/packages/editor/src/extensions/image/index.ts
@@ -57,6 +57,68 @@ export const ExtensionImage = TiptapImage.extend<ExtensionImageOptions>({
 
   defining: false,
 
+  addHaloEditorMetadata() {
+    return {
+      ai: {
+        description:
+          "An image with alternative text, optional dimensions, and an optional destination link, normally used as the media child of a figure. Standalone images are legacy content that the editor may normalize into a figure.",
+        exposure: "recommended",
+        useWhen: ["An image directly supports the surrounding content."],
+        avoidWhen: ["No meaningful or accessible image source is available."],
+        contentGuidelines: [
+          "Provide concise alternative text that describes the image's purpose.",
+        ],
+        attributeGuidance: {
+          src: {
+            description: "URL of the image resource.",
+            format: "absolute or site-relative URL",
+          },
+          alt: {
+            description: "Alternative text for accessibility.",
+            omitWhen: ["The image is purely decorative."],
+          },
+          title: {
+            description: "Optional advisory title for the image.",
+            omitWhen: ["It would merely repeat the alternative text."],
+          },
+          width: {
+            description: "Rendered image width.",
+            format: "HTML dimension or CSS length",
+            examples: ["100%", "640px"],
+            omitWhen: ["Natural or container sizing is appropriate."],
+          },
+          height: {
+            description: "Rendered image height.",
+            format: "HTML dimension or CSS length",
+            examples: ["auto", "360px"],
+            omitWhen: ["Natural or proportional sizing is appropriate."],
+          },
+          href: {
+            description: "Optional URL opened when the image is activated.",
+            format: "absolute or site-relative URL",
+            omitWhen: ["The image should not act as a link."],
+          },
+          file: {
+            description:
+              "Editor-only upload state that is not part of persisted article HTML.",
+            omitWhen: ["Generating or editing persisted article content."],
+          },
+        },
+        generation: {
+          mode: "direct-html",
+          guidelines: [
+            "Use a stable accessible URL; uploading a local file requires a separate plugin capability.",
+            "Place the image inside a figure and keep the figure contentType set to image.",
+          ],
+        },
+        examples: [
+          '<figure data-content-type="image"><img src="https://example.com/diagram.png" alt="Architecture diagram"></figure>',
+          '<figure data-content-type="image"><img src="https://example.com/photo.jpg" alt="Team members at the event" width="640px" height="auto"></figure>',
+        ],
+      },
+    };
+  },
+
   addAttributes() {
     return {
       ...this.parent?.(),

--- a/ui/packages/editor/src/extensions/indent/index.ts
+++ b/ui/packages/editor/src/extensions/indent/index.ts
@@ -37,6 +37,38 @@ export const ExtensionIndent = Extension.create<ExtensionIndentOptions>({
   name: "indent",
   priority: 800,
 
+  addHaloEditorMetadata() {
+    return {
+      contributions: this.options.names.map((name) => ({
+        targets: [{ kind: "node" as const, name }],
+        metadata: {
+          ai: {
+            attributeGuidance: {
+              indent: {
+                description: "Left indentation in pixels.",
+                examples: [
+                  this.options.minIndentLevel,
+                  this.options.indentRange,
+                  this.options.maxIndentLevel,
+                ],
+                guidelines: [
+                  `Use values between ${this.options.minIndentLevel} and ${this.options.maxIndentLevel}, normally in increments of ${this.options.indentRange}.`,
+                ],
+                omitWhen: ["No block indentation is needed."],
+              },
+              lineIndent: {
+                description:
+                  "Whether the first line uses the editor's standard first-line indentation.",
+                allowedValues: [true, false],
+                omitWhen: ["No first-line indentation is needed."],
+              },
+            },
+          },
+        },
+      })),
+    };
+  },
+
   addOptions() {
     return {
       names: ["heading", "paragraph"],

--- a/ui/packages/editor/src/extensions/italic/index.ts
+++ b/ui/packages/editor/src/extensions/italic/index.ts
@@ -9,6 +9,20 @@ import type { ExtensionOptions } from "@/types";
 export type ExtensionItalicOptions = ExtensionOptions & Partial<ItalicOptions>;
 
 export const ExtensionItalic = TiptapItalic.extend<ExtensionItalicOptions>({
+  addHaloEditorMetadata() {
+    return {
+      ai: {
+        description: "Emphasis for inline text, usually rendered in italics.",
+        exposure: "recommended",
+        useWhen: ["Adding semantic emphasis or marking a title or term."],
+        generation: {
+          mode: "direct-html",
+        },
+        examples: ["<p>This point is <em>especially relevant</em>.</p>"],
+      },
+    };
+  },
+
   addOptions() {
     return {
       ...this.parent?.(),

--- a/ui/packages/editor/src/extensions/link/index.ts
+++ b/ui/packages/editor/src/extensions/link/index.ts
@@ -4,6 +4,56 @@ import type { ExtensionOptions } from "@/types";
 export type ExtensionLinkOptions = ExtensionOptions & Partial<LinkOptions>;
 
 export const ExtensionLink = TiptapLink.extend<ExtensionLinkOptions>({
+  addHaloEditorMetadata() {
+    return {
+      ai: {
+        description: "A hyperlink applied to inline content.",
+        exposure: "recommended",
+        useWhen: ["Linking a relevant source, page, download, or reference."],
+        avoidWhen: ["No trustworthy destination URL is available."],
+        contentGuidelines: [
+          "Use descriptive link text instead of repeating the raw URL when possible.",
+        ],
+        attributeGuidance: {
+          href: {
+            description: "Destination URL for the link.",
+            format: "absolute or site-relative URL",
+            examples: ["https://www.halo.run/", "/docs/getting-started"],
+          },
+          target: {
+            description: "Browsing context in which to open the destination.",
+            allowedValues: ["_blank", "_self", "_parent", "_top", null],
+            omitWhen: ["The current browsing context should be used."],
+          },
+          rel: {
+            description: "Space-separated relationship tokens.",
+            format: "HTML link types",
+            examples: ["nofollow", "noopener noreferrer"],
+            omitWhen: ["No relationship tokens are needed."],
+          },
+          title: {
+            description: "Optional advisory text describing the destination.",
+            omitWhen: [
+              "It would repeat the visible link text or add no useful context.",
+            ],
+          },
+          class: {
+            description:
+              "Optional CSS classes supplied by an integration or theme.",
+            omitWhen: ["No integration-specific link styling is required."],
+          },
+        },
+        generation: {
+          mode: "direct-html",
+        },
+        examples: [
+          '<p>Read the <a href="https://www.halo.run/">Halo documentation</a>.</p>',
+          '<p>Open the <a href="https://example.com/report" target="_blank" rel="noopener noreferrer" title="External report">external report</a>.</p>',
+        ],
+      },
+    };
+  },
+
   addOptions() {
     return {
       ...this.parent?.(),

--- a/ui/packages/editor/src/extensions/list-item/index.ts
+++ b/ui/packages/editor/src/extensions/list-item/index.ts
@@ -1,0 +1,29 @@
+import { ListItem as TiptapListItem } from "@tiptap/extension-list";
+
+export const ExtensionListItem = TiptapListItem.extend({
+  addHaloEditorMetadata() {
+    return {
+      ai: {
+        description:
+          "A single item inside a bullet list or ordered list. It is not a top-level content block.",
+        exposure: "recommended",
+        useWhen: ["Adding an item to a bullet list or ordered list."],
+        avoidWhen: ["There is no containing list."],
+        generation: {
+          mode: "direct-html",
+        },
+        examples: [
+          "<ul><li><p>An unordered list item</p></li></ul>",
+          "<ol><li><p>An ordered list item</p></li></ol>",
+          "<ul><li><p>An item with another block</p><blockquote><p>Supporting quotation</p></blockquote></li></ul>",
+        ],
+      },
+      structure: {
+        allowedParents: ["bulletList", "orderedList"],
+        minPerParent: 1,
+        description:
+          "listItem may appear only inside bulletList or orderedList, and each such list contains at least one item.",
+      },
+    };
+  },
+});

--- a/ui/packages/editor/src/extensions/ordered-list/index.ts
+++ b/ui/packages/editor/src/extensions/ordered-list/index.ts
@@ -1,5 +1,4 @@
 import {
-  ListItem,
   OrderedList as TiptapOrderedList,
   type OrderedListOptions,
 } from "@tiptap/extension-list";
@@ -7,12 +6,44 @@ import { markRaw } from "vue";
 import MingcuteListOrderedLine from "~icons/mingcute/list-ordered-line";
 import type { Editor, Range } from "@/tiptap";
 import type { ExtensionOptions } from "@/types";
+import { ExtensionListItem } from "../list-item";
 
 export type ExtensionOrderedListOptions = Partial<OrderedListOptions> &
   ExtensionOptions;
 
 export const ExtensionOrderedList =
   TiptapOrderedList.extend<ExtensionOrderedListOptions>({
+    addHaloEditorMetadata() {
+      return {
+        ai: {
+          description: "An ordered list whose item sequence is meaningful.",
+          aliases: ["numbered list"],
+          exposure: "recommended",
+          useWhen: ["Presenting steps, rankings, or another ordered sequence."],
+          avoidWhen: ["Item order is not significant."],
+          attributeGuidance: {
+            start: {
+              description: "Starting ordinal for the first list item.",
+              examples: [1, 3, 10],
+              omitWhen: ["The list starts at 1."],
+            },
+            type: {
+              description: "HTML numbering style.",
+              allowedValues: ["1", "a", "A", "i", "I", null],
+              omitWhen: ["Default decimal numbering is appropriate."],
+            },
+          },
+          generation: {
+            mode: "direct-html",
+          },
+          examples: [
+            "<ol><li><p>First step</p></li><li><p>Second step</p></li></ol>",
+            '<ol start="3" type="I"><li><p>Third numbered item</p></li><li><p>Fourth numbered item</p></li></ol>',
+          ],
+        },
+      };
+    },
+
     addOptions() {
       return {
         ...this.parent?.(),
@@ -35,6 +66,6 @@ export const ExtensionOrderedList =
       };
     },
     addExtensions() {
-      return [ListItem];
+      return [ExtensionListItem];
     },
   });

--- a/ui/packages/editor/src/extensions/paragraph/index.ts
+++ b/ui/packages/editor/src/extensions/paragraph/index.ts
@@ -23,6 +23,27 @@ export type ExtensionParagraphOptions = ExtensionOptions &
 
 export const ExtensionParagraph =
   TiptapParagraph.extend<ExtensionParagraphOptions>({
+    addHaloEditorMetadata() {
+      return {
+        ai: {
+          description: "A standard paragraph of body text.",
+          exposure: "recommended",
+          useWhen: ["Writing ordinary prose or separating ideas into blocks."],
+          attributeGuidance: {
+            lineHeight: {
+              description: "CSS line-height applied to this paragraph.",
+              examples: [1.5, 2, "1.6"],
+              omitWhen: ["The default line height is sufficient."],
+            },
+          },
+          generation: {
+            mode: "direct-html",
+          },
+          examples: ["<p>A concise paragraph of body text.</p>"],
+        },
+      };
+    },
+
     addAttributes() {
       return {
         lineHeight: {

--- a/ui/packages/editor/src/extensions/strike/index.ts
+++ b/ui/packages/editor/src/extensions/strike/index.ts
@@ -9,6 +9,21 @@ import type { ExtensionOptions } from "@/types";
 export type ExtensionStrikeOptions = ExtensionOptions & Partial<StrikeOptions>;
 
 export const ExtensionStrike = TiptapStrike.extend<ExtensionStrikeOptions>({
+  addHaloEditorMetadata() {
+    return {
+      ai: {
+        description: "Inline text shown as deleted or no longer applicable.",
+        exposure: "available",
+        useWhen: ["Showing an obsolete value while preserving it for context."],
+        avoidWhen: ["Merely emphasizing text."],
+        generation: {
+          mode: "direct-html",
+        },
+        examples: ["<p>The old value was <s>10</s> 12.</p>"],
+      },
+    };
+  },
+
   addOptions() {
     return {
       ...this.parent?.(),

--- a/ui/packages/editor/src/extensions/subscript/index.ts
+++ b/ui/packages/editor/src/extensions/subscript/index.ts
@@ -13,6 +13,21 @@ export type ExtensionSubscriptOptions = Partial<SubscriptExtensionOptions> &
 
 export const ExtensionSubscript =
   TiptapSubscript.extend<ExtensionSubscriptOptions>({
+    addHaloEditorMetadata() {
+      return {
+        ai: {
+          description:
+            "Inline subscript text for chemical formulas and similar notation.",
+          exposure: "available",
+          useWhen: ["Writing a subscript such as the 2 in H2O."],
+          generation: {
+            mode: "direct-html",
+          },
+          examples: ["<p>H<sub>2</sub>O</p>"],
+        },
+      };
+    },
+
     addOptions() {
       return {
         ...this.parent?.(),

--- a/ui/packages/editor/src/extensions/superscript/index.ts
+++ b/ui/packages/editor/src/extensions/superscript/index.ts
@@ -13,6 +13,21 @@ export type ExtensionSuperscriptOptions = Partial<SuperscriptExtensionOptions> &
 
 export const ExtensionSuperscript =
   TiptapSuperscript.extend<ExtensionSuperscriptOptions>({
+    addHaloEditorMetadata() {
+      return {
+        ai: {
+          description:
+            "Inline superscript text for exponents, ordinals, and references.",
+          exposure: "available",
+          useWhen: ["Writing an exponent or superscript annotation."],
+          generation: {
+            mode: "direct-html",
+          },
+          examples: ["<p>x<sup>2</sup></p>"],
+        },
+      };
+    },
+
     addOptions() {
       return {
         ...this.parent?.(),

--- a/ui/packages/editor/src/extensions/table/index.ts
+++ b/ui/packages/editor/src/extensions/table/index.ts
@@ -222,6 +222,30 @@ export type ExtensionTableOptions = ExtensionOptions & Partial<TableOptions>;
 export const ExtensionTable = TiptapTable.extend<ExtensionTableOptions>({
   allowGapCursor: true,
 
+  addHaloEditorMetadata() {
+    return {
+      ai: {
+        description: "A table of rows containing header or data cells.",
+        exposure: "recommended",
+        useWhen: ["Comparing structured values across rows and columns."],
+        avoidWhen: [
+          "The information is a simple list or the table would be used only for visual layout.",
+        ],
+        contentGuidelines: [
+          "Use header cells where they clarify row or column meaning.",
+          "Keep each cell focused on one value or concise piece of content.",
+        ],
+        generation: {
+          mode: "direct-html",
+        },
+        examples: [
+          "<table><tbody><tr><th><p>Name</p></th><th><p>Status</p></th></tr><tr><td><p>Halo</p></td><td><p>Active</p></td></tr></tbody></table>",
+          '<table><tbody><tr><th colspan="2"><p>Quarterly results</p></th></tr><tr><td rowspan="2"><p>Revenue</p></td><td><p>Q1</p></td></tr><tr><td><p>Q2</p></td></tr></tbody></table>',
+        ],
+      },
+    };
+  },
+
   addExtensions() {
     return [TableCell, TableRow, TableHeader];
   },

--- a/ui/packages/editor/src/extensions/table/table-cell.ts
+++ b/ui/packages/editor/src/extensions/table/table-cell.ts
@@ -138,6 +138,53 @@ const TableCell = Node.create<TableCellOptions>({
   isolating: true,
   fakeSelection: true,
 
+  addHaloEditorMetadata() {
+    return {
+      ai: {
+        description:
+          "A data cell inside a table row. It is not a top-level content block.",
+        aliases: ["td"],
+        exposure: "recommended",
+        useWhen: ["Adding an ordinary value to a table row."],
+        avoidWhen: [
+          "The cell labels a row or column and should be a header cell.",
+        ],
+        attributeGuidance: {
+          colspan: {
+            description: "Number of columns spanned by this cell.",
+            examples: [1, 2, 3],
+          },
+          rowspan: {
+            description: "Number of rows spanned by this cell.",
+            examples: [1, 2, 3],
+          },
+          colwidth: {
+            description: "Column widths associated with the cell.",
+            format: "array of pixel widths",
+            examples: [null],
+            omitWhen: ["Automatic table sizing is appropriate."],
+          },
+          style: {
+            description: "Optional CSS declarations for the cell.",
+            format: "CSS declarations",
+            omitWhen: ["Default cell styling is appropriate."],
+          },
+        },
+        generation: {
+          mode: "direct-html",
+        },
+        examples: [
+          "<table><tbody><tr><td><p>Value</p></td></tr></tbody></table>",
+          '<table><tbody><tr><td colspan="2"><p>Value across two columns</p></td></tr></tbody></table>',
+        ],
+      },
+      structure: {
+        allowedParents: ["tableRow"],
+        description: "tableCell may appear only inside tableRow.",
+      },
+    };
+  },
+
   addOptions() {
     return {
       HTMLAttributes: {},

--- a/ui/packages/editor/src/extensions/table/table-header.ts
+++ b/ui/packages/editor/src/extensions/table/table-header.ts
@@ -28,6 +28,51 @@ const TableHeader = Node.create<TableCellOptions>({
   isolating: true,
   fakeSelection: true,
 
+  addHaloEditorMetadata() {
+    return {
+      ai: {
+        description:
+          "A header cell inside a table row. It is not a top-level content block.",
+        aliases: ["th"],
+        exposure: "recommended",
+        useWhen: ["Labeling the meaning of a table row or column."],
+        avoidWhen: ["The cell contains ordinary table data."],
+        attributeGuidance: {
+          colspan: {
+            description: "Number of columns spanned by this header cell.",
+            examples: [1, 2, 3],
+          },
+          rowspan: {
+            description: "Number of rows spanned by this header cell.",
+            examples: [1, 2, 3],
+          },
+          colwidth: {
+            description: "Column widths associated with the header cell.",
+            format: "array of pixel widths",
+            examples: [null],
+            omitWhen: ["Automatic table sizing is appropriate."],
+          },
+          style: {
+            description: "Optional CSS declarations for the header cell.",
+            format: "CSS declarations",
+            omitWhen: ["Default header styling is appropriate."],
+          },
+        },
+        generation: {
+          mode: "direct-html",
+        },
+        examples: [
+          "<table><tbody><tr><th><p>Label</p></th></tr></tbody></table>",
+          '<table><tbody><tr><th rowspan="2"><p>Grouped label</p></th><th><p>First value</p></th></tr><tr><th><p>Second value</p></th></tr></tbody></table>',
+        ],
+      },
+      structure: {
+        allowedParents: ["tableRow"],
+        description: "tableHeader may appear only inside tableRow.",
+      },
+    };
+  },
+
   addOptions() {
     return {
       HTMLAttributes: {},

--- a/ui/packages/editor/src/extensions/table/table-row.ts
+++ b/ui/packages/editor/src/extensions/table/table-row.ts
@@ -3,6 +3,41 @@ import { TableRow as BuiltInTableRow } from "@tiptap/extension-table";
 const TableRow = BuiltInTableRow.extend({
   allowGapCursor: false,
 
+  addHaloEditorMetadata() {
+    return {
+      ai: {
+        description:
+          "A row of header or data cells inside a table. It is not a top-level content block.",
+        aliases: ["tr"],
+        exposure: "recommended",
+        useWhen: ["Adding one record or header row to a table."],
+        avoidWhen: ["There is no containing table."],
+        attributeGuidance: {
+          style: {
+            description:
+              "CSS declarations for row presentation, including height.",
+            format: "CSS declarations",
+            examples: ["height: 60px;"],
+            omitWhen: ["Default row sizing is appropriate."],
+          },
+        },
+        generation: {
+          mode: "direct-html",
+        },
+        examples: [
+          "<table><tbody><tr><td><p>Value</p></td></tr></tbody></table>",
+          "<table><tbody><tr><th><p>Label</p></th><th><p>Status</p></th></tr></tbody></table>",
+        ],
+      },
+      structure: {
+        allowedParents: ["table"],
+        minPerParent: 1,
+        description:
+          "tableRow may appear only inside table, and each table contains at least one row.",
+      },
+    };
+  },
+
   addAttributes() {
     return {
       style: {

--- a/ui/packages/editor/src/extensions/task-list/index.ts
+++ b/ui/packages/editor/src/extensions/task-list/index.ts
@@ -1,5 +1,5 @@
 import {
-  TaskItem,
+  TaskItem as TiptapTaskItem,
   TaskList as TiptapTaskList,
   type TaskListOptions,
 } from "@tiptap/extension-list";
@@ -11,8 +11,59 @@ import type { ExtensionOptions } from "@/types";
 export type ExtensionTaskListOptions = Partial<TaskListOptions> &
   ExtensionOptions;
 
+const ExtensionTaskItem = TiptapTaskItem.extend({
+  addHaloEditorMetadata() {
+    return {
+      ai: {
+        description:
+          "A checkable task inside a task list. It is not a top-level content block.",
+        exposure: "recommended",
+        useWhen: ["Adding a completed or incomplete action to a task list."],
+        avoidWhen: ["There is no containing task list."],
+        attributeGuidance: {
+          checked: {
+            description: "Whether this task is complete.",
+            allowedValues: [true, false],
+          },
+        },
+        generation: {
+          mode: "direct-html",
+        },
+        examples: [
+          '<ul data-type="taskList"><li data-type="taskItem" data-checked="false"><label><input type="checkbox"><span></span></label><div><p>Review the draft</p></div></li></ul>',
+          '<ul data-type="taskList"><li data-type="taskItem" data-checked="true"><label><input type="checkbox" checked><span></span></label><div><p>Publish the article</p></div></li></ul>',
+        ],
+      },
+      structure: {
+        allowedParents: ["taskList"],
+        minPerParent: 1,
+        description:
+          "taskItem may appear only inside taskList, and each task list contains at least one task.",
+      },
+    };
+  },
+});
+
 export const ExtensionTaskList =
   TiptapTaskList.extend<ExtensionTaskListOptions>({
+    addHaloEditorMetadata() {
+      return {
+        ai: {
+          description: "A checklist of actionable tasks.",
+          aliases: ["checklist"],
+          exposure: "recommended",
+          useWhen: ["Presenting actions with explicit completion state."],
+          avoidWhen: ["Items are informational rather than actionable."],
+          generation: {
+            mode: "direct-html",
+          },
+          examples: [
+            '<ul data-type="taskList"><li data-type="taskItem" data-checked="true"><label><input type="checkbox" checked><span></span></label><div><p>Draft the article</p></div></li><li data-type="taskItem" data-checked="false"><label><input type="checkbox"><span></span></label><div><p>Review the draft</p></div></li></ul>',
+          ],
+        },
+      };
+    },
+
     addOptions() {
       return {
         ...this.parent?.(),
@@ -30,6 +81,6 @@ export const ExtensionTaskList =
       };
     },
     addExtensions() {
-      return [TaskItem];
+      return [ExtensionTaskItem];
     },
   });

--- a/ui/packages/editor/src/extensions/text-align/index.ts
+++ b/ui/packages/editor/src/extensions/text-align/index.ts
@@ -7,6 +7,25 @@ export type ExtensionTextAlignOptions = ExtensionOptions &
   Partial<TextAlignOptions>;
 
 export const ExtensionTextAlign =
-  TiptapTextAlign.extend<ExtensionTextAlignOptions>().configure({
+  TiptapTextAlign.extend<ExtensionTextAlignOptions>({
+    addHaloEditorMetadata() {
+      return {
+        contributions: (this.options.types ?? []).map((name) => ({
+          targets: [{ kind: "node" as const, name }],
+          metadata: {
+            ai: {
+              attributeGuidance: {
+                textAlign: {
+                  description: "Horizontal alignment of text in this block.",
+                  allowedValues: this.options.alignments,
+                  omitWhen: ["The editor default alignment is appropriate."],
+                },
+              },
+            },
+          },
+        })),
+      };
+    },
+  }).configure({
     types: ["heading", "paragraph"],
   });

--- a/ui/packages/editor/src/extensions/text-style/index.ts
+++ b/ui/packages/editor/src/extensions/text-style/index.ts
@@ -10,6 +10,68 @@ export const ExtensionTextStyle =
     // Set the priority of this extension to 110 to ensure it loads before other extensions.
     // It must load before the highlight plugin, otherwise, it will cause span and mark to display in parallel.
     priority: 110,
+    addHaloEditorMetadata() {
+      return {
+        contributions: [
+          {
+            targets: [{ kind: "mark", name: "textStyle" }],
+            metadata: {
+              ai: {
+                description:
+                  "Inline text styling carried by a span, including color, font family, font size, background color, or line height.",
+                exposure: "available",
+                useWhen: [
+                  "A specific inline visual style is explicitly useful or requested.",
+                ],
+                avoidWhen: [
+                  "Semantic marks such as strong, emphasis, or code better express the meaning.",
+                ],
+                attributeGuidance: {
+                  backgroundColor: {
+                    description: "CSS background color for the inline text.",
+                    format: "CSS color",
+                    examples: ["#fff3a3", "rgb(255, 243, 163)"],
+                    omitWhen: ["No custom background color is needed."],
+                  },
+                  color: {
+                    description: "CSS foreground color for the inline text.",
+                    format: "CSS color",
+                    examples: ["#1f2937", "rgb(31, 41, 55)"],
+                    omitWhen: ["The inherited text color is appropriate."],
+                  },
+                  fontFamily: {
+                    description: "CSS font-family for the inline text.",
+                    format: "CSS font-family",
+                    examples: ["serif", '"JetBrains Mono", monospace'],
+                    omitWhen: ["The inherited font is appropriate."],
+                  },
+                  fontSize: {
+                    description: "CSS font-size for the inline text.",
+                    format: "CSS length",
+                    examples: ["14px", "1.25rem"],
+                    omitWhen: ["The inherited font size is appropriate."],
+                  },
+                  lineHeight: {
+                    description: "CSS line-height for the inline text.",
+                    format: "CSS line-height",
+                    examples: ["1.5", "24px"],
+                    omitWhen: ["The inherited line height is appropriate."],
+                  },
+                },
+                generation: {
+                  mode: "direct-html",
+                },
+                examples: [
+                  '<p><span style="color: #1f2937; font-size: 18px">Styled text</span></p>',
+                  '<p><span style="background-color: #fff3a3; font-family: serif">Highlighted serif text</span></p>',
+                  '<p><span style="line-height: 1.8">Text with a custom line height</span></p>',
+                ],
+              },
+            },
+          },
+        ],
+      };
+    },
   }).configure({
     backgroundColor: {
       types: ["textStyle"],

--- a/ui/packages/editor/src/extensions/text/index.ts
+++ b/ui/packages/editor/src/extensions/text/index.ts
@@ -45,6 +45,26 @@ export const TEXT_BUBBLE_MENU_KEY = new PluginKey("textBubbleMenu");
 export type ExtensionTextOptions = ExtensionOptions;
 
 export const ExtensionText = TiptapText.extend<ExtensionTextOptions>({
+  addHaloEditorMetadata() {
+    return {
+      ai: {
+        description:
+          "Plain text content inside text-bearing nodes such as paragraphs, headings, and captions.",
+        exposure: "recommended",
+        useWhen: [
+          "Writing ordinary textual content inside a node that accepts inline text.",
+        ],
+        contentGuidelines: [
+          "Place text inside a valid text-bearing parent rather than as a top-level node.",
+        ],
+        generation: {
+          mode: "direct-html",
+        },
+        examples: ["<p>Plain text content</p>"],
+      },
+    };
+  },
+
   addOptions() {
     return {
       ...this.parent?.(),

--- a/ui/packages/editor/src/extensions/underline/index.ts
+++ b/ui/packages/editor/src/extensions/underline/index.ts
@@ -13,6 +13,21 @@ export type ExtensionUnderlineOptions = ExtensionOptions &
 
 export const ExtensionUnderline =
   TiptapUnderline.extend<ExtensionUnderlineOptions>({
+    addHaloEditorMetadata() {
+      return {
+        ai: {
+          description: "Underlined inline text.",
+          exposure: "available",
+          useWhen: ["Underline is explicitly requested."],
+          avoidWhen: ["The text could be mistaken for a hyperlink."],
+          generation: {
+            mode: "direct-html",
+          },
+          examples: ["<p><u>Underlined text</u></p>"],
+        },
+      };
+    },
+
     addOptions() {
       return {
         ...this.parent?.(),

--- a/ui/packages/editor/src/extensions/video/index.ts
+++ b/ui/packages/editor/src/extensions/video/index.ts
@@ -61,6 +61,64 @@ export const ExtensionVideo = Node.create<ExtensionVideoOptions>({
 
   group: "block",
 
+  addHaloEditorMetadata() {
+    return {
+      ai: {
+        description:
+          "A video player for a referenced video resource, normally used as the media child of a figure. Standalone videos are legacy content that the editor may normalize into a figure.",
+        exposure: "available",
+        useWhen: ["Embedding a relevant video with a known URL."],
+        avoidWhen: ["No accessible video source is available."],
+        attributeGuidance: {
+          src: {
+            description: "URL of the video resource.",
+            format: "absolute or site-relative URL",
+          },
+          width: {
+            description: "Rendered video width.",
+            format: "HTML dimension or CSS length",
+            examples: ["100%", "720px"],
+          },
+          height: {
+            description: "Rendered video height.",
+            format: "HTML dimension or CSS length",
+            examples: ["auto", "405px"],
+          },
+          autoplay: {
+            description: "Whether playback starts automatically.",
+            allowedValues: [true, false],
+            omitWhen: ["User-initiated playback is preferred."],
+          },
+          controls: {
+            description: "Whether native playback controls are visible.",
+            allowedValues: [true, false],
+          },
+          loop: {
+            description: "Whether playback restarts after reaching the end.",
+            allowedValues: [true, false],
+            omitWhen: ["The video should play once."],
+          },
+          file: {
+            description:
+              "Editor-only upload state that is not part of persisted article HTML.",
+            omitWhen: ["Generating or editing persisted article content."],
+          },
+        },
+        generation: {
+          mode: "direct-html",
+          guidelines: [
+            "Use a stable accessible URL; uploading a local file requires a separate plugin capability.",
+            "Place the video inside a figure and keep the figure contentType set to video.",
+          ],
+        },
+        examples: [
+          '<figure data-content-type="video"><video src="https://example.com/video.mp4" width="100%" controls></video></figure>',
+          '<figure data-content-type="video"><video src="https://example.com/loop.mp4" width="640px" height="360px" controls loop></video></figure>',
+        ],
+      },
+    };
+  },
+
   addAttributes() {
     return {
       ...this.parent?.(),

--- a/ui/packages/editor/src/index.ts
+++ b/ui/packages/editor/src/index.ts
@@ -3,6 +3,7 @@ import "./styles/index.scss";
 import "./styles/tailwind.css";
 
 export * from "./components";
+export * from "./editor-metadata";
 export * from "./extensions";
 export * from "./tiptap";
 export * from "./types";

--- a/ui/packages/shared/src/utils/index.ts
+++ b/ui/packages/shared/src/utils/index.ts
@@ -3,8 +3,6 @@ import { DateUtils } from "./date";
 import { IdUtils } from "./id";
 import { PermissionUtils } from "./permission";
 
-export { utf8ByteLength } from "./string";
-
 export const utils = {
   date: new DateUtils(),
   attachment: new AttachmentUtils(),

--- a/ui/packages/shared/src/utils/index.ts
+++ b/ui/packages/shared/src/utils/index.ts
@@ -3,6 +3,8 @@ import { DateUtils } from "./date";
 import { IdUtils } from "./id";
 import { PermissionUtils } from "./permission";
 
+export { utf8ByteLength } from "./string";
+
 export const utils = {
   date: new DateUtils(),
   attachment: new AttachmentUtils(),

--- a/ui/packages/shared/src/utils/string.ts
+++ b/ui/packages/shared/src/utils/string.ts
@@ -1,5 +1,0 @@
-const textEncoder = new TextEncoder();
-
-export function utf8ByteLength(value: string) {
-  return textEncoder.encode(value).byteLength;
-}

--- a/ui/packages/shared/src/utils/string.ts
+++ b/ui/packages/shared/src/utils/string.ts
@@ -1,0 +1,5 @@
+const textEncoder = new TextEncoder();
+
+export function utf8ByteLength(value: string) {
+  return textEncoder.encode(value).byteLength;
+}


### PR DESCRIPTION
#### What type of PR is this?

- [x] Feature
- [ ] Bug fix
- [ ] Improvement
- [ ] Cleanup
- [ ] Documentation

#### What this PR does / why we need it:

- 为 Tiptap Node、Mark 和 Extension 增加 `addHaloEditorMetadata()` 声明能力。
- 根据最终 Editor schema 同步生成稳定、可序列化的 AI Manifest。
- 支持扩展继承、全局属性贡献、结构约束、属性说明、生成能力和 HTML 示例。
- 为 Halo 内置编辑器组件补充完整的 AI 使用说明，包括代码块、媒体、表格、列表、Figure 和文本样式。
- 对第三方元数据执行字段过滤、大小限制和容错处理，但不影响编辑器运行时行为。

#### Which issue(s) this PR fixes:

Fixes #10173

#### Special notes for your reviewer:

本 PR 使用 AI 辅助完成设计与实现，相关代码、组件元数据和测试结果已经人工复核。

#### Does this PR introduce a user-facing change?

```release-note
富文本编辑器扩展现可声明供 AI 使用的组件元数据，帮助 Agent 正确理解并生成代码块、媒体、表格等编辑器内容。
```
