### PR TITLE
fix: improve gap cursor interaction around block nodes

### DIFF
--- a/ui/packages/editor/src/extensions/gap-cursor/gap-cursor-view.ts
+++ b/ui/packages/editor/src/extensions/gap-cursor/gap-cursor-view.ts
@@ -17,6 +17,7 @@ import {
 } from "./gap-cursor-selection";
 
 const VERTICAL_GAP_CLICK_DISTANCE = 24;
+const GAP_CURSOR_CORNER_CLICK_DISTANCE = 12;
 const INTERACTIVE_ELEMENT_SELECTOR = [
   "button",
   "a",
@@ -28,24 +29,34 @@ const INTERACTIVE_ELEMENT_SELECTOR = [
   ".grip-row",
   ".grip-column",
   ".grip-table",
+  ".cm-editor",
 ].join(", ");
 
 interface GapCursorMouseHit {
   pos: number;
   side: GapCursorSide;
   distance: number;
+  source: "corner" | "gutter";
 }
 
 export function handleGapCursorMouseDown(
   view: EditorView,
   event: MouseEvent
 ): boolean {
+  return handleGapCursorMouseDownFrom(view, event);
+}
+
+function handleGapCursorMouseDownFrom(
+  view: EditorView,
+  event: MouseEvent,
+  source?: GapCursorMouseHit["source"]
+): boolean {
   if (!canHandleMouseDown(view, event)) {
     return false;
   }
 
   const hit = findGapCursorMouseHit(view, event);
-  if (!hit) {
+  if (!hit || (source && hit.source !== source)) {
     return false;
   }
 
@@ -91,6 +102,7 @@ export class GapCursorPositioner {
 
   constructor(view: EditorView) {
     this.view = view;
+    view.dom.addEventListener("mousedown", this.handleCornerMouseDown, true);
     if (typeof ResizeObserver !== "undefined") {
       this.resizeObserver = new ResizeObserver(this.position);
       this.resizeObserver.observe(view.dom);
@@ -106,8 +118,23 @@ export class GapCursorPositioner {
 
   destroy() {
     this.resizeObserver?.disconnect();
+    this.view.dom.removeEventListener(
+      "mousedown",
+      this.handleCornerMouseDown,
+      true
+    );
     window.removeEventListener("resize", this.position);
   }
+
+  private handleCornerMouseDown = (event: MouseEvent) => {
+    if (!isPotentialCapturedCornerMouseDown(this.view, event)) {
+      return;
+    }
+    if (!handleGapCursorMouseDownFrom(this.view, event, "corner")) {
+      return;
+    }
+    event.stopImmediatePropagation();
+  };
 
   private position = () => {
     const { selection } = this.view.state;
@@ -170,6 +197,31 @@ function canHandleMouseDown(view: EditorView, event: MouseEvent): boolean {
   return !hasModifier;
 }
 
+function isPotentialCapturedCornerMouseDown(
+  view: EditorView,
+  event: MouseEvent
+): boolean {
+  if (!canHandleMouseDown(view, event)) {
+    return false;
+  }
+
+  const eventElement = event.target instanceof Element ? event.target : null;
+  if (!eventElement || eventElement.closest(INTERACTIVE_ELEMENT_SELECTOR)) {
+    return false;
+  }
+
+  const nodeViewElement = eventElement.closest<HTMLElement>(
+    "[data-node-view-wrapper], [data-gap-cursor-click-area]"
+  );
+  if (!nodeViewElement || !view.dom.contains(nodeViewElement)) {
+    return false;
+  }
+
+  const rect =
+    getGapCursorVisualElement(nodeViewElement).getBoundingClientRect();
+  return isPointInsideBeforeCorner(event.clientX, event.clientY, rect);
+}
+
 function findGapCursorMouseHit(
   view: EditorView,
   event: MouseEvent
@@ -201,6 +253,7 @@ function findGapCursorMouseHit(
 
     const visualElement = getGapCursorVisualElement(element);
     const rect = visualElement.getBoundingClientRect();
+    addBeforeCornerHit(hits, pos, x, y, rect);
     if (
       eventElement &&
       visualElement.contains(eventElement) &&
@@ -255,6 +308,34 @@ function isGapCursorClickArea(
   return nodeElement.contains(clickArea);
 }
 
+function addBeforeCornerHit(
+  hits: GapCursorMouseHit[],
+  pos: number,
+  x: number,
+  y: number,
+  rect: DOMRect
+) {
+  if (!isPointInsideBeforeCorner(x, y, rect)) {
+    return;
+  }
+
+  hits.push({
+    pos,
+    side: "before",
+    distance: Math.hypot(x - rect.left, y - rect.top),
+    source: "corner",
+  });
+}
+
+function isPointInsideBeforeCorner(x: number, y: number, rect: DOMRect) {
+  return (
+    x >= rect.left &&
+    x <= rect.left + GAP_CURSOR_CORNER_CLICK_DISTANCE &&
+    y >= rect.top &&
+    y <= rect.top + GAP_CURSOR_CORNER_CLICK_DISTANCE
+  );
+}
+
 function addHorizontalHit(
   hits: GapCursorMouseHit[],
   pos: number,
@@ -269,7 +350,12 @@ function addHorizontalHit(
   }
 
   if (x < rect.left) {
-    hits.push({ pos, side: "before", distance: rect.left - x });
+    hits.push({
+      pos,
+      side: "before",
+      distance: rect.left - x,
+      source: "gutter",
+    });
     return;
   }
   if (x > rect.right) {
@@ -277,6 +363,7 @@ function addHorizontalHit(
       pos: pos + nodeSize,
       side: "after",
       distance: x - rect.right,
+      source: "gutter",
     });
   }
 }
@@ -296,7 +383,12 @@ function addVerticalHit(
 
   const distanceAbove = rect.top - y;
   if (distanceAbove > 0 && distanceAbove <= VERTICAL_GAP_CLICK_DISTANCE) {
-    hits.push({ pos, side: "before", distance: distanceAbove });
+    hits.push({
+      pos,
+      side: "before",
+      distance: distanceAbove,
+      source: "gutter",
+    });
     return;
   }
 
@@ -306,6 +398,7 @@ function addVerticalHit(
       pos: pos + nodeSize,
       side: "after",
       distance: distanceBelow,
+      source: "gutter",
     });
   }
 }

--- a/ui/packages/editor/src/extensions/gap-cursor/index.spec.ts
+++ b/ui/packages/editor/src/extensions/gap-cursor/index.spec.ts
@@ -174,6 +174,62 @@ describe("ExtensionGapCursor", () => {
     expect(editor.state.selection.from).toBe(0);
   });
 
+  it("places a click just inside a block's top-left corner before it", () => {
+    const editor = createEditor();
+    const card = editor.view.nodeDOM(0) as HTMLElement;
+    card.dataset.nodeViewWrapper = "";
+    setRect(editor.view.dom, 0, 0, 300, 300);
+    setRect(card, 50, 50, 200, 100);
+
+    const event = new MouseEvent("mousedown", {
+      bubbles: true,
+      cancelable: true,
+      button: 0,
+      clientX: 58,
+      clientY: 58,
+    });
+    card.dispatchEvent(event);
+
+    expect(event.defaultPrevented).toBe(true);
+    expect(editor.state.selection).toBeInstanceOf(GapCursor);
+    expect(editor.state.selection.from).toBe(0);
+    expect(
+      editor.view.dom.querySelector(".halo-gap-cursor--before")
+    ).not.toBeNull();
+
+    editor.view.dispatch(
+      editor.state.tr.setSelection(TextSelection.create(editor.state.doc, 2))
+    );
+    expect(runMouseDown(editor, 63, 58, card)).toBeFalsy();
+    expect(editor.state.selection).toBeInstanceOf(TextSelection);
+    expect(editor.state.selection.from).toBe(2);
+  });
+
+  it("keeps interactive content in the top-left corner clickable", () => {
+    const editor = createEditor();
+    const card = editor.view.nodeDOM(0) as HTMLElement;
+    card.dataset.nodeViewWrapper = "";
+    const button = document.createElement("button");
+    const codeMirror = document.createElement("div");
+    codeMirror.className = "cm-editor";
+    const stopPropagation = (event: Event) => event.stopPropagation();
+    button.addEventListener("mousedown", stopPropagation);
+    codeMirror.addEventListener("mousedown", stopPropagation);
+    card.append(button, codeMirror);
+    setRect(editor.view.dom, 0, 0, 300, 300);
+    setRect(card, 50, 50, 200, 100);
+    editor.view.dispatch(
+      editor.state.tr.setSelection(TextSelection.create(editor.state.doc, 2))
+    );
+
+    const buttonEvent = dispatchMouseDown(button, 58, 58);
+    const codeMirrorEvent = dispatchMouseDown(codeMirror, 58, 58);
+    expect(buttonEvent.defaultPrevented).toBe(false);
+    expect(codeMirrorEvent.defaultPrevented).toBe(false);
+    expect(editor.state.selection).toBeInstanceOf(TextSelection);
+    expect(editor.state.selection.from).toBe(2);
+  });
+
   it("places a click in the whitespace below a block after it", () => {
     const editor = createEditor();
     const card = editor.view.nodeDOM(0) as HTMLElement;
@@ -235,6 +291,12 @@ describe("ExtensionGapCursor", () => {
     );
     expect(editor.state.selection.from).toBe(1);
     expect(cursor?.style.transform).toBe("translate(150px, 150px)");
+
+    expect(runMouseDown(editor, 58, 58, visualAnchor)).toBe(true);
+    expect(editor.state.selection.from).toBe(0);
+    expect(
+      editor.view.dom.querySelector(".halo-gap-cursor--before")
+    ).not.toBeNull();
 
     expect(runMouseDown(editor, 100, 100, visualAnchor)).toBeFalsy();
   });
@@ -1202,6 +1264,18 @@ function runMouseDown(
   return editor.view.someProp("handleDOMEvents", (handlers) => {
     return handlers.mousedown?.(editor.view, event) ?? false;
   });
+}
+
+function dispatchMouseDown(target: Element, clientX: number, clientY: number) {
+  const event = new MouseEvent("mousedown", {
+    bubbles: true,
+    cancelable: true,
+    button: 0,
+    clientX,
+    clientY,
+  });
+  target.dispatchEvent(event);
+  return event;
 }
 
 function runTextInput(editor: Editor, text: string) {

--- a/ui/packages/editor/src/styles/index.scss
+++ b/ui/packages/editor/src/styles/index.scss
@@ -14,7 +14,11 @@
 
 .halo-rich-text-editor {
   .ProseMirror {
-    :where(* > :first-child, [data-editor-ui="true"] + *) {
+    :where(
+      * > :first-child,
+      * > .ProseMirror-gapcursor:first-child + *,
+      [data-editor-ui="true"] + *
+    ) {
       margin-top: 0 !important;
     }
   }


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/area ui
/area editor

#### What this PR does / why we need it:

优化块组件前间隙光标的鼠标定位，并修复顶部间隙光标导致内容偏移的问题。

#### How to test it?

1. 将块组件放在编辑器首位。
2. 点击块组件左上角，应出现位于块前的间隙光标。
3. 内容位置不应发生偏移。
4. 块内的按钮和代码编辑器仍应正常响应点击。

#### Does this PR introduce a user-facing change?

```release-note
优化块组件前间隙光标的鼠标定位，并修复定位后内容跳动的问题。
```