### PR TITLE
Refresh plugin status while starting

### DIFF
--- a/ui/console-src/modules/system/plugins/composables/__tests__/use-plugin.spec.ts
+++ b/ui/console-src/modules/system/plugins/composables/__tests__/use-plugin.spec.ts
@@ -1,0 +1,18 @@
+import { PluginStatusPhaseEnum } from "@halo-dev/api-client";
+import { describe, expect, it } from "vite-plus/test";
+import { getPluginStatusRefetchInterval } from "../use-plugin";
+
+describe("getPluginStatusRefetchInterval", () => {
+  it.each([
+    [1000, true, PluginStatusPhaseEnum.Pending],
+    [1000, true, PluginStatusPhaseEnum.Starting],
+    [false, true, PluginStatusPhaseEnum.Started],
+    [false, true, PluginStatusPhaseEnum.Failed],
+    [false, false, PluginStatusPhaseEnum.Starting],
+  ])(
+    "returns %s when enabled is %s and phase is %s",
+    (expected, enabled, phase) => {
+      expect(getPluginStatusRefetchInterval(enabled, phase)).toBe(expected);
+    }
+  );
+});

--- a/ui/console-src/modules/system/plugins/composables/use-plugin.ts
+++ b/ui/console-src/modules/system/plugins/composables/use-plugin.ts
@@ -14,6 +14,20 @@ import { computed, defineAsyncComponent, ref, shallowRef } from "vue";
 import { useI18n } from "vue-i18n";
 import { usePluginModuleStore } from "@/stores/plugin";
 
+export function getPluginStatusRefetchInterval(
+  enabled: boolean | undefined,
+  phase: PluginStatusPhaseEnum | undefined
+) {
+  if (
+    enabled &&
+    phase !== PluginStatusPhaseEnum.Started &&
+    phase !== PluginStatusPhaseEnum.Failed
+  ) {
+    return 1000;
+  }
+  return false;
+}
+
 export function usePluginLifeCycle(plugin?: Ref<Plugin | undefined>) {
   const { t } = useI18n();
   const queryClient = useQueryClient();
@@ -356,6 +370,8 @@ export function usePluginDetailTabs(
         tabs.value = [...initialTabs, ...(await getTabsFromExtensions())];
       }
     },
+    refetchInterval: (data) =>
+      getPluginStatusRefetchInterval(data?.spec.enabled, data?.status?.phase),
   });
 
   const { data: setting } = useQuery({


### PR DESCRIPTION
#### What type of PR is this?

- [ ] Feature
- [x] Bug fix
- [ ] Improvement
- [ ] Cleanup
- [ ] Documentation

#### What this PR does / why we need it:

Refreshes plugin details every second while an enabled plugin is starting, so the detail page and modal display the latest startup status without requiring a manual refresh.

Polling stops when the plugin reaches either the `STARTED` or `FAILED` terminal phase, or when the plugin is disabled.

#### Which issue(s) this PR fixes:

N/A

#### Special notes for your reviewer:

- Added unit coverage for transitional, terminal, and disabled plugin states.
- No backend API or generated client changes are included.
- AI assistance was used to review the change and prepare this PR description.

#### Does this PR introduce a user-facing change?

```release-note
修复插件启动过程中详情页状态不会自动更新的问题。
```
