### PR TITLE
refactor: migrate range selection to Tiptap NodeRange

### DIFF
--- a/ui/packages/editor/package.json
+++ b/ui/packages/editor/package.json
@@ -60,6 +60,7 @@
     "@tiptap/extension-italic": "^3.29.0",
     "@tiptap/extension-link": "^3.29.0",
     "@tiptap/extension-list": "^3.29.0",
+    "@tiptap/extension-node-range": "3.29.0",
     "@tiptap/extension-paragraph": "^3.29.0",
     "@tiptap/extension-strike": "^3.29.0",
     "@tiptap/extension-subscript": "^3.29.0",

--- a/ui/packages/editor/src/components/bubble/EditorBubbleMenu.vue
+++ b/ui/packages/editor/src/components/bubble/EditorBubbleMenu.vue
@@ -1,21 +1,59 @@
 <script lang="ts" setup>
 import { BubbleMenu } from "@tiptap/vue-3/menus";
-import { type PropType } from "vue";
-import {
-  Editor,
-  EditorState,
-  EditorView,
-  PluginKey,
-  VueEditor,
-} from "@/tiptap";
+import { onBeforeUnmount, onMounted, shallowRef, type PropType } from "vue";
+import { isNodeRangeMouseSelectionActive } from "@/extensions/range-selection";
+import { PluginKey, VueEditor } from "@/tiptap";
 import type { BubbleItemType, NodeBubbleMenuType } from "@/types";
 import BubbleItem from "./BubbleItem.vue";
+import { shouldShowBubbleMenu } from "./should-show";
 
 const props = defineProps({
   editor: {
     type: Object as PropType<VueEditor>,
     required: true,
   },
+});
+
+const isPointerSelectionActive = shallowRef(false);
+let pointerSelectionReleaseTimer: number | undefined;
+
+const updatePointerSelectionState = () => {
+  const isActive = isNodeRangeMouseSelectionActive(props.editor.state);
+
+  if (isActive) {
+    if (pointerSelectionReleaseTimer !== undefined) {
+      window.clearTimeout(pointerSelectionReleaseTimer);
+      pointerSelectionReleaseTimer = undefined;
+    }
+    isPointerSelectionActive.value = true;
+    return;
+  }
+
+  if (
+    !isPointerSelectionActive.value ||
+    pointerSelectionReleaseTimer !== undefined
+  ) {
+    return;
+  }
+
+  // Clicking inside an existing text selection collapses it after mouseup.
+  // Keep the menu hidden through that native click to avoid a one-frame flash.
+  pointerSelectionReleaseTimer = window.setTimeout(() => {
+    pointerSelectionReleaseTimer = undefined;
+    isPointerSelectionActive.value = false;
+  });
+};
+
+onMounted(() => {
+  updatePointerSelectionState();
+  props.editor.on("transaction", updatePointerSelectionState);
+});
+
+onBeforeUnmount(() => {
+  if (pointerSelectionReleaseTimer !== undefined) {
+    window.clearTimeout(pointerSelectionReleaseTimer);
+  }
+  props.editor.off("transaction", updatePointerSelectionState);
 });
 
 const getBubbleMenuFromExtensions = (): NodeBubbleMenuType[] => {
@@ -132,31 +170,16 @@ const mergeBubbleMenu = (
 const sortBubbleMenuItems = (items: BubbleItemType[] | undefined) => {
   return items?.sort((a, b) => a.priority - b.priority);
 };
-
-const shouldShow = (
-  props: {
-    editor: Editor;
-    element: HTMLElement;
-    view: EditorView;
-    state: EditorState;
-    oldState?: EditorState;
-    from: number;
-    to: number;
-  },
-  bubbleMenu: NodeBubbleMenuType
-) => {
-  if (!props.editor.isEditable) {
-    return false;
-  }
-  return bubbleMenu.shouldShow?.(props);
-};
 </script>
 <template>
   <bubble-menu
     v-for="(bubbleMenu, index) in getBubbleMenuFromExtensions()"
     :key="index"
     :plugin-key="bubbleMenu?.pluginKey"
-    :should-show="(prop) => shouldShow(prop, bubbleMenu) ?? false"
+    :class="{
+      'bubble-menu-pointer-selection-active': isPointerSelectionActive,
+    }"
+    :should-show="(prop) => shouldShowBubbleMenu(prop, bubbleMenu) ?? false"
     :editor="editor"
     :options="{
       ...(bubbleMenu.options as any),
@@ -192,5 +215,10 @@ const shouldShow = (
 .bubble-menu {
   max-width: calc(100vw - 30px);
   overflow-x: auto;
+}
+
+.bubble-menu-pointer-selection-active {
+  visibility: hidden !important;
+  pointer-events: none;
 }
 </style>

--- a/ui/packages/editor/src/components/bubble/should-show.ts
+++ b/ui/packages/editor/src/components/bubble/should-show.ts
@@ -1,0 +1,24 @@
+import { isNodeRangeSelection } from "@/extensions/range-selection";
+import type { Editor, EditorState, EditorView } from "@/tiptap";
+import type { NodeBubbleMenuType } from "@/types";
+
+export interface BubbleMenuShouldShowProps {
+  editor: Editor;
+  element: HTMLElement;
+  view: EditorView;
+  state: EditorState;
+  oldState?: EditorState;
+  from: number;
+  to: number;
+}
+
+export function shouldShowBubbleMenu(
+  props: BubbleMenuShouldShowProps,
+  bubbleMenu: NodeBubbleMenuType
+) {
+  if (!props.editor.isEditable || isNodeRangeSelection(props.state.selection)) {
+    return false;
+  }
+
+  return bubbleMenu.shouldShow?.(props);
+}

--- a/ui/packages/editor/src/components/drag/EditorDragHandle.vue
+++ b/ui/packages/editor/src/components/drag/EditorDragHandle.vue
@@ -21,6 +21,7 @@ import type {
 } from "@/types";
 import { isBlockEmpty } from "@/utils";
 import defaultDragItems from "./default-drag";
+import { topLevelDragHandleOptions } from "./drag-handle-options";
 import EditorDragMenu from "./EditorDragMenu.vue";
 
 const { editor } = defineProps({
@@ -407,6 +408,7 @@ const sortDragButtonItems = (items: DragButtonType[]): DragButtonType[] => {
   <!-- @vue-ignore-->
   <DragHandle
     :editor="editor"
+    :nested="topLevelDragHandleOptions"
     :compute-position-config="{
       middleware: [offset(5)],
     }"

--- a/ui/packages/editor/src/components/drag/drag-handle-options.ts
+++ b/ui/packages/editor/src/components/drag/drag-handle-options.ts
@@ -1,0 +1,19 @@
+import type {
+  DragHandleRule,
+  NestedOptions,
+} from "@tiptap/extension-drag-handle";
+
+export const topLevelDragHandleRule: DragHandleRule = {
+  id: "topLevelOnly",
+  evaluate: ({ depth }) => (depth === 1 ? 0 : 1000),
+};
+
+/**
+ * Use the official nested drag path for exact node boundaries while preserving
+ * existing top-level-only drag handle behavior.
+ */
+export const topLevelDragHandleOptions = {
+  defaultRules: false,
+  edgeDetection: "none",
+  rules: [topLevelDragHandleRule],
+} satisfies NestedOptions;

--- a/ui/packages/editor/src/extensions/code-block/code-block.ts
+++ b/ui/packages/editor/src/extensions/code-block/code-block.ts
@@ -265,7 +265,10 @@ export const ExtensionCodeBlock = TiptapCodeBlock.extend<
             return false;
           }
           const head = codeBlack.start;
-          const anchor = codeBlack.start + codeBlack.node.nodeSize - 1;
+          const anchor = codeBlack.start + codeBlack.node.content.size;
+          if (selection.from === head && selection.to === anchor) {
+            return false;
+          }
           const $head = tr.doc.resolve(head);
           const $anchor = tr.doc.resolve(anchor);
           this.editor.view.dispatch(

--- a/ui/packages/editor/src/extensions/extensions-kit.ts
+++ b/ui/packages/editor/src/extensions/extensions-kit.ts
@@ -146,7 +146,7 @@ export interface ExtensionsKitOptions {
   orderedList: Partial<ExtensionOrderedListOptions> | false;
   paragraph: Partial<ExtensionParagraphOptions> | false;
   placeholder: Partial<PlaceholderOptions> | false;
-  rangeSelection?: boolean | Partial<ExtensionRangeSelectionOptions>;
+  rangeSelection: Partial<ExtensionRangeSelectionOptions> | false;
   searchAndReplace?: boolean | Partial<ExtensionSearchAndReplaceOptions>;
   smartScroll: Partial<SmartScrollOptions> | false;
   strike: Partial<ExtensionStrikeOptions> | false;
@@ -342,9 +342,7 @@ export const ExtensionsKit = Extension.create<ExtensionsKitOptions>({
 
     if (this.options.rangeSelection !== false) {
       internalExtensions.push(
-        typeof this.options.rangeSelection === "object"
-          ? ExtensionRangeSelection.configure(this.options.rangeSelection)
-          : ExtensionRangeSelection
+        ExtensionRangeSelection.configure(this.options.rangeSelection)
       );
     }
 

--- a/ui/packages/editor/src/extensions/extensions-kit.ts
+++ b/ui/packages/editor/src/extensions/extensions-kit.ts
@@ -74,7 +74,10 @@ import {
   type ExtensionParagraphOptions,
 } from "./paragraph";
 import { ExtensionPlaceholder } from "./placeholder";
-import { ExtensionRangeSelection } from "./range-selection";
+import {
+  ExtensionRangeSelection,
+  type ExtensionRangeSelectionOptions,
+} from "./range-selection";
 import {
   ExtensionSearchAndReplace,
   type ExtensionSearchAndReplaceOptions,
@@ -143,7 +146,7 @@ export interface ExtensionsKitOptions {
   orderedList: Partial<ExtensionOrderedListOptions> | false;
   paragraph: Partial<ExtensionParagraphOptions> | false;
   placeholder: Partial<PlaceholderOptions> | false;
-  rangeSelection?: boolean;
+  rangeSelection?: boolean | Partial<ExtensionRangeSelectionOptions>;
   searchAndReplace?: boolean | Partial<ExtensionSearchAndReplaceOptions>;
   smartScroll: Partial<SmartScrollOptions> | false;
   strike: Partial<ExtensionStrikeOptions> | false;
@@ -338,7 +341,11 @@ export const ExtensionsKit = Extension.create<ExtensionsKitOptions>({
     }
 
     if (this.options.rangeSelection !== false) {
-      internalExtensions.push(ExtensionRangeSelection);
+      internalExtensions.push(
+        typeof this.options.rangeSelection === "object"
+          ? ExtensionRangeSelection.configure(this.options.rangeSelection)
+          : ExtensionRangeSelection
+      );
     }
 
     if (this.options.searchAndReplace !== false) {

--- a/ui/packages/editor/src/extensions/figure/index.ts
+++ b/ui/packages/editor/src/extensions/figure/index.ts
@@ -9,7 +9,7 @@ import {
 } from "@/tiptap";
 import type { ExtensionOptions } from "@/types";
 import { ExtensionParagraph } from "../paragraph";
-import { RangeSelection } from "../range-selection";
+import { NodeRangeSelection } from "../range-selection";
 import { ExtensionFigureCaption } from "./figure-caption";
 
 declare module "@/tiptap" {
@@ -157,7 +157,7 @@ export const ExtensionFigure = Node.create<ExtensionFigureOptions>({
           const node = beforeResolve.node(depth);
           if (node.type.name === this.name) {
             const figurePos = beforeResolve.before(depth);
-            const rangeSelection = RangeSelection.create(
+            const rangeSelection = NodeRangeSelection.create(
               doc,
               figurePos,
               figurePos + node.nodeSize

--- a/ui/packages/editor/src/extensions/range-selection/index.ts
+++ b/ui/packages/editor/src/extensions/range-selection/index.ts
@@ -1,25 +1,29 @@
+import NodeRange, {
+  getNodeRangeDecorations,
+  getSelectionRanges,
+  isNodeRangeSelection,
+  NodeRangeSelection,
+  type NodeRangeOptions,
+} from "@tiptap/extension-node-range";
 import {
-  Decoration,
+  callOrReturn,
   DecorationSet,
-  EditorView,
-  Extension,
+  getExtensionField,
   Plugin,
   PluginKey,
-  callOrReturn,
-  getExtensionField,
+  type EditorState,
+  type EditorView,
   type ParentConfig,
+  type ResolvedPos,
 } from "@/tiptap";
-import RangeSelection from "./range-selection";
 
 declare module "@tiptap/core" {
   export interface NodeConfig<Options, Storage> {
     /**
-     * Whether to allow displaying a fake selection state on the node.
+     * Whether to display a fake selection state on the node.
      *
-     * Typically, it is only necessary to display a fake selection state on child nodes,
-     * so the parent node can be set to false.
-     *
-     * default: true
+     * @deprecated NodeRange renders node-aligned selection decorations without
+     * requiring nodes to opt in.
      */
     fakeSelection?:
       | boolean
@@ -33,129 +37,321 @@ declare module "@tiptap/core" {
   }
 }
 
-const range = {
-  anchor: 0,
-  head: 0,
-  enable: false,
-};
+export interface ExtensionRangeSelectionOptions extends NodeRangeOptions {
+  /**
+   * Whether Shift-ArrowUp and Shift-ArrowDown should extend the node range.
+   *
+   * Disabled by default to preserve native keyboard text selection.
+   */
+  arrowShortcuts: boolean;
+}
 
-export const ExtensionRangeSelection = Extension.create({
-  priority: 100,
-  name: "rangeSelectionExtension",
+interface MouseFallbackPluginState {
+  active: boolean;
+  decorations: DecorationSet;
+}
 
-  addProseMirrorPlugins() {
-    return [
-      new Plugin({
-        key: new PluginKey("rangeSelectionPlugin"),
-        props: {
-          decorations: ({ doc, selection }) => {
-            const { isEditable, isFocused } = this.editor;
-            if (!isEditable || !isFocused) {
-              return null;
-            }
-            if (!(selection instanceof RangeSelection)) {
-              return null;
-            }
-            const { $from, $to } = selection;
-            const decorations: Decoration[] = [];
-            doc.nodesBetween($from.pos, $to.pos, (node, pos) => {
-              if (node.isText || node.type.name === "paragraph") {
-                return;
-              }
-              if (node.type.spec.fakeSelection) {
-                decorations.push(
-                  Decoration.node(pos, pos + node.nodeSize, {
-                    class: "no-selection range-fake-selection",
-                  })
-                );
-              }
-            });
-            return DecorationSet.create(doc, decorations);
-          },
+interface MouseFallbackPluginMeta {
+  active?: boolean;
+  decorations?: DecorationSet;
+}
 
-          createSelectionBetween: (view, anchor, head) => {
-            if (anchor.pos === head.pos) {
-              return null;
-            }
-            return RangeSelection.valid(view.state, anchor.pos, head.pos)
-              ? new RangeSelection(anchor, head)
-              : null;
-          },
-          handleDOMEvents: {
-            mousedown: (view: EditorView, event) => {
-              const coords = { left: event.clientX, top: event.clientY };
-              const $pos = view.posAtCoords(coords);
-              if (!$pos || !$pos.pos) {
-                return;
-              }
-              range.enable = true;
-              range.anchor = $pos.pos;
-            },
-            mousemove: (view, event) => {
-              if (!range.enable) {
-                return;
-              }
-              const coords = { left: event.clientX, top: event.clientY };
-              const $pos = view.posAtCoords(coords);
-              if (
-                !$pos ||
-                !$pos.pos ||
-                $pos.pos === range.anchor ||
-                $pos.pos === range.head
-              ) {
-                return;
-              }
-              range.head = $pos.pos;
-              const selection = RangeSelection.between(
-                view.state.doc.resolve(range.anchor),
-                view.state.doc.resolve(range.head)
-              );
-              if (selection) {
-                view.dispatch(view.state.tr.setSelection(selection));
-              }
-            },
-            mouseup: () => {
-              range.enable = false;
-              range.anchor = 0;
-              range.head = 0;
-            },
-            mouseleave: () => {
-              range.enable = false;
-              range.anchor = 0;
-              range.head = 0;
-            },
-          },
-        },
-      }),
-    ];
-  },
+const mouseFallbackPluginKey = new PluginKey<MouseFallbackPluginState>(
+  "nodeRangeMouseFallback"
+);
 
-  addKeyboardShortcuts() {
-    return {
-      "Mod-a": ({ editor }) => {
-        editor.view.dispatch(
-          editor.view.state.tr.setSelection(
-            RangeSelection.allRange(editor.view.state.doc)
-          )
+export function isNodeRangeMouseSelectionActive(state: EditorState) {
+  return mouseFallbackPluginKey.getState(state)?.active ?? false;
+}
+
+/**
+ * NodeRange converts the native selection on mouseup. Empty text blocks and
+ * complex NodeViews may not produce a cross-parent native selection, so the
+ * fallback keeps the pointer positions needed to render the same official
+ * preview and construct the final NodeRangeSelection.
+ */
+function isMouseSelectionEnabled(
+  event: MouseEvent,
+  key: NodeRangeOptions["key"]
+) {
+  const isMac = /Mac/.test(navigator.platform);
+  const isMod = isMac ? event.metaKey : event.ctrlKey;
+
+  return (
+    key === null ||
+    key === undefined ||
+    (key === "Shift" && event.shiftKey) ||
+    (key === "Control" && event.ctrlKey) ||
+    (key === "Alt" && event.altKey) ||
+    (key === "Meta" && event.metaKey) ||
+    (key === "Mod" && isMod)
+  );
+}
+
+function isEditorUiTarget(target: EventTarget | null) {
+  return (
+    target instanceof Element &&
+    target.closest(
+      '[data-editor-ui="true"], [data-drag-handle], .column-resize-handle, .row-resize-handle'
+    ) !== null
+  );
+}
+
+function getTopLevelNodeStart($pos: ResolvedPos) {
+  return $pos.depth > 0 ? $pos.before(1) : $pos.posAtIndex($pos.index(0), 0);
+}
+
+export const ExtensionRangeSelection =
+  NodeRange.extend<ExtensionRangeSelectionOptions>({
+    name: "rangeSelectionExtension",
+
+    addOptions() {
+      return {
+        ...this.parent?.(),
+        depth: undefined,
+        key: null,
+        arrowShortcuts: false,
+      };
+    },
+
+    addKeyboardShortcuts() {
+      const shortcuts = { ...(this.parent?.() ?? {}) };
+
+      if (!this.options.arrowShortcuts) {
+        delete shortcuts["Shift-ArrowUp"];
+        delete shortcuts["Shift-ArrowDown"];
+      }
+
+      return shortcuts;
+    },
+
+    addProseMirrorPlugins() {
+      const parentPlugins = this.parent?.() ?? [];
+      let activeView: EditorView | undefined;
+      let anchorPos: number | undefined;
+      let headPos: number | undefined;
+      let movedAcrossPosition = false;
+
+      const updatePointerPreview = (view: EditorView) => {
+        const { doc, selection, tr } = view.state;
+        let decorations = DecorationSet.empty;
+
+        if (
+          movedAcrossPosition &&
+          anchorPos !== undefined &&
+          headPos !== undefined &&
+          anchorPos !== headPos &&
+          !isNodeRangeSelection(selection) &&
+          selection.$anchor.sameParent(selection.$head)
+        ) {
+          const $anchor = doc.resolve(anchorPos);
+          const $head = doc.resolve(headPos);
+
+          if (getTopLevelNodeStart($anchor) !== getTopLevelNodeStart($head)) {
+            const ranges = getSelectionRanges(
+              $anchor.min($head),
+              $anchor.max($head),
+              this.options.depth
+            );
+            decorations = getNodeRangeDecorations(ranges);
+          }
+        }
+
+        tr.setMeta(mouseFallbackPluginKey, {
+          active: true,
+          decorations,
+        } satisfies MouseFallbackPluginMeta);
+        view.dispatch(tr);
+      };
+
+      const updateHeadPosition = (event: MouseEvent) => {
+        if (!activeView) {
+          return;
+        }
+
+        const result = activeView.posAtCoords({
+          left: event.clientX,
+          top: event.clientY,
+        });
+        if (!result) {
+          return;
+        }
+
+        if (headPos === result.pos) {
+          return;
+        }
+
+        headPos = result.pos;
+        movedAcrossPosition ||= headPos !== anchorPos;
+        updatePointerPreview(activeView);
+      };
+
+      const resetMouseSelection = () => {
+        document.removeEventListener("mousemove", updateHeadPosition);
+        document.removeEventListener("mouseup", finishMouseSelection);
+        activeView = undefined;
+        anchorPos = undefined;
+        headPos = undefined;
+        movedAcrossPosition = false;
+      };
+
+      const finishMouseSelection = (event: MouseEvent) => {
+        const view = activeView;
+        updateHeadPosition(event);
+
+        const anchor = anchorPos;
+        const head = headPos;
+        const hasMoved = movedAcrossPosition;
+        resetMouseSelection();
+
+        if (!view) {
+          return;
+        }
+
+        const { doc, selection } = view.state;
+        const tr = view.state.tr.setMeta(mouseFallbackPluginKey, {
+          active: false,
+          decorations: DecorationSet.empty,
+        } satisfies MouseFallbackPluginMeta);
+
+        if (
+          !hasMoved ||
+          anchor === undefined ||
+          head === undefined ||
+          anchor === head
+        ) {
+          view.dispatch(tr);
+          return;
+        }
+
+        if (
+          isNodeRangeSelection(selection) ||
+          !selection.$anchor.sameParent(selection.$head)
+        ) {
+          view.dispatch(tr);
+          return;
+        }
+
+        const $anchor = doc.resolve(anchor);
+        const $head = doc.resolve(head);
+        if (getTopLevelNodeStart($anchor) === getTopLevelNodeStart($head)) {
+          view.dispatch(tr);
+          return;
+        }
+
+        const $from = $anchor.min($head);
+        const $to = $anchor.max($head);
+        if (!getSelectionRanges($from, $to, this.options.depth).length) {
+          view.dispatch(tr);
+          return;
+        }
+
+        tr.setSelection(
+          NodeRangeSelection.create(doc, anchor, head, this.options.depth)
         );
-        return true;
-      },
-    };
-  },
+        view.dispatch(tr);
+      };
 
-  extendNodeSchema(extension) {
-    const context = {
-      name: extension.name,
-      options: extension.options,
-      storage: extension.storage,
-    };
+      return [
+        ...parentPlugins,
+        new Plugin<MouseFallbackPluginState>({
+          key: mouseFallbackPluginKey,
+          state: {
+            init: () => ({
+              active: false,
+              decorations: DecorationSet.empty,
+            }),
+            apply: (tr, value) => {
+              const meta = tr.getMeta(mouseFallbackPluginKey) as
+                | MouseFallbackPluginMeta
+                | undefined;
 
-    return {
-      fakeSelection:
-        callOrReturn(getExtensionField(extension, "fakeSelection", context)) ??
-        false,
-    };
-  },
-});
+              return {
+                active: meta?.active ?? value.active,
+                decorations:
+                  meta?.decorations ??
+                  value.decorations.map(tr.mapping, tr.doc),
+              };
+            },
+          },
+          view: () => ({
+            destroy: resetMouseSelection,
+          }),
+          props: {
+            decorations: (state) =>
+              mouseFallbackPluginKey.getState(state)?.decorations ?? null,
+            attributes: (state) => {
+              const hasPointerPreview = Boolean(
+                mouseFallbackPluginKey.getState(state)?.decorations.find()
+                  .length
+              );
 
-export { RangeSelection };
+              return {
+                class: hasPointerPreview
+                  ? "ProseMirror-noderangeselection"
+                  : "",
+              };
+            },
+            handleDOMEvents: {
+              mousedown: (view, event) => {
+                if (
+                  event.button !== 0 ||
+                  isEditorUiTarget(event.target) ||
+                  !isMouseSelectionEnabled(event, this.options.key)
+                ) {
+                  return false;
+                }
+
+                const result = view.posAtCoords({
+                  left: event.clientX,
+                  top: event.clientY,
+                });
+                if (!result) {
+                  return false;
+                }
+
+                resetMouseSelection();
+                activeView = view;
+                anchorPos = result.pos;
+                headPos = result.pos;
+                view.dispatch(
+                  view.state.tr.setMeta(mouseFallbackPluginKey, {
+                    active: true,
+                    decorations: DecorationSet.empty,
+                  } satisfies MouseFallbackPluginMeta)
+                );
+                document.addEventListener("mousemove", updateHeadPosition);
+                document.addEventListener("mouseup", finishMouseSelection);
+
+                return false;
+              },
+            },
+          },
+        }),
+      ];
+    },
+
+    extendNodeSchema(extension) {
+      const context = {
+        name: extension.name,
+        options: extension.options,
+        storage: extension.storage,
+      };
+
+      return {
+        fakeSelection:
+          callOrReturn(
+            getExtensionField(extension, "fakeSelection", context)
+          ) ?? false,
+      };
+    },
+  });
+
+export {
+  getNodeRangeDecorations,
+  NodeRange as TiptapNodeRange,
+  type GetSelectionRangesOptions,
+  type NodeRangeOptions,
+} from "@tiptap/extension-node-range";
+export { getSelectionRanges, isNodeRangeSelection, NodeRangeSelection };
+export { RangeSelection } from "./range-selection";

--- a/ui/packages/editor/src/extensions/range-selection/range-selection.ts
+++ b/ui/packages/editor/src/extensions/range-selection/range-selection.ts
@@ -1,142 +1,48 @@
 import {
-  EditorState,
-  Node,
-  ResolvedPos,
+  getSelectionRanges,
+  NodeRangeSelection,
+} from "@tiptap/extension-node-range";
+import {
   Selection,
-  type Mappable,
+  type EditorState,
+  type Node,
+  type ResolvedPos,
 } from "@/tiptap/pm";
 
 /**
- * The RangeSelection class represents a selection range within a document.
- * The content can include text, paragraphs, block-level content, etc.
+ * Compatibility layer for the former Halo RangeSelection.
  *
- * It has a starting position and an ending position. When the given range includes block-level content,
- * the RangeSelection will automatically expand to include the block-level content at the corresponding depth.
- *
- * The RangeSelection must not contain empty content.
+ * @deprecated Use NodeRangeSelection from @tiptap/extension-node-range.
  */
-class RangeSelection extends Selection {
-  /**
-   * Creates a RangeSelection between the specified positions.
-   *
-   * @param $anchor - The starting position of the selection.
-   * @param $head - The ending position of the selection.
-   */
-  constructor($anchor: ResolvedPos, $head: ResolvedPos) {
-    checkRangeSelection($anchor, $head);
-    super($anchor, $head);
+export class RangeSelection extends NodeRangeSelection {
+  static [Symbol.hasInstance](instance: unknown) {
+    return instance instanceof NodeRangeSelection;
   }
 
-  map(doc: Node, mapping: Mappable): Selection {
-    const $head = doc.resolve(mapping.map(this.head));
-    const $anchor = doc.resolve(mapping.map(this.anchor));
-    return new RangeSelection($anchor, $head);
-  }
-
-  eq(other: Selection): boolean {
-    return (
-      other instanceof RangeSelection &&
-      other.anchor == this.anchor &&
-      other.head == this.head
-    );
-  }
-
-  getBookmark() {
-    return new RangeBookmark(this.anchor, this.head);
-  }
-
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  toJSON(): any {
-    return { type: "range", anchor: this.anchor, head: this.head };
-  }
-
-  /**
-   * Validates if the given positions can form a valid RangeSelection in the given state.
-   *
-   * @param state - The editor state.
-   * @param anchor - The starting position.
-   * @param head - The ending position.
-   * @returns True if the positions form a valid RangeSelection, otherwise false.
-   */
   static valid(state: EditorState, anchor: number, head: number) {
-    const nodes = rangeNodesBetween(
-      state.doc.resolve(anchor),
-      state.doc.resolve(head)
+    if (anchor === head) {
+      return false;
+    }
+
+    const $anchor = state.doc.resolve(anchor);
+    const $head = state.doc.resolve(head);
+
+    return (
+      getSelectionRanges($anchor.min($head), $anchor.max($head)).length > 0
     );
-
-    if (nodes.length === 0) {
-      return false;
-    }
-
-    if (nodes.reverse()[0].pos < 0) {
-      return false;
-    }
-
-    return true;
   }
 
-  /**
-   * Returns a RangeSelection spanning the given positions.
-   *
-   * When the given range includes block-level content, if only a part is included,
-   * the selection will be expanded to encompass the block-level content at the corresponding depth.
-   *
-   * Expansion: If the selection includes all depth nodes of the current block-level content but not the entire last node,
-   * the selection will be expanded to include the node at that depth.
-   *
-   * @param $anchor - The starting position of the selection.
-   * @param $head - The ending position of the selection.
-   * @returns A new RangeSelection that spans the given positions.
-   */
   static between($anchor: ResolvedPos, $head: ResolvedPos) {
-    checkRangeSelection($anchor, $head);
-
-    const doc = $anchor.doc;
-    const dir = $anchor.pos < $head.pos ? 1 : -1;
-    const anchorPos = dir > 0 ? $anchor.pos : $head.pos;
-    const headPos = dir > 0 ? $head.pos : $anchor.pos;
-    const nodes = rangeNodesBetween($anchor, $head);
-
-    if (nodes.length === 0) {
+    if ($anchor.pos === $head.pos) {
       return null;
     }
 
-    const lastNode = nodes[nodes.length - 1];
-    if (lastNode.pos < 0) {
+    const ranges = getSelectionRanges($anchor.min($head), $anchor.max($head));
+    if (ranges.length === 0) {
       return null;
     }
 
-    let fromOffset = 0;
-    nodes.forEach(({ pos }) => {
-      if (pos < 0) {
-        fromOffset = pos;
-      }
-    });
-
-    const toOffset =
-      headPos - anchorPos - lastNode.pos - lastNode.node.nodeSize;
-    const anchor =
-      dir > 0
-        ? anchorPos + fromOffset
-        : headPos - (toOffset > 0 ? 0 : toOffset);
-    const head =
-      dir > 0
-        ? headPos - (toOffset > 0 ? 0 : toOffset)
-        : anchorPos + fromOffset;
-    return new RangeSelection(doc.resolve(anchor), doc.resolve(head));
-  }
-
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  static fromJSON(doc: Node, json: any) {
-    if (typeof json.anchor != "number" || typeof json.head != "number") {
-      throw new RangeError("Invalid input for RangeSelection.fromJSON");
-    }
-
-    return new RangeSelection(doc.resolve(json.anchor), doc.resolve(json.head));
-  }
-
-  static create(doc: Node, anchor: number, head: number) {
-    return new this(doc.resolve(anchor), doc.resolve(head));
+    return new RangeSelection($anchor, $head);
   }
 
   static allRange(doc: Node) {
@@ -144,52 +50,10 @@ class RangeSelection extends Selection {
   }
 }
 
-Selection.jsonID("range", RangeSelection);
-
-class RangeBookmark {
-  constructor(
-    readonly anchor: number,
-    readonly head: number
-  ) {}
-
-  map(mapping: Mappable) {
-    return new RangeBookmark(mapping.map(this.anchor), mapping.map(this.head));
-  }
-  resolve(doc: Node) {
-    return new RangeSelection(doc.resolve(this.anchor), doc.resolve(this.head));
-  }
-}
-
-export function checkRangeSelection($anchor: ResolvedPos, $head: ResolvedPos) {
-  if ($anchor.pos === $head.pos) {
-    console.warn("The RangeSelection cannot be empty.");
-  }
-}
-
-export function rangeNodesBetween($anchor: ResolvedPos, $head: ResolvedPos) {
-  const doc = $anchor.doc;
-  const dir = $anchor.pos < $head.pos ? 1 : -1;
-  const anchorPos = dir > 0 ? $anchor.pos : $head.pos;
-  const headPos = dir > 0 ? $head.pos : $anchor.pos;
-
-  const nodes: Array<{
-    node: Node;
-    pos: number;
-    parent: Node | null;
-    index: number;
-  }> = [];
-  doc.nodesBetween(
-    anchorPos,
-    headPos,
-    (node, pos, parent, index) => {
-      if (node.isText || node.type.name === "paragraph") {
-        return true;
-      }
-      nodes.push({ node, pos, parent, index });
-    },
-    -anchorPos
-  );
-  return nodes;
+try {
+  Selection.jsonID("range", RangeSelection);
+} catch {
+  // The compatibility JSON ID may already be registered by another bundle.
 }
 
 export default RangeSelection;

--- a/ui/packages/editor/src/extensions/text/index.ts
+++ b/ui/packages/editor/src/extensions/text/index.ts
@@ -15,7 +15,6 @@ import BlockActionSeparator from "@/components/block/BlockActionSeparator.vue";
 import ColorBubbleItem from "@/extensions/color/ColorBubbleItem.vue";
 import HighlightBubbleItem from "@/extensions/highlight/HighlightBubbleItem.vue";
 import LinkBubbleButton from "@/extensions/link/LinkBubbleButton.vue";
-import { RangeSelection } from "@/extensions/range-selection";
 import { i18n } from "@/locales";
 import { PluginKey, type EditorState } from "@/tiptap/pm";
 import { isActive, isTextSelection } from "@/tiptap/vue-3";
@@ -73,10 +72,7 @@ export const ExtensionText = TiptapText.extend<ExtensionTextOptions>({
               return false;
             }
 
-            if (
-              !isTextSelection(selection) &&
-              !(selection instanceof RangeSelection)
-            ) {
+            if (!isTextSelection(selection)) {
               return false;
             }
 

--- a/ui/packages/editor/src/styles/range-selection.scss
+++ b/ui/packages/editor/src/styles/range-selection.scss
@@ -1,13 +1,19 @@
 .halo-rich-text-editor {
   $editorRangeFakeSelection: rgba(27, 162, 227, 0.2);
 
+  .ProseMirror-noderangeselection,
   .no-selection {
     *::selection {
       background-color: transparent;
       color: inherit;
     }
+
+    * {
+      caret-color: transparent;
+    }
   }
 
+  .ProseMirror-selectednoderange,
   .range-fake-selection {
     position: relative;
 

--- a/ui/patches/@tiptap__extension-drag-handle@3.29.0.patch
+++ b/ui/patches/@tiptap__extension-drag-handle@3.29.0.patch
@@ -1,5 +1,4 @@
 diff --git a/dist/index.cjs b/dist/index.cjs
-index 67f4b0e59f69..2f2e17ea82d7 100644
 --- a/dist/index.cjs
 +++ b/dist/index.cjs
 @@ -36,9 +36,7 @@ var import_core2 = require("@tiptap/core");
@@ -12,19 +11,7 @@ index 67f4b0e59f69..2f2e17ea82d7 100644
  
  // src/helpers/dragHandler.ts
  var import_extension_node_range = require("@tiptap/extension-node-range");
-@@ -550,6 +548,11 @@ function dragHandler(event, editor, nestedOptions, dragContext, dragImagePropert
-   });
-   wrapper.style.position = "absolute";
-   wrapper.style.top = "-10000px";
-+  wrapper.style.paddingLeft = "12px";
-+  wrapper.style.paddingTop = "12px";
-+  const firstElement = view.nodeDOM(ranges[0].$from.pos);
-+  const firstElementLeft = firstElement instanceof Element ? firstElement.getBoundingClientRect().left : 0;
-+  wrapper.style.left = `${firstElementLeft}px`;
-   document.body.append(wrapper);
-   event.dataTransfer.clearData();
-   const wrapperRect = wrapper.getBoundingClientRect();
-@@ -671,23 +674,10 @@ function createDroppedNodeRangeSelection(doc, anchorPos, nodeCount, depth) {
+@@ -671,23 +669,10 @@ function createDroppedNodeRangeSelection(doc, anchorPos, nodeCount, depth) {
  
  // src/drag-handle-plugin.ts
  var getRelativePos = (state, absolutePos) => {
@@ -50,7 +37,7 @@ index 67f4b0e59f69..2f2e17ea82d7 100644
  };
  var getOuterDomNode = (view, domNode) => {
    let tmpDomNode = domNode;
-@@ -730,8 +720,8 @@ var DragHandlePlugin = ({
+@@ -730,8 +715,8 @@ var DragHandlePlugin = ({
        return;
      }
      pendingRestore = mapPendingRestoreAnchor(pendingRestore, tr, {
@@ -61,7 +48,7 @@ index 67f4b0e59f69..2f2e17ea82d7 100644
      });
    }
    function buildRestoreTransaction(state) {
-@@ -873,17 +863,10 @@ var DragHandlePlugin = ({
+@@ -873,17 +858,10 @@ var DragHandlePlugin = ({
              return value;
            }
            if (tr.docChanged && currentNodePos !== -1 && element) {
@@ -84,7 +71,6 @@ index 67f4b0e59f69..2f2e17ea82d7 100644
            }
            return value;
 diff --git a/dist/index.js b/dist/index.js
-index 8fec3ceacf3c..f57291597913 100644
 --- a/dist/index.js
 +++ b/dist/index.js
 @@ -4,13 +4,7 @@ import { Extension } from "@tiptap/core";
@@ -101,19 +87,7 @@ index 8fec3ceacf3c..f57291597913 100644
  
  // src/helpers/dragHandler.ts
  import { getSelectionRanges, NodeRangeSelection } from "@tiptap/extension-node-range";
-@@ -522,6 +516,11 @@ function dragHandler(event, editor, nestedOptions, dragContext, dragImagePropert
-   });
-   wrapper.style.position = "absolute";
-   wrapper.style.top = "-10000px";
-+  wrapper.style.paddingLeft = "12px";
-+  wrapper.style.paddingTop = "12px";
-+  const firstElement = view.nodeDOM(ranges[0].$from.pos);
-+  const firstElementLeft = firstElement instanceof Element ? firstElement.getBoundingClientRect().left : 0;
-+  wrapper.style.left = `${firstElementLeft}px`;
-   document.body.append(wrapper);
-   event.dataTransfer.clearData();
-   const wrapperRect = wrapper.getBoundingClientRect();
-@@ -643,23 +642,10 @@ function createDroppedNodeRangeSelection(doc, anchorPos, nodeCount, depth) {
+@@ -643,23 +637,10 @@ function createDroppedNodeRangeSelection(doc, anchorPos, nodeCount, depth) {
  
  // src/drag-handle-plugin.ts
  var getRelativePos = (state, absolutePos) => {
@@ -139,7 +113,7 @@ index 8fec3ceacf3c..f57291597913 100644
  };
  var getOuterDomNode = (view, domNode) => {
    let tmpDomNode = domNode;
-@@ -702,8 +688,8 @@ var DragHandlePlugin = ({
+@@ -702,8 +683,8 @@ var DragHandlePlugin = ({
        return;
      }
      pendingRestore = mapPendingRestoreAnchor(pendingRestore, tr, {
@@ -150,7 +124,7 @@ index 8fec3ceacf3c..f57291597913 100644
      });
    }
    function buildRestoreTransaction(state) {
-@@ -845,17 +831,10 @@ var DragHandlePlugin = ({
+@@ -845,17 +826,10 @@ var DragHandlePlugin = ({
              return value;
            }
            if (tr.docChanged && currentNodePos !== -1 && element) {

--- a/ui/pnpm-lock.yaml
+++ b/ui/pnpm-lock.yaml
@@ -22,7 +22,7 @@ overrides:
   prosemirror-view: 1.40.0
 
 patchedDependencies:
-  '@tiptap/extension-drag-handle@3.29.0': 9ac918f7853d887889eecfa21fef4a2653abebf50b2bb9e8ce7488057e0e280f
+  '@tiptap/extension-drag-handle@3.29.0': 4f18ee6bd0ef5fc2dc97fd4993f083c205f9dc61e156104b1b5b6da879717b3c
 
 importers:
 
@@ -539,7 +539,7 @@ importers:
         version: 3.29.0(@tiptap/core@3.29.0)
       '@tiptap/extension-drag-handle':
         specifier: ^3.29.0
-        version: 3.29.0(patch_hash=9ac918f7853d887889eecfa21fef4a2653abebf50b2bb9e8ce7488057e0e280f)(@tiptap/core@3.29.0)(@tiptap/extension-collaboration@3.29.0)(@tiptap/extension-node-range@3.29.0)(@tiptap/pm@3.29.0)(@tiptap/y-tiptap@3.0.7)
+        version: 3.29.0(patch_hash=4f18ee6bd0ef5fc2dc97fd4993f083c205f9dc61e156104b1b5b6da879717b3c)(@tiptap/core@3.29.0)(@tiptap/extension-collaboration@3.29.0)(@tiptap/extension-node-range@3.29.0)(@tiptap/pm@3.29.0)(@tiptap/y-tiptap@3.0.7)
       '@tiptap/extension-drag-handle-vue-3':
         specifier: ^3.29.0
         version: 3.29.0(@tiptap/extension-drag-handle@3.29.0)(@tiptap/pm@3.29.0)(@tiptap/vue-3@3.29.0)(vue@3.5.40)
@@ -569,6 +569,9 @@ importers:
         version: 3.29.0(@tiptap/core@3.29.0)(@tiptap/pm@3.29.0)
       '@tiptap/extension-list':
         specifier: ^3.29.0
+        version: 3.29.0(@tiptap/core@3.29.0)(@tiptap/pm@3.29.0)
+      '@tiptap/extension-node-range':
+        specifier: 3.29.0
         version: 3.29.0(@tiptap/core@3.29.0)(@tiptap/pm@3.29.0)
       '@tiptap/extension-paragraph':
         specifier: ^3.29.0
@@ -9380,12 +9383,12 @@ snapshots:
 
   '@tiptap/extension-drag-handle-vue-3@3.29.0(@tiptap/extension-drag-handle@3.29.0)(@tiptap/pm@3.29.0)(@tiptap/vue-3@3.29.0)(vue@3.5.40)':
     dependencies:
-      '@tiptap/extension-drag-handle': 3.29.0(patch_hash=9ac918f7853d887889eecfa21fef4a2653abebf50b2bb9e8ce7488057e0e280f)(@tiptap/core@3.29.0)(@tiptap/extension-collaboration@3.29.0)(@tiptap/extension-node-range@3.29.0)(@tiptap/pm@3.29.0)(@tiptap/y-tiptap@3.0.7)
+      '@tiptap/extension-drag-handle': 3.29.0(patch_hash=4f18ee6bd0ef5fc2dc97fd4993f083c205f9dc61e156104b1b5b6da879717b3c)(@tiptap/core@3.29.0)(@tiptap/extension-collaboration@3.29.0)(@tiptap/extension-node-range@3.29.0)(@tiptap/pm@3.29.0)(@tiptap/y-tiptap@3.0.7)
       '@tiptap/pm': 3.29.0
       '@tiptap/vue-3': 3.29.0(@floating-ui/dom@1.7.6)(@tiptap/core@3.29.0)(@tiptap/pm@3.29.0)(vue@3.5.40)
       vue: 3.5.40(typescript@5.9.3)
 
-  '@tiptap/extension-drag-handle@3.29.0(patch_hash=9ac918f7853d887889eecfa21fef4a2653abebf50b2bb9e8ce7488057e0e280f)(@tiptap/core@3.29.0)(@tiptap/extension-collaboration@3.29.0)(@tiptap/extension-node-range@3.29.0)(@tiptap/pm@3.29.0)(@tiptap/y-tiptap@3.0.7)':
+  '@tiptap/extension-drag-handle@3.29.0(patch_hash=4f18ee6bd0ef5fc2dc97fd4993f083c205f9dc61e156104b1b5b6da879717b3c)(@tiptap/core@3.29.0)(@tiptap/extension-collaboration@3.29.0)(@tiptap/extension-node-range@3.29.0)(@tiptap/pm@3.29.0)(@tiptap/y-tiptap@3.0.7)':
     dependencies:
       '@floating-ui/dom': 1.7.6
       '@tiptap/core': 3.29.0(@tiptap/pm@3.29.0)


### PR DESCRIPTION
#### What type of PR is this?

/kind improvement
/area editor
/area ui

#### What this PR does / why we need it:

本 PR 使用 `@tiptap/extension-node-range` 替换了 Halo 自定义的块级范围选择实现。

为了实现上面的功能，还做了一下副作用：
1. 优化代码块及其他顶层块组件的 NodeSelection 和拖拽行为。
2. 目前会在范围选择过程中隐藏 BubbleMenu。
3. 精简 DragHandle 的 pnpm patch：移除上游已修复的拖拽预览补丁，继续排除不需要的 Collaboration/Yjs 依赖。

#### Does this PR introduce a user-facing change?
```release-note
优化编辑器的块级范围选择和拖拽体验
```
