### PR TITLE
fix: make login auth scheduler injectable to fix flaky test

### DIFF
--- a/application/src/main/java/run/halo/app/security/authentication/login/LoginReactiveAuthenticationManager.java
+++ b/application/src/main/java/run/halo/app/security/authentication/login/LoginReactiveAuthenticationManager.java
@@ -11,6 +11,7 @@ import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
+import reactor.core.scheduler.Scheduler;
 import reactor.core.scheduler.Schedulers;
 import run.halo.app.core.user.service.UserService;
 import run.halo.app.security.authentication.UserAccountStatusChecker;
@@ -33,14 +34,27 @@ class LoginReactiveAuthenticationManager implements ReactiveAuthenticationManage
 
     private final ReactiveUserDetailsPasswordService passwordService;
 
+    private Scheduler scheduler = Schedulers.boundedElastic();
+
+    /**
+     * Sets the scheduler used to offload password encoder operations. Package-private so that unit tests can inject a
+     * deterministic scheduler.
+     */
+    void setScheduler(Scheduler scheduler) {
+        this.scheduler = scheduler;
+    }
+
     @Override
     public Mono<Authentication> authenticate(Authentication authentication) {
         var loginId = authentication.getName();
         var credentials = authentication.getCredentials();
         var password = credentials != null ? credentials.toString() : null;
 
+        // Note: when the email strategy wins, the username fallback is raced by the cancel from
+        // next() below (it runs on a boundedElastic thread while this chain subscribes on the
+        // caller thread), so the fallback subscription is best-effort and may be skipped.
         return Flux.concat(Mono.defer(() -> lookupByEmail(loginId)), Mono.defer(() -> lookupByUsername(loginId)))
-                .publishOn(Schedulers.boundedElastic())
+                .publishOn(scheduler)
                 .filter(userDetails -> password != null && passwordEncoder.matches(password, userDetails.getPassword()))
                 .next()
                 .switchIfEmpty(Mono.error(() -> new BadCredentialsException("Invalid Credentials")))

--- a/application/src/test/java/run/halo/app/security/authentication/login/LoginReactiveAuthenticationManagerTest.java
+++ b/application/src/test/java/run/halo/app/security/authentication/login/LoginReactiveAuthenticationManagerTest.java
@@ -24,6 +24,7 @@ import org.springframework.security.core.userdetails.User;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import reactor.core.publisher.Mono;
+import reactor.core.scheduler.Schedulers;
 import reactor.test.StepVerifier;
 import run.halo.app.core.user.service.UserService;
 import run.halo.app.extension.Metadata;
@@ -102,9 +103,6 @@ class LoginReactiveAuthenticationManagerTest {
 
         var userDetails = createUserDetails("actualuser", "encoded-password");
         when(userDetailsService.findByUsername("actualuser")).thenReturn(Mono.just(userDetails));
-        // the username fallback is subscribed after the email strategy completes, but its result is
-        // discarded once the email-resolved user wins
-        when(userDetailsService.findByUsername("test@example.com")).thenReturn(Mono.empty());
         when(passwordEncoder.matches("password", "encoded-password")).thenReturn(true);
         stubPasswordService();
 
@@ -114,8 +112,9 @@ class LoginReactiveAuthenticationManagerTest {
                 .assertNext(auth -> assertEquals(userDetails, auth.getPrincipal()))
                 .verifyComplete();
 
-        // a resolved email lookup wins, although the username fallback has already been subscribed
-        verify(userDetailsService).findByUsername("test@example.com");
+        // with the immediate scheduler, the email win cancels the concat before the username
+        // fallback gets subscribed, so the raw identifier is never treated as a username
+        verify(userDetailsService, never()).findByUsername("test@example.com");
     }
 
     @Test
@@ -201,8 +200,6 @@ class LoginReactiveAuthenticationManagerTest {
 
         var userDetails = createUserDetails("actualuser", "encoded-password");
         when(userDetailsService.findByUsername("actualuser")).thenReturn(Mono.just(userDetails));
-        // the username fallback is subscribed after the email strategy completes
-        when(userDetailsService.findByUsername("test@example.com")).thenReturn(Mono.empty());
         when(passwordEncoder.matches("password", "encoded-password")).thenReturn(true);
 
         when(passwordEncoder.upgradeEncoding("encoded-password")).thenReturn(true);
@@ -246,7 +243,12 @@ class LoginReactiveAuthenticationManagerTest {
         when(passwordService.updatePassword(eq(userDetails), eq("new-encoded-password")))
                 .thenReturn(Mono.just(upgradedUser));
 
-        var result = authenticate("testuser", "password");
+        // Keep the default boundedElastic scheduler (no setScheduler) for this test.
+        var manager = new LoginReactiveAuthenticationManager(
+                userDetailsService, userService, passwordEncoder, passwordService);
+        var token = UsernamePasswordAuthenticationToken.unauthenticated("testuser", "password");
+
+        var result = manager.authenticate(token);
 
         StepVerifier.create(result).expectNextCount(1).verifyComplete();
 
@@ -284,6 +286,10 @@ class LoginReactiveAuthenticationManagerTest {
     private Mono<Authentication> authenticate(String username, String password) {
         var manager = new LoginReactiveAuthenticationManager(
                 userDetailsService, userService, passwordEncoder, passwordService);
+        // Run the whole chain on the caller thread so that strategy order, fallback subscription
+        // and password upgrades are fully deterministic. The production scheduler is covered by
+        // shouldRunPasswordEncoderOperationsOnBoundedElasticThread.
+        manager.setScheduler(Schedulers.immediate());
         var token = UsernamePasswordAuthenticationToken.unauthenticated(username, password);
         return manager.authenticate(token);
     }


### PR DESCRIPTION
#### What type of PR is this?

- [ ] Feature
- [x] Bug fix
- [ ] Improvement
- [ ] Cleanup
- [ ] Documentation

#### What this PR does / why we need it:

Fixes a flaky `UnnecessaryStubbingException` in `LoginReactiveAuthenticationManagerTest.shouldUpgradePasswordWhenAuthenticatedByEmail` (CI-only, ~1e-4 per run, unreproducible locally).

**Root cause:** #10199 moved `publishOn(Schedulers.boundedElastic())` downstream of the `Flux.concat`, splitting the chain across two threads:

- The caller thread synchronously subscribes the email strategy, then the username fallback.
- A boundedElastic worker concurrently runs `filter` → `next()`, and `next()` cancels upstream on the first match.

When the email strategy wins, the worker's cancel can reach the concat before the caller thread subscribes the username fallback, so `findByUsername("test@example.com")` is never invoked. The chain still completes with the email user (all assertions pass), but Mockito's strict-stubs check then reports the fallback stub as unused → `UnnecessaryStubbingException`. Confirmed empirically with a temporary probe: 3/20,000 runs skipped the fallback subscription.

**Fix:**

- Hoist the per-call `Schedulers.boundedElastic()` into a field (also avoids creating a new boundedElastic thread per login on a hot path) and add a package-private `setScheduler` so unit tests can inject `Schedulers.immediate()`.
- Unit tests now run the whole chain synchronously on the test thread → fully deterministic: the email-wins tests assert the fallback is never subscribed (restoring the pre-#10196 intent), and the racy fallback stubs are removed.
- Production offloading is still covered by `shouldRunPasswordEncoderOperationsOnBoundedElasticThread`, which keeps the default boundedElastic scheduler.

The production fallback-subscription nondeterminism itself is benign (its result is discarded when email wins) and is documented in a comment.

#### Which issue(s) this PR fixes:

No issue filed.

#### Special notes for your reviewer:

This change was developed with Claude Code (LLM) assistance and reviewed by the author before submitting.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```