### PR TITLE
Remove Gitpod and ClawCloud deployment links from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,12 +37,6 @@ Halo 是一款强大易用的开源建站工具，从个人博客、知识库，
 docker run -d --name halo -p 8090:8090 -v ~/.halo2:/root/.halo2 halohub/halo:2.25
 ```
 
-或者点击下方按钮使用 [Gitpod](https://gitpod.io/) 或 [ClawCloud Run](https://template.us-west-1.run.claw.cloud/deploy?templateName=halo) 启动一个体验环境：
-
-[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/halo-sigs/gitpod-demo)
-
-[![Run on ClawCloud](https://raw.githubusercontent.com/ClawCloud/Run-Template/refs/heads/main/Run-on-ClawCloud.svg)](https://template.us-west-1.run.claw.cloud/deploy?templateName=halo)
-
 **以上方式仅作为体验使用，推荐使用开源 Linux 服务器运维管理面板 [1Panel](https://github.com/1Panel-dev/1Panel) 进行部署（[查看文档](https://docs.halo.run/getting-started/install/1panel)），轻松搞定反向代理、SSL 证书及升级备份任务。更多部署方式，请[查看文档](https://docs.halo.run/category/%E5%AE%89%E8%A3%85%E6%8C%87%E5%8D%97)。**
 
 ## 在线体验


### PR DESCRIPTION
#### What type of PR is this?

- [ ] Feature
- [ ] Bug fix
- [ ] Improvement
- [ ] Cleanup
- [x] Documentation

#### What this PR does / why we need it:

Remove the Gitpod and ClawCloud Run one-click trial environment options from the README Quick Start section. The Docker quick-start command and links to the recommended deployment documentation remain unchanged.

#### Which issue(s) this PR fixes:

None.

#### Special notes for your reviewer:

This is a documentation-only change. It does not affect application code or runtime behavior.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```