### PR TITLE
fix: clean up orphaned plugin JARs on uninstall

### DIFF
--- a/application/src/main/java/run/halo/app/core/reconciler/PluginReconciler.java
+++ b/application/src/main/java/run/halo/app/core/reconciler/PluginReconciler.java
@@ -41,6 +41,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.pf4j.PluginState;
 import org.pf4j.PluginWrapper;
 import org.pf4j.RuntimeMode;
+import org.pf4j.util.FileUtils;
 import org.springframework.beans.factory.DisposableBean;
 import org.springframework.core.io.FileSystemResource;
 import org.springframework.stereotype.Component;
@@ -336,8 +337,11 @@ class PluginReconciler implements Reconciler<Request>, DisposableBean {
     }
 
     private String readPluginNameFromJar(Path jarPath) {
+        Path manifestPath = null;
         try {
-            var manifestPath = org.pf4j.util.FileUtils.getPath(jarPath, "plugin.yaml");
+            // FileUtils.getPath opens a zip FileSystem that must be closed via closePath,
+            // otherwise the JAR stays locked (deletion would fail on Windows) and fds leak.
+            manifestPath = FileUtils.getPath(jarPath, "plugin.yaml");
             var resource = new FileSystemResource(manifestPath);
             var loader = new YamlUnstructuredLoader(resource);
             var unstructuredList = loader.load();
@@ -347,6 +351,8 @@ class PluginReconciler implements Reconciler<Request>, DisposableBean {
             }
         } catch (Exception e) {
             log.warn("Failed to read manifest from {}", jarPath, e);
+        } finally {
+            FileUtils.closePath(manifestPath);
         }
         return null;
     }

--- a/application/src/main/java/run/halo/app/core/reconciler/PluginReconciler.java
+++ b/application/src/main/java/run/halo/app/core/reconciler/PluginReconciler.java
@@ -42,6 +42,7 @@ import org.pf4j.PluginState;
 import org.pf4j.PluginWrapper;
 import org.pf4j.RuntimeMode;
 import org.springframework.beans.factory.DisposableBean;
+import org.springframework.core.io.FileSystemResource;
 import org.springframework.stereotype.Component;
 import org.springframework.util.Assert;
 import org.springframework.util.CollectionUtils;
@@ -295,9 +296,59 @@ class PluginReconciler implements Reconciler<Request>, DisposableBean {
             log.info("Deleting plugin {} in plugin manager.", pluginName);
             var deleted = pluginManager.deletePlugin(pluginName);
             if (!deleted) {
-                log.warn("Failed to delete plugin {}", pluginName);
+                throw new RequeueException(
+                        Result.requeue(Duration.ofSeconds(10)),
+                        "Failed to delete plugin " + pluginName + " in plugin manager");
             }
         }
+        // Clean up orphaned JARs (historical leftovers from failed upgrades/uninstalls)
+        cleanUpOrphanedJars(pluginName);
+    }
+
+    private void cleanUpOrphanedJars(String pluginName) {
+        var prefix = pluginName + "-";
+        for (var pluginRoot : pluginManager.getPluginsRoots()) {
+            if (!Files.exists(pluginRoot)) {
+                continue;
+            }
+            try (var files = Files.list(pluginRoot)) {
+                files.filter(f -> {
+                            var fn = f.getFileName().toString();
+                            return fn.startsWith(prefix) && fn.endsWith(".jar");
+                        })
+                        .forEach(jar -> {
+                            var name = readPluginNameFromJar(jar);
+                            if (pluginName.equals(name)) {
+                                try {
+                                    log.info("Deleting orphaned plugin JAR {}", jar);
+                                    Files.deleteIfExists(jar);
+                                } catch (IOException e) {
+                                    throw new RequeueException(
+                                            Result.requeue(Duration.ofSeconds(10)),
+                                            "Failed to delete orphaned JAR " + jar + " for plugin " + pluginName);
+                                }
+                            }
+                        });
+            } catch (IOException e) {
+                log.warn("Failed to list plugins directory {} for cleanup", pluginRoot, e);
+            }
+        }
+    }
+
+    private String readPluginNameFromJar(Path jarPath) {
+        try {
+            var manifestPath = org.pf4j.util.FileUtils.getPath(jarPath, "plugin.yaml");
+            var resource = new FileSystemResource(manifestPath);
+            var loader = new YamlUnstructuredLoader(resource);
+            var unstructuredList = loader.load();
+            if (unstructuredList.size() == 1) {
+                var metadata = unstructuredList.get(0).getMetadata();
+                return metadata != null ? metadata.getName() : null;
+            }
+        } catch (Exception e) {
+            log.warn("Failed to read manifest from {}", jarPath, e);
+        }
+        return null;
     }
 
     private Result enablePlugin(Plugin plugin) {

--- a/application/src/main/java/run/halo/app/core/reconciler/PluginReconciler.java
+++ b/application/src/main/java/run/halo/app/core/reconciler/PluginReconciler.java
@@ -41,9 +41,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.pf4j.PluginState;
 import org.pf4j.PluginWrapper;
 import org.pf4j.RuntimeMode;
-import org.pf4j.util.FileUtils;
 import org.springframework.beans.factory.DisposableBean;
-import org.springframework.core.io.FileSystemResource;
 import org.springframework.stereotype.Component;
 import org.springframework.util.Assert;
 import org.springframework.util.CollectionUtils;
@@ -77,6 +75,7 @@ import run.halo.app.plugin.PluginConst;
 import run.halo.app.plugin.PluginProperties;
 import run.halo.app.plugin.PluginService;
 import run.halo.app.plugin.SpringPluginManager;
+import run.halo.app.plugin.YamlPluginFinder;
 import run.halo.app.plugin.resources.BundleResourceUtils;
 
 /**
@@ -337,24 +336,13 @@ class PluginReconciler implements Reconciler<Request>, DisposableBean {
     }
 
     private String readPluginNameFromJar(Path jarPath) {
-        Path manifestPath = null;
         try {
-            // FileUtils.getPath opens a zip FileSystem that must be closed via closePath,
-            // otherwise the JAR stays locked (deletion would fail on Windows) and fds leak.
-            manifestPath = FileUtils.getPath(jarPath, "plugin.yaml");
-            var resource = new FileSystemResource(manifestPath);
-            var loader = new YamlUnstructuredLoader(resource);
-            var unstructuredList = loader.load();
-            if (unstructuredList.size() == 1) {
-                var metadata = unstructuredList.get(0).getMetadata();
-                return metadata != null ? metadata.getName() : null;
-            }
+            // YamlPluginFinder properly closes the zip FileSystem opened for the JAR.
+            return new YamlPluginFinder().find(jarPath).getMetadata().getName();
         } catch (Exception e) {
             log.warn("Failed to read manifest from {}", jarPath, e);
-        } finally {
-            FileUtils.closePath(manifestPath);
+            return null;
         }
-        return null;
     }
 
     private Result enablePlugin(Plugin plugin) {

--- a/application/src/test/java/run/halo/app/core/reconciler/PluginReconcilerTest.java
+++ b/application/src/test/java/run/halo/app/core/reconciler/PluginReconcilerTest.java
@@ -17,9 +17,11 @@ import static run.halo.app.plugin.PluginConst.PLUGIN_PATH;
 import static run.halo.app.plugin.PluginConst.RELOAD_ANNO;
 import static run.halo.app.plugin.PluginConst.RUNTIME_MODE_ANNO;
 
+import java.io.FileOutputStream;
 import java.io.IOException;
 import java.net.URL;
 import java.net.URLClassLoader;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -33,6 +35,8 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.Consumer;
+import java.util.jar.JarEntry;
+import java.util.jar.JarOutputStream;
 import org.jspecify.annotations.Nullable;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
@@ -479,6 +483,14 @@ class PluginReconcilerTest {
     @Nested
     class WhenDeleting {
 
+        @TempDir
+        Path tempDir;
+
+        @BeforeEach
+        void setUpDeleting() {
+            lenient().when(pluginManager.getPluginsRoots()).thenReturn(List.of());
+        }
+
         @Test
         void shouldDoNothingWithoutFinalizer() {
             var fakePlugin = createPlugin(name, plugin -> {
@@ -510,6 +522,7 @@ class PluginReconcilerTest {
             when(client.fetch(Plugin.class, name)).thenReturn(Optional.of(fakePlugin));
             when(client.fetch(Setting.class, "fake-setting")).thenReturn(Optional.empty());
             when(client.fetch(ReverseProxy.class, reverseProxyName)).thenReturn(Optional.empty());
+            when(pluginManager.deletePlugin(name)).thenReturn(true);
 
             when(pluginManager.getPlugin(name))
                     .thenReturn(mock(PluginWrapper.class))
@@ -527,6 +540,114 @@ class PluginReconcilerTest {
             verify(client).fetch(Setting.class, "fake-setting");
             verify(client).fetch(ReverseProxy.class, reverseProxyName);
             verify(client).update(fakePlugin);
+        }
+
+        @Test
+        void shouldRequeueWhenDeletePluginFails() {
+            var fakePlugin = createPlugin(name, plugin -> {
+                var metadata = plugin.getMetadata();
+                metadata.setDeletionTimestamp(clock.instant());
+                metadata.setFinalizers(new HashSet<>(Set.of(finalizer)));
+                plugin.getStatus().setLastProbeState(PluginState.STARTED);
+            });
+
+            when(client.fetch(Plugin.class, name)).thenReturn(Optional.of(fakePlugin));
+            when(client.fetch(ReverseProxy.class, reverseProxyName)).thenReturn(Optional.empty());
+            when(pluginManager.getPlugin(name)).thenReturn(mock(PluginWrapper.class));
+            when(pluginManager.deletePlugin(name)).thenReturn(false);
+
+            assertThrows(RequeueException.class, () -> reconciler.reconcile(new Request(name)));
+
+            // finalizer was removed from in-memory object by removeFinalizers,
+            // but client.update was never called, so the store still has it.
+            verify(pluginManager).deletePlugin(name);
+            verify(client, never()).update(fakePlugin);
+        }
+
+        @Test
+        void shouldCleanUpOrphanedJars() throws IOException {
+            var fakePlugin = createPlugin(name, plugin -> {
+                var metadata = plugin.getMetadata();
+                metadata.setDeletionTimestamp(clock.instant());
+                metadata.setFinalizers(new HashSet<>(Set.of(finalizer)));
+                plugin.getStatus().setLastProbeState(PluginState.STARTED);
+            });
+
+            // Create orphaned JARs in plugins root
+            var pluginRoot = tempDir.resolve("plugins");
+            Files.createDirectories(pluginRoot);
+            var jar1 = createTestJar(pluginRoot, name, "1.0.0");
+            var jar2 = createTestJar(pluginRoot, name, "2.0.0");
+            var jarOther = createTestJar(pluginRoot, "other-plugin", "1.0.0");
+
+            when(client.fetch(Plugin.class, name)).thenReturn(Optional.of(fakePlugin));
+            when(client.fetch(ReverseProxy.class, reverseProxyName)).thenReturn(Optional.empty());
+            when(pluginManager.getPluginsRoots()).thenReturn(List.of(pluginRoot));
+
+            // plugin not loaded in PF4J
+            when(pluginManager.getPlugin(name)).thenReturn(null);
+
+            var result = reconciler.reconcile(new Request(name));
+
+            assertFalse(result.reEnqueue());
+            assertFalse(fakePlugin.getMetadata().getFinalizers().contains(finalizer));
+            // orphaned JARs of the plugin should be deleted
+            assertFalse(Files.exists(jar1));
+            assertFalse(Files.exists(jar2));
+            // other plugin's JAR should NOT be deleted
+            assertTrue(Files.exists(jarOther));
+        }
+
+        @Test
+        void shouldCleanUpWhenPf4jDeleteSucceeds() throws IOException {
+            var fakePlugin = createPlugin(name, plugin -> {
+                var metadata = plugin.getMetadata();
+                metadata.setDeletionTimestamp(clock.instant());
+                metadata.setFinalizers(new HashSet<>(Set.of(finalizer)));
+                plugin.getStatus().setLastProbeState(PluginState.STARTED);
+            });
+
+            // Create an old JAR as well
+            var pluginRoot = tempDir.resolve("plugins");
+            Files.createDirectories(pluginRoot);
+            var oldJar = createTestJar(pluginRoot, name, "1.0.0");
+
+            when(client.fetch(Plugin.class, name)).thenReturn(Optional.of(fakePlugin));
+            when(client.fetch(ReverseProxy.class, reverseProxyName)).thenReturn(Optional.empty());
+            when(pluginManager.getPluginsRoots()).thenReturn(List.of(pluginRoot));
+
+            // plugin IS loaded in PF4J, delete succeeds
+            when(pluginManager.getPlugin(name))
+                    .thenReturn(mock(PluginWrapper.class))
+                    .thenReturn(null);
+            when(pluginManager.deletePlugin(name)).thenReturn(true);
+
+            var result = reconciler.reconcile(new Request(name));
+
+            assertFalse(result.reEnqueue());
+            assertFalse(fakePlugin.getMetadata().getFinalizers().contains(finalizer));
+            verify(pluginManager).deletePlugin(name);
+            // old JAR should also be cleaned up
+            assertFalse(Files.exists(oldJar));
+        }
+
+        /** Create a JAR file with a plugin.yaml manifest for testing. */
+        private Path createTestJar(Path dir, String pluginName, String version) throws IOException {
+            var jar = dir.resolve(pluginName + "-" + version + ".jar");
+            try (var jos = new JarOutputStream(new FileOutputStream(jar.toFile()))) {
+                jos.putNextEntry(new JarEntry("plugin.yaml"));
+                var manifest = """
+                        apiVersion: v1alpha1
+                        kind: Plugin
+                        metadata:
+                          name: %s
+                        spec:
+                          version: %s
+                        """.formatted(pluginName, version);
+                jos.write(manifest.getBytes(StandardCharsets.UTF_8));
+                jos.closeEntry();
+            }
+            return jar;
         }
 
         @Test


### PR DESCRIPTION
## What this PR does

Fixes #10174 — plugin JAR files becoming orphaned in the plugins directory after upgrades or uninstalls.

### Problem

1. `cleanupResources` only called PF4J `deletePlugin` when the plugin was still loaded; if the plugin failed to load, JAR deletion was skipped entirely
2. When `deletePlugin` returned `false`, only a warning was logged and the finalizer was removed, permanently losing the cleanup opportunity
3. Historical orphaned JARs (from previous buggy versions) were never cleaned up

### Solution

- Throws `RequeueException` when PF4J `deletePlugin` fails, preventing premature finalizer removal
- Adds `cleanUpOrphanedJars` to scan the plugins directory by filename prefix (`{name}-`) and verify ownership via `plugin.yaml` manifest, deleting all matching JARs regardless of PF4J load state
- Fixes `shouldCleanUpResourceFully` test to stub `deletePlugin` returning `true` (was relying on Mockito default `false`, masking the bug)

### Changes

- `PluginReconciler.java`: modified `cleanupResources`, added `cleanUpOrphanedJars` and `readPluginNameFromJar`
- `PluginReconcilerTest.java`: fixed existing test + 3 new regression tests

Fixes https://github.com/halo-dev/halo/issues/10174