### PR TITLE
Fix plugin startup for incompatible Halo versions

### DIFF
--- a/application/src/main/java/run/halo/app/core/reconciler/PluginReconciler.java
+++ b/application/src/main/java/run/halo/app/core/reconciler/PluginReconciler.java
@@ -69,6 +69,7 @@ import run.halo.app.infra.ConditionList;
 import run.halo.app.infra.ConditionStatus;
 import run.halo.app.infra.utils.PathUtils;
 import run.halo.app.infra.utils.SettingUtils;
+import run.halo.app.infra.utils.VersionUtils;
 import run.halo.app.infra.utils.YamlUnstructuredLoader;
 import run.halo.app.plugin.OptionalDependentResolver;
 import run.halo.app.plugin.PluginConst;
@@ -348,13 +349,30 @@ class PluginReconciler implements Reconciler<Request>, DisposableBean {
     private Result enablePlugin(Plugin plugin) {
         // start the plugin
         var pluginName = plugin.getMetadata().getName();
-        log.info("Starting plugin {}", pluginName);
         var status = plugin.getStatus();
+        var conditions = status.getConditions();
+        var systemVersion = pluginManager.getSystemVersion();
+        var requires = plugin.getSpec().getRequires();
+        if (!VersionUtils.satisfiesRequires(systemVersion, requires)) {
+            removeConditionBy(conditions, ConditionType.PROGRESSING);
+            conditions.addAndEvictFIFO(Condition.builder()
+                    .type(ConditionType.READY)
+                    .status(ConditionStatus.FALSE)
+                    .reason(ConditionReason.UNSATISFIED_REQUIRES_VERSION)
+                    .message("Plugin requires Halo version [%s], but the current version is [%s]."
+                            .formatted(requires, systemVersion))
+                    .lastTransitionTime(clock.instant())
+                    .build());
+            status.setPhase(Plugin.Phase.FAILED);
+            removeStartTaskIfPresent(pluginName);
+            return Result.doNotRetry();
+        }
+
+        log.info("Starting plugin {}", pluginName);
 
         // check if the parent plugin is started
         var unstartedDependencies = pluginService.getRequiredDependencies(
                 plugin, pw -> pw == null || !PluginState.STARTED.equals(pw.getPluginState()));
-        var conditions = status.getConditions();
         if (!CollectionUtils.isEmpty(unstartedDependencies)) {
             removeConditionBy(conditions, ConditionType.READY);
             conditions.addAndEvictFIFO(Condition.builder()
@@ -1003,5 +1021,7 @@ class PluginReconciler implements Reconciler<Request>, DisposableBean {
         public static final String DISABLE_ERROR = "DisableError";
         public static final String INVALID_RUNTIME_MODE = "InvalidRuntimeMode";
         public static final String PLUGIN_PATH_NOT_SET = "PluginPathNotSet";
+
+        public static final String UNSATISFIED_REQUIRES_VERSION = "UnsatisfiedRequiresVersion";
     }
 }

--- a/application/src/main/java/run/halo/app/core/reconciler/PluginReconciler.java
+++ b/application/src/main/java/run/halo/app/core/reconciler/PluginReconciler.java
@@ -351,23 +351,6 @@ class PluginReconciler implements Reconciler<Request>, DisposableBean {
         var pluginName = plugin.getMetadata().getName();
         var status = plugin.getStatus();
         var conditions = status.getConditions();
-        var systemVersion = pluginManager.getSystemVersion();
-        var requires = plugin.getSpec().getRequires();
-        if (!VersionUtils.satisfiesRequires(systemVersion, requires)) {
-            removeConditionBy(conditions, ConditionType.PROGRESSING);
-            conditions.addAndEvictFIFO(Condition.builder()
-                    .type(ConditionType.READY)
-                    .status(ConditionStatus.FALSE)
-                    .reason(ConditionReason.UNSATISFIED_REQUIRES_VERSION)
-                    .message("Plugin requires Halo version [%s], but the current version is [%s]."
-                            .formatted(requires, systemVersion))
-                    .lastTransitionTime(clock.instant())
-                    .build());
-            status.setPhase(Plugin.Phase.FAILED);
-            removeStartTaskIfPresent(pluginName);
-            return Result.doNotRetry();
-        }
-
         log.info("Starting plugin {}", pluginName);
 
         // check if the parent plugin is started
@@ -464,6 +447,29 @@ class PluginReconciler implements Reconciler<Request>, DisposableBean {
             log.debug("Plugin {} is starting...", pluginName);
         }
         return Result.requeue(Duration.ofSeconds(2));
+    }
+
+    private Result checkRequiresVersion(Plugin plugin) {
+        var pluginName = plugin.getMetadata().getName();
+        var status = plugin.getStatus();
+        var conditions = status.getConditions();
+        var systemVersion = pluginManager.getSystemVersion();
+        var requires = plugin.getSpec().getRequires();
+        if (!VersionUtils.satisfiesRequires(systemVersion, requires)) {
+            removeConditionBy(conditions, ConditionType.PROGRESSING);
+            conditions.addAndEvictFIFO(Condition.builder()
+                    .type(ConditionType.READY)
+                    .status(ConditionStatus.FALSE)
+                    .reason(ConditionReason.UNSATISFIED_REQUIRES_VERSION)
+                    .message("Plugin requires Halo version [%s], but the current version is [%s]."
+                            .formatted(requires, systemVersion))
+                    .lastTransitionTime(clock.instant())
+                    .build());
+            status.setPhase(Plugin.Phase.FAILED);
+            removeStartTaskIfPresent(pluginName);
+            return Result.doNotRetry();
+        }
+        return null;
     }
 
     void requestToReloadPluginsOptionallyDependentOn(String pluginName) {
@@ -666,6 +672,13 @@ class PluginReconciler implements Reconciler<Request>, DisposableBean {
 
             if (requestToReload) {
                 removeRequestToReload(plugin);
+            }
+        }
+
+        if (requestToEnable(plugin)) {
+            var result = checkRequiresVersion(plugin);
+            if (result != null) {
+                return result;
             }
         }
 

--- a/application/src/test/java/run/halo/app/core/reconciler/PluginReconcilerTest.java
+++ b/application/src/test/java/run/halo/app/core/reconciler/PluginReconcilerTest.java
@@ -15,6 +15,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static run.halo.app.plugin.PluginConst.PLUGIN_PATH;
 import static run.halo.app.plugin.PluginConst.RELOAD_ANNO;
+import static run.halo.app.plugin.PluginConst.REQUEST_TO_UNLOAD_LABEL;
 import static run.halo.app.plugin.PluginConst.RUNTIME_MODE_ANNO;
 
 import java.io.FileOutputStream;
@@ -237,6 +238,63 @@ class PluginReconcilerTest {
         }
 
         @Test
+        void shouldUnloadBeforeReportingUnsatisfiedRequiresVersionOnReload() {
+            var fakePlugin = createPlugin(name, plugin -> {
+                var spec = plugin.getSpec();
+                spec.setVersion("1.2.3");
+                spec.setRequires(">=2.26.0");
+                spec.setEnabled(true);
+                plugin.getMetadata().setAnnotations(new HashMap<>(Map.of(RELOAD_ANNO, "true")));
+            });
+
+            when(client.fetch(Plugin.class, name)).thenReturn(Optional.of(fakePlugin));
+            when(pluginManager.getPluginsRoots()).thenReturn(List.of(tempPath));
+            when(pluginManager.getSystemVersion()).thenReturn("2.25.4");
+            var pluginWrapper = mockPluginWrapper(PluginState.RESOLVED);
+            when(pluginManager.getPlugin(name)).thenReturn(pluginWrapper);
+            lenient().when(pluginManager.getUnresolvedPlugins()).thenReturn(List.of(pluginWrapper));
+            lenient().when(pluginManager.getResolvedPlugins()).thenReturn(List.of());
+
+            var result = reconciler.reconcile(new Request(name));
+
+            assertFalse(result.reEnqueue());
+            assertFalse(fakePlugin.getMetadata().getAnnotations().containsKey(RELOAD_ANNO));
+            assertEquals(Plugin.Phase.FAILED, fakePlugin.getStatus().getPhase());
+            assertEquals(
+                    PluginReconciler.ConditionReason.UNSATISFIED_REQUIRES_VERSION,
+                    fakePlugin.getStatus().getConditions().peekFirst().getReason());
+            verify(pluginManager).unloadPlugin(name);
+            verify(pluginManager, never()).loadPlugin(any(Path.class));
+        }
+
+        @Test
+        void shouldHonorUnloadRequestBeforeReportingUnsatisfiedRequiresVersion() {
+            var fakePlugin = createPlugin(name, plugin -> {
+                var spec = plugin.getSpec();
+                spec.setVersion("1.2.3");
+                spec.setRequires(">=2.26.0");
+                spec.setEnabled(true);
+                plugin.getMetadata().setLabels(new HashMap<>(Map.of(REQUEST_TO_UNLOAD_LABEL, "parent-plugin")));
+            });
+
+            when(client.fetch(Plugin.class, name)).thenReturn(Optional.of(fakePlugin));
+            when(pluginManager.getPluginsRoots()).thenReturn(List.of(tempPath));
+            lenient().when(pluginManager.getSystemVersion()).thenReturn("2.25.4");
+            var pluginWrapper = mockPluginWrapper(PluginState.RESOLVED);
+            when(pluginManager.getPlugin(name)).thenReturn(pluginWrapper);
+            when(pluginManager.getResolvedPlugins()).thenReturn(List.of(pluginWrapper));
+
+            var result = reconciler.reconcile(new Request(name));
+
+            assertFalse(result.reEnqueue());
+            var condition = fakePlugin.getStatus().getConditions().peekFirst();
+            assertEquals(PluginReconciler.ConditionType.INITIALIZED, condition.getType());
+            assertEquals(PluginReconciler.ConditionReason.REQUEST_TO_UNLOAD, condition.getReason());
+            verify(pluginManager).unloadPlugin(name);
+            verify(pluginManager, never()).loadPlugin(any(Path.class));
+        }
+
+        @Test
         void shouldReportIfFailedToStartPlugin() throws IOException {
             var fakePlugin = createPlugin(name, plugin -> {
                 var spec = plugin.getSpec();
@@ -274,27 +332,20 @@ class PluginReconcilerTest {
         }
 
         @Test
-        void shouldNotRetryIfRequiresVersionIsNotSatisfied() {
+        void shouldCheckRequiresVersionBeforeWaitingForDependencies() {
             var fakePlugin = createPlugin(name, plugin -> {
                 var spec = plugin.getSpec();
                 spec.setVersion("1.2.3");
                 spec.setRequires(">=2.26.0");
+                spec.setPluginDependencies(Map.of("unresolved-plugin", "*"));
                 spec.setEnabled(true);
             });
-            var disabledPlugin = mockPluginWrapper(PluginState.DISABLED);
-
             when(client.fetch(Plugin.class, name)).thenReturn(Optional.of(fakePlugin));
             when(pluginManager.getPluginsRoots()).thenReturn(List.of(tempPath));
             when(pluginManager.getSystemVersion()).thenReturn("2.25.4");
-            when(pluginManager.getPlugin(name))
-                    // loading plugin
-                    .thenReturn(null)
-                    // resolving static resources
-                    .thenReturn(mockPluginWrapperForNoStaticResources())
-                    // before starting
-                    .thenReturn(disabledPlugin)
-                    // sync plugin state
-                    .thenReturn(disabledPlugin);
+            lenient()
+                    .when(pluginService.getRequiredDependencies(any(), any()))
+                    .thenReturn(List.of("unresolved-plugin"));
 
             var result = reconciler.reconcile(new Request(name));
 

--- a/application/src/test/java/run/halo/app/core/reconciler/PluginReconcilerTest.java
+++ b/application/src/test/java/run/halo/app/core/reconciler/PluginReconcilerTest.java
@@ -125,6 +125,7 @@ class PluginReconcilerTest {
         @BeforeEach
         void setUp() throws IOException {
             lenient().when(pluginService.getRequiredDependencies(any(), any())).thenReturn(List.of());
+            lenient().when(pluginManager.getSystemVersion()).thenReturn("0.0.0");
             Files.createFile(tempPath.resolve("fake-plugin-1.2.3.jar"));
         }
 
@@ -269,6 +270,43 @@ class PluginReconcilerTest {
             assertEquals(PluginReconciler.ConditionReason.START_ERROR, condition.getReason());
             assertTrue(condition.getMessage().contains("Fake error"));
 
+            verify(pluginManager, never()).startPlugin(name);
+        }
+
+        @Test
+        void shouldNotRetryIfRequiresVersionIsNotSatisfied() {
+            var fakePlugin = createPlugin(name, plugin -> {
+                var spec = plugin.getSpec();
+                spec.setVersion("1.2.3");
+                spec.setRequires(">=2.26.0");
+                spec.setEnabled(true);
+            });
+            var disabledPlugin = mockPluginWrapper(PluginState.DISABLED);
+
+            when(client.fetch(Plugin.class, name)).thenReturn(Optional.of(fakePlugin));
+            when(pluginManager.getPluginsRoots()).thenReturn(List.of(tempPath));
+            when(pluginManager.getSystemVersion()).thenReturn("2.25.4");
+            when(pluginManager.getPlugin(name))
+                    // loading plugin
+                    .thenReturn(null)
+                    // resolving static resources
+                    .thenReturn(mockPluginWrapperForNoStaticResources())
+                    // before starting
+                    .thenReturn(disabledPlugin)
+                    // sync plugin state
+                    .thenReturn(disabledPlugin);
+
+            var result = reconciler.reconcile(new Request(name));
+
+            assertFalse(result.reEnqueue());
+            assertEquals(Plugin.Phase.FAILED, fakePlugin.getStatus().getPhase());
+            var condition = fakePlugin.getStatus().getConditions().peekFirst();
+            assertEquals(PluginReconciler.ConditionType.READY, condition.getType());
+            assertEquals(ConditionStatus.FALSE, condition.getStatus());
+            assertEquals("UnsatisfiedRequiresVersion", condition.getReason());
+            assertEquals(
+                    "Plugin requires Halo version [>=2.26.0], but the current version is [2.25.4].",
+                    condition.getMessage());
             verify(pluginManager, never()).startPlugin(name);
         }
 


### PR DESCRIPTION
#### What type of PR is this?

- [ ] Feature
- [x] Bug fix
- [ ] Improvement
- [ ] Cleanup
- [ ] Documentation

#### What this PR does / why we need it:

PF4J marks a plugin as `DISABLED` when its `spec.requires` constraint is not satisfied. `PluginReconciler` previously did not treat this case as terminal, leaving the plugin in `STARTING` and re-enqueuing reconciliation every two seconds.

This change validates the plugin's required Halo version before starting it. When the requirement is not satisfied, the reconciler:

- sets the plugin phase to `FAILED`;
- records an `UnsatisfiedRequiresVersion` condition containing the required and current versions;
- stops retrying without scheduling the plugin startup task.

A regression test covers Halo 2.25.4 loading an enabled plugin that requires Halo 2.26.0 or later.

Reproduction before the fix:

1. Keep an enabled plugin requiring Halo `>=2.26.0` in the plugin directory.
2. Start Halo 2.25.4 with the existing data.
3. Observe that the plugin remains in `STARTING` and reconciliation is re-enqueued every two seconds.

After the fix, the plugin enters `FAILED`, startup is not attempted, and the incompatibility reason is available to the Console.

#### Which issue(s) this PR fixes:

Fixes #10271

#### Special notes for your reviewer:

`PluginService` already validates `spec.requires` during installation and upgrade. This change applies the same existing version validation to reconciliation of installed plugins.

The implementation and regression test were prepared with assistance from OpenAI Codex and reviewed against the reproduced runtime behavior and project test suite.

#### Does this PR introduce a user-facing change?

```release-note
修复插件所需的 Halo 版本不满足时，插件持续尝试启动且未显示版本不兼容原因的问题。
```
