### PR TITLE
Downgrade Vue Router to 5.1.0

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -93,7 +93,7 @@
     "vue-draggable-plus": "^0.4.1",
     "vue-grid-layout": "3.0.0-beta1",
     "vue-i18n": "^11.2.8",
-    "vue-router": "^5.2.0"
+    "vue-router": "5.1.0"
   },
   "devDependencies": {
     "@iconify-json/fluent": "^1.2.45",

--- a/ui/packages/components/package.json
+++ b/ui/packages/components/package.json
@@ -67,6 +67,6 @@
   },
   "peerDependencies": {
     "vue": "^3.5.x",
-    "vue-router": "^5.2.x"
+    "vue-router": "~5.1.0"
   }
 }

--- a/ui/packages/shared/package.json
+++ b/ui/packages/shared/package.json
@@ -45,7 +45,7 @@
   },
   "peerDependencies": {
     "vue": "^3.5.x",
-    "vue-router": "^5.2.x"
+    "vue-router": "~5.1.0"
   },
   "inlinedDependencies": {
     "@formkit/core": "2.1.0",

--- a/ui/pnpm-lock.yaml
+++ b/ui/pnpm-lock.yaml
@@ -159,7 +159,7 @@ importers:
         version: 14.4.0(axios@1.16.1)(change-case@5.4.4)(fuse.js@7.1.0)(nprogress@0.2.0)(qrcode@1.5.3)(sortablejs@1.14.0)(vue@3.5.40)
       '@vueuse/router':
         specifier: ^14.4.0
-        version: 14.4.0(vue-router@5.2.0)(vue@3.5.40)
+        version: 14.4.0(vue-router@5.1.0)(vue@3.5.40)
       '@vueuse/shared':
         specifier: ^14.4.0
         version: 14.4.0(vue@3.5.40)
@@ -254,8 +254,8 @@ importers:
         specifier: ^11.2.8
         version: 11.2.8(vue@3.5.40)
       vue-router:
-        specifier: ^5.2.0
-        version: 5.2.0(@rspack/core@1.3.12)(@voidzero-dev/vite-plus-core@0.2.8)(@vue/compiler-sfc@3.5.40)(esbuild@0.25.5)(pinia@4.0.2)(rolldown@1.2.1)(rollup@4.43.0)(vue@3.5.40)(webpack@5.99.9)
+        specifier: 5.1.0
+        version: 5.1.0(@rspack/core@1.3.12)(@voidzero-dev/vite-plus-core@0.2.8)(@vue/compiler-sfc@3.5.40)(esbuild@0.25.5)(pinia@4.0.2)(rolldown@1.2.1)(rollup@4.43.0)(vue@3.5.40)(webpack@5.99.9)
     devDependencies:
       '@iconify-json/fluent':
         specifier: ^1.2.45
@@ -463,8 +463,8 @@ importers:
         specifier: ^3.5.x
         version: 3.5.40(typescript@6.0.3)
       vue-router:
-        specifier: ^5.2.x
-        version: 5.2.0(@rspack/core@1.3.12)(@voidzero-dev/vite-plus-core@0.2.8)(@vue/compiler-sfc@3.5.40)(esbuild@0.25.5)(pinia@4.0.2)(rolldown@1.2.1)(rollup@4.43.0)(vue@3.5.40)(webpack@5.99.9)
+        specifier: ~5.1.0
+        version: 5.1.0(@rspack/core@1.3.12)(@voidzero-dev/vite-plus-core@0.2.8)(@vue/compiler-sfc@3.5.40)(esbuild@0.25.5)(pinia@4.0.2)(rolldown@1.2.1)(rollup@4.43.0)(vue@3.5.40)(webpack@5.99.9)
     devDependencies:
       '@storybook/addon-docs':
         specifier: ^10.4.1
@@ -668,8 +668,8 @@ importers:
         specifier: ^3.5.x
         version: 3.5.40(typescript@6.0.3)
       vue-router:
-        specifier: ^5.2.x
-        version: 5.2.0(@rspack/core@1.3.12)(@voidzero-dev/vite-plus-core@0.2.8)(@vue/compiler-sfc@3.5.40)(esbuild@0.25.5)(pinia@4.0.2)(rolldown@1.2.1)(rollup@4.43.0)(vue@3.5.40)(webpack@5.99.9)
+        specifier: ~5.1.0
+        version: 5.1.0(@rspack/core@1.3.12)(@voidzero-dev/vite-plus-core@0.2.8)(@vue/compiler-sfc@3.5.40)(esbuild@0.25.5)(pinia@4.0.2)(rolldown@1.2.1)(rollup@4.43.0)(vue@3.5.40)(webpack@5.99.9)
     devDependencies:
       dayjs:
         specifier: ^1.11.19
@@ -5740,9 +5740,6 @@ packages:
   mitt@3.0.1:
     resolution: {integrity: sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==}
 
-  mlly@1.8.0:
-    resolution: {integrity: sha512-l8D9ODSRWLe2KHJSifWGwBqpTZXIXTeo8mlKjY+E2HAakaTeNpqAyBZ8GSqLzHgw4XmHmC8whvpjJNMbFZN7/g==}
-
   mlly@1.8.2:
     resolution: {integrity: sha512-d+ObxMQFmbt10sretNDytwt85VrbkhhUA/JBGm1MPaWJ65Cl4wOgLaB1NYvJSZ0Ef03MMEU/0xpPMXUIQ29UfA==}
 
@@ -7217,10 +7214,6 @@ packages:
       svelte:
         optional: true
 
-  unplugin-utils@0.3.1:
-    resolution: {integrity: sha512-5lWVjgi6vuHhJ526bI4nlCOmkCIF3nnfXkCMDeMJrtdvxTs6ZFCM8oNufGTsDbKv/tJ/xj8RpvXjRuPBZJuJog==}
-    engines: {node: '>=20.19.0'}
-
   unplugin-utils@0.3.2:
     resolution: {integrity: sha512-xVToRh2CTmLk2HnEG7ac4rl1MJTT3RFkpS8B++/SnB0kXvuaavD+n3m/vrzyWQOdJNSZQACnbz01pnppbwV5BA==}
     engines: {node: '>=20.19.0'}
@@ -7474,14 +7467,14 @@ packages:
     peerDependencies:
       vue: ^3.0.0
 
-  vue-router@5.2.0:
-    resolution: {integrity: sha512-QAC5i0LEb1GLG0LXDQmHu8L7FX12j0KwU/JTKmLQUJMrn04gQdKP6Du+p0QwpHb3iy71vBlqnHQ8WAfOSAWhqw==}
+  vue-router@5.1.0:
+    resolution: {integrity: sha512-HAbiLzLEHQwxPgvsbOJDAwtavszEgLwri6XfyrsPECIFez8+59xc9LofWVdc/HEaSRT822lJ8H9Ns38VVond5g==}
     peerDependencies:
       '@pinia/colada': '>=0.21.2'
-      '@vue/compiler-sfc': ^3.5.34 || ^4.0.0
-      pinia: ^3.0.4 || ^4.0.2
-      vite: ^7.3.0 || ^8.0.0
-      vue: ^3.5.34 || ^4.0.0
+      '@vue/compiler-sfc': ^3.5.34
+      pinia: ^3.0.4
+      vite: ^7.0.0 || ^8.0.0
+      vue: ^3.5.34
     peerDependenciesMeta:
       '@pinia/colada':
         optional: true
@@ -8403,7 +8396,7 @@ snapshots:
     dependencies:
       '@antfu/install-pkg': 1.1.0
       '@iconify/types': 2.0.0
-      mlly: 1.8.0
+      mlly: 1.8.2
 
   '@iconify/vue@5.0.0(vue@3.5.40)':
     dependencies:
@@ -10414,9 +10407,9 @@ snapshots:
     dependencies:
       '@vue/compiler-sfc': 3.5.40
       ast-kit: 2.2.0
-      local-pkg: 1.1.2
+      local-pkg: 1.2.1
       magic-string-ast: 1.0.3
-      unplugin-utils: 0.3.1
+      unplugin-utils: 0.3.2
     optionalDependencies:
       vue: 3.5.40(typescript@6.0.3)
 
@@ -10606,11 +10599,11 @@ snapshots:
 
   '@vueuse/metadata@14.4.0': {}
 
-  '@vueuse/router@14.4.0(vue-router@5.2.0)(vue@3.5.40)':
+  '@vueuse/router@14.4.0(vue-router@5.1.0)(vue@3.5.40)':
     dependencies:
       '@vueuse/shared': 14.4.0(vue@3.5.40)
       vue: 3.5.40(typescript@6.0.3)
-      vue-router: 5.2.0(@rspack/core@1.3.12)(@voidzero-dev/vite-plus-core@0.2.8)(@vue/compiler-sfc@3.5.40)(esbuild@0.25.5)(pinia@4.0.2)(rolldown@1.2.1)(rollup@4.43.0)(vue@3.5.40)(webpack@5.99.9)
+      vue-router: 5.1.0(@rspack/core@1.3.12)(@voidzero-dev/vite-plus-core@0.2.8)(@vue/compiler-sfc@3.5.40)(esbuild@0.25.5)(pinia@4.0.2)(rolldown@1.2.1)(rollup@4.43.0)(vue@3.5.40)(webpack@5.99.9)
 
   '@vueuse/shared@14.4.0(vue@3.5.40)':
     dependencies:
@@ -12560,13 +12553,13 @@ snapshots:
 
   local-pkg@1.1.2:
     dependencies:
-      mlly: 1.8.0
+      mlly: 1.8.2
       pkg-types: 2.3.0
       quansync: 0.2.11
 
   local-pkg@1.2.1:
     dependencies:
-      mlly: 1.8.0
+      mlly: 1.8.2
       pkg-types: 2.3.0
       quansync: 0.2.11
 
@@ -12733,13 +12726,6 @@ snapshots:
   mitt@2.1.0: {}
 
   mitt@3.0.1: {}
-
-  mlly@1.8.0:
-    dependencies:
-      acorn: 8.17.0
-      pathe: 2.0.3
-      pkg-types: 1.3.1
-      ufo: 1.6.3
 
   mlly@1.8.2:
     dependencies:
@@ -13169,7 +13155,7 @@ snapshots:
   pkg-types@1.3.1:
     dependencies:
       confbox: 0.1.8
-      mlly: 1.8.0
+      mlly: 1.8.2
       pathe: 2.0.3
 
   pkg-types@2.3.0:
@@ -13199,7 +13185,7 @@ snapshots:
   postcss-load-config@4.0.2(postcss@8.5.25)(ts-node@10.9.2):
     dependencies:
       lilconfig: 3.1.3
-      yaml: 2.8.2
+      yaml: 2.9.0
     optionalDependencies:
       postcss: 8.5.25
       ts-node: 10.9.2(@types/node@24.11.0)(typescript@6.0.3)
@@ -14325,7 +14311,7 @@ snapshots:
       compare-versions: 6.1.1
       debug: 4.4.3(supports-color@8.1.1)
       kolorist: 1.8.0
-      local-pkg: 1.1.2
+      local-pkg: 1.2.1
       magic-string: 0.30.21
       typescript: 6.0.3
       unplugin: 2.3.11
@@ -14350,11 +14336,6 @@ snapshots:
       unplugin: 2.3.11
     optionalDependencies:
       '@vue/compiler-sfc': 3.5.40
-
-  unplugin-utils@0.3.1:
-    dependencies:
-      pathe: 2.0.3
-      picomatch: 4.0.5
 
   unplugin-utils@0.3.2:
     dependencies:
@@ -14702,7 +14683,7 @@ snapshots:
     dependencies:
       vue: 3.5.40(typescript@6.0.3)
 
-  vue-router@5.2.0(@rspack/core@1.3.12)(@voidzero-dev/vite-plus-core@0.2.8)(@vue/compiler-sfc@3.5.40)(esbuild@0.25.5)(pinia@4.0.2)(rolldown@1.2.1)(rollup@4.43.0)(vue@3.5.40)(webpack@5.99.9):
+  vue-router@5.1.0(@rspack/core@1.3.12)(@voidzero-dev/vite-plus-core@0.2.8)(@vue/compiler-sfc@3.5.40)(esbuild@0.25.5)(pinia@4.0.2)(rolldown@1.2.1)(rollup@4.43.0)(vue@3.5.40)(webpack@5.99.9):
     dependencies:
       '@babel/generator': 8.0.0
       '@vue-macros/common': 3.1.4(vue@3.5.40)
@@ -14714,7 +14695,6 @@ snapshots:
       magic-string: 0.30.21
       mlly: 1.8.2
       muggle-string: 0.4.1
-      nostics: 1.2.0
       pathe: 2.0.3
       picomatch: 4.0.5
       scule: 1.3.0
@@ -14928,7 +14908,7 @@ snapshots:
     dependencies:
       eslint-visitor-keys: 3.4.3
       lodash: 4.18.1
-      yaml: 2.8.2
+      yaml: 2.9.0
 
   yaml@2.8.2: {}
 


### PR DESCRIPTION
#### What type of PR is this?

- [ ] Feature
- [x] Bug fix
- [ ] Improvement
- [ ] Cleanup
- [ ] Documentation

#### What this PR does / why we need it:

Downgrades Vue Router from 5.2.0 to 5.1.0.

Vue Router 5.2.0 has a regression in its non-production global build: `vue-router.global.js` references `nostics` as an undefined external global and fails before `VueRouter` is initialized. Halo uses this global build when running the UI in development mode.

The application dependency is pinned to exactly 5.1.0, and the workspace package peer ranges are constrained to `~5.1.0` to prevent pnpm from resolving 5.2.x again.

#### Which issue(s) this PR fixes:

Related to https://github.com/vuejs/router/issues/2755

#### Special notes for your reviewer:

Vue Router 5.1.0 declares the optional Pinia peer range as `^3.0.4`, while Halo uses Pinia 4.0.2. This produces a peer dependency warning. Halo does not use Vue Router's experimental Pinia integration, and the standard Router runtime and builds pass with this combination.

The dependency update and validation were prepared with AI assistance.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
