### PR TITLE
Fix page size warnings when listing comment replies

### DIFF
--- a/application/src/main/java/run/halo/app/theme/finders/impl/CommentPublicQueryServiceImpl.java
+++ b/application/src/main/java/run/halo/app/theme/finders/impl/CommentPublicQueryServiceImpl.java
@@ -103,7 +103,7 @@ public class CommentPublicQueryServiceImpl implements CommentPublicQueryService 
                 .flatMap(listOptions -> {
                     var pageRequest = Optional.ofNullable(pageParam)
                             .map(page -> page.withSort(page.getSort().and(defaultReplySort())))
-                            .orElse(PageRequestImpl.ofSize(0));
+                            .orElseGet(() -> PageRequestImpl.ofSize(PageRequestImpl.MAX_SIZE));
                     return client.listBy(Reply.class, listOptions, pageRequest)
                             .flatMap(list -> Flux.fromStream(list.get().map(this::toReplyVo))
                                     .flatMapSequential(Function.identity())

--- a/application/src/test/java/run/halo/app/theme/finders/impl/CommentPublicQueryServiceIntegrationTest.java
+++ b/application/src/test/java/run/halo/app/theme/finders/impl/CommentPublicQueryServiceIntegrationTest.java
@@ -13,9 +13,12 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.skyscreamer.jsonassert.JSONAssert;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.system.CapturedOutput;
+import org.springframework.boot.test.system.OutputCaptureExtension;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.annotation.DirtiesContext;
 import reactor.core.publisher.Flux;
@@ -93,6 +96,20 @@ class CommentPublicQueryServiceIntegrationTest {
                                 .isEqualTo("comment-approved");
                     })
                     .verifyComplete();
+        }
+
+        @Test
+        @ExtendWith(OutputCaptureExtension.class)
+        void listWithRepliesDoesNotLogInvalidPageSizeWarning(CapturedOutput output) {
+            Ref ref = Ref.of("fake-post", GroupVersionKind.fromExtension(Post.class));
+            commentPublicQueryService
+                    .list(ref, 1, 10)
+                    .flatMap(comments -> commentPublicQueryService.convertToWithReplyVo(comments, 10))
+                    .as(StepVerifier::create)
+                    .expectNextCount(1)
+                    .verifyComplete();
+
+            assertThat(output.getAll()).doesNotContain("Page size must be greater than 0");
         }
 
         @Test


### PR DESCRIPTION
#### What type of PR is this?

- [ ] Feature
- [x] Bug fix
- [ ] Improvement
- [ ] Cleanup
- [ ] Documentation

#### What this PR does / why we need it:

When comments are listed with replies, `Optional.orElse` eagerly creates a zero-sized fallback page request for every comment, even when a valid page request is already present. This produces one unnecessary page-size warning per comment.

This change uses a lazy fallback with the supported maximum page size, preserving the existing fallback behavior without constructing an invalid page request.

A regression test covers the complete list-with-replies flow and verifies that the warning is not emitted.

#### Which issue(s) this PR fixes:

Fixes https://github.com/halo-dev/plugin-comment-widget/issues/203

#### Special notes for your reviewer:

The regression test reproduced the warning before the fix and passes after the fix. The related comment query integration tests and Java formatting checks pass.

This change was implemented with assistance from OpenAI Codex and reviewed through focused regression testing.

#### Does this PR introduce a user-facing change?

```release-note
修复同时加载评论回复时重复输出分页大小警告日志的问题。
```
