### PR TITLE
Update App Store preset plugin to 1.18.1

### DIFF
--- a/application/build.gradle
+++ b/application/build.gradle
@@ -178,7 +178,7 @@ tasks.register('downloadPluginPresets', Download) {
         // Please see https://github.com/halo-dev/plugin-app-store/issues/55
         // https://www.halo.run/store/apps/app-VYJbF/releases/app-release-qafgml3o
         [
-            url       : 'https://www.halo.run/store/apps/app-VYJbF/releases/download/app-release-1tbawcta/assets/app-release-1tbawcta-gkb19umt',
+            url       : 'https://www.halo.run/store/apps/app-VYJbF/releases/download/app-release-k0bgjukb/assets/app-release-k0bgjukb-aizf1wnc',
             filename  : 'appstore.jar',
             autoEnable: true,
         ],


### PR DESCRIPTION
#### What type of PR is this?

- [ ] Feature
- [ ] Bug fix
- [x] Improvement
- [ ] Cleanup
- [ ] Documentation

#### What this PR does / why we need it:

Updates the bundled App Store preset plugin download URL from the 1.17.0 asset to the 1.18.1 release asset.

This keeps the `downloadPluginPresets` Gradle task using the current App Store plugin when assembling the application presets.

#### Which issue(s) this PR fixes:

N/A

#### Special notes for your reviewer:

The new URL resolves to `appstore-1.18.1.jar`.

Validated with:

- `git diff --check`
- HTTP 200 check for the new Halo Store asset URL
- `./gradlew :application:downloadPluginPresets --rerun-tasks`

AI assistance was used to prepare this PR, and the resulting change was reviewed against the current source.

#### Does this PR introduce a user-facing change?

```release-note
预置的应用市场插件更新至 1.18.1。
```