### PR TITLE
fix: normalize IDN external URL to Punycode for RFC 3986 compliance

### DIFF
--- a/application/src/main/java/run/halo/app/infra/SystemConfigFirstExternalUrlSupplier.java
+++ b/application/src/main/java/run/halo/app/infra/SystemConfigFirstExternalUrlSupplier.java
@@ -1,9 +1,12 @@
 package run.halo.app.infra;
 
+import java.net.IDN;
 import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.util.Optional;
 import lombok.extern.slf4j.Slf4j;
@@ -41,16 +44,17 @@ class SystemConfigFirstExternalUrlSupplier implements ExternalUrlSupplier {
         this.haloProperties = haloProperties;
         this.webFluxProperties = webFluxProperties;
         this.systemConfigFetcher = systemConfigFetcher;
+        this.externalUrl = toSafeUrl(haloProperties.getExternalUrl());
     }
 
     @EventListener
     void onExtensionInitialized(ExtensionInitializedEvent ignored) {
-        refetchExternalUrl().ifPresent(externalUrl -> this.externalUrl = externalUrl);
+        refetchExternalUrl().ifPresent(externalUrl -> this.externalUrl = toSafeUrl(externalUrl));
     }
 
     @EventListener
     void onExternalUrlChanged(ExternalUrlChangedEvent event) {
-        this.externalUrl = event.getExternalUrl();
+        this.externalUrl = toSafeUrl(event.getExternalUrl());
     }
 
     Optional<URL> refetchExternalUrl() {
@@ -95,20 +99,58 @@ class SystemConfigFirstExternalUrlSupplier implements ExternalUrlSupplier {
         }
         var externalUrl = haloProperties.getExternalUrl();
         if (externalUrl != null) {
-            return externalUrl;
+            return toSafeUrl(externalUrl);
         }
         try {
-            externalUrl = request.getURI().resolve(getBasePath()).toURL();
+            return toSafeUrl(request.getURI().resolve(getBasePath()).toURL());
         } catch (MalformedURLException e) {
             throw new RuntimeException("Cannot parse request URI to URL.", e);
         }
-        return externalUrl;
     }
 
     @Nullable
     @Override
     public URL getRaw() {
-        return externalUrl != null ? externalUrl : haloProperties.getExternalUrl();
+        var raw = externalUrl != null ? externalUrl : haloProperties.getExternalUrl();
+        return toSafeUrl(raw);
+    }
+
+    @Nullable
+    private URL toSafeUrl(@Nullable URL url) {
+        if (url == null) {
+            return null;
+        }
+        var host = url.getHost();
+        if (host == null) {
+            return url;
+        }
+        // Some JVMs percent-encode non-ASCII hosts; decode first, then convert to Punycode
+        String asciiHost;
+        try {
+            var decodedHost = URLDecoder.decode(host, StandardCharsets.UTF_8);
+            asciiHost = IDN.toASCII(decodedHost);
+        } catch (IllegalArgumentException e) {
+            log.warn("Failed to normalize URL host {}", url, e);
+            return url;
+        }
+        if (asciiHost.equals(host)) {
+            return url;
+        }
+        // Rebuild via URI to preserve fragment and userinfo
+        try {
+            return new URI(
+                            url.getProtocol(),
+                            url.getUserInfo(),
+                            asciiHost,
+                            url.getPort(),
+                            url.getPath(),
+                            url.getQuery(),
+                            url.getRef())
+                    .toURL();
+        } catch (URISyntaxException | MalformedURLException e) {
+            log.warn("Failed to rebuild normalized URL {}", url, e);
+            return url;
+        }
     }
 
     private String getBasePath() {

--- a/application/src/main/java/run/halo/app/infra/SystemConfigFirstExternalUrlSupplier.java
+++ b/application/src/main/java/run/halo/app/infra/SystemConfigFirstExternalUrlSupplier.java
@@ -86,7 +86,7 @@ class SystemConfigFirstExternalUrlSupplier implements ExternalUrlSupplier {
             if (externalUrl != null) {
                 return externalUrl.toURI();
             }
-            return haloProperties.getExternalUrl().toURI();
+            return toSafeUrl(haloProperties.getExternalUrl()).toURI();
         } catch (URISyntaxException e) {
             throw Exceptions.propagate(e);
         }
@@ -124,31 +124,48 @@ class SystemConfigFirstExternalUrlSupplier implements ExternalUrlSupplier {
         if (host == null) {
             return url;
         }
+        if (host.indexOf('%') < 0 && host.chars().allMatch(character -> character < 128)) {
+            return url;
+        }
         // Some JVMs percent-encode non-ASCII hosts; decode first, then convert to Punycode
         String asciiHost;
         try {
             var decodedHost = URLDecoder.decode(host, StandardCharsets.UTF_8);
             asciiHost = IDN.toASCII(decodedHost);
         } catch (IllegalArgumentException e) {
-            log.warn("Failed to normalize URL host {}", url, e);
+            log.warn("Failed to normalize URL host {}", host, e);
             return url;
         }
         if (asciiHost.equals(host)) {
             return url;
         }
-        // Rebuild via URI to preserve fragment and userinfo
+        // Replace only the host in the original URL form to preserve already encoded components.
         try {
-            return new URI(
-                            url.getProtocol(),
-                            url.getUserInfo(),
-                            asciiHost,
-                            url.getPort(),
-                            url.getPath(),
-                            url.getQuery(),
-                            url.getRef())
+            var authority = url.getAuthority();
+            if (authority == null) {
+                return url;
+            }
+            var hostIndex = authority.lastIndexOf(host);
+            if (hostIndex < 0) {
+                throw new IllegalArgumentException("Cannot locate host in URL authority");
+            }
+            var asciiAuthority =
+                    authority.substring(0, hostIndex) + asciiHost + authority.substring(hostIndex + host.length());
+            var externalForm = url.toExternalForm();
+            var authorityIndex =
+                    externalForm.indexOf(authority, url.getProtocol().length() + 1);
+            if (authorityIndex < 0) {
+                throw new IllegalArgumentException("Cannot locate authority in URL");
+            }
+            return URI.create(externalForm.substring(0, authorityIndex)
+                            + asciiAuthority
+                            + externalForm.substring(authorityIndex + authority.length()))
                     .toURL();
-        } catch (URISyntaxException | MalformedURLException e) {
-            log.warn("Failed to rebuild normalized URL {}", url, e);
+        } catch (IllegalArgumentException | MalformedURLException e) {
+            log.warn(
+                    "Failed to rebuild URL with normalized host {}: {}",
+                    host,
+                    e.getClass().getSimpleName());
             return url;
         }
     }

--- a/application/src/test/java/run/halo/app/infra/SystemConfigFirstExternalUrlSupplierTest.java
+++ b/application/src/test/java/run/halo/app/infra/SystemConfigFirstExternalUrlSupplierTest.java
@@ -132,7 +132,7 @@ class SystemConfigFirstExternalUrlSupplierTest {
         }
 
         @Test
-        void shouldNormalizeChineseDomainUrl() throws MalformedURLException {
+        void shouldNormalizeChineseDomainUrlFromFallback() throws MalformedURLException {
             // Simulate Spring Boot property binding: new URL("https://abcd.中国") stores non-ASCII host
             var chineseUrl = new URL("https://abcd.中国");
             when(haloProperties.getExternalUrl()).thenReturn(chineseUrl);
@@ -149,8 +149,35 @@ class SystemConfigFirstExternalUrlSupplierTest {
                     .doesNotThrowAnyException();
 
             var uri = externalUrl.get();
-            assertThat(uri.toASCIIString()).doesNotContain("中国");
+            assertThat(uri.getHost()).isEqualTo("abcd.xn--fiqs8s");
             assertThatCode(() -> UriComponentsBuilder.fromUri(uri).build()).doesNotThrowAnyException();
+        }
+
+        @Test
+        void shouldNormalizeChineseDomainUrlFromConstructor() throws MalformedURLException {
+            var chineseUrl = new URL("https://abcd.中国");
+            when(haloProperties.getExternalUrl()).thenReturn(chineseUrl);
+            when(haloProperties.isUseAbsolutePermalink()).thenReturn(true);
+
+            var supplier =
+                    new SystemConfigFirstExternalUrlSupplier(haloProperties, webFluxProperties, systemConfigFetcher);
+
+            var raw = supplier.getRaw();
+            assertThat(raw).isNotNull();
+            assertThat(raw.getHost()).isEqualTo("abcd.xn--fiqs8s");
+            assertThat(supplier.get().getHost()).isEqualTo("abcd.xn--fiqs8s");
+        }
+
+        @Test
+        void shouldPreserveEncodedComponentsWhenNormalizingChineseDomain() throws MalformedURLException {
+            var chineseUrl = new URL("https://user%40name:pass%25word@abcd.中国:8443/a%20b?x=%25#f%20g");
+            when(haloProperties.getExternalUrl()).thenReturn(chineseUrl);
+
+            var raw = externalUrl.getRaw();
+
+            assertThat(raw).isNotNull();
+            assertThat(raw.toExternalForm())
+                    .isEqualTo("https://user%40name:pass%25word@abcd.xn--fiqs8s:8443/a%20b?x=%25#f%20g");
         }
     }
 

--- a/application/src/test/java/run/halo/app/infra/SystemConfigFirstExternalUrlSupplierTest.java
+++ b/application/src/test/java/run/halo/app/infra/SystemConfigFirstExternalUrlSupplierTest.java
@@ -1,5 +1,7 @@
 package run.halo.app.infra;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.Mockito.*;
@@ -16,6 +18,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.boot.webflux.autoconfigure.WebFluxProperties;
 import org.springframework.http.HttpRequest;
+import org.springframework.web.util.UriComponentsBuilder;
 import reactor.core.publisher.Mono;
 import run.halo.app.infra.properties.HaloProperties;
 
@@ -127,10 +130,48 @@ class SystemConfigFirstExternalUrlSupplierTest {
             when(haloProperties.getExternalUrl()).thenReturn(null);
             assertNull(externalUrl.getRaw());
         }
+
+        @Test
+        void shouldNormalizeChineseDomainUrl() throws MalformedURLException {
+            // Simulate Spring Boot property binding: new URL("https://abcd.中国") stores non-ASCII host
+            var chineseUrl = new URL("https://abcd.中国");
+            when(haloProperties.getExternalUrl()).thenReturn(chineseUrl);
+            when(haloProperties.isUseAbsolutePermalink()).thenReturn(true);
+
+            var raw = externalUrl.getRaw();
+            assertThat(raw).isNotNull();
+            assertThat(raw.getHost()).isEqualTo("abcd.xn--fiqs8s");
+
+            // The returned URL must be parseable by UriComponentsBuilder without throwing
+            // (original bug: InvalidUrlException "Bad authority" with Chinese domains)
+            assertThatCode(() ->
+                            UriComponentsBuilder.fromUriString(raw.toString()).build())
+                    .doesNotThrowAnyException();
+
+            var uri = externalUrl.get();
+            assertThat(uri.toASCIIString()).doesNotContain("中国");
+            assertThatCode(() -> UriComponentsBuilder.fromUri(uri).build()).doesNotThrowAnyException();
+        }
     }
 
     @Nested
     class SystemConfigSupplier {
+
+        @Test
+        void shouldNormalizeChineseDomainFromSystemConfig() {
+            var basic = new SystemSetting.Basic();
+            basic.setExternalUrl("https://abcd.中国");
+            when(systemConfigFetcher.getBasic()).thenReturn(Mono.just(basic));
+            externalUrl.onExtensionInitialized(null);
+
+            var raw = externalUrl.getRaw();
+            assertThat(raw).isNotNull();
+            assertThat(raw.getHost()).isEqualTo("abcd.xn--fiqs8s");
+
+            assertThatCode(() ->
+                            UriComponentsBuilder.fromUriString(raw.toString()).build())
+                    .doesNotThrowAnyException();
+        }
 
         @Test
         void shouldGetUrlWhenUseAbsolutePermalink() throws Exception {


### PR DESCRIPTION
Fixes #7570

### Problem

When the external URL uses a Chinese domain name (e.g., `https://abcd.中国`), Spring Boot binds it to `java.net.URL` which stores the host in non-ASCII form. `UriComponentsBuilder.fromUriString()` with the RFC 3986 parser rejects non-ASCII authority characters, throwing:

```
InvalidUrlException: Bad authority
    at SubscriptionRouter.getUnsubscribeUrl()
```

This breaks email notifications, unsubscribe links, and any other feature that builds URLs from the external URL configuration.

### Solution

Add `toSafeUrl()` normalization in `SystemConfigFirstExternalUrlSupplier` to convert non-ASCII hosts to Punycode via `java.net.IDN.toASCII()`:

1. **Constructor** — normalize `haloProperties.getExternalUrl()` on bean creation (primary path in production)
2. **`onExternalUrlChanged()`** — normalize incoming URLs from settings changes
3. **`getRaw()` / `getURL()`** — retain fallback normalization for edge cases (e.g., `externalUrl` field not yet populated)

The helper decodes any percent-encoding first (some JVMs percent-encode non-ASCII in `URL.getHost()`), then converts to Punycode. ASCII hosts pass through unchanged.

### Changes

- `SystemConfigFirstExternalUrlSupplier.java` — add `toSafeUrl()`, apply at all URL entry/exit points
- `SystemConfigFirstExternalUrlSupplierTest.java` — add Chinese domain test case