### PR TITLE
fix: improve complex node view selection feedback

### DIFF
--- a/ui/packages/editor/src/styles/node-select.scss
+++ b/ui/packages/editor/src/styles/node-select.scss
@@ -23,4 +23,9 @@
       }
     }
   }
+
+  [data-node-view-wrapper].ProseMirror-selectednode {
+    outline: 2px solid $editorNodeCardBorderSelected;
+    box-shadow: 0 0 0 3px rgba(47, 142, 244, 0.14);
+  }
 }

--- a/ui/packages/editor/src/styles/range-selection.scss
+++ b/ui/packages/editor/src/styles/range-selection.scss
@@ -37,4 +37,10 @@
       }
     }
   }
+
+  [data-node-view-wrapper].ProseMirror-selectednoderange,
+  [data-node-view-wrapper].range-fake-selection {
+    outline: 2px solid rgba(47, 142, 244);
+    box-shadow: 0 0 0 3px rgba(47, 142, 244, 0.14);
+  }
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/area ui
/area editor

#### What this PR does / why we need it:

修复复杂 NodeView 被选中时，高亮效果可能被内部背景遮挡的问题。

#### How to test it?

1. 在编辑器中插入包含不透明背景的 NodeView。
2. 使用节点选区或范围选区选中该节点。
3. 节点外侧应显示清晰的选中高亮。

#### Does this PR introduce a user-facing change?

```release-note
改进复杂编辑器块被选中时的高亮反馈。
```