### PR TITLE
feat: select links on double click

### DIFF
--- a/ui/packages/editor/src/extensions/link/index.ts
+++ b/ui/packages/editor/src/extensions/link/index.ts
@@ -1,9 +1,51 @@
+import { getMarkRange } from "@tiptap/core";
 import TiptapLink, { type LinkOptions } from "@tiptap/extension-link";
+import { Plugin, PluginKey, TextSelection } from "@tiptap/pm/state";
 import type { ExtensionOptions } from "@/types";
 
 export type ExtensionLinkOptions = ExtensionOptions & Partial<LinkOptions>;
 
 export const ExtensionLink = TiptapLink.extend<ExtensionLinkOptions>({
+  addProseMirrorPlugins() {
+    const linkType = this.type;
+
+    return [
+      ...(this.parent?.() ?? []),
+      new Plugin({
+        key: new PluginKey("haloLinkDoubleClickSelection"),
+        props: {
+          handleDoubleClick(view, pos, event) {
+            const target = event.target;
+
+            if (!(target instanceof Element)) {
+              return false;
+            }
+
+            const link = target.closest("a");
+
+            if (!link || !view.dom.contains(link)) {
+              return false;
+            }
+
+            const range = getMarkRange(view.state.doc.resolve(pos), linkType);
+
+            if (!range) {
+              return false;
+            }
+
+            view.dispatch(
+              view.state.tr.setSelection(
+                TextSelection.create(view.state.doc, range.from, range.to)
+              )
+            );
+
+            return true;
+          },
+        },
+      }),
+    ];
+  },
+
   addHaloEditorMetadata() {
     return {
       ai: {


### PR DESCRIPTION
#### What type of PR is this?

/kind feature
/area editor
/area ui

#### What this PR does / why we need it:

为编辑器链接扩展增加双击处理。双击链接时，编辑器选中完整链接范围。

#### Does this PR introduce a user-facing change?
```release-note
编辑器现在支持双击快速选中整个链接。
```
