### PR TITLE
fix: only log extension gvk and name in GcReconciler

### DIFF
--- a/application/src/main/java/run/halo/app/extension/gc/GcReconciler.java
+++ b/application/src/main/java/run/halo/app/extension/gc/GcReconciler.java
@@ -82,8 +82,10 @@ class GcReconciler implements Reconciler<GcRequest> {
                         .subscribeOn(this.scheduler))
                 .as(tx::transactional)
                 .then()
-                .doOnSuccess(
-                        ignored -> log.info("Extension {}/{} was deleted", extension.groupVersionKind(), extension));
+                .doOnSuccess(ignored -> log.info(
+                        "Extension {}/{} was deleted",
+                        extension.groupVersionKind(),
+                        extension.getMetadata().getName()));
     }
 
     @Override


### PR DESCRIPTION
## What type of PR is this?

/kind bug

## What this PR does / why we need it:

`GcReconciler` currently logs the full extension object when an extension is successfully deleted:

```java
log.info("Extension {}/{} was deleted", extension.groupVersionKind(), extension);
```

This may output the entire extension data, including potentially sensitive or unnecessarily large fields. This PR changes the log to only include the extension's GroupVersionKind and name, which is enough to identify the deleted resource.

## Which issue(s) this PR fixes:

None.

## Special notes for your reviewer:

None.

## PR Checklist

- [x] The commit message follows the project's conventions
- [x] Tests for the changes have been added / updated if needed
- [x] All tests pass locally:
  - `./gradlew :application:test --tests run.halo.app.extension.gc.GcReconcilerTest`