### PR TITLE
improvement: offload password encoder operations to boundedElastic

### DIFF
--- a/application/src/main/java/run/halo/app/security/authentication/login/LoginReactiveAuthenticationManager.java
+++ b/application/src/main/java/run/halo/app/security/authentication/login/LoginReactiveAuthenticationManager.java
@@ -39,9 +39,8 @@ class LoginReactiveAuthenticationManager implements ReactiveAuthenticationManage
         var credentials = authentication.getCredentials();
         var password = credentials != null ? credentials.toString() : null;
 
-        return Flux.concat(
-                        Mono.defer(() -> lookupByEmail(loginId)).publishOn(Schedulers.boundedElastic()),
-                        Mono.defer(() -> lookupByUsername(loginId)).publishOn(Schedulers.boundedElastic()))
+        return Flux.concat(Mono.defer(() -> lookupByEmail(loginId)), Mono.defer(() -> lookupByUsername(loginId)))
+                .publishOn(Schedulers.boundedElastic())
                 .filter(userDetails -> password != null && passwordEncoder.matches(password, userDetails.getPassword()))
                 .next()
                 .switchIfEmpty(Mono.error(() -> new BadCredentialsException("Invalid Credentials")))

--- a/application/src/test/java/run/halo/app/security/authentication/login/LoginReactiveAuthenticationManagerTest.java
+++ b/application/src/test/java/run/halo/app/security/authentication/login/LoginReactiveAuthenticationManagerTest.java
@@ -1,6 +1,7 @@
 package run.halo.app.security.authentication.login;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
@@ -9,6 +10,7 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.util.concurrent.atomic.AtomicReference;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
@@ -100,6 +102,9 @@ class LoginReactiveAuthenticationManagerTest {
 
         var userDetails = createUserDetails("actualuser", "encoded-password");
         when(userDetailsService.findByUsername("actualuser")).thenReturn(Mono.just(userDetails));
+        // the username fallback is subscribed after the email strategy completes, but its result is
+        // discarded once the email-resolved user wins
+        when(userDetailsService.findByUsername("test@example.com")).thenReturn(Mono.empty());
         when(passwordEncoder.matches("password", "encoded-password")).thenReturn(true);
         stubPasswordService();
 
@@ -109,8 +114,8 @@ class LoginReactiveAuthenticationManagerTest {
                 .assertNext(auth -> assertEquals(userDetails, auth.getPrincipal()))
                 .verifyComplete();
 
-        // a resolved email lookup wins, so the raw identifier is never treated as a username
-        verify(userDetailsService, never()).findByUsername("test@example.com");
+        // a resolved email lookup wins, although the username fallback has already been subscribed
+        verify(userDetailsService).findByUsername("test@example.com");
     }
 
     @Test
@@ -196,6 +201,8 @@ class LoginReactiveAuthenticationManagerTest {
 
         var userDetails = createUserDetails("actualuser", "encoded-password");
         when(userDetailsService.findByUsername("actualuser")).thenReturn(Mono.just(userDetails));
+        // the username fallback is subscribed after the email strategy completes
+        when(userDetailsService.findByUsername("test@example.com")).thenReturn(Mono.empty());
         when(passwordEncoder.matches("password", "encoded-password")).thenReturn(true);
 
         when(passwordEncoder.upgradeEncoding("encoded-password")).thenReturn(true);
@@ -215,6 +222,36 @@ class LoginReactiveAuthenticationManagerTest {
                 .verifyComplete();
 
         verify(passwordService).updatePassword(userDetails, "new-encoded-password");
+    }
+
+    @Test
+    void shouldRunPasswordEncoderOperationsOnBoundedElasticThread() {
+        var matchingThread = new AtomicReference<Thread>();
+        var encodingThread = new AtomicReference<Thread>();
+
+        var userDetails = createUserDetails("testuser", "encoded-password");
+        when(userDetailsService.findByUsername("testuser")).thenReturn(Mono.just(userDetails));
+        when(passwordEncoder.matches("password", "encoded-password")).thenAnswer(invocation -> {
+            matchingThread.set(Thread.currentThread());
+            return true;
+        });
+
+        when(passwordEncoder.upgradeEncoding("encoded-password")).thenReturn(true);
+        when(passwordEncoder.encode("password")).thenAnswer(invocation -> {
+            encodingThread.set(Thread.currentThread());
+            return "new-encoded-password";
+        });
+
+        var upgradedUser = createUserDetails("testuser", "new-encoded-password");
+        when(passwordService.updatePassword(eq(userDetails), eq("new-encoded-password")))
+                .thenReturn(Mono.just(upgradedUser));
+
+        var result = authenticate("testuser", "password");
+
+        StepVerifier.create(result).expectNextCount(1).verifyComplete();
+
+        assertBoundedElasticThread(matchingThread.get());
+        assertBoundedElasticThread(encodingThread.get());
     }
 
     // ── Exception handling ─────────────────────────────────────────
@@ -255,6 +292,12 @@ class LoginReactiveAuthenticationManagerTest {
         lenient()
                 .when(passwordService.updatePassword(any(), anyString()))
                 .thenAnswer(invocation -> Mono.just(invocation.getArgument(0)));
+    }
+
+    private static void assertBoundedElasticThread(Thread thread) {
+        assertTrue(
+                thread != null && thread.getName().startsWith("boundedElastic-"),
+                () -> "Expected a boundedElastic thread, but got " + thread);
     }
 
     private UserDetails createUserDetails(String username, String password) {


### PR DESCRIPTION
#### What type of PR is this?

- [ ] Feature
- [ ] Bug fix
- [x] Improvement
- [ ] Cleanup
- [ ] Documentation

#### What this PR does / why we need it:

`PasswordEncoder#matches` and `#encode` may contain blocking IO. This PR moves `publishOn(Schedulers.boundedElastic())` after the reactive login lookups, so a single boundary keeps those blocking operations off the event loop while the reactive lookups themselves stay on the reactive scheduler.

Note: with a single `publishOn` after `Flux.concat`, the username fallback lookup may be subscribed even when the email strategy resolves; its result is discarded once the email-resolved user wins.

#### Which issue(s) this PR fixes:

N/A

#### Special notes for your reviewer:

- Updated `LoginReactiveAuthenticationManagerTest` to match the new behavior: on successful email login the fallback lookup is subscribed but never used for authentication.
- Added a regression test asserting `matches` and `encode` run on `boundedElastic-*` threads.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```