### PR TITLE
chore: upgrade Spring Boot to 4.1.1

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -40,7 +40,7 @@ apache = ['apache-commons-lang3', 'apache-tika-core']
 therapi = ['therapi-runtime-javadoc', 'therapi-runtime-javadoc-scribe']
 
 [plugins]
-spring-boot = 'org.springframework.boot:4.1.0'
+spring-boot = 'org.springframework.boot:4.1.1'
 spring-dependency-management = 'io.spring.dependency-management:1.1.7'
 git-properties = 'com.gorylenko.gradle-git-properties:4.0.1'
 undercouch-download = 'de.undercouch.download:5.7.0'


### PR DESCRIPTION
#### What type of PR is this?

- [ ] Feature
- [ ] Bug fix
- [x] Improvement
- [ ] Cleanup
- [ ] Documentation

#### What this PR does / why we need it:

Upgrade Spring Boot from 4.1.0 to 4.1.1.

Spring Boot 4.1.1 was released on 20 August 2026 and includes [98 bug fixes, documentation improvements, and dependency upgrades](https://github.com/spring-projects/spring-boot/releases/tag/v4.1.1). Notable managed upgrades that Halo picks up automatically:

- Spring Framework 7.0.9
- Spring Security 7.1.1
- Spring Data BOM 2026.0.1
- Spring Session 4.1.1
- Reactor BOM 2025.0.7
- Micrometer 1.17.1
- Netty 4.2.17.Final
- R2DBC MySQL 1.4.3, MariaDB 1.4.1, PostgreSQL 1.1.2

#### Which issue(s) this PR fixes:

Fixes #

#### Special notes for your reviewer:

Straightforward version bump in `gradle/libs.versions.toml`. Halo does not use the Protobuf Gradle plugin, so the 4.1.1 gRPC auto-configuration change does not apply.

Backend compile and tests were run locally:

- `./gradlew :api:compileJava :api:compileTestJava :application:compileJava :application:compileTestJava --refresh-dependencies`
- `./gradlew :api:test :application:test`

This PR was prepared with LLM assistance. The change is a single version bump and was reviewed before opening the PR.

#### Does this PR introduce a user-facing change?

```release-note
Upgrade Spring Boot to 4.1.1
```