### PR TITLE
Fix PostCSS viewport height correction warning

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -140,7 +140,6 @@
     "lint-staged": "^16.2.7",
     "npm-run-all": "^4.1.5",
     "postcss": "^8.5.26",
-    "postcss-viewport-height-correction": "^1.1.1",
     "rollup-plugin-gzip": "^4.2.0",
     "sass-embedded": "^1.102.0",
     "tailwindcss": "^3.4.17",

--- a/ui/pnpm-lock.yaml
+++ b/ui/pnpm-lock.yaml
@@ -389,9 +389,6 @@ importers:
       postcss:
         specifier: ^8.5.26
         version: 8.5.26
-      postcss-viewport-height-correction:
-        specifier: ^1.1.1
-        version: 1.1.1
       rollup-plugin-gzip:
         specifier: ^4.2.0
         version: 4.2.0(rollup@4.43.0)
@@ -6369,9 +6366,6 @@ packages:
   perfect-debounce@2.1.0:
     resolution: {integrity: sha512-LjgdTytVFXeUgtHZr9WYViYSM/g8MkcTPYDlPa3cDqMirHjKiSZPYd6DoL7pK8AJQr+uWkQvCjHNdiMqsrJs+g==}
 
-  picocolors@0.2.1:
-    resolution: {integrity: sha512-cMlDqaLEqfSaW8Z7N5Jw+lyIW869EzT73/F5lhtY9cLGoVxSXznfgfXMO0Z5K0o0Q2TkTXq+0KFsdnSe3jDViA==}
-
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
 
@@ -6477,14 +6471,6 @@ packages:
 
   postcss-value-parser@4.2.0:
     resolution: {integrity: sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==}
-
-  postcss-viewport-height-correction@1.1.1:
-    resolution: {integrity: sha512-kphLY4Au76uD2t4lZZ6mAExx6uMiWsxbFiBckfSJJZAbBZZGPNbLSztaDRSI4JUdKpK4JBbscfyKJf03Y2ae0g==}
-    engines: {node: '>=8.0.0'}
-
-  postcss@7.0.39:
-    resolution: {integrity: sha512-yioayjNbHn6z1/Bywyb2Y4s3yvDAeXGOyxqD+LnVOinq6Mdmd++SW2wUNVzavyyHxd6+DxzWGIuosg6P1Rj8uA==}
-    engines: {node: '>=6.0.0'}
 
   postcss@8.5.26:
     resolution: {integrity: sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==}
@@ -13633,8 +13619,6 @@ snapshots:
 
   perfect-debounce@2.1.0: {}
 
-  picocolors@0.2.1: {}
-
   picocolors@1.1.1: {}
 
   picomatch@2.3.1: {}
@@ -13716,15 +13700,6 @@ snapshots:
       util-deprecate: 1.0.2
 
   postcss-value-parser@4.2.0: {}
-
-  postcss-viewport-height-correction@1.1.1:
-    dependencies:
-      postcss: 7.0.39
-
-  postcss@7.0.39:
-    dependencies:
-      picocolors: 0.2.1
-      source-map: 0.6.1
 
   postcss@8.5.26:
     dependencies:

--- a/ui/postcss.config.cjs
+++ b/ui/postcss.config.cjs
@@ -2,6 +2,6 @@ module.exports = {
   plugins: {
     tailwindcss: {},
     autoprefixer: {},
-    "postcss-viewport-height-correction": {},
+    "./src/vite/postcss-viewport-height-correction.cjs": {},
   },
 };

--- a/ui/src/vite/__tests__/postcss-viewport-height-correction.spec.ts
+++ b/ui/src/vite/__tests__/postcss-viewport-height-correction.spec.ts
@@ -1,0 +1,25 @@
+import { createRequire } from "node:module";
+import postcss from "postcss";
+import { describe, expect, it } from "vite-plus/test";
+
+const require = createRequire(import.meta.url);
+const viewportHeightCorrection = require("../postcss-viewport-height-correction.cjs");
+
+describe("postcss viewport height correction", () => {
+  it("preserves the source and importance of cloned declarations", async () => {
+    const result = await postcss([viewportHeightCorrection]).process(
+      ".modal { height: 100vh !important; }",
+      { from: "fixture.css" }
+    );
+    const declarations = result.root.nodes[0].nodes;
+
+    expect(declarations).toHaveLength(2);
+    expect(declarations[1]).toMatchObject({
+      important: true,
+      value: "calc(var(--vh, 1vh) * 100)",
+    });
+    expect(declarations[1].source?.input.file).toBe(
+      declarations[0].source?.input.file
+    );
+  });
+});

--- a/ui/src/vite/postcss-viewport-height-correction.cjs
+++ b/ui/src/vite/postcss-viewport-height-correction.cjs
@@ -1,0 +1,19 @@
+const hasViewportHeight = /-?[0-9.]+vh/;
+const viewportHeight = /(-?[0-9.]+)vh/g;
+const correctedViewportHeight = /var\(--vh,\s*1vh\)/;
+
+module.exports = () => ({
+  postcssPlugin: "postcss-viewport-height-correction",
+  Declaration(declaration) {
+    const { value } = declaration;
+    if (!hasViewportHeight.test(value) || correctedViewportHeight.test(value)) {
+      return;
+    }
+
+    declaration.cloneAfter({
+      value: value.replace(viewportHeight, "calc(var(--vh, 1vh) * $1)"),
+    });
+  },
+});
+
+module.exports.postcss = true;


### PR DESCRIPTION
#### What type of PR is this?

- [ ] Feature
- [x] Bug fix
- [ ] Improvement
- [ ] Cleanup
- [ ] Documentation

#### What this PR does / why we need it:

Vite+ 0.2.9 reports that a PostCSS plugin did not provide source information while processing stylesheets.

The warning is caused by `postcss-viewport-height-correction`, which uses the legacy PostCSS 7 plugin API and creates declarations without preserving their source information.

This PR:

- replaces the legacy dependency with a local PostCSS 8 plugin
- clones the original declaration so source and `!important` metadata are preserved
- retains the existing `vh` fallback and corrected CSS output
- removes the obsolete PostCSS 7 dependency tree
- adds a regression test for source and importance preservation

To reproduce the issue before the fix:

1. Run `pnpm -C ui dev`.
2. Request `/console.html` and `/src/styles/tailwind.css`.
3. Observe the warning about a PostCSS plugin not passing the `from` option.

Repeating the same steps after the fix no longer produces the warning. Styles containing `100vh` still generate both the original fallback and the corrected `calc(var(--vh, 1vh) * 100)` declaration.

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

This change was implemented with assistance from Codex and reviewed against the generated CSS and the full UI validation suite.

Validation:

- `pnpm -C ui install --frozen-lockfile`
- `pnpm -C ui test:unit`
- `pnpm -C ui typecheck`
- `pnpm -C ui build`
- focused ESLint and formatting checks
- manual Vite+ development-server reproduction and generated CSS verification

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
