### PR TITLE
Fix remember-me state for OAuth login

### DIFF
--- a/application/src/main/resources/templates/gateway_fragments/common.html
+++ b/application/src/main/resources/templates/gateway_fragments/common.html
@@ -158,12 +158,10 @@
         return;
       }
 
-      rememberMeCheckbox.addEventListener("change", function (e) {
-        const rememberMe = e.target.checked;
-
-        socialAuthProviders.forEach((form) => {
+      socialAuthProviders.forEach((form) => {
+        form.addEventListener("submit", function () {
           const url = new URL(form.action, window.location.origin);
-          url.searchParams.set("remember-me", rememberMe ? "true" : "false");
+          url.searchParams.set("remember-me", rememberMeCheckbox.checked ? "true" : "false");
           form.action = url.pathname + url.search;
         });
       });


### PR DESCRIPTION
#### What type of PR is this?

- [ ] Feature
- [x] Bug fix
- [ ] Improvement
- [ ] Cleanup
- [ ] Documentation

#### What this PR does / why we need it:

Social login forms initially use `remember-me=false` and previously updated this parameter only when the checkbox emitted a `change` event.

If the checkbox was already checked when the login page was rendered or its state was restored by the browser, no change event occurred. Submitting an OAuth login could therefore cache `remember-me=false` even though the checkbox appeared checked.

This change reads the checkbox's current state when the social login form is submitted, ensuring that the OAuth flow receives the displayed remember-me choice.

To reproduce the issue before this change:

1. Open the login page with the remember-me checkbox already checked, such as after a failed local login attempt.
2. Submit a social OAuth login without toggling the checkbox.
3. The social login request contains `remember-me=false`.

After this change, the request contains the checkbox's current state at submission time.

#### Which issue(s) this PR fixes:

N/A

#### Special notes for your reviewer:

This change was prepared with LLM assistance and reviewed against the existing login parameter cache and OAuth login flow.

#### Does this PR introduce a user-facing change?

```release-note
修复使用 OAuth 登录时“保持登录会话”选项可能未生效的问题。
```
