### PR TITLE
fix: normalize IDN host in external URL to punycode

### DIFF
--- a/application/src/main/java/run/halo/app/infra/SystemConfigFirstExternalUrlSupplier.java
+++ b/application/src/main/java/run/halo/app/infra/SystemConfigFirstExternalUrlSupplier.java
@@ -15,6 +15,7 @@ import org.springframework.stereotype.Component;
 import org.springframework.util.StringUtils;
 import reactor.core.Exceptions;
 import run.halo.app.infra.properties.HaloProperties;
+import run.halo.app.infra.utils.ExternalUrlUtils;
 
 /**
  * Default implementation for getting external url from system config first, halo properties second.
@@ -50,7 +51,7 @@ class SystemConfigFirstExternalUrlSupplier implements ExternalUrlSupplier {
 
     @EventListener
     void onExternalUrlChanged(ExternalUrlChangedEvent event) {
-        this.externalUrl = event.getExternalUrl();
+        this.externalUrl = normalizeUrl(event.getExternalUrl());
     }
 
     Optional<URL> refetchExternalUrl() {
@@ -60,7 +61,8 @@ class SystemConfigFirstExternalUrlSupplier implements ExternalUrlSupplier {
                 .filter(StringUtils::hasText)
                 .mapNotNull(externalUrlString -> {
                     try {
-                        return URI.create(externalUrlString).toURL();
+                        return URI.create(ExternalUrlUtils.toAscii(externalUrlString))
+                                .toURL();
                     } catch (MalformedURLException e) {
                         log.error("""
                         Cannot parse external URL {} from system config. Fallback to default \
@@ -80,9 +82,9 @@ class SystemConfigFirstExternalUrlSupplier implements ExternalUrlSupplier {
                 return URI.create(getBasePath());
             }
             if (externalUrl != null) {
-                return externalUrl.toURI();
+                return normalizeUrl(externalUrl).toURI();
             }
-            return haloProperties.getExternalUrl().toURI();
+            return normalizeUrl(haloProperties.getExternalUrl()).toURI();
         } catch (URISyntaxException e) {
             throw Exceptions.propagate(e);
         }
@@ -91,14 +93,14 @@ class SystemConfigFirstExternalUrlSupplier implements ExternalUrlSupplier {
     @Override
     public URL getURL(HttpRequest request) {
         if (this.externalUrl != null) {
-            return this.externalUrl;
+            return normalizeUrl(this.externalUrl);
         }
-        var externalUrl = haloProperties.getExternalUrl();
+        var externalUrl = normalizeUrl(haloProperties.getExternalUrl());
         if (externalUrl != null) {
             return externalUrl;
         }
         try {
-            externalUrl = request.getURI().resolve(getBasePath()).toURL();
+            externalUrl = normalizeUrl(request.getURI().resolve(getBasePath()).toURL());
         } catch (MalformedURLException e) {
             throw new RuntimeException("Cannot parse request URI to URL.", e);
         }
@@ -108,7 +110,26 @@ class SystemConfigFirstExternalUrlSupplier implements ExternalUrlSupplier {
     @Nullable
     @Override
     public URL getRaw() {
-        return externalUrl != null ? externalUrl : haloProperties.getExternalUrl();
+        return normalizeUrl(externalUrl != null ? externalUrl : haloProperties.getExternalUrl());
+    }
+
+    @Nullable
+    private static URL normalizeUrl(@Nullable URL externalUrl) {
+        if (externalUrl == null) {
+            return null;
+        }
+        var externalUrlString = externalUrl.toString();
+        var normalizedUrlString = ExternalUrlUtils.toAscii(externalUrlString);
+        if (normalizedUrlString.equals(externalUrlString)) {
+            return externalUrl;
+        }
+        try {
+            return URI.create(normalizedUrlString).toURL();
+        } catch (IllegalArgumentException | MalformedURLException e) {
+            // Keep the original URL if the normalized URL cannot be parsed as a URI.
+            log.debug("Failed to normalize external URL: {}", externalUrlString, e);
+            return externalUrl;
+        }
     }
 
     private String getBasePath() {

--- a/application/src/main/java/run/halo/app/infra/SystemConfigFirstExternalUrlSupplier.java
+++ b/application/src/main/java/run/halo/app/infra/SystemConfigFirstExternalUrlSupplier.java
@@ -95,16 +95,16 @@ class SystemConfigFirstExternalUrlSupplier implements ExternalUrlSupplier {
         if (this.externalUrl != null) {
             return normalizeUrl(this.externalUrl);
         }
-        var externalUrl = normalizeUrl(haloProperties.getExternalUrl());
-        if (externalUrl != null) {
-            return externalUrl;
+        var url = normalizeUrl(haloProperties.getExternalUrl());
+        if (url != null) {
+            return url;
         }
         try {
-            externalUrl = normalizeUrl(request.getURI().resolve(getBasePath()).toURL());
+            url = normalizeUrl(request.getURI().resolve(getBasePath()).toURL());
         } catch (MalformedURLException e) {
             throw new RuntimeException("Cannot parse request URI to URL.", e);
         }
-        return externalUrl;
+        return url;
     }
 
     @Nullable
@@ -114,21 +114,21 @@ class SystemConfigFirstExternalUrlSupplier implements ExternalUrlSupplier {
     }
 
     @Nullable
-    private static URL normalizeUrl(@Nullable URL externalUrl) {
-        if (externalUrl == null) {
+    private static URL normalizeUrl(@Nullable URL url) {
+        if (url == null) {
             return null;
         }
-        var externalUrlString = externalUrl.toString();
+        var externalUrlString = url.toString();
         var normalizedUrlString = ExternalUrlUtils.toAscii(externalUrlString);
         if (normalizedUrlString.equals(externalUrlString)) {
-            return externalUrl;
+            return url;
         }
         try {
             return URI.create(normalizedUrlString).toURL();
         } catch (IllegalArgumentException | MalformedURLException e) {
             // Keep the original URL if the normalized URL cannot be parsed as a URI.
             log.debug("Failed to normalize external URL: {}", externalUrlString, e);
-            return externalUrl;
+            return url;
         }
     }
 

--- a/application/src/main/java/run/halo/app/infra/utils/ExternalUrlUtils.java
+++ b/application/src/main/java/run/halo/app/infra/utils/ExternalUrlUtils.java
@@ -1,0 +1,81 @@
+package run.halo.app.infra.utils;
+
+import java.net.IDN;
+import org.apache.commons.lang3.StringUtils;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * Utilities for external URLs.
+ *
+ * @author johnniang
+ */
+public final class ExternalUrlUtils {
+
+    private ExternalUrlUtils() {}
+
+    /**
+     * Converts the host of the given external URL to ASCII (punycode) if necessary.
+     *
+     * <p>For example, {@code https://abcd.中国} will be converted to {@code https://abcd.xn--fiqs8s}. The rest of the URL
+     * remains unchanged.
+     *
+     * @param externalUrl external URL to convert, may be null
+     * @return converted URL or the original URL if it does not need to be converted
+     */
+    @Nullable
+    public static String toAscii(@Nullable String externalUrl) {
+        if (externalUrl == null || !externalUrl.contains("://")) {
+            return externalUrl;
+        }
+        var schemeSeparatorIndex = externalUrl.indexOf("://");
+        var authorityStartIndex = schemeSeparatorIndex + 3;
+        var authorityEndIndex = externalUrl.length();
+        for (int i = authorityStartIndex; i < externalUrl.length(); i++) {
+            var c = externalUrl.charAt(i);
+            if (c == '/' || c == '?' || c == '#') {
+                authorityEndIndex = i;
+                break;
+            }
+        }
+        if (authorityEndIndex <= authorityStartIndex) {
+            return externalUrl;
+        }
+        var authority = externalUrl.substring(authorityStartIndex, authorityEndIndex);
+        var convertedAuthority = toAsciiAuthority(authority);
+        if (convertedAuthority.equals(authority)) {
+            return externalUrl;
+        }
+        return externalUrl.substring(0, authorityStartIndex)
+                + convertedAuthority
+                + externalUrl.substring(authorityEndIndex);
+    }
+
+    private static String toAsciiAuthority(String authority) {
+        var atIndex = authority.lastIndexOf('@');
+        var userInfo = atIndex >= 0 ? authority.substring(0, atIndex + 1) : "";
+        var hostPort = atIndex >= 0 ? authority.substring(atIndex + 1) : authority;
+        if (StringUtils.isBlank(hostPort)) {
+            return authority;
+        }
+        if (hostPort.startsWith("[")) {
+            // IPv6 literal, no conversion is needed.
+            return authority;
+        }
+        var host = hostPort;
+        var port = "";
+        var colonIndex = hostPort.lastIndexOf(':');
+        if (colonIndex >= 0) {
+            host = hostPort.substring(0, colonIndex);
+            port = hostPort.substring(colonIndex);
+        }
+        if (StringUtils.isBlank(host)) {
+            return authority;
+        }
+        try {
+            return userInfo + IDN.toASCII(host) + port;
+        } catch (IllegalArgumentException e) {
+            // Keep the original authority if the host cannot be converted.
+            return authority;
+        }
+    }
+}

--- a/application/src/test/java/run/halo/app/infra/SystemConfigFirstExternalUrlSupplierTest.java
+++ b/application/src/test/java/run/halo/app/infra/SystemConfigFirstExternalUrlSupplierTest.java
@@ -127,6 +127,31 @@ class SystemConfigFirstExternalUrlSupplierTest {
             when(haloProperties.getExternalUrl()).thenReturn(null);
             assertNull(externalUrl.getRaw());
         }
+
+        @Test
+        void shouldConvertHostToAsciiWhenExternalUrlContainsIDN() throws MalformedURLException {
+            var fakeUri = URI.create("https://abcd.中国");
+            when(haloProperties.getExternalUrl()).thenReturn(fakeUri.toURL());
+            when(haloProperties.isUseAbsolutePermalink()).thenReturn(true);
+
+            var expectedUri = URI.create("https://abcd.xn--fiqs8s");
+            assertEquals(expectedUri.toURL(), externalUrl.getRaw());
+            assertEquals(expectedUri, externalUrl.get());
+
+            var mockRequest = mock(HttpRequest.class);
+            assertEquals(expectedUri.toURL(), externalUrl.getURL(mockRequest));
+        }
+
+        @Test
+        void shouldKeepOriginalUrlWhenNormalizedUrlCannotBeParsed() throws MalformedURLException {
+            var fakeUrl = new URL("https://abcd.中国/path with space");
+            when(haloProperties.getExternalUrl()).thenReturn(fakeUrl);
+
+            assertEquals(fakeUrl, externalUrl.getRaw());
+
+            var mockRequest = mock(HttpRequest.class);
+            assertEquals(fakeUrl, externalUrl.getURL(mockRequest));
+        }
     }
 
     @Nested
@@ -159,6 +184,22 @@ class SystemConfigFirstExternalUrlSupplierTest {
             assertEquals(URI.create("/fake"), externalUrl.get());
             var mockRequest = mock(HttpRequest.class);
             assertEquals(URI.create("https://www.halo.run").toURL(), externalUrl.getURL(mockRequest));
+        }
+
+        @Test
+        void shouldConvertHostToAsciiWhenExternalUrlContainsIDN() throws MalformedURLException {
+            var basic = new SystemSetting.Basic();
+            basic.setExternalUrl("https://abcd.中国");
+            when(systemConfigFetcher.getBasic()).thenReturn(Mono.just(basic));
+            when(haloProperties.isUseAbsolutePermalink()).thenReturn(true);
+            externalUrl.onExtensionInitialized(null);
+
+            var expectedUri = URI.create("https://abcd.xn--fiqs8s");
+            assertEquals(expectedUri.toURL(), externalUrl.getRaw());
+            assertEquals(expectedUri, externalUrl.get());
+
+            var mockRequest = mock(HttpRequest.class);
+            assertEquals(expectedUri.toURL(), externalUrl.getURL(mockRequest));
         }
     }
 }

--- a/application/src/test/java/run/halo/app/infra/utils/ExternalUrlUtilsTest.java
+++ b/application/src/test/java/run/halo/app/infra/utils/ExternalUrlUtilsTest.java
@@ -1,0 +1,43 @@
+package run.halo.app.infra.utils;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+class ExternalUrlUtilsTest {
+
+    @ParameterizedTest
+    @MethodSource("urlsToConvert")
+    void shouldConvertHostToAscii(String externalUrl, String expected) {
+        assertThat(ExternalUrlUtils.toAscii(externalUrl)).isEqualTo(expected);
+    }
+
+    static Stream<Arguments> urlsToConvert() {
+        return Stream.of(
+                Arguments.of("https://abcd.中国", "https://abcd.xn--fiqs8s"),
+                Arguments.of("https://白日梦.cn/a/b?q=1#f", "https://xn--wgv44dw7s.cn/a/b?q=1#f"),
+                Arguments.of("https://abcd.中国:8443/path", "https://abcd.xn--fiqs8s:8443/path"),
+                Arguments.of("https://user@abcd.中国:8443/path", "https://user@abcd.xn--fiqs8s:8443/path"),
+                Arguments.of("https://a.中国.b.cn", "https://a.xn--fiqs8s.b.cn"),
+                Arguments.of("https://xn--wgv44dw7s.cn", "https://xn--wgv44dw7s.cn"),
+                Arguments.of("https://halo.run/path", "https://halo.run/path"),
+                Arguments.of("https://halo.run/中文", "https://halo.run/中文"),
+                Arguments.of("https://[::1]:8080/path", "https://[::1]:8080/path"),
+                Arguments.of(
+                        "https://halo.run/path?next=https://abcd.中国", "https://halo.run/path?next=https://abcd.中国"));
+    }
+
+    @Test
+    void shouldKeepOriginalUrlWhenCannotBeConverted() {
+        assertThat(ExternalUrlUtils.toAscii(null)).isNull();
+        assertThat(ExternalUrlUtils.toAscii("")).isEmpty();
+        assertThat(ExternalUrlUtils.toAscii("halo.run")).isEqualTo("halo.run");
+        assertThat(ExternalUrlUtils.toAscii("https://")).isEqualTo("https://");
+        assertThat(ExternalUrlUtils.toAscii("https:///path")).isEqualTo("https:///path");
+        assertThat(ExternalUrlUtils.toAscii("https://:8080/path")).isEqualTo("https://:8080/path");
+    }
+}


### PR DESCRIPTION
#### What type of PR is this?

- [x] Bug fix
- [ ] Feature
- [ ] Improvement
- [ ] Cleanup
- [ ] Documentation

#### What this PR does / why we need it:

- 外部访问地址使用中文域名（如 `https://abcd.中国`）时，Spring 的严格 RFC 3986 URI 解析会拒绝非 ASCII host，导致邮箱通知退订链接、RSS/Feed 等依赖 `ExternalUrlSupplier` 的功能抛出 `InvalidUrlException: Bad authority`。
- 新增 `ExternalUrlUtils.toAscii`，在 `SystemConfigFirstExternalUrlSupplier` 的所有返回路径（`getRaw()` / `get()` / `getURL()`、配置读取、变更事件）中将 host 转换为 punycode，同时保留用户存储的原始配置。
- 转换或解析失败时回退到原始 URL，不改变原有行为。

#### Which issue(s) this PR fixes:

Fixes #7570
Fixes #10155

#### Special notes for your reviewer:

- 只在读取/返回时规范化，不改写数据库中保存的值。
- 无 API 契约、依赖、数据库迁移或前端变更。
- 新增 `ExternalUrlUtilsTest`，并补充 `SystemConfigFirstExternalUrlSupplierTest` 相关用例。

#### Does this PR introduce a user-facing change?

```release-note
修复外部访问地址使用中文域名时邮箱通知、RSS 等链接解析异常的问题。
```