### PR TITLE
improvement: try email login before username login

### DIFF
--- a/application/src/main/java/run/halo/app/security/authentication/login/LoginReactiveAuthenticationManager.java
+++ b/application/src/main/java/run/halo/app/security/authentication/login/LoginReactiveAuthenticationManager.java
@@ -16,9 +16,11 @@ import run.halo.app.core.user.service.UserService;
 import run.halo.app.security.authentication.UserAccountStatusChecker;
 
 /**
- * A {@link ReactiveAuthenticationManager} that authenticates by trying multiple login strategies in order: username
- * first, then verified email. Each strategy only executes when the login identifier matches its expected format (e.g.,
- * email lookup only runs for identifiers containing {@code @}).
+ * A {@link ReactiveAuthenticationManager} that authenticates by trying multiple login strategies in order: verified
+ * email first, then username. Each strategy only executes when the login identifier matches its expected format (e.g.,
+ * email lookup only runs for identifiers containing {@code @}, while username lookup acts as a generic fallback for any
+ * identifier). The password is checked after each lookup, and only a strategy that both resolves the identifier and
+ * matches the password wins; otherwise the chain falls through to the next strategy.
  */
 @RequiredArgsConstructor
 class LoginReactiveAuthenticationManager implements ReactiveAuthenticationManager {
@@ -37,8 +39,9 @@ class LoginReactiveAuthenticationManager implements ReactiveAuthenticationManage
         var credentials = authentication.getCredentials();
         var password = credentials != null ? credentials.toString() : null;
 
-        return Flux.concat(lookupByUsername(loginId), lookupByEmail(loginId))
-                .publishOn(Schedulers.boundedElastic())
+        return Flux.concat(
+                        Mono.defer(() -> lookupByEmail(loginId)).publishOn(Schedulers.boundedElastic()),
+                        Mono.defer(() -> lookupByUsername(loginId)).publishOn(Schedulers.boundedElastic()))
                 .filter(userDetails -> password != null && passwordEncoder.matches(password, userDetails.getPassword()))
                 .next()
                 .switchIfEmpty(Mono.error(() -> new BadCredentialsException("Invalid Credentials")))
@@ -48,14 +51,9 @@ class LoginReactiveAuthenticationManager implements ReactiveAuthenticationManage
                         userDetails, userDetails.getPassword(), userDetails.getAuthorities()));
     }
 
-    /** Looks up the user by username. Skips email-like identifiers since usernames never contain {@code @}. */
+    /** Looks up the user by username. This is the generic fallback strategy for any identifier. */
     Mono<UserDetails> lookupByUsername(String loginId) {
-        if (loginId.contains("@")) {
-            return Mono.empty();
-        }
-        return userDetailsService
-                .findByUsername(loginId)
-                .onErrorResume(BadCredentialsException.class, e -> Mono.empty());
+        return userDetailsService.findByUsername(loginId);
     }
 
     /** Looks up the user by verified email. Skips identifiers that don't look like email addresses. */
@@ -65,9 +63,8 @@ class LoginReactiveAuthenticationManager implements ReactiveAuthenticationManage
         }
         return userService
                 .findUserByVerifiedEmail(loginId)
-                .flatMap(user -> userDetailsService
-                        .findByUsername(user.getMetadata().getName())
-                        .onErrorResume(BadCredentialsException.class, e -> Mono.empty()));
+                .flatMap(user ->
+                        userDetailsService.findByUsername(user.getMetadata().getName()));
     }
 
     private Mono<UserDetails> upgradePasswordIfNeeded(UserDetails userDetails, String password) {

--- a/application/src/test/java/run/halo/app/security/authentication/login/LoginReactiveAuthenticationManagerTest.java
+++ b/application/src/test/java/run/halo/app/security/authentication/login/LoginReactiveAuthenticationManagerTest.java
@@ -94,7 +94,7 @@ class LoginReactiveAuthenticationManagerTest {
 
     @Test
     void shouldAuthenticateByEmailWithCorrectPassword() {
-        // tryByUsername skips @ input, goes directly to tryByEmail
+        // email lookup is attempted first for @ input
         var emailUser = createUserExtension("actualuser");
         when(userService.findUserByVerifiedEmail("test@example.com")).thenReturn(Mono.just(emailUser));
 
@@ -109,13 +109,16 @@ class LoginReactiveAuthenticationManagerTest {
                 .assertNext(auth -> assertEquals(userDetails, auth.getPrincipal()))
                 .verifyComplete();
 
-        // @ input bypasses username lookup entirely
+        // a resolved email lookup wins, so the raw identifier is never treated as a username
         verify(userDetailsService, never()).findByUsername("test@example.com");
     }
 
     @Test
     void shouldFailWhenEmailNotFound() {
         when(userService.findUserByVerifiedEmail("test@example.com")).thenReturn(Mono.empty());
+        // username lookup acts as the generic fallback, and missing usernames error with BadCredentialsException
+        when(userDetailsService.findByUsername("test@example.com"))
+                .thenReturn(Mono.error(new BadCredentialsException("Invalid Credentials")));
 
         var result = authenticate("test@example.com", "password");
 
@@ -130,10 +133,32 @@ class LoginReactiveAuthenticationManagerTest {
         var userDetails = createUserDetails("actualuser", "encoded-password");
         when(userDetailsService.findByUsername("actualuser")).thenReturn(Mono.just(userDetails));
         when(passwordEncoder.matches("password", "encoded-password")).thenReturn(false);
+        // wrong password on the email strategy falls through to the username strategy, which cannot
+        // resolve an email address and errors with BadCredentialsException
+        when(userDetailsService.findByUsername("test@example.com"))
+                .thenReturn(Mono.error(new BadCredentialsException("Invalid Credentials")));
 
         var result = authenticate("test@example.com", "password");
 
         StepVerifier.create(result).expectError(BadCredentialsException.class).verify();
+
+        verify(userDetailsService).findByUsername("test@example.com");
+    }
+
+    @Test
+    void shouldFallBackToUsernameLookupWhenEmailNotVerified() {
+        when(userService.findUserByVerifiedEmail("alice@example.com")).thenReturn(Mono.empty());
+
+        var userDetails = createUserDetails("alice@example.com", "encoded-password");
+        when(userDetailsService.findByUsername("alice@example.com")).thenReturn(Mono.just(userDetails));
+        when(passwordEncoder.matches("password", "encoded-password")).thenReturn(true);
+        stubPasswordService();
+
+        var result = authenticate("alice@example.com", "password");
+
+        StepVerifier.create(result)
+                .assertNext(auth -> assertEquals(userDetails, auth.getPrincipal()))
+                .verifyComplete();
     }
 
     // ── Password upgrade ───────────────────────────────────────────
@@ -209,6 +234,8 @@ class LoginReactiveAuthenticationManagerTest {
     @Test
     void shouldFailWhenAllStrategiesExhaustedForEmail() {
         when(userService.findUserByVerifiedEmail("unknown@example.com")).thenReturn(Mono.empty());
+        when(userDetailsService.findByUsername("unknown@example.com"))
+                .thenReturn(Mono.error(new BadCredentialsException("Invalid Credentials")));
 
         var result = authenticate("unknown@example.com", "password");
 


### PR DESCRIPTION
## What

Reorder the login strategies in `LoginReactiveAuthenticationManager` so that verified **email** login is tried first, followed by **username** login. The password is verified after each lookup, and only a strategy that both resolves the identifier and matches the password wins; otherwise the chain falls through to the next strategy.

## Why

- The previous username-first order gated `lookupByUsername` on the identifier not containing `@`, so an email-like identifier could never fall back to the username strategy. Swapping the order and removing the `@` check turns username lookup into a generic fallback for any identifier, which also prepares the chain for future strategies such as phone + password.
- The `onErrorResume(BadCredentialsException, ...)` in `lookupByUsername` was incorrect: `DefaultUserDetailService.findByUsername` emits `BadCredentialsException` when the user is not found, so the resume swallowed the terminal "user not found" failure of the last strategy and let `switchIfEmpty` re-create an identical exception, hiding which strategy actually failed. With username lookup as the final fallback, its lookup failure should propagate naturally.

## How

- `authenticate` now chains `lookupByEmail` → `lookupByUsername` with a shared password check after each lookup.
- Each strategy is wrapped in `Mono.defer` (evaluated only when the chain reaches it) and hops to `boundedElastic` via its own `publishOn` before the shared password check, so the potentially blocking `passwordEncoder.matches` always runs on a `boundedElastic` worker.
- Because the async hop lives inside each strategy rather than between `concat` and `.next()`, a matched strategy cancels the chain synchronously and the next strategy is never evaluated — the previous `publishOn` placement (between `concat` and `.next()`) let `concat` subscribe the next strategy even after a match, which would have caused an extra `findByUsername` lookup on every successful email login once the `@` gate was removed.
- Removed the `@` gate and the incorrect `onErrorResume` from `lookupByUsername`, and removed the redundant `onErrorResume` in `lookupByEmail` for the same reason.
- Updated and extended `LoginReactiveAuthenticationManagerTest` to cover the new strategy order, the username fallback for unverified email identifiers, and fall-through on a wrong password.

## Testing

- `./gradlew :application:test` passes.

Note: this PR was prepared with AI assistance (Codex), reviewed and adjusted by the author.