### PR TITLE
fix: regenerate OpenAPI docs after springdoc upgrade

### DIFF
--- a/api-docs/openapi/v3_0/aggregated.json
+++ b/api-docs/openapi/v3_0/aggregated.json
@@ -17287,8 +17287,8 @@
       },
       "CopyOperation": {
         "required": [
-          "op",
           "from",
+          "op",
           "path"
         ],
         "type": "object",
@@ -19592,8 +19592,8 @@
       },
       "MoveOperation": {
         "required": [
-          "op",
           "from",
+          "op",
           "path"
         ],
         "type": "object",
@@ -22696,6 +22696,7 @@
             "format": "email"
           },
           "externalUrl": {
+            "pattern": "",
             "type": "string"
           },
           "language": {

--- a/api-docs/openapi/v3_0/apis_console.api_v1alpha1.json
+++ b/api-docs/openapi/v3_0/apis_console.api_v1alpha1.json
@@ -4700,8 +4700,8 @@
       },
       "CopyOperation": {
         "required": [
-          "op",
           "from",
+          "op",
           "path"
         ],
         "type": "object",
@@ -5766,8 +5766,8 @@
       },
       "MoveOperation": {
         "required": [
-          "op",
           "from",
+          "op",
           "path"
         ],
         "type": "object",

--- a/api-docs/openapi/v3_0/apis_extension.api_v1alpha1.json
+++ b/api-docs/openapi/v3_0/apis_extension.api_v1alpha1.json
@@ -10159,8 +10159,8 @@
       },
       "CopyOperation": {
         "required": [
-          "op",
           "from",
+          "op",
           "path"
         ],
         "type": "object",
@@ -11255,8 +11255,8 @@
       },
       "MoveOperation": {
         "required": [
-          "op",
           "from",
+          "op",
           "path"
         ],
         "type": "object",

--- a/api-docs/openapi/v3_0/apis_public.api_v1alpha1.json
+++ b/api-docs/openapi/v3_0/apis_public.api_v1alpha1.json
@@ -1918,8 +1918,8 @@
       },
       "CopyOperation": {
         "required": [
-          "op",
           "from",
+          "op",
           "path"
         ],
         "type": "object",
@@ -2573,8 +2573,8 @@
       },
       "MoveOperation": {
         "required": [
-          "op",
           "from",
+          "op",
           "path"
         ],
         "type": "object",

--- a/api-docs/openapi/v3_0/apis_uc.api_v1alpha1.json
+++ b/api-docs/openapi/v3_0/apis_uc.api_v1alpha1.json
@@ -1997,8 +1997,8 @@
       },
       "CopyOperation": {
         "required": [
-          "op",
           "from",
+          "op",
           "path"
         ],
         "type": "object",
@@ -2349,8 +2349,8 @@
       },
       "MoveOperation": {
         "required": [
-          "op",
           "from",
+          "op",
           "path"
         ],
         "type": "object",


### PR DESCRIPTION
This issue was introduced by https://github.com/halo-dev/halo/pull/10220 due to upgrading springdoc.

The OpenAPI docs have been regenerated using the generateOpenApiDocs task. No API client regeneration is needed since there are no contract changes.

What changes are included in this PR?
- Regenerate the OpenAPI docs: the required fields of CopyOperation and MoveOperation are reordered (from, op, path), and pattern is added to externalUrl.