### PR TITLE
Add dedicated Vite and Rsbuild bundler kit entry points

### DIFF
--- a/ui/packages/ui-plugin-bundler-kit/README.md
+++ b/ui/packages/ui-plugin-bundler-kit/README.md
@@ -29,17 +29,19 @@ pnpm add @halo-dev/ui-plugin-bundler-kit
 
 ### Additional Dependencies
 
-**For Vite users**, you need to install Vite:
+**For Vite users**, install Vite and its Vue plugin:
 
 ```bash
-npm install vite
+npm install vite @vitejs/plugin-vue
 ```
 
-**For Rsbuild users**, you need to install Rsbuild:
+**For Rsbuild users**, install Rsbuild and its Vue plugin:
 
 ```bash
-npm install @rsbuild/core
+npm install @rsbuild/core @rsbuild/plugin-vue
 ```
+
+Since 2.26.0, import the configuration helper from its build-system-specific entry point. Imports from the package root are deprecated and will be removed in 2.27.0.
 
 ## Usage
 
@@ -48,7 +50,7 @@ npm install @rsbuild/core
 Create or update `vite.config.ts` file in your UI plugin project root:
 
 ```typescript
-import { viteConfig } from "@halo-dev/ui-plugin-bundler-kit";
+import { viteConfig } from "@halo-dev/ui-plugin-bundler-kit/vite";
 
 export default viteConfig({
   // provider defaults to "plugin"
@@ -69,7 +71,7 @@ export default viteConfig({
 Create or update `rsbuild.config.ts` file in your UI plugin project root:
 
 ```typescript
-import { rsbuildConfig } from "@halo-dev/ui-plugin-bundler-kit";
+import { rsbuildConfig } from "@halo-dev/ui-plugin-bundler-kit/rsbuild";
 
 export default rsbuildConfig({
   // provider defaults to "plugin"
@@ -101,7 +103,7 @@ theme-root/
 Vite:
 
 ```typescript
-import { viteConfig } from "@halo-dev/ui-plugin-bundler-kit";
+import { viteConfig } from "@halo-dev/ui-plugin-bundler-kit/vite";
 
 export default viteConfig({
   provider: "theme",
@@ -112,7 +114,7 @@ export default viteConfig({
 Rsbuild:
 
 ```typescript
-import { rsbuildConfig } from "@halo-dev/ui-plugin-bundler-kit";
+import { rsbuildConfig } from "@halo-dev/ui-plugin-bundler-kit/rsbuild";
 
 export default rsbuildConfig({
   provider: "theme",
@@ -190,7 +192,7 @@ The reactive record contains only Halo-owned `name`, `type`, `version`, and `pen
 
 ### Legacy Configuration (Deprecated)
 
-> ⚠️ **Note**: The `HaloUIPluginBundlerKit` function is deprecated. Please use `viteConfig` or `rsbuildConfig` instead. It does not support `provider: "theme"`.
+> ⚠️ **Note**: The `HaloUIPluginBundlerKit` function is deprecated and will be removed in 2.27.0. Import `viteConfig` from `@halo-dev/ui-plugin-bundler-kit/vite` or `rsbuildConfig` from `@halo-dev/ui-plugin-bundler-kit/rsbuild` instead. It does not support `provider: "theme"`.
 
 ```typescript
 import { HaloUIPluginBundlerKit } from "@halo-dev/ui-plugin-bundler-kit";
@@ -277,7 +279,7 @@ interface RsBuildUserConfig {
 Vite:
 
 ```typescript
-import { viteConfig } from "@halo-dev/ui-plugin-bundler-kit";
+import { viteConfig } from "@halo-dev/ui-plugin-bundler-kit/vite";
 
 export default viteConfig({
   vue: {
@@ -294,7 +296,7 @@ export default viteConfig({
 Rsbuild:
 
 ```typescript
-import { rsbuildConfig } from "@halo-dev/ui-plugin-bundler-kit";
+import { rsbuildConfig } from "@halo-dev/ui-plugin-bundler-kit/rsbuild";
 
 export default rsbuildConfig({
   vue: {
@@ -313,7 +315,7 @@ The helper owns the Vue plugin instance. Keep `@vitejs/plugin-vue` and `@rsbuild
 ### Adding Path Aliases (Vite)
 
 ```typescript
-import { viteConfig } from "@halo-dev/ui-plugin-bundler-kit";
+import { viteConfig } from "@halo-dev/ui-plugin-bundler-kit/vite";
 import path from "path";
 
 export default viteConfig({
@@ -331,7 +333,7 @@ export default viteConfig({
 ### Adding Path Aliases (Rsbuild)
 
 ```typescript
-import { rsbuildConfig } from "@halo-dev/ui-plugin-bundler-kit";
+import { rsbuildConfig } from "@halo-dev/ui-plugin-bundler-kit/rsbuild";
 
 export default rsbuildConfig({
   rsbuild: {
@@ -348,7 +350,7 @@ export default rsbuildConfig({
 ### Adding Additional Vite Plugins
 
 ```typescript
-import { viteConfig } from "@halo-dev/ui-plugin-bundler-kit";
+import { viteConfig } from "@halo-dev/ui-plugin-bundler-kit/vite";
 import { defineConfig } from "vite";
 import UnoCSS from "unocss/vite";
 
@@ -364,7 +366,7 @@ export default viteConfig({
 ### Adding Additional Rsbuild Plugins
 
 ```typescript
-import { rsbuildConfig } from "@halo-dev/ui-plugin-bundler-kit";
+import { rsbuildConfig } from "@halo-dev/ui-plugin-bundler-kit/rsbuild";
 import { pluginSass } from "@rsbuild/plugin-sass";
 
 export default rsbuildConfig({
@@ -379,7 +381,7 @@ export default rsbuildConfig({
 ### Custom Plugin Manifest Path
 
 ```typescript
-import { viteConfig } from "@halo-dev/ui-plugin-bundler-kit";
+import { viteConfig } from "@halo-dev/ui-plugin-bundler-kit/vite";
 
 export default viteConfig({
   manifestPath: "application/src/main/resources/plugin.yaml", // Custom manifest file path
@@ -392,7 +394,7 @@ export default viteConfig({
 ### Custom Theme Manifest Path
 
 ```typescript
-import { viteConfig } from "@halo-dev/ui-plugin-bundler-kit";
+import { viteConfig } from "@halo-dev/ui-plugin-bundler-kit/vite";
 
 export default viteConfig({
   provider: "theme",

--- a/ui/packages/ui-plugin-bundler-kit/package.json
+++ b/ui/packages/ui-plugin-bundler-kit/package.json
@@ -16,6 +16,8 @@
   "types": "./dist/index.d.mts",
   "exports": {
     ".": "./dist/index.mjs",
+    "./rsbuild": "./dist/rsbuild.mjs",
+    "./vite": "./dist/vite.mjs",
     "./package.json": "./package.json"
   },
   "scripts": {

--- a/ui/packages/ui-plugin-bundler-kit/src/__tests__/public-api.spec.ts
+++ b/ui/packages/ui-plugin-bundler-kit/src/__tests__/public-api.spec.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from "vite-plus/test";
+import packageJson from "../../package.json";
 import * as bundlerKit from "../index";
+import * as rsbuildEntry from "../rsbuild";
+import * as viteEntry from "../vite";
 
 describe("public API", () => {
   it("exports only supported bundler helpers", () => {
@@ -8,5 +11,14 @@ describe("public API", () => {
       "rsbuildConfig",
       "viteConfig",
     ]);
+  });
+
+  it("provides isolated bundler entry points", () => {
+    expect(Object.keys(viteEntry)).toEqual(["viteConfig"]);
+    expect(Object.keys(rsbuildEntry)).toEqual(["rsbuildConfig"]);
+    expect(bundlerKit.viteConfig).toBe(viteEntry.viteConfig);
+    expect(bundlerKit.rsbuildConfig).toBe(rsbuildEntry.rsbuildConfig);
+    expect(packageJson.exports["./vite"]).toBe("./dist/vite.mjs");
+    expect(packageJson.exports["./rsbuild"]).toBe("./dist/rsbuild.mjs");
   });
 });

--- a/ui/packages/ui-plugin-bundler-kit/src/index.ts
+++ b/ui/packages/ui-plugin-bundler-kit/src/index.ts
@@ -1,3 +1,14 @@
+import { rsbuildConfig as createRsbuildConfig } from "./rsbuild";
+import { viteConfig as createViteConfig } from "./vite";
+
 export { HaloUIPluginBundlerKit } from "./legacy";
-export { rsbuildConfig } from "./rsbuild";
-export { viteConfig } from "./vite";
+
+/**
+ * @deprecated Import from `@halo-dev/ui-plugin-bundler-kit/rsbuild` instead.
+ */
+export const rsbuildConfig = createRsbuildConfig;
+
+/**
+ * @deprecated Import from `@halo-dev/ui-plugin-bundler-kit/vite` instead.
+ */
+export const viteConfig = createViteConfig;

--- a/ui/packages/ui-plugin-bundler-kit/src/legacy.ts
+++ b/ui/packages/ui-plugin-bundler-kit/src/legacy.ts
@@ -17,7 +17,9 @@ interface HaloUIPluginBundlerKitOptions {
 }
 
 /**
- * @deprecated Use `viteConfig` or `rsbuildConfig` instead.
+ * @deprecated Import `viteConfig` from `@halo-dev/ui-plugin-bundler-kit/vite`
+ * or `rsbuildConfig` from `@halo-dev/ui-plugin-bundler-kit/rsbuild` instead.
+ * This function will be removed in 2.27.0.
  */
 export function HaloUIPluginBundlerKit(
   options: HaloUIPluginBundlerKitOptions = {}

--- a/ui/packages/ui-plugin-bundler-kit/src/rsbuild.ts
+++ b/ui/packages/ui-plugin-bundler-kit/src/rsbuild.ts
@@ -264,7 +264,7 @@ function getManifestPath(provider: Provider, config?: RsBuildUserConfig) {
  *
  * @example
  * ```ts
- * import { rsbuildConfig } from "@halo-dev/ui-plugin-bundler-kit";
+ * import { rsbuildConfig } from "@halo-dev/ui-plugin-bundler-kit/rsbuild";
  *
  * export default rsbuildConfig({
  *   rsbuild: {

--- a/ui/packages/ui-plugin-bundler-kit/src/vite.ts
+++ b/ui/packages/ui-plugin-bundler-kit/src/vite.ts
@@ -202,7 +202,7 @@ function getManifestPath(provider: Provider, config?: ViteUserConfig) {
  *
  * @example
  * ```ts
- * import { viteConfig } from "@halo-dev/ui-plugin-bundler-kit";
+ * import { viteConfig } from "@halo-dev/ui-plugin-bundler-kit/vite";
  *
  * export default viteConfig({
  *   vite: {

--- a/ui/packages/ui-plugin-bundler-kit/vite.config.ts
+++ b/ui/packages/ui-plugin-bundler-kit/vite.config.ts
@@ -1,7 +1,7 @@
 import { defineConfig } from "vite-plus";
 export default defineConfig({
   pack: {
-    entry: ["./src/index.ts"],
+    entry: ["./src/index.ts", "./src/vite.ts", "./src/rsbuild.ts"],
     format: ["esm"],
     dts: {
       tsgo: true,


### PR DESCRIPTION
#### What type of PR is this?

- [ ] Feature
- [ ] Bug fix
- [x] Improvement
- [ ] Cleanup
- [ ] Documentation

#### What this PR does / why we need it:

The package root currently imports both Vite and Rsbuild integrations and declares both toolchains as required peer dependencies. As a result, plugin developers need both build systems to be resolvable even when they only use one.

Build-system-specific entry points are required before these dependencies can be decoupled. This PR introduces the following dedicated entry points:

- `@halo-dev/ui-plugin-bundler-kit/vite`
- `@halo-dev/ui-plugin-bundler-kit/rsbuild`

The existing root exports remain compatible in 2.26.0 but are now marked as deprecated, preserving the original function references while giving existing plugins a compatibility window before the root exports are removed in 2.27.0.

The deprecated `HaloUIPluginBundlerKit` helper now points to the same migration paths. Documentation examples and installation instructions have also been updated.

#### Which issue(s) this PR fixes:

N/A

#### Special notes for your reviewer:

- The existing peer dependency declarations remain unchanged in 2.26.0 to preserve current installation behavior.
- Generated package artifacts expose separate Vite and Rsbuild entries without cross-importing the other build system.
- The generated root declaration includes the expected deprecation annotations.
- Validation completed:
  - `corepack pnpm@11.17.0 -C ui --filter @halo-dev/ui-plugin-bundler-kit build`
  - `corepack pnpm@11.17.0 -C ui --filter @halo-dev/ui-plugin-bundler-kit typecheck`
  - Focused public API tests: 2 passed
  - Tests excluding the existing runtime snapshot mismatch: 64 passed
- The complete unit test run reports 70 passed and one unrelated existing failure: the Halo 2.26 runtime snapshot does not yet contain three rich-text-editor upload scheduler exports.
- This change was implemented with LLM assistance and reviewed against the source diff and generated package artifacts.

#### Does this PR introduce a user-facing change?

```release-note
UI 插件构建工具包新增 Vite 和 Rsbuild 独立导入入口，现有根入口已弃用并计划在 2.27.0 移除。
```
