### PR TITLE
improvement: modularize AGENTS.md contributor guides

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,199 +1,35 @@
-# Halo — AGENTS.md
+# Repository Guidelines
 
-Open-source CMS/blogging platform. Java 21 / Spring Boot WebFlux + R2DBC + Vue 3 + TypeScript + TailwindCSS.
+Halo is a full-stack monorepo: Java 21 / Spring Boot WebFlux + R2DBC backend and a Vue 3 + TypeScript + TailwindCSS frontend. Work from the repo root and load **every relevant module guide** for the areas you touch.
 
-Versions live in `gradle/libs.versions.toml`, `gradle.properties`, and `ui/package.json`. Do not hard-code them.
+## Modules
 
-## Start here
+|       Module        |                           Path                            |                              Guide                               |
+|---------------------|-----------------------------------------------------------|------------------------------------------------------------------|
+| API library         | `api/` (extension model, contracts, security)             | [api/AGENTS.md](api/AGENTS.md)                                   |
+| Backend application | `application/` (services, routers, migrations, packaging) | [application/AGENTS.md](application/AGENTS.md)                   |
+| Frontend            | `ui/` (console, user center, workspace packages)          | [ui/AGENTS.md](ui/AGENTS.md)                                     |
+| Application BOM     | `platform/application/` (shared dependency constraints)   | [platform/application/AGENTS.md](platform/application/AGENTS.md) |
+| Plugin BOM          | `platform/plugin/` (plugin-facing constraints)            | [platform/plugin/AGENTS.md](platform/plugin/AGENTS.md)           |
 
-- This repository is usually opened and worked from the **repo root**, even for frontend-only changes. Prefer root-scoped commands such as `./gradlew :application:test` and `pnpm -C ui lint`.
-- Backend and frontend changes are often part of the same task. Treat this as a **full-stack repo**, not two isolated projects.
-- This root file is the **repo-wide baseline**. Nested `AGENTS.md` files add local rules. When a task touches multiple areas, load **every relevant nested file**, not just the one closest to the first edited file.
+## Quick Commands
 
-## Quick commands (run from repo root)
+Run from the repo root:
 
-```bash
-./gradlew build                                # full repo build: backend + UI packaging + tests
-./gradlew spotlessApply                        # format Java and repo-level markdown/json/properties
-./gradlew :api:test                            # API module tests
-./gradlew :application:test                    # backend tests
-./gradlew :application:bootRun                 # backend dev server
-pnpm -C ui install                             # install frontend deps
-pnpm -C ui build                               # frontend build
-pnpm -C ui typecheck && pnpm -C ui lint        # frontend validation
-pnpm -C ui test:unit                           # frontend unit tests
-./gradlew generateOpenApiDocs && pnpm -C ui api-client:gen   # refresh OpenAPI-generated UI client
-```
+- `./gradlew build` — full backend build and tests.
+- `./gradlew spotlessApply` — format Java, Markdown, JSON, and properties.
+- `./gradlew :application:test` — backend tests.
+- `pnpm -C ui typecheck && pnpm -C ui lint` — frontend validation.
+- `pnpm -C ui test:unit` — frontend unit tests.
+- `./gradlew generateOpenApiDocs && pnpm -C ui api-client:gen` — regenerate the UI client after contract changes.
 
-## How work is split in this repo
+## Cross-Module Rules
 
-|         Area         |          Path           |                           Use it for                           |                        Also load                         |
-|----------------------|-------------------------|----------------------------------------------------------------|----------------------------------------------------------|
-| Public API contracts | `api/`                  | Extension model, service interfaces, security abstractions     | `application/AGENTS.md` when implementations also change |
-| Backend application  | `application/`          | WebFlux services, routers, security, migrations, packaging     | `ui/AGENTS.md` when payloads or UX also change           |
-| Frontend             | `ui/`                   | Console, user center, workspace packages, generated API client | `application/AGENTS.md` for API or OpenAPI work          |
-| Application BOM      | `platform/application/` | Shared dependency constraints                                  | root only unless API/application also change             |
-| Plugin BOM           | `platform/plugin/`      | Plugin-facing dependency constraints                           | `api/AGENTS.md` when plugin API changes                  |
-
-## Nested AGENTS.md files
-
-Use the root file plus the relevant nested file(s):
-
-|  Subproject  |                                Path                                |                           What it adds                            |
-|--------------|--------------------------------------------------------------------|-------------------------------------------------------------------|
-| API library  | [`api/AGENTS.md`](api/AGENTS.md)                                   | Public API boundaries, extension model, service contract pitfalls |
-| Application  | [`application/AGENTS.md`](application/AGENTS.md)                   | WebFlux implementation patterns, routers, security, tests         |
-| Frontend     | [`ui/AGENTS.md`](ui/AGENTS.md)                                     | pnpm workspace commands, module layout, UI conventions            |
-| Platform BOM | [`platform/application/AGENTS.md`](platform/application/AGENTS.md) | Dependency constraint rules                                       |
-| Plugin BOM   | [`platform/plugin/AGENTS.md`](platform/plugin/AGENTS.md)           | Plugin BOM rules and downstream compatibility notes               |
-
-## Cross-module workflows
-
-### Full-stack feature work
-
-1. Start at the repo root.
-2. Load the nested `AGENTS.md` for **every** touched module.
-3. Keep API contracts, backend handlers, and UI usage in sync in the same change.
-
-### Backend contract or OpenAPI changes
-
-If you change any of these, also consider UI impact:
-
-- public request/response DTOs
-- REST routes or router contracts
-- OpenAPI annotations or generated schema
-- auth/session behavior consumed by console or user center
-
-Then regenerate the client:
-
-```bash
-./gradlew generateOpenApiDocs
-pnpm -C ui api-client:gen
-```
-
-Do not edit generated files in `ui/packages/api-client/src/` directly.
-
-### UI packaging
-
-The UI is embedded into the backend JAR. `application:copyUiDist` copies `ui/build/dist` into the application resources during the backend build. If the UI output changes, assume the backend packaging path matters too.
-
-## Repository structure
-
-- **`api/`** — Public API library published as `run.halo.app`; changes here affect external plugins.
-- **`application/`** — Main Spring Boot application; all business logic lives here.
-- **`platform/application/`** — Application BOM for dependency versions.
-- **`platform/plugin/`** — Plugin BOM for downstream plugin development.
-- **`ui/`** — pnpm workspace for admin console (`/console`) and user center (`/uc`).
-- **`docs/`** — Human-facing developer documentation.
-
-## Code style and examples
-
-**Java:** Spotless + Palantir Java Format (`2.90.0`) with 4-space indentation and 120-character lines. Spotless is the source of truth.
-
-**Frontend:** `vp fmt` (`pnpm -C ui format`) + ESLint. See [`ui/AGENTS.md`](ui/AGENTS.md) for module conventions.
-
-Example validation paths:
-
-```bash
-# backend-only change
-./gradlew spotlessApply
-./gradlew :application:test
-
-# frontend-only change
-pnpm -C ui format
-pnpm -C ui typecheck && pnpm -C ui lint
-
-# cross-stack contract change
-./gradlew generateOpenApiDocs
-pnpm -C ui api-client:gen
-pnpm -C ui typecheck && pnpm -C ui lint
-./gradlew :application:test
-```
-
-## Key development notes
-
-- Preset plugins are downloaded at build time via `downloadPluginPresets`.
-- Database migrations use `r2dbc-migrate`, not Flyway/Liquibase.
-- Migration scripts live in `application/src/main/resources/db/migration/{h2,mariadb,mysql,postgresql}/`.
-- Extension type schemas live in `application/src/main/resources/extensions/`; runtime data is stored as JSON in the database.
-- Profile-specific configs include `application-local.yaml`, `application-dev.yaml`, and `application-postgresql.yaml`.
-- Default work directory is `~/.halo2` unless overridden by `halo.work-dir`.
-- Virtual threads are enabled. Do not introduce blocking I/O in reactive paths.
-- AI-assisted contributions are allowed, but material usage should be disclosed in PR descriptions.
-
-## Repository & upstream context
-
-This AGENTS.md is shared by two repositories:
-
-|      Repository       |         Purpose         |
-|-----------------------|-------------------------|
-| `halo-dev/halo`       | Open-source edition     |
-| `lxware-dev/halo-pro` | Pro/proprietary edition |
-
-Always identify the current upstream before pushing or opening a PR:
-
-```bash
-git remote -v
-```
-
-PRs must target the `upstream` remote of the current repo. Opening against the wrong upstream is costly to unwind.
-
-## Git workflow
-
-```bash
-git fetch upstream && git checkout upstream/main && git checkout -b feat/xxx
-```
-
-- **Branch naming:** `upgrade/gradle-X`, `feat/name`, `fix/name`, `improvement/name`
-- **PR template:** `.github/pull_request_template.md`
-- **CI:** `.github/workflows/halo.yaml`
-- **Never `git add -A` or `git add .`** — H2 artifacts and build outputs can appear under `application/`; stage specific files only.
-- **Stale worktrees can lock `main`.** If `git checkout main` fails, inspect with `git worktree list` and remove the stale worktree explicitly.
-
-## Before you submit
-
-Run the checks that match the touched area, and do not leave red CI behind:
-
-```bash
-./gradlew spotlessApply
-./gradlew :application:test
-pnpm -C ui typecheck && pnpm -C ui lint
-```
-
-Add or update tests for the code you change.
-
-## Boundaries
-
-- ✅ **Always:** Work from the repo root for command orchestration; load all touched nested `AGENTS.md` files; stage files explicitly; regenerate the UI API client after OpenAPI contract changes; add or update tests for changed behavior.
-- ⚠️ **Ask first:** Public API changes in `api/`; new Gradle or npm dependencies; database migration scripts; security configuration; CI workflow changes; destructive changes to generated client output.
-- 🚫 **Never:** Commit secrets or credentials; hard-code versions; introduce blocking I/O into reactive flows; edit generated API client files directly; open a PR without verifying the correct upstream.
-
-## Critical pitfalls
-
-### 1. H2 database paths must be absolute
-
-Use `r2dbc:h2:file:///tmp/halo-db`. Relative paths such as `file:./tmp/...` create stray `application/tmp/` directories.
-
-### 2. Gradle wrapper upgrades require two commands
-
-```bash
-./gradlew wrapper --gradle-version=X.Y.Z
-./gradlew wrapper
-```
-
-### 3. `format 'misc'` must stay in the root `build.gradle`
-
-Do not move it into `application/build.gradle`. Putting `java` and `misc` formatting in the same submodule triggers a Gradle 9.x implicit dependency validation error.
-
-## Config and version files
-
-|            What            |                                  Where                                  |
-|----------------------------|-------------------------------------------------------------------------|
-| Dependency versions        | `gradle/libs.versions.toml`                                             |
-| Project version            | `gradle.properties`                                                     |
-| Spring Boot plugin version | `gradle/libs.versions.toml` → `[plugins] spring-boot`                   |
-| JDK release                | `api/build.gradle`, `application/build.gradle` → `options.release = 21` |
-| Frontend dependencies      | `ui/package.json`                                                       |
-| App configuration          | `application/src/main/resources/application.yaml`                       |
-| Extension schemas          | `application/src/main/resources/extensions/`                            |
+- Keep API contracts, backend handlers, and UI usage in sync; never hand-edit `ui/packages/api-client/src/` — regenerate it after contract changes.
+- Versions live in `gradle/libs.versions.toml`, `gradle.properties`, or `ui/package.json`; never hard-code them.
+- Branch naming: `feat/`, `fix/`, `improvement/`, `upgrade/`; PRs target `upstream` and follow `.github/pull_request_template.md`.
+- Stage specific files only; never `git add -A` (H2 artifacts and build outputs appear under `application/`).
+- Add tests for changed behavior; keep CI green.
+- Ask before public API changes, new dependencies, database migrations, security configuration, or CI workflow changes.
+- Never commit secrets or introduce blocking I/O into reactive flows.
 

--- a/api/AGENTS.md
+++ b/api/AGENTS.md
@@ -1,101 +1,25 @@
-# API Module — AGENTS.md
+# API Library Guidelines
 
-`java-library` module at `api/`. It defines the extension model, reactive interfaces, security abstractions, and service contracts used by `application` and external plugins.
+`api/` is the public API library: the extension model, service contracts, and security abstractions consumed by the application and by plugins. Changes here affect downstream compatibility.
 
-Read this file together with the root [`AGENTS.md`](../AGENTS.md). If a task changes both contracts and implementations, also load [`application/AGENTS.md`](../application/AGENTS.md). If API or OpenAPI-visible DTOs affect the console or user center, also load [`ui/AGENTS.md`](../ui/AGENTS.md).
+## Scope
 
-## Quick commands
+- Source: `api/src/main/java/run/halo/app/` (core, extension, plugin, security, migration, theme, and related packages).
+- Tests: `api/src/test/`.
 
-```bash
-./gradlew :api:compileJava
-./gradlew :api:test
-./gradlew :api:test --tests "*Xxx*"
-./gradlew :api:spotlessApply
-```
+## Commands
 
-## When to work here
+- `./gradlew :api:test` — run API library tests.
+- `./gradlew spotlessApply` — format Java and Markdown.
 
-- service interfaces implemented in `application`
-- extension model types and metadata contracts
-- public security abstractions
-- plugin-facing APIs and extension points
-- shared DTOs or annotations that affect generated OpenAPI
+## Conventions
 
-Because plugins depend on this module, changes here are higher risk than ordinary backend refactors.
-
-## Key packages
-
-|                Package                |                                                    Purpose                                                     |
-|---------------------------------------|----------------------------------------------------------------------------------------------------------------|
-| `run.halo.app.extension`              | Kubernetes-style extension model: `Extension`, `Metadata`, `Scheme`, `ReactiveExtensionClient`, `Unstructured` |
-| `run.halo.app.extension.router`       | REST router framework for extensions: `IListRequest`, `SortableRequest`, `QueryParamBuildUtil`                 |
-| `run.halo.app.extension.controller`   | Controller pattern for reconciling extensions                                                                  |
-| `run.halo.app.core.extension`         | Core extensions: `Post`, `Category`, `Tag`, `Comment`, `User`, `Role`, `Plugin`, `Theme`, `Setting`            |
-| `run.halo.app.core.extension.service` | Core service interfaces such as `UserService`, `RoleService`, `PostService`                                    |
-| `run.halo.app.infra`                  | Infrastructure abstractions                                                                                    |
-| `run.halo.app.security`               | Security abstractions including `HaloOAuth2AuthenticationToken`                                                |
-| `run.halo.app.plugin`                 | Plugin API and extension points                                                                                |
-| `run.halo.app.theme`                  | Theme API                                                                                                      |
-| `run.halo.app.content`                | Content abstractions                                                                                           |
-| `run.halo.app.event`                  | Event types                                                                                                    |
-| `run.halo.app.search`                 | Search abstractions                                                                                            |
-| `run.halo.app.migration`              | Migration framework                                                                                            |
-| `run.halo.app.notification`           | Notification abstractions                                                                                      |
-
-## Extension model
-
-Halo's core data model uses a Kubernetes-style extension system:
-
-- **`Extension`** — all domain objects implement this and expose metadata, API version, and kind.
-- **`Metadata`** — holds `name`, labels, annotations, version, and timestamps.
-- **`Scheme`** — registers an extension type with its `GroupVersionKind`, Java type, and JSON schema.
-- **`ReactiveExtensionClient`** — the generic CRUD entry point.
-- **`Unstructured`** — fallback representation when the concrete type is unknown.
-
-Example:
-
-```java
-@GVK(group = "content.halo.run", version = "v1alpha1", kind = "Post",
-    singular = "post", plural = "posts")
-public class Post extends AbstractExtension { ... }
-```
-
-## Service interfaces
-
-Interfaces live here; implementations belong in `application`.
-
-- `UserService` — prefer this over raw `ReactiveExtensionClient` for user creation and role wiring.
-- `RoleService` — role CRUD and dependency resolution.
-- `PostService` / `SinglePageService` — content publishing pipeline.
-- `NotificationCenter` — notification dispatch.
-- `ThemeService` / `PluginService` — theme and plugin lifecycle.
-
-If an interface signature changes, expect follow-on changes in `application` and often in `ui`.
-
-## OpenAPI and downstream impact
-
-Changes in `api` can surface in generated docs and the UI API client. If you touch OpenAPI-visible DTOs, schema annotations, or route-facing types, regenerate the client from the repo root:
-
-```bash
-./gradlew generateOpenApiDocs
-pnpm -C ui api-client:gen
-```
-
-## Test patterns
-
-- Run focused tests with `./gradlew :api:test --tests "*NamePattern*"`.
-- Add or update tests for any changed contract behavior.
-- Prefer contract-level assertions that make downstream breakage obvious.
-
-## Pitfalls
-
-- **`@Schema(pattern = ...)` must stay inline.** Extracting the regex into a constant makes the generated OpenAPI contain the constant name instead of the pattern.
-- **Rate limiter keys must not include user-controlled input.** Each unique key becomes its own limiter; use authenticated identity or client IP only.
-- **Use `setName("prefix-" + UUID)`, not `setGenerateName()`.** Service implementations often read `metadata.name` before persistence; `generateName` is still null at that point.
+- Java 21, 4-space indentation, formatted with Spotless.
+- The API is a compatibility surface: prefer additive changes, and flag any breaking signature or contract change for review before merging.
+- Extension definitions and schemas live in `application/src/main/resources/extensions/`; when you change them, update `application/` and `ui/` together.
+- Tests: JUnit 5, named `XxxTest` (unit) or `XxxIntegrationTest` (integration).
 
 ## Boundaries
 
-- ✅ **Always:** Keep API contracts minimal and stable; update downstream implementations and tests together; think about plugin compatibility before changing signatures.
-- ⚠️ **Ask first:** Breaking changes to public APIs, plugin extension points, public annotations, or serialization shape.
-- 🚫 **Never:** Hide a breaking API change behind silent defaults; change public contracts without updating `application`; edit generated UI client files instead of regenerating them.
+- Public API changes in `api/` require explicit approval — treat them as affecting every plugin built against Halo.
 

--- a/application/AGENTS.md
+++ b/application/AGENTS.md
@@ -1,141 +1,30 @@
-# Application Module — AGENTS.md
+# Backend Application Guidelines
 
-Executable Spring Boot WebFlux application at `application/`. This module implements the contracts from `api`, owns routers, security, migrations, plugin/theme runtime behavior, and packages the UI into the backend artifact.
+`application/` is the WebFlux + R2DBC backend: services, routers, security, migrations, and packaging. Everything here is reactive — never block threads.
 
-Read this file together with the root [`AGENTS.md`](../AGENTS.md). If a change affects public contracts, also load [`api/AGENTS.md`](../api/AGENTS.md). If a change affects console or user-center payloads, auth flows, or generated OpenAPI, also load [`ui/AGENTS.md`](../ui/AGENTS.md).
+## Structure
 
-## Quick commands
+- `application/src/main/java/` — services, routers, endpoints, and configuration.
+- `application/src/main/resources/application*.yaml` — environment configuration.
+- `application/src/main/resources/db/migration/{h2,mariadb,mysql,postgresql}/` — per-dialect migrations.
+- `application/src/main/resources/extensions/` — extension schemas and role templates.
+- `application/src/test/` — backend tests.
 
-```bash
-./gradlew :application:compileJava
-./gradlew :application:test
-./gradlew :application:test --tests "*PostService*"
-./gradlew :application:spotlessApply
-./gradlew :application:bootRun
-./gradlew generateOpenApiDocs
-```
+## Commands
 
-## Cross-stack touchpoints
+- `./gradlew :application:test` — run backend tests.
+- `./gradlew :application:bootRun` — start the backend dev server.
+- `./gradlew :application:copyUiDist` — embed the built UI into the JAR.
+- `./gradlew generateOpenApiDocs` — emit the OpenAPI spec used to regenerate the UI client.
 
-- `generateOpenApiDocs` is driven from this module and feeds the generated UI API client.
-- `copyUiDist` pulls `ui/build/dist` into the backend resources during packaging.
-- If request/response shape, auth behavior, or route semantics change here, assume the UI may need changes too.
+## Conventions
 
-## Key packages
-
-|                    Package                    |                                         Purpose                                         |
-|-----------------------------------------------|-----------------------------------------------------------------------------------------|
-| `run.halo.app.core.extension.service.impl`    | Service implementations such as `UserServiceImpl`, `PostServiceImpl`, `RoleServiceImpl` |
-| `run.halo.app.content`                        | Content management: publishing, snapshots, contributors                                 |
-| `run.halo.app.security`                       | Security filters, OAuth2, authorization                                                 |
-| `run.halo.app.security.authentication.oauth2` | OAuth2 login flow                                                                       |
-| `run.halo.app.extension.controller`           | Extension reconcilers and controllers                                                   |
-| `run.halo.app.infra`                          | System config, theme/plugin management                                                  |
-| `run.halo.app.notification`                   | `DefaultNotificationCenter` and related behavior                                        |
-| `run.halo.app.plugin`                         | Plugin lifecycle and extension registration                                             |
-| `run.halo.app.theme`                          | Theme engine and route integration                                                      |
-| `run.halo.app.search`                         | Lucene-backed search                                                                    |
-| `run.halo.app.migration`                      | `r2dbc-migrate` integration                                                             |
-
-## Service implementation pattern
-
-Most services follow the same reactive shape:
-
-```java
-@Component
-public class XxxServiceImpl implements XxxService {
-    private final ReactiveExtensionClient client;
-
-    @Override
-    public Mono<Xxx> doSomething(String name) {
-        return client.fetch(Xxx.class, name)
-            .switchIfEmpty(Mono.error(new ExtensionNotFoundException(name, Xxx.class)))
-            .flatMap(xxx -> {
-                // mutate
-                return client.update(xxx);
-            });
-    }
-}
-```
-
-Key service reminders:
-
-- `UserServiceImpl` owns duplicate checks, create hooks, and role grants. Use it instead of raw `ReactiveExtensionClient` for user creation.
-- `UserConnectionServiceImpl` owns OAuth2 connection persistence.
-- `DefaultNotificationCenter` resolves `ReasonType` and dispatches notifications.
-
-## Security
-
-### OAuth2 authentication flow
-
-1. `MapOAuth2AuthenticationFilter` maps `OAuth2User` to Halo `UserDetails`.
-2. Auto-registration creates the Halo user from OAuth2 attributes.
-3. `DefaultOAuth2LoginHandlerEnhancer` creates or updates `UserConnection`.
-
-Key classes:
-
-- `MapOAuth2AuthenticationFilter.java`
-- `OAuth2SecurityConfigurer.java`
-- `HaloOAuth2AuthenticationToken.java` in `api`
-
-Pitfalls:
-
-- The pre-auth check in `MapOAuth2AuthenticationFilter` must exclude `OAuth2AuthenticationToken` instances.
-- Use `UserService.createUser()`, not raw extension creation plus manual role binding.
-- Do not use `setGenerateName()` with `createUser()` because the name is still null when downstream code reads it.
-
-## REST router pattern
-
-Routers use Spring WebFlux functional endpoints:
-
-```java
-@Component
-public class PostRouter implements RouterFunction<ServerResponse> {
-    @Override
-    public RouterFunction<ServerResponse> route() {
-        return RouterFunctions.route()
-            .GET("/posts", this::list)
-            .POST("/posts", this::create)
-            .build();
-    }
-}
-```
-
-Router packages:
-
-- `run.halo.app.core.extension.router`
-- `run.halo.app.content.router`
-- `run.halo.app.security.router`
-
-## Config and resources
-
-|       What        |                               Path                               |
-|-------------------|------------------------------------------------------------------|
-| Application YAML  | `application/src/main/resources/application.yaml`                |
-| Extension schemas | `application/src/main/resources/extensions/`                     |
-| Role templates    | `application/src/main/resources/extensions/role-template-*.yaml` |
-| i18n resources    | `application/src/main/resources/i18n/`                           |
-| DB migrations     | `application/src/main/resources/db/migration/`                   |
-
-## Test patterns
-
-```bash
-./gradlew :application:test --tests "*ClassName*"
-./gradlew :application:test --tests "*oauth2*"
-./gradlew :application:test --tests "*PostService*" --tests "*ContentService*"
-```
-
-Tests use JUnit 5, Spring Boot Test, Mockito, and `StepVerifier`.
-
-When testing OAuth2 auto-registration:
-
-- mock `UserService.createUser(any(User.class), anySet())`
-- inspect created users with `ArgumentCaptor`
-- use lenient Mockito settings only when the reactive setup truly requires it
+- Keep reactive flows non-blocking; no blocking I/O in request paths.
+- Database migrations are versioned per dialect — never auto-generate them, and review them with the `application/` guide in mind.
+- Tests: JUnit 5 with Spring Boot test support; name unit tests `XxxTest` and integration tests `XxxIntegrationTest`.
+- After DTO, route, or schema changes, regenerate the UI client (`./gradlew generateOpenApiDocs && pnpm -C ui api-client:gen`) and update `ui/` usage.
 
 ## Boundaries
 
-- ✅ **Always:** Preserve reactive, non-blocking behavior; update API contracts and UI consumers together when backend behavior changes; run focused backend tests for the touched area.
-- ⚠️ **Ask first:** Security model changes, migration scripts, plugin preset behavior, or anything that breaks public API assumptions.
-- 🚫 **Never:** Add blocking I/O in the request path; bypass `UserService` for user creation flows; change generated OpenAPI behavior without considering UI regeneration.
+- Ask before adding database migrations, changing security configuration, or introducing new dependencies.
 

--- a/platform/application/AGENTS.md
+++ b/platform/application/AGENTS.md
@@ -1,49 +1,8 @@
-# Platform Application BOM — AGENTS.md
+# Application BOM Guidelines
 
-`java-platform` module at `platform/application/`. This BOM declares shared dependency constraints for the application-side modules and is published as `run.halo.tools.platform:platform-application`.
+`platform/application/` is a Java platform BOM constraining dependencies shared by the backend.
 
-Read this file together with the root [`AGENTS.md`](../../AGENTS.md). If the dependency change affects code in `api` or `application`, also load the corresponding nested `AGENTS.md`.
-
-## Quick commands
-
-```bash
-./gradlew :platform:application:compileJava
-```
-
-This module has no source code; changes here are dependency-constraint changes only.
-
-## Purpose
-
-- centralize dependency versions used by `api` and `application`
-- import the Spring Boot BOM baseline
-- keep downstream build files versionless wherever possible
-
-## Key dependencies
-
-See `platform/application/build.gradle` for the full constraint list. Important families include:
-
-|    Dependency     |           Purpose            |
-|-------------------|------------------------------|
-| Spring Boot BOM   | Framework baseline           |
-| Lucene            | Search engine                |
-| Resilience4j      | Rate limiting and resilience |
-| PF4J              | Plugin framework             |
-| Guava             | Shared utilities             |
-| SpringDoc OpenAPI | API documentation generation |
-| Bouncy Castle     | Cryptography                 |
-| jsoup             | HTML parsing                 |
-| Thumbnailator     | Thumbnail generation         |
-| UA Parser         | User-agent parsing           |
-
-## Rules
-
-- Put shared versions here instead of repeating them in `api/build.gradle` or `application/build.gradle`.
-- If a version is already managed in `gradle/libs.versions.toml`, update it there instead of duplicating it here.
-- If a dependency is shared by `api` and `application`, add the constraint here first, then use the dependency without an inline version downstream.
-
-## Boundaries
-
-- ✅ **Always:** Keep version management centralized and consistent with `gradle/libs.versions.toml`.
-- ⚠️ **Ask first:** New shared libraries, major upgrades with compatibility risk, or BOM changes that affect plugin consumers indirectly.
-- 🚫 **Never:** Scatter shared versions back into module build files; add implementation-style logic to this `java-platform` module.
+- Declare shared dependency versions in `gradle/libs.versions.toml` and reference them from `build.gradle`; add constraints here only when a dependency is used across backend modules.
+- Changes ripple through the whole backend build — verify with `./gradlew build`.
+- New shared dependencies require approval before merging.
 

--- a/platform/plugin/AGENTS.md
+++ b/platform/plugin/AGENTS.md
@@ -1,45 +1,8 @@
-# Platform Plugin BOM — AGENTS.md
+# Plugin BOM Guidelines
 
-`java-platform` module at `platform/plugin/`. This BOM is published as `run.halo.tools.platform:platform-plugin` and defines the dependency baseline that external Halo plugins consume.
+`platform/plugin/` is a BOM constraining plugin-facing dependencies.
 
-Read this file together with the root [`AGENTS.md`](../../AGENTS.md). If a change affects the public API surface that plugin authors use, also load [`api/AGENTS.md`](../../api/AGENTS.md).
-
-## Quick commands
-
-```bash
-./gradlew :platform:plugin:compileJava
-```
-
-This module has no source code; it only declares dependency constraints.
-
-## Purpose
-
-Plugin developers import this BOM so they get compatible versions automatically:
-
-```groovy
-dependencies {
-    implementation platform('run.halo.tools.platform:platform-plugin:<version>')
-    implementation 'run.halo.app:api'
-}
-```
-
-## Key dependencies
-
-|         Dependency         |                    Purpose                     |
-|----------------------------|------------------------------------------------|
-| `platform:application` BOM | Inherits the application-side version baseline |
-| `project(':api')`          | Core Halo API consumed by plugins              |
-| future plugin API modules  | Reserved for additional plugin-facing APIs     |
-
-## Rules
-
-- This BOM extends `:platform:application`, so upstream version changes flow into plugin builds.
-- New plugin-facing API modules should be constrained here so downstream plugin builds stay versionless.
-- Treat changes here as ecosystem changes, not local build tweaks.
-
-## Boundaries
-
-- ✅ **Always:** Preserve plugin compatibility and keep dependency declarations centralized.
-- ⚠️ **Ask first:** Version or dependency changes that alter the plugin development contract.
-- 🚫 **Never:** Add implementation-style dependencies or source logic to this `java-platform` module.
+- Combine changes here with the matching `api/` contract changes, since plugins compile against both.
+- Verify compatibility with the plugin ecosystem before upgrading or adding constraints.
+- Changes affecting the plugin API require approval, as with `api/` changes.
 

--- a/ui/AGENTS.md
+++ b/ui/AGENTS.md
@@ -1,158 +1,33 @@
-# UI (Frontend) — AGENTS.md
+# Frontend Guidelines
 
-pnpm workspace at `ui/`. It contains the admin console, user center, shared packages, and the generated API client used by the frontend.
+`ui/` is the Vue 3 + TypeScript + TailwindCSS frontend, managed with pnpm workspaces.
 
-Read this file together with the root [`AGENTS.md`](../AGENTS.md). If a change touches backend contracts, auth flows, or generated OpenAPI, also load [`application/AGENTS.md`](../application/AGENTS.md). If a shared public type or extension contract changes, also load [`api/AGENTS.md`](../api/AGENTS.md).
+## Structure
 
-## Quick commands
+- `ui/src/` — console application.
+- `ui/uc-src/` — user center application.
+- `ui/packages/` — shared workspace packages (`@halo-dev/api-client`, `@halo-dev/components`, `@halo-dev/console-shared`, `@halo-dev/editor`, `@halo-dev/shared`, `@halo-dev/ui-plugin-bundler-kit`).
+- Unit tests: `*.spec.ts` files, usually under `__tests__/` next to the code they cover.
 
-Prefer root-scoped commands:
+## Commands
 
-```bash
-pnpm -C ui install
-pnpm -C ui dev
-pnpm -C ui build
-pnpm -C ui build:packages
-pnpm -C ui test:unit
-pnpm -C ui lint
-pnpm -C ui format
-pnpm -C ui format:check
-pnpm -C ui typecheck
-pnpm -C ui api-client:gen
-```
+Run from the repo root:
 
-Local wrappers also exist:
-
-```bash
-make -C ui dev
-make -C ui build
-make -C ui test
-make -C ui api-client-gen
-```
-
-## Cross-stack touchpoints
-
-- `packages/api-client` is generated from backend OpenAPI docs. Do not hand-edit generated files.
-- Backend route, DTO, auth, or schema changes often require `./gradlew generateOpenApiDocs && pnpm -C ui api-client:gen`.
-- The frontend build output is bundled into the backend JAR during the application build.
-
-## Directory layout
-
-```text
-ui/
-├── console-src/            # Admin console
-│   ├── modules/            # Feature modules, auto-discovered via import.meta.glob
-│   ├── stores/             # Console-specific Pinia stores
-│   ├── router/             # Console router config
-│   ├── layouts/            # Console layouts
-│   └── styles/             # Console styles
-├── src/                    # Shared frontend code
-│   ├── components/         # Shared Vue components
-│   ├── composables/        # Shared composables
-│   ├── stores/             # Shared Pinia stores
-│   ├── formkit/            # FormKit setup and theme
-│   ├── locales/            # i18n JSON files
-│   └── styles/             # Shared Tailwind/theme files
-├── uc-src/                 # User center
-├── packages/               # Workspace packages
-├── public/                 # Static assets
-└── scripts/                # Build scripts
-```
-
-## Workspace packages
-
-| Package                 | Purpose                                           |
-| ----------------------- | ------------------------------------------------- |
-| `api-client`            | Generated Axios-based API client from OpenAPI     |
-| `components`            | Shared UI components and icons                    |
-| `editor`                | Tiptap-based rich-text editor                     |
-| `console-shared`        | Console-specific shared stores, events, and utils |
-| `shared`                | Cross-platform shared types and utilities         |
-| `ui-plugin-bundler-kit` | Build tooling for Halo UI plugins                 |
+- `pnpm -C ui install` / `pnpm -C ui dev` — install dependencies / run the dev server.
+- `pnpm -C ui build` — production build.
+- `pnpm -C ui typecheck` — `vue-tsc` type checking.
+- `pnpm -C ui lint` — ESLint (fails on any warning).
+- `pnpm -C ui format` / `pnpm -C ui format:check` — Prettier formatting.
+- `pnpm -C ui test:unit` — Vitest unit tests.
+- `./gradlew generateOpenApiDocs && pnpm -C ui api-client:gen` — regenerate `ui/packages/api-client` after backend contract changes.
 
 ## Conventions
 
-### Module pattern
-
-Each feature in `console-src/modules/<feature>/module.ts` uses `definePlugin()`:
-
-```ts
-export default definePlugin({
-  name: 'posts',
-  routes: [...],
-  menus: [...],
-  permissions: [...],
-})
-```
-
-Modules are auto-discovered via `import.meta.glob("./**/module.ts")`.
-
-### Startup order
-
-`components -> i18n -> vue-query -> api-client -> pinia -> core modules -> user -> permissions -> plugin modules -> router -> mount`
-
-### Path aliases
-
-- `@/*` → `src/*`
-- `@console/*` → `console-src/*`
-- `@uc/*` → `uc-src/*`
-
-Defined in `tsconfig.app.json`.
-
-### Tech stack
-
-- **State:** Pinia
-- **i18n:** `vue-i18n` with JSON locale files in `src/locales/`
-- **Forms:** FormKit
-- **Icons:** Iconify via `@iconify/vue`
-- **CSS:** TailwindCSS 3.4 + `tailwindcss-themer`
-- **Build tool:** `vite-plus` (`vp`)
-- **Testing:** Vitest
-- **Data fetching:** TanStack Query (`@tanstack/vue-query`)
-
-### Theme
-
-Default theme tokens:
-
-- Primary: `#4CCBA0`
-- Secondary: `#0E1731`
-- Danger: `#D71D1D`
-
-Prefer theme tokens over hard-coded colors in features.
-
-### Formatting
-
-Use `vp fmt` via `pnpm -C ui format`. Pre-commit hooks run `lint-staged` for staged UI files.
-
-## Testing
-
-- **Framework:** Vitest with jsdom
-- **Location:** colocated `.spec.ts` files
-- **Single file:** `pnpm -C ui test:unit -- src/utils/foo.spec.ts`
-- **Pattern:** `pnpm -C ui test:unit -- -t "test name pattern"`
-- **Watch:** `pnpm -C ui test:unit:watch`
-
-Add or update tests for changed UI behavior, especially utilities, composables, and package exports.
-
-## Validation flow
-
-- Run `pnpm -C ui build:packages` before `pnpm -C ui build` when workspace packages changed.
-- Use `pnpm -C ui typecheck && pnpm -C ui lint` as the normal validation path.
-- Regenerate the API client after backend contract changes:
-
-```bash
-./gradlew generateOpenApiDocs
-pnpm -C ui api-client:gen
-```
+- Follow existing component and composable patterns; match surrounding code rather than introducing new stylistic islands.
+- Never hand-edit `ui/packages/api-client/src/` — it is generated; regenerate it instead.
+- Keep dependency versions in `ui/package.json`; never hard-code versions.
+- Payload or UX changes usually ship together with the backend change that defines the contract.
 
 ## Boundaries
 
-- ✅ **Always:** Work from the repo root for command orchestration; run `pnpm -C ui format`; run `pnpm -C ui build:packages` when package code changes; keep frontend behavior in sync with backend contract changes.
-- ⚠️ **Ask first:** Public exports from `packages/*`; new npm dependencies; `vite.config.ts` or `tsconfig*.json` changes; global FormKit or theme token changes.
-- 🚫 **Never:** Commit `node_modules/`; hand-edit `packages/api-client/src/`; hard-code theme colors in feature code when a token exists; treat `--no-verify` as a normal fix for broken hooks.
-
-## Pitfalls
-
-1. **`pnpm install` is required after dependency changes or fresh clones.** Missing workspace links can break lint-staged and local package resolution.
-2. **API client generation is a two-step flow.** `generateOpenApiDocs` must finish before `pnpm -C ui api-client:gen`.
-3. **Package build order matters.** Run `pnpm -C ui build:packages` first when `packages/*` changed.
+- New npm dependencies require approval.


### PR DESCRIPTION
#### What type of PR is this?

- [x] Documentation

#### What this PR does / why we need it:

- Splits the root AGENTS.md contributor guide into per-module guides (`api/`, `application/`, `ui/`, `platform/application/`, `platform/plugin/`), so contributors load only the rules relevant to the area they touch.
- Keeps the root AGENTS.md as a lean overview with a module map, quick commands, and cross-module rules.
- Each module guide covers scope/structure, commands, conventions, and boundaries.

#### Which issue(s) this PR fixes:

N/A

#### Special notes for your reviewer:

- Documentation-only change; no runtime behavior affected.
- Verified with `./gradlew spotlessApply`, `./gradlew :api:test`, and `./gradlew :application:test` — all pass.
- Generated with AI assistance (Codex); content reviewed against the repository layout and git history.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```