### PR TITLE
Bump UI package versions to 2.26.0

### DIFF
--- a/ui/packages/api-client/package.json
+++ b/ui/packages/api-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@halo-dev/api-client",
-  "version": "2.25.2",
+  "version": "2.26.0",
   "description": "API Client for Halo 2",
   "homepage": "https://github.com/halo-dev/halo/tree/main/ui/packages/api-client#readme",
   "bugs": {

--- a/ui/packages/components/package.json
+++ b/ui/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@halo-dev/components",
-  "version": "2.25.2",
+  "version": "2.26.0",
   "description": "",
   "keywords": [
     "@halo-dev/components",

--- a/ui/packages/editor/package.json
+++ b/ui/packages/editor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@halo-dev/richtext-editor",
-  "version": "2.25.2",
+  "version": "2.26.0",
   "description": "Default editor for Halo",
   "homepage": "https://github.com/halo-dev/halo/tree/main/ui/packages/editor#readme",
   "bugs": {

--- a/ui/packages/shared/package.json
+++ b/ui/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@halo-dev/ui-shared",
-  "version": "2.25.2",
+  "version": "2.26.0",
   "description": "",
   "keywords": [],
   "homepage": "https://github.com/halo-dev/halo/tree/main/ui/packages/shared#readme",

--- a/ui/packages/ui-plugin-bundler-kit/src/runtime-snapshots/halo-2.26.0.json
+++ b/ui/packages/ui-plugin-bundler-kit/src/runtime-snapshots/halo-2.26.0.json
@@ -365,7 +365,7 @@
       }
     },
     "@halo-dev/ui-shared": {
-      "version": "2.25.2",
+      "version": "2.26.0",
       "exports": [
         "FormType",
         "THUMBNAIL_WIDTH_MAP",
@@ -381,7 +381,7 @@
       }
     },
     "@halo-dev/components": {
-      "version": "2.25.2",
+      "version": "2.26.0",
       "exports": [
         "AvatarGroupContextInjectionKey",
         "Dialog",
@@ -505,7 +505,7 @@
       }
     },
     "@halo-dev/api-client": {
-      "version": "2.25.2",
+      "version": "2.26.0",
       "exports": [
         "AddOperationOpEnum",
         "AnnotationSettingV1AlphaUcApi",
@@ -883,7 +883,7 @@
       }
     },
     "@halo-dev/richtext-editor": {
-      "version": "2.25.2",
+      "version": "2.26.0",
       "exports": [
         "AUDIO_BUBBLE_MENU_KEY",
         "AddMarkStep",


### PR DESCRIPTION
#### What type of PR is this?

- [ ] Feature
- [ ] Bug fix
- [x] Improvement
- [ ] Cleanup
- [ ] Documentation

#### What this PR does / why we need it:

Bumps the published UI workspace package versions from `2.25.2` to `2.26.0` for:

- `@halo-dev/api-client`
- `@halo-dev/components`
- `@halo-dev/richtext-editor`
- `@halo-dev/ui-shared`

Also updates the Halo 2.26 host runtime snapshot to keep its shared package version metadata aligned with the published packages.

#### Which issue(s) this PR fixes:

N/A

#### Special notes for your reviewer:

Prepared with AI assistance and reviewed before submission.

Validation:

- `corepack pnpm@11.17.0 -C ui --filter @halo-dev/ui-plugin-bundler-kit snapshot:check`
- `corepack pnpm@11.17.0 -C ui --filter @halo-dev/ui-plugin-bundler-kit test:unit`
- `corepack pnpm@11.17.0 -C ui format:check`
- `corepack pnpm@11.17.0 -C ui typecheck`
- `corepack pnpm@11.17.0 -C ui lint`

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
