### PR TITLE
Fix untranslated startup API errors

### DIFF
--- a/ui/console-src/main.ts
+++ b/ui/console-src/main.ts
@@ -47,13 +47,13 @@ async function initApp() {
   try {
     setupCoreModules({ app, router, platform: "console", modules });
 
+    await setLanguage();
+
     const currentUserStore = stores.currentUser();
     await currentUserStore.fetchCurrentUser();
 
     const globalInfoStore = stores.globalInfo();
     await globalInfoStore.fetchGlobalInfo();
-
-    await setLanguage();
 
     if (currentUserStore.isAnonymous) {
       setupAppComponents();

--- a/ui/uc-src/main.ts
+++ b/ui/uc-src/main.ts
@@ -41,13 +41,13 @@ async function initApp() {
   try {
     setupCoreModules({ app, router, platform: "uc", modules });
 
+    await setLanguage();
+
     const currentUserStore = stores.currentUser();
     await currentUserStore.fetchCurrentUser();
 
     const globalInfoStore = stores.globalInfo();
     await globalInfoStore.fetchGlobalInfo();
-
-    await setLanguage();
 
     if (currentUserStore.isAnonymous) {
       setupAppComponents();


### PR DESCRIPTION
#### What type of PR is this?

- [ ] Feature
- [x] Bug fix
- [ ] Improvement
- [ ] Cleanup
- [ ] Documentation

#### What this PR does / why we need it:

Initialize the language packs before fetching the current user and global information in the Console and User Center.

Startup API errors are handled by the shared API response interceptor, which uses i18n messages for dialogs and toast notifications. Previously, these requests could fail before the language packs were loaded, causing raw translation keys to be displayed.

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

This change only reorders the existing initialization calls in both application entry points.

Validation:

- `./node_modules/.bin/vp fmt console-src/main.ts uc-src/main.ts --check`
- `./node_modules/.bin/vue-tsc --noEmit -p tsconfig.app.json --composite false`
- `git diff --check`

This change was prepared with assistance from OpenAI Codex and reviewed against the locale-loading and API error-interceptor flows.

#### Does this PR introduce a user-facing change?

```release-note
修复 Console 和个人中心初始化请求失败时显示国际化键名的问题。
```
