### PR TITLE
fix: preserve terminal gap cursor before block replacement

### DIFF
--- a/ui/packages/editor/src/extensions/gap-cursor/index.spec.ts
+++ b/ui/packages/editor/src/extensions/gap-cursor/index.spec.ts
@@ -667,6 +667,30 @@ describe("ExtensionGapCursor", () => {
     ).not.toBeNull();
   });
 
+  it("keeps a terminal gap across a later transaction until Backspace replaces the block", () => {
+    const editor = createEditorWithTrailingNode([
+      { type: "testCard" },
+      { type: "paragraph" },
+    ]);
+    editor.view.dispatch(
+      editor.state.tr.setSelection(TextSelection.create(editor.state.doc, 2))
+    );
+
+    expect(runKey(editor, "Backspace")).toBe(true);
+    editor.view.dispatch(editor.state.tr.setMeta("testIntervening", true));
+
+    expect(editor.state.doc.childCount).toBe(1);
+    expect(editor.state.doc.firstChild?.type.name).toBe("testCard");
+    expect(editor.state.selection).toBeInstanceOf(GapCursor);
+    expect(editor.state.selection.from).toBe(1);
+
+    expect(runKey(editor, "Backspace")).toBe(true);
+
+    expect(editor.state.doc.childCount).toBe(1);
+    expect(editor.state.doc.firstChild?.type.name).toBe("paragraph");
+    expect(editor.state.selection).toBeInstanceOf(TextSelection);
+  });
+
   it("deletes an empty paragraph between structural blocks with forward Delete", () => {
     const editor = createEditorWithContent([
       { type: "testCard" },

--- a/ui/packages/editor/src/extensions/trailing-node/index.ts
+++ b/ui/packages/editor/src/extensions/trailing-node/index.ts
@@ -3,7 +3,13 @@ import {
   TrailingNode,
   type TrailingNodeOptions,
 } from "@tiptap/extensions";
-import { Plugin, type Transaction } from "@/tiptap/pm";
+import {
+  GapCursor,
+  Plugin,
+  type EditorState,
+  type Transaction,
+} from "@/tiptap/pm";
+import { isGapCursorTargetNode } from "@/utils/gap-cursor";
 
 function shouldSkipTrailingNode(transaction: Transaction) {
   let current: Transaction | undefined = transaction;
@@ -23,6 +29,15 @@ function shouldSkipTrailingNode(transaction: Transaction) {
   }
 
   return false;
+}
+
+function shouldPreserveTerminalGapCursor(state: EditorState) {
+  const { doc, selection } = state;
+  return (
+    selection instanceof GapCursor &&
+    selection.from === doc.content.size &&
+    isGapCursorTargetNode(selection.$from.nodeBefore)
+  );
 }
 
 export const ExtensionTrailingNode = TrailingNode.extend<TrailingNodeOptions>({
@@ -56,6 +71,9 @@ function preserveSkipMetaAcrossAppendRounds(plugin: Plugin) {
       // after the direct skip was observed. ProseMirror links that transaction
       // to its root through `appendedTransaction`.
       if (transactions.some(shouldSkipTrailingNode)) {
+        return null;
+      }
+      if (shouldPreserveTerminalGapCursor(newState)) {
         return null;
       }
       return appendTransaction.call(plugin, transactions, oldState, newState);


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/area ui
/area editor

#### What this PR does / why we need it:

修复文档只剩一个结构块时，块后的间隙光标无法通过退格键替换为空段落的问题。

#### How to test it?

1. 插入一个结构块，并在其后添加段落。
2. 清空并删除段落，使间隙光标出现在结构块之后。
3. 再次按下退格键，结构块应被替换为空段落。

#### Does this PR introduce a user-facing change?

```release-note
修复文档末尾结构块后的间隙光标按退格键无效的问题。
```