### PR TITLE
Add AI Foundation preset plugin

### DIFF
--- a/application/build.gradle
+++ b/application/build.gradle
@@ -173,6 +173,11 @@ tasks.register('downloadPluginPresets', Download) {
             filename  : 'plugin-editor-hyperlink-card.jar',
             autoEnable: true,
         ],
+        [
+            url       : 'https://github.com/halo-dev/plugin-ai-foundation/releases/download/v1.0.0/plugin-ai-foundation-1.0.0.jar',
+            filename  : 'plugin-ai-foundation.jar',
+            autoEnable: true,
+        ],
 
         // Currently, plugin-app-store is not open source, so we need to download it from the official website.
         // Please see https://github.com/halo-dev/plugin-app-store/issues/55


### PR DESCRIPTION
#### What type of PR is this?

- [x] Feature
- [ ] Bug fix
- [ ] Improvement
- [ ] Cleanup
- [ ] Documentation

#### What this PR does / why we need it:

Adds AI Foundation v1.0.0 to the preset plugins bundled by the `downloadPluginPresets` task.

During initial system setup, Halo installs the plugin as `plugin-ai-foundation.jar` and enables it automatically. This makes Halo's official AI capability platform available by default for configuring providers and for plugins that integrate with its SDK.

#### Which issue(s) this PR fixes:

N/A

#### Special notes for your reviewer:

- The published v1.0.0 plugin requires Halo 2.25.0 or later; the current `main` version is 2.26.0-SNAPSHOT.
- The release asset URL responds with HTTP 200 and matches the published `plugin-ai-foundation-1.0.0.jar` asset.
- The published SHA-256 digest is `7edd2af4cf97822c57a73131ad0b7810b1332e97b8e1584c6404d9f5d23fb5a4`.
- AI assistance was used to prepare this PR description, and the change was reviewed against the current source.

Validated with:

- `git diff --check`
- HTTP 200 check for the v1.0.0 release asset URL
- GitHub release asset and plugin compatibility metadata checks

#### Does this PR introduce a user-facing change?

```release-note
新安装 Halo 完成初始化时，将自动安装并启用 AI Foundation 预置插件。
```
