### PR TITLE
fix: destroy plugins when application context closes on restart

### DIFF
--- a/application/src/main/java/run/halo/app/plugin/HaloPluginManager.java
+++ b/application/src/main/java/run/halo/app/plugin/HaloPluginManager.java
@@ -6,6 +6,7 @@ import java.util.List;
 import java.util.Stack;
 import lombok.extern.slf4j.Slf4j;
 import org.pf4j.*;
+import org.springframework.beans.factory.DisposableBean;
 import org.springframework.beans.factory.InitializingBean;
 import org.springframework.context.ApplicationContext;
 import org.springframework.data.util.Lazy;
@@ -20,7 +21,7 @@ import run.halo.app.plugin.event.PluginStartedEvent;
  * @since 2.0.0
  */
 @Slf4j
-class HaloPluginManager extends DefaultPluginManager implements SpringPluginManager, InitializingBean {
+class HaloPluginManager extends DefaultPluginManager implements SpringPluginManager, InitializingBean, DisposableBean {
 
     private final ApplicationContext rootContext;
 
@@ -124,7 +125,54 @@ class HaloPluginManager extends DefaultPluginManager implements SpringPluginMana
 
     @Override
     public void stopPlugins() {
-        throw new UnsupportedOperationException("The operation of stopping all plugins is not supported.");
+        // Stop started plugins one by one. PF4J's stopPlugin stops a plugin's
+        // dependents first and ignores plugins that are not started, so the
+        // dependency order is handled by PF4J itself. Copy the list because
+        // stopping a plugin mutates it. A failure of one plugin must not
+        // prevent the others from being stopped.
+        var pluginsToStop = new ArrayList<>(startedPlugins());
+        log.debug(
+                "Stopping {} started plugin(s): {}",
+                pluginsToStop.size(),
+                pluginsToStop.stream().map(PluginWrapper::getPluginId).toList());
+        for (var pw : pluginsToStop) {
+            try {
+                var pluginState = stopPlugin(pw.getPluginId());
+                log.debug("Plugin '{}' stop result: {}.", pw.getPluginId(), pluginState);
+            } catch (Exception e) {
+                log.warn("Error stopping plugin '{}' during shutdown.", pw.getPluginId(), e);
+            }
+        }
+    }
+
+    @Override
+    public void unloadPlugins() {
+        // Unload resolved plugins one by one to release their class loaders.
+        // PF4J's unloadPlugin unloads a plugin's dependents first and ignores
+        // plugins that are not loaded. Copy the list because unloading a plugin
+        // mutates it. A failure of one plugin must not prevent the others from
+        // being unloaded.
+        var pluginsToUnload = new ArrayList<>(getResolvedPlugins());
+        log.debug(
+                "Unloading {} resolved plugin(s): {}",
+                pluginsToUnload.size(),
+                pluginsToUnload.stream().map(PluginWrapper::getPluginId).toList());
+        for (var pw : pluginsToUnload) {
+            try {
+                var unloaded = unloadPlugin(pw.getPluginId());
+                log.debug("Plugin '{}' unload result: {}.", pw.getPluginId(), unloaded);
+            } catch (Exception e) {
+                log.warn("Error unloading plugin '{}' during shutdown.", pw.getPluginId(), e);
+            }
+        }
+    }
+
+    @Override
+    public void destroy() {
+        log.info("Stopping and unloading all plugins before application context shutdown...");
+        stopPlugins();
+        unloadPlugins();
+        log.info("All plugins stopped and unloaded.");
     }
 
     @Override

--- a/application/src/test/java/run/halo/app/plugin/HaloPluginManagerTest.java
+++ b/application/src/test/java/run/halo/app/plugin/HaloPluginManagerTest.java
@@ -1,16 +1,30 @@
 package run.halo.app.plugin;
 
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.github.zafarkhaja.semver.Version;
 import java.nio.file.Path;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.io.TempDir;
-import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.pf4j.PluginState;
+import org.pf4j.PluginWrapper;
 import org.pf4j.RuntimeMode;
 import org.springframework.context.ApplicationContext;
 import run.halo.app.infra.SystemVersionSupplier;
@@ -30,32 +44,139 @@ class HaloPluginManagerTest {
     @Mock
     ApplicationContext rootContext;
 
-    @InjectMocks
-    HaloPluginManager pluginManager;
-
     @TempDir
     Path tempDir;
 
-    @Test
-    void shouldGetDependentsWhilePluginsNotResolved() throws Exception {
+    HaloPluginManager pluginManager;
+
+    @BeforeEach
+    void setUp() throws Exception {
         when(pluginProperties.getRuntimeMode()).thenReturn(RuntimeMode.DEPLOYMENT);
         when(systemVersionSupplier.get()).thenReturn(Version.of(1, 2, 3));
         when(pluginsRootGetter.get()).thenReturn(tempDir);
+
+        pluginManager =
+                spy(new HaloPluginManager(rootContext, pluginProperties, systemVersionSupplier, pluginsRootGetter));
         pluginManager.afterPropertiesSet();
-        // if we don't invoke resolves
-        var dependents = pluginManager.getDependents("fake-plugin");
-        assertTrue(dependents.isEmpty());
     }
 
     @Test
-    void shouldGetDependentsWhilePluginsResolved() throws Exception {
-        when(pluginProperties.getRuntimeMode()).thenReturn(RuntimeMode.DEPLOYMENT);
-        when(systemVersionSupplier.get()).thenReturn(Version.of(1, 2, 3));
-        when(pluginsRootGetter.get()).thenReturn(tempDir);
-        pluginManager.afterPropertiesSet();
-        pluginManager.loadPlugins();
-        // if we don't invoke resolves
+    void shouldGetDependentsWhilePluginsNotResolved() {
         var dependents = pluginManager.getDependents("fake-plugin");
-        assertTrue(dependents.isEmpty());
+        assertEquals(0, dependents.size());
+    }
+
+    @Test
+    void shouldGetDependentsWhilePluginsResolved() {
+        pluginManager.loadPlugins();
+        var dependents = pluginManager.getDependents("fake-plugin");
+        assertEquals(0, dependents.size());
+    }
+
+    @Test
+    void stopPluginsShouldStopAllStartedPlugins() {
+        // Dependency ordering (dependents before dependencies) is handled by
+        // PF4J's stopPlugin itself, so here we only assert every started plugin
+        // is attempted.
+        doReturn(List.of(mockPluginWrapper("plugin-a"), mockPluginWrapper("plugin-b")))
+                .when(pluginManager)
+                .startedPlugins();
+        doReturn(PluginState.STOPPED).when(pluginManager).stopPlugin(anyString());
+
+        pluginManager.stopPlugins();
+
+        verify(pluginManager).stopPlugin("plugin-a");
+        verify(pluginManager).stopPlugin("plugin-b");
+    }
+
+    @Test
+    void stopPluginsShouldHandleEmptyStartedPlugins() {
+        doReturn(List.of()).when(pluginManager).startedPlugins();
+
+        assertDoesNotThrow(() -> pluginManager.stopPlugins());
+
+        verify(pluginManager, never()).stopPlugin(anyString());
+    }
+
+    @Test
+    void stopPluginsShouldContinueOnStopFailure() {
+        doReturn(List.of(mockPluginWrapper("plugin-1"), mockPluginWrapper("plugin-2")))
+                .when(pluginManager)
+                .startedPlugins();
+        // First plugin fails to stop
+        doThrow(new RuntimeException("stop failed")).when(pluginManager).stopPlugin("plugin-1");
+        doReturn(PluginState.STOPPED).when(pluginManager).stopPlugin("plugin-2");
+
+        assertDoesNotThrow(() -> pluginManager.stopPlugins());
+
+        // Both should be attempted
+        verify(pluginManager).stopPlugin("plugin-1");
+        verify(pluginManager).stopPlugin("plugin-2");
+    }
+
+    @Test
+    void stopPluginsShouldOnlyStopStartedPlugins() {
+        // Only started plugins are returned
+        doReturn(List.of(mockPluginWrapper("plugin-started")))
+                .when(pluginManager)
+                .startedPlugins();
+        doReturn(PluginState.STOPPED).when(pluginManager).stopPlugin(anyString());
+
+        pluginManager.stopPlugins();
+
+        verify(pluginManager, times(1)).stopPlugin(anyString());
+    }
+
+    @Test
+    void unloadPluginsShouldUnloadAllResolvedPlugins() {
+        doReturn(List.of(mockPluginWrapper("plugin-a"), mockPluginWrapper("plugin-b")))
+                .when(pluginManager)
+                .getResolvedPlugins();
+        doReturn(true).when(pluginManager).unloadPlugin(anyString());
+
+        pluginManager.unloadPlugins();
+
+        verify(pluginManager).unloadPlugin("plugin-a");
+        verify(pluginManager).unloadPlugin("plugin-b");
+    }
+
+    @Test
+    void unloadPluginsShouldContinueOnUnloadFailure() {
+        doReturn(List.of(mockPluginWrapper("plugin-1"), mockPluginWrapper("plugin-2")))
+                .when(pluginManager)
+                .getResolvedPlugins();
+        // First plugin fails to unload
+        doThrow(new RuntimeException("unload failed")).when(pluginManager).unloadPlugin("plugin-1");
+        doReturn(true).when(pluginManager).unloadPlugin("plugin-2");
+
+        assertDoesNotThrow(() -> pluginManager.unloadPlugins());
+
+        // Both should be attempted
+        verify(pluginManager).unloadPlugin("plugin-1");
+        verify(pluginManager).unloadPlugin("plugin-2");
+    }
+
+    @Test
+    void destroyShouldStopAndUnloadPlugins() {
+        doReturn(List.of()).when(pluginManager).startedPlugins();
+        doReturn(List.of()).when(pluginManager).getResolvedPlugins();
+
+        assertDoesNotThrow(() -> pluginManager.destroy());
+
+        var inOrder = inOrder(pluginManager);
+        inOrder.verify(pluginManager).stopPlugins();
+        inOrder.verify(pluginManager).unloadPlugins();
+    }
+
+    @Test
+    void startPluginsShouldThrowUnsupportedOperationException() {
+        // startPlugins must still throw — bulk start is explicitly unsupported
+        assertThrows(UnsupportedOperationException.class, () -> pluginManager.startPlugins());
+    }
+
+    private static PluginWrapper mockPluginWrapper(String pluginId) {
+        var pw = mock(PluginWrapper.class);
+        when(pw.getPluginId()).thenReturn(pluginId);
+        return pw;
     }
 }


### PR DESCRIPTION
## What this PR does

Fixes a bug where plugins are not destroyed during in-app restart (`RestartEndpoint`).

### Problem

When `RestartEndpoint.doRestart()` closes the root Spring `ApplicationContext` via `closeRecursively()`, plugin `ApplicationContext` instances were **never shut down**. This happened because:

1. `HaloPluginManager` did not implement `DisposableBean`, so Spring had no lifecycle callback to stop plugins
2. `HaloPluginManager.stopPlugins()` explicitly threw `UnsupportedOperationException`
3. Plugin `ApplicationContext` instances only registered **JVM shutdown hooks**, not Spring context close hooks — and JVM doesn't exit during in-app restart

This meant after restart, old plugin contexts remained alive with dangling references to the destroyed root context, causing:

- ❌ Plugin HTTP endpoints broken (handler mappings in destroyed root context)
- ❌ Extension points broken (`SpringExtensionFactory` references stale root context beans)
- ❌ Scheduled tasks broken (scheduler disposed but plugins still running)
- ❌ Memory leaks (old PluginClassLoaders not GC-able)
- ❌ Conflicts when new root context reloads plugins (same jar, two ClassLoaders)

### Fix

**`HaloPluginManager.java`**:

- Implements `DisposableBean` — `destroy()` now stops **and unloads** all plugins during Spring context close
- Replaces `stopPlugins()` `UnsupportedOperationException` with stopping each started plugin one by one. Dependency ordering (dependents before dependencies) is delegated to PF4J's `stopPlugin`, which stops a plugin's dependents first and ignores plugins that are not started
- Adds an `unloadPlugins()` override that unloads each resolved plugin one by one, releasing plugin `ClassLoader`s. PF4J's `unloadPlugin` likewise unloads dependents first, so ordering is handled by PF4J itself
- Single plugin stop/unload failures are isolated — one failing plugin does not block others (PF4J's own `unloadPlugins()` does not isolate failures, e.g. a `ClassLoader` close error would abort the rest)
- Adds debug logs listing the plugins to stop/unload and each plugin's stop/unload result for easier diagnosis

### Testing

Added unit tests in `HaloPluginManagerTest.java` covering:

- ✅ Stops all started plugins
- ✅ Empty startedPlugins() is safe (no NPE)
- ✅ Continues gracefully when a plugin fails to stop
- ✅ Non-started plugins are never touched
- ✅ Unloads all resolved plugins
- ✅ Continues gracefully when a plugin fails to unload
- ✅ `destroy()` stops plugins first, then unloads them
- ✅ `startPlugins()` still throws `UnsupportedOperationException` (unchanged)

Dependency ordering is intentionally **not** tested here — it is PF4J's responsibility and already covered by PF4J itself.

### Related

- `RestartEndpoint.java` — the caller that triggers this via `closeRecursively(context)`
- `DefaultSpringPlugin.stop()` — the per-plugin stop logic that closes the plugin ApplicationContext
- `PluginApplicationContext.registerShutdownHook()` — the JVM hook that was insufficient for in-app restart
