### PR TITLE
fix: prevent duplicate in-app notifications with multiple notifiers

### DIFF
--- a/application/src/main/java/run/halo/app/notification/DefaultNotificationCenter.java
+++ b/application/src/main/java/run/halo/app/notification/DefaultNotificationCenter.java
@@ -92,14 +92,18 @@ public class DefaultNotificationCenter implements NotificationCenter {
         return getNotifiersBySubscriber(subscriber, reason)
                 .flatMap(notifierName -> client.fetch(NotifierDescriptor.class, notifierName))
                 .flatMap(descriptor -> prepareNotificationElement(subscriber, reason, descriptor))
-                .flatMap(element -> {
-                    var dispatchMono = sendNotification(element);
+                .collectList()
+                .filter(elements -> !elements.isEmpty())
+                .flatMap(elements -> {
+                    var dispatchMono = Flux.fromIterable(elements)
+                            .flatMap(this::sendNotification)
+                            .then();
                     if (subscriber.isAnonymous()) {
                         return dispatchMono;
                     }
                     // create notification for user
-                    var innerNofificationMono = createNotification(element);
-                    return Mono.when(dispatchMono, innerNofificationMono);
+                    var innerNotificationMono = createNotification(elements.get(0));
+                    return Mono.when(dispatchMono, innerNotificationMono);
                 })
                 .then();
     }

--- a/application/src/test/java/run/halo/app/notification/DefaultNotificationCenterTest.java
+++ b/application/src/test/java/run/halo/app/notification/DefaultNotificationCenterTest.java
@@ -187,6 +187,40 @@ class DefaultNotificationCenterTest {
     }
 
     @Test
+    public void testDispatchNotificationWithMultipleNotifiers() {
+        var spyNotificationCenter = spy(notificationCenter);
+
+        doReturn(Flux.just("email-notifier", "wechat-notifier"))
+                .when(spyNotificationCenter)
+                .getNotifiersBySubscriber(any(), any());
+
+        when(client.fetch(eq(NotifierDescriptor.class), eq("email-notifier")))
+                .thenReturn(Mono.just(mock(NotifierDescriptor.class)));
+        when(client.fetch(eq(NotifierDescriptor.class), eq("wechat-notifier")))
+                .thenReturn(Mono.just(mock(NotifierDescriptor.class)));
+
+        var notificationElement = mock(DefaultNotificationCenter.NotificationElement.class);
+        doReturn(Mono.just(notificationElement))
+                .when(spyNotificationCenter)
+                .prepareNotificationElement(any(), any(), any());
+
+        doReturn(Mono.empty()).when(spyNotificationCenter).sendNotification(any());
+        doReturn(Mono.empty()).when(spyNotificationCenter).createNotification(any());
+
+        var reason = new Reason();
+        reason.setMetadata(new Metadata());
+        reason.getMetadata().setName("reason-a");
+        reason.setSpec(new Reason.Spec());
+        reason.getSpec().setReasonType("new-reply-on-comment");
+
+        var subscriber = new Subscriber(UserIdentity.of("fake-user"), "subscription-a");
+        spyNotificationCenter.dispatchNotification(reason, subscriber).block();
+
+        verify(spyNotificationCenter, times(2)).sendNotification(any());
+        verify(spyNotificationCenter, times(1)).createNotification(any());
+    }
+
+    @Test
     public void testPrepareNotificationElement() {
         var spyNotificationCenter = spy(notificationCenter);
 


### PR DESCRIPTION
#### What type of PR is this?

- [ ] Feature
- [x] Bug fix
- [ ] Improvement
- [ ] Cleanup
- [ ] Documentation

#### What this PR does / why we need it:

When multiple notifiers are enabled for a subscriber, `DefaultNotificationCenter` creates one in-app `Notification` for each notifier, resulting in duplicate in-app messages.

This change dispatches notifications through every enabled notifier while creating only one in-app `Notification` per reason and subscriber. It also adds a regression test covering two enabled notifiers.

#### Which issue(s) this PR fixes:

Fixes #7747

#### Special notes for your reviewer:

None.

#### Does this PR introduce a user-facing change?

```release-note
Fix duplicate in-app notifications when multiple notifiers are enabled.
```