### PR TITLE
Migrate Node and pnpm workflows to Vite+

### DIFF
--- a/.github/actions/setup-env/action.yaml
+++ b/.github/actions/setup-env/action.yaml
@@ -15,17 +15,15 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - uses: pnpm/action-setup@v6
-      name: Setup pnpm
+    - name: Setup Vite+
+      uses: voidzero-dev/setup-vp@v1
       with:
-        package_json_file: ui/package.json
-
-    - name: Set up Node.js
-      uses: actions/setup-node@v6
-      with:
+        working-directory: ui
+        version-file: pnpm-workspace.yaml
         node-version: ${{ inputs.node-version }}
-        cache: "pnpm"
-        cache-dependency-path: "ui/pnpm-lock.yaml"
+        cache: true
+        cache-dependency-path: pnpm-lock.yaml
+        run-install: false
 
     - name: Setup JDK
       uses: actions/setup-java@v5

--- a/.github/workflows/openapi-check.yaml
+++ b/.github/workflows/openapi-check.yaml
@@ -32,15 +32,17 @@ jobs:
       - name: Setup Environment
         uses: ./.github/actions/setup-env
       - name: Install UI dependencies
-        run: ./gradlew pnpmInstall
+        working-directory: ui
+        run: vp install --frozen-lockfile
       - name: Regenerate OpenAPI docs
         run: ./gradlew generateOpenApiDocs --no-configuration-cache
       - name: Regenerate api-client
-        run: cd ui && pnpm run api-client:gen
+        working-directory: ui
+        run: vp run api-client:gen
       - name: Verify OpenAPI docs and api-client are in sync
         run: |
           if ! git diff --exit-code -- api-docs/openapi ui/packages/api-client/src; then
-            echo "::error::OpenAPI docs or api-client generated code is out of sync with the current API. Run './gradlew generateOpenApiDocs --no-configuration-cache' and 'cd ui && pnpm run api-client:gen', then commit the changes under api-docs/openapi and ui/packages/api-client/src."
+            echo "::error::OpenAPI docs or api-client generated code is out of sync with the current API. Run './gradlew generateOpenApiDocs --no-configuration-cache' and 'vp -C ui run api-client:gen', then commit the changes under api-docs/openapi and ui/packages/api-client/src."
             git diff --stat api-docs/openapi ui/packages/api-client/src
             exit 1
           fi

--- a/.github/workflows/packages-preview-release.yaml
+++ b/.github/workflows/packages-preview-release.yaml
@@ -20,10 +20,13 @@ jobs:
         uses: ./.github/actions/setup-env
 
       - name: Install Dependencies
-        run: ./gradlew pnpmInstall
+        working-directory: ui
+        run: vp install --frozen-lockfile
 
       - name: Build Packages
-        run: cd ui && pnpm build:packages
+        working-directory: ui
+        run: vp run build:packages
 
       - name: Release
-        run: cd ui && pnpx pkg-pr-new publish --compact --pnpm './packages/*'
+        working-directory: ui
+        run: vp dlx pkg-pr-new publish --compact --pnpm './packages/*'

--- a/.github/workflows/release-ui-packages.yaml
+++ b/.github/workflows/release-ui-packages.yaml
@@ -19,6 +19,9 @@ jobs:
           fetch-depth: 0
       - name: Setup Environment
         uses: ./.github/actions/setup-env
-      - run: ./gradlew pnpmInstall
+      - name: Install Dependencies
+        working-directory: ui
+        run: vp install --frozen-lockfile
       - name: Publish to NPM
-        run: cd ui && pnpm build:packages && pnpm -r publish --access public --no-git-checks
+        working-directory: ui
+        run: vp run build:packages && vp pm publish -r --access public --no-git-checks


### PR DESCRIPTION
#### What type of PR is this?

- [ ] Feature
- [ ] Bug fix
- [x] Improvement
- [ ] Cleanup
- [ ] Documentation

#### What this PR does / why we need it:

- Replaces the separate Node.js and pnpm setup actions with `voidzero-dev/setup-vp`.
- Uses Vite+ commands to install dependencies, run workspace scripts, execute temporary CLIs, and publish UI packages.
- Keeps the Vite+ version sourced from `ui/pnpm-workspace.yaml` and enables dependency caching for the UI workspace.

#### Which issue(s) this PR fixes:

None.

#### Special notes for your reviewer:

The shared setup action keeps `run-install` disabled so workflows can control installation explicitly and existing Gradle jobs retain their current lifecycle.

Validation performed:

- `go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.7 .github/workflows/*.yaml`
- `vp install --frozen-lockfile`
- `vp run build:packages`
- `vp run api-client:gen`
- `vp pm publish -r --access public --no-git-checks --dry-run`
- `git diff --check`

The real preview and npm publishing operations were not executed. This change was prepared with Codex assistance and reviewed through the validation listed above.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```