### PR TITLE
fix: preserve default storage policy settings across restarts

### DIFF
--- a/application/src/main/resources/extensions/attachment-local-policy.yaml
+++ b/application/src/main/resources/extensions/attachment-local-policy.yaml
@@ -10,6 +10,8 @@ apiVersion: storage.halo.run/v1alpha1
 kind: Policy
 metadata:
   name: default-policy
+  labels:
+    halo.run/do-not-overwrite: "true"
   finalizers:
     - system-protection
 spec:

--- a/application/src/test/java/run/halo/app/core/attachment/AttachmentLocalPolicyResourceTest.java
+++ b/application/src/test/java/run/halo/app/core/attachment/AttachmentLocalPolicyResourceTest.java
@@ -1,0 +1,54 @@
+package run.halo.app.core.attachment;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.core.io.ClassPathResource;
+import run.halo.app.extension.ExtensionUtil;
+import run.halo.app.infra.utils.YamlUnstructuredLoader;
+
+/**
+ * Tests for the built-in local attachment policy resource.
+ *
+ * <p>The default policy (and its config map) are initialized from <code>extensions/attachment-local-policy.yaml</code>
+ * on every startup. The <code>halo.run/do-not-overwrite</code> label is required to prevent the initializer from
+ * reverting user modifications, such as the display priority label, on restart.
+ *
+ * @author bedhere
+ * @since 2.27.0
+ */
+class AttachmentLocalPolicyResourceTest {
+
+    @Test
+    void defaultPolicyShouldBeMarkedAsDoNotOverwrite() {
+        var resource = new ClassPathResource("extensions/attachment-local-policy.yaml");
+        var unstructuredList = new YamlUnstructuredLoader(resource).load();
+
+        var defaultPolicy = unstructuredList.stream()
+                .filter(unstructured -> "Policy".equals(unstructured.getKind()))
+                .filter(unstructured ->
+                        "default-policy".equals(unstructured.getMetadata().getName()))
+                .findFirst()
+                .orElseThrow();
+
+        assertThat(defaultPolicy.getMetadata().getLabels())
+                .as("Default policy must not be overwritten on startup, otherwise user "
+                        + "modifications (e.g. upload display priority) are reverted on restart.")
+                .containsEntry(ExtensionUtil.DO_NOT_OVERWRITE_LABEL, "true");
+    }
+
+    @Test
+    void defaultPolicyConfigMapShouldBeMarkedAsDoNotOverwrite() {
+        var resource = new ClassPathResource("extensions/attachment-local-policy.yaml");
+        var unstructuredList = new YamlUnstructuredLoader(resource).load();
+
+        var configMap = unstructuredList.stream()
+                .filter(unstructured -> "ConfigMap".equals(unstructured.getKind()))
+                .filter(unstructured -> "default-policy-config"
+                        .equals(unstructured.getMetadata().getName()))
+                .findFirst()
+                .orElseThrow();
+
+        assertThat(configMap.getMetadata().getLabels()).containsEntry(ExtensionUtil.DO_NOT_OVERWRITE_LABEL, "true");
+    }
+}

--- a/application/src/test/java/run/halo/app/infra/ExtensionResourceInitializerTest.java
+++ b/application/src/test/java/run/halo/app/infra/ExtensionResourceInitializerTest.java
@@ -10,6 +10,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -24,6 +25,7 @@ import org.springframework.boot.context.event.ApplicationStartedEvent;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.util.FileSystemUtils;
 import reactor.core.publisher.Mono;
+import run.halo.app.extension.ExtensionUtil;
 import run.halo.app.extension.GroupVersionKind;
 import run.halo.app.extension.ReactiveExtensionClient;
 import run.halo.app.extension.Unstructured;
@@ -164,5 +166,26 @@ class ExtensionResourceInitializerTest {
                  }
             ]
             """, JsonUtils.objectToJson(values), false);
+    }
+
+    @Test
+    void shouldNotUpdateExtensionWithDoNotOverwriteLabel() throws Exception {
+        when(haloProperties.isRequiredExtensionDisabled()).thenReturn(true);
+        var existing = new Unstructured(Map.of(
+                "apiVersion", "v1",
+                "kind", "FakeExtension",
+                "metadata",
+                        Map.of(
+                                "name",
+                                "fake-extension",
+                                "labels",
+                                Map.of(ExtensionUtil.DO_NOT_OVERWRITE_LABEL, "true"))));
+
+        when(extensionClient.fetch(any(GroupVersionKind.class), any())).thenReturn(Mono.just(existing));
+
+        extensionResourceInitializer.start();
+
+        verify(extensionClient, never()).update(any());
+        verify(extensionClient, never()).create(any());
     }
 }


### PR DESCRIPTION
#### What type of PR is this?

<!--
请选择一个主要类型：
Select one primary type:
-->
- [ ] Feature
- [x] Bug fix
- [ ] Improvement
- [ ] Cleanup
- [ ] Documentation

#### What this PR does / why we need it:

修复默认存储策略（`default-policy`）的配置在 Halo 重启后丢失的问题。

系统内置的"本地存储"策略会在每次启动时通过 `ExtensionResourceInitializer` 从
`extensions/attachment-local-policy.yaml` 重新初始化。此前同文件中的
`default-policy-config` ConfigMap 已带有 `halo.run/do-not-overwrite: "true"` 标签
（在 #8230 中引入），因此用户修改的存储配置数据（如存储位置）可以保留；
但 `default-policy` 本身漏加了该标签，导致每次启动时初始化器都会用内置 YAML
强制覆盖它，用户在该策略上保存的修改——例如"上传界面显示优先级"（保存在
`metadata.labels["storage.halo.run/policy-priority-in-upload-ui"]`）以及自定义的
显示名称——在重启后都会被还原为默认值（对应 Issue #8259）。

本 PR 为 `default-policy` 补上与 ConfigMap 一致的
`halo.run/do-not-overwrite: "true"` 标签，使初始化器在启动时跳过对该策略的覆盖，
从而保留用户的修改。

#### Which issue(s) this PR fixes:

<!--
PR 合并时自动关闭 issue。
Automatically closes linked issue when PR is merged.

用法：`Fixes #<issue 号>`，或者 `Fixes (粘贴 issue 完整链接)`
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Fixes #8259

#### Special notes for your reviewer:

- 修复方式与 #8230 引入的 do-not-overwrite 机制完全一致，不引入新的行为变更。
- 新增测试：
  - `AttachmentLocalPolicyResourceTest`：断言 `default-policy` 及其 ConfigMap 均带有
    `halo.run/do-not-overwrite` 标签（防止该保护标签将来被误删）；
  - `ExtensionResourceInitializerTest`：新增用例验证带 do-not-overwrite 标签的扩展
    在启动初始化时不会被 update / create 覆盖。
- 本地验证：目标测试修复前失败（FAIL）、修复后通过（PASS）；
  `./gradlew spotlessCheck` 通过；`run.halo.app.core.attachment.*` 与
  `run.halo.app.infra.*` 包全量测试通过。
- 说明：完整后端测试套件中 `CategoryFinderImplTest.listAsTreeTreatsInvalidParentsAsRoots`
  存在一个预先存在的失败（根节点输出顺序为名称字典序，与测试期望的输入顺序不符），
  已在未包含本次修改的基线上复现，与本次 PR 无关。
- 本 PR 由 AI 辅助生成，代码已经人工审查（This PR was prepared with AI assistance
  and reviewed locally）。

#### Does this PR introduce a user-facing change?

<!--
如果当前 Pull Request 的修改不会造成用户侧的任何变更，在 `release-note` 代码块儿中填写 `NONE`。
否则请填写用户侧能够理解的 Release Note。如果当前 Pull Request 包含破坏性更新（Break Change），
Release Note 需要以 `action required` 开头。
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->

```release-note
修复默认存储策略（本地存储）的配置（如"上传界面显示优先级"）在重启后被还原的问题
```
