### PR TITLE
fix: include owner in post and single page contributors

### DIFF
--- a/application/src/main/java/run/halo/app/core/reconciler/PostReconciler.java
+++ b/application/src/main/java/run/halo/app/core/reconciler/PostReconciler.java
@@ -14,6 +14,7 @@ import java.time.Duration;
 import java.time.Instant;
 import java.util.*;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.BooleanUtils;
@@ -156,12 +157,16 @@ public class PostReconciler implements Reconciler<Reconciler.Request> {
             var ref = Ref.of(post);
             // handle contributors
             var headSnapshot = post.getSpec().getHeadSnapshot();
-            var contributors = listSnapshots(ref).stream()
+            var snapshotContributors = listSnapshots(ref).stream()
                     .map(snapshot -> {
                         Set<String> usernames = snapshot.getSpec().getContributors();
                         return Objects.requireNonNullElseGet(usernames, () -> new HashSet<String>());
                     })
-                    .flatMap(Set::stream)
+                    .flatMap(Set::stream);
+            // the owner is always treated as a contributor, even if they never edited the content
+            // see https://github.com/halo-dev/halo/issues/8284
+            var ownerContributor = Stream.ofNullable(post.getSpec().getOwner()).filter(StringUtils::isNotBlank);
+            var contributors = Stream.concat(snapshotContributors, ownerContributor)
                     .distinct()
                     .sorted()
                     .toList();

--- a/application/src/main/java/run/halo/app/core/reconciler/SinglePageReconciler.java
+++ b/application/src/main/java/run/halo/app/core/reconciler/SinglePageReconciler.java
@@ -7,6 +7,7 @@ import com.google.common.hash.Hashing;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.*;
+import java.util.stream.Stream;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
@@ -327,7 +328,7 @@ public class SinglePageReconciler implements Reconciler<Reconciler.Request> {
 
             // handle contributors
             String headSnapshot = singlePage.getSpec().getHeadSnapshot();
-            List<String> contributors = listSnapshots(Ref.of(singlePage)).stream()
+            Stream<String> snapshotContributors = listSnapshots(Ref.of(singlePage)).stream()
                     .peek(snapshot -> {
                         snapshot.getSpec().setContentPatch(StringUtils.EMPTY);
                         snapshot.getSpec().setRawPatch(StringUtils.EMPTY);
@@ -336,7 +337,11 @@ public class SinglePageReconciler implements Reconciler<Reconciler.Request> {
                         Set<String> usernames = snapshot.getSpec().getContributors();
                         return Objects.requireNonNullElseGet(usernames, () -> new HashSet<String>());
                     })
-                    .flatMap(Set::stream)
+                    .flatMap(Set::stream);
+            // the owner is always treated as a contributor, even if they never edited the content
+            // see https://github.com/halo-dev/halo/issues/8284
+            Stream<String> ownerContributor = Stream.ofNullable(spec.getOwner()).filter(StringUtils::isNotBlank);
+            List<String> contributors = Stream.concat(snapshotContributors, ownerContributor)
                     .distinct()
                     .sorted()
                     .toList();

--- a/application/src/test/java/run/halo/app/core/reconciler/PostReconcilerTest.java
+++ b/application/src/test/java/run/halo/app/core/reconciler/PostReconcilerTest.java
@@ -99,6 +99,63 @@ class PostReconcilerTest {
     }
 
     @Test
+    void shouldIncludeOwnerInContributorsEvenIfOwnerNeverEditedContent() {
+        // https://github.com/halo-dev/halo/issues/8284
+        String name = "post-A";
+        Post post = TestPost.postV1();
+        post.getSpec().setPublish(false);
+        post.getSpec().setHeadSnapshot("post-A-head-snapshot");
+        post.getSpec().setOwner("test1");
+        when(client.fetch(eq(Post.class), eq(name))).thenReturn(Optional.of(post));
+        when(postService.getContent(
+                        eq(post.getSpec().getReleaseSnapshot()),
+                        eq(post.getSpec().getBaseSnapshot())))
+                .thenReturn(Mono.empty());
+
+        Snapshot snapshotV1 = TestPost.snapshotV1();
+        Snapshot snapshotV2 = TestPost.snapshotV2();
+        snapshotV1.getSpec().setContributors(Set.of("guqing"));
+        snapshotV2.getSpec().setContributors(Set.of("guqing", "zhangsan"));
+        when(client.listAll(eq(Snapshot.class), any(), any())).thenReturn(List.of(snapshotV1, snapshotV2));
+
+        ArgumentCaptor<Post> captor = ArgumentCaptor.forClass(Post.class);
+        postReconciler.reconcile(new Reconciler.Request(name));
+
+        verify(client, times(1)).update(captor.capture());
+
+        Post value = captor.getValue();
+        assertThat(value.getStatus().getContributors()).isEqualTo(List.of("guqing", "test1", "zhangsan"));
+    }
+
+    @Test
+    void shouldNotDuplicateOwnerWhenOwnerAlreadyContributed() {
+        String name = "post-A";
+        Post post = TestPost.postV1();
+        post.getSpec().setPublish(false);
+        post.getSpec().setHeadSnapshot("post-A-head-snapshot");
+        post.getSpec().setOwner("guqing");
+        when(client.fetch(eq(Post.class), eq(name))).thenReturn(Optional.of(post));
+        when(postService.getContent(
+                        eq(post.getSpec().getReleaseSnapshot()),
+                        eq(post.getSpec().getBaseSnapshot())))
+                .thenReturn(Mono.empty());
+
+        Snapshot snapshotV1 = TestPost.snapshotV1();
+        Snapshot snapshotV2 = TestPost.snapshotV2();
+        snapshotV1.getSpec().setContributors(Set.of("guqing"));
+        snapshotV2.getSpec().setContributors(Set.of("guqing", "zhangsan"));
+        when(client.listAll(eq(Snapshot.class), any(), any())).thenReturn(List.of(snapshotV1, snapshotV2));
+
+        ArgumentCaptor<Post> captor = ArgumentCaptor.forClass(Post.class);
+        postReconciler.reconcile(new Reconciler.Request(name));
+
+        verify(client, times(1)).update(captor.capture());
+
+        Post value = captor.getValue();
+        assertThat(value.getStatus().getContributors()).isEqualTo(List.of("guqing", "zhangsan"));
+    }
+
+    @Test
     void shouldGenerateBlankExcerptWhenContentIsNull() {
         var name = "post-A";
         Post post = TestPost.postV1();

--- a/application/src/test/java/run/halo/app/core/reconciler/SinglePageReconcilerTest.java
+++ b/application/src/test/java/run/halo/app/core/reconciler/SinglePageReconcilerTest.java
@@ -109,6 +109,79 @@ class SinglePageReconcilerTest {
     }
 
     @Test
+    void shouldIncludeOwnerInContributorsEvenIfOwnerNeverEditedContent() {
+        // https://github.com/halo-dev/halo/issues/8284
+        String name = "page-A";
+        SinglePage page = pageV1();
+        page.getSpec().setHeadSnapshot("page-A-head-snapshot");
+        page.getSpec().setReleaseSnapshot(page.getSpec().getHeadSnapshot());
+        page.getSpec().setOwner("test1");
+        when(client.fetch(eq(SinglePage.class), eq(name))).thenReturn(Optional.of(page));
+        when(singlePageService.getContent(
+                        eq(page.getSpec().getReleaseSnapshot()),
+                        eq(page.getSpec().getBaseSnapshot())))
+                .thenReturn(Mono.just(ContentWrapper.builder()
+                        .snapshotName(page.getSpec().getHeadSnapshot())
+                        .raw("hello world")
+                        .content("<p>hello world</p>")
+                        .rawType("markdown")
+                        .build()));
+
+        Snapshot snapshotV1 = snapshotV1();
+        Snapshot snapshotV2 = TestPost.snapshotV2();
+        snapshotV1.getSpec().setContributors(Set.of("guqing"));
+        snapshotV2.getSpec().setContributors(Set.of("guqing", "zhangsan"));
+        when(client.listAll(eq(Snapshot.class), any(), any())).thenReturn(List.of(snapshotV1, snapshotV2));
+        when(externalUrlSupplier.get()).thenReturn(URI.create(""));
+
+        when(extensionGetter.getEnabledExtension(eq(ExcerptGenerator.class))).thenReturn(Mono.empty());
+
+        ArgumentCaptor<SinglePage> captor = ArgumentCaptor.forClass(SinglePage.class);
+        singlePageReconciler.reconcile(new Reconciler.Request(name));
+
+        verify(client, times(3)).update(captor.capture());
+
+        SinglePage value = captor.getValue();
+        assertThat(value.getStatus().getContributors()).isEqualTo(List.of("guqing", "test1", "zhangsan"));
+    }
+
+    @Test
+    void shouldNotDuplicateOwnerWhenOwnerAlreadyContributed() {
+        String name = "page-A";
+        SinglePage page = pageV1();
+        page.getSpec().setHeadSnapshot("page-A-head-snapshot");
+        page.getSpec().setReleaseSnapshot(page.getSpec().getHeadSnapshot());
+        page.getSpec().setOwner("guqing");
+        when(client.fetch(eq(SinglePage.class), eq(name))).thenReturn(Optional.of(page));
+        when(singlePageService.getContent(
+                        eq(page.getSpec().getReleaseSnapshot()),
+                        eq(page.getSpec().getBaseSnapshot())))
+                .thenReturn(Mono.just(ContentWrapper.builder()
+                        .snapshotName(page.getSpec().getHeadSnapshot())
+                        .raw("hello world")
+                        .content("<p>hello world</p>")
+                        .rawType("markdown")
+                        .build()));
+
+        Snapshot snapshotV1 = snapshotV1();
+        Snapshot snapshotV2 = TestPost.snapshotV2();
+        snapshotV1.getSpec().setContributors(Set.of("guqing"));
+        snapshotV2.getSpec().setContributors(Set.of("guqing", "zhangsan"));
+        when(client.listAll(eq(Snapshot.class), any(), any())).thenReturn(List.of(snapshotV1, snapshotV2));
+        when(externalUrlSupplier.get()).thenReturn(URI.create(""));
+
+        when(extensionGetter.getEnabledExtension(eq(ExcerptGenerator.class))).thenReturn(Mono.empty());
+
+        ArgumentCaptor<SinglePage> captor = ArgumentCaptor.forClass(SinglePage.class);
+        singlePageReconciler.reconcile(new Reconciler.Request(name));
+
+        verify(client, times(3)).update(captor.capture());
+
+        SinglePage value = captor.getValue();
+        assertThat(value.getStatus().getContributors()).isEqualTo(List.of("guqing", "zhangsan"));
+    }
+
+    @Test
     void shouldRegenerateExcerptWhenAutoGenerateBecomesTrue() {
         // https://github.com/halo-dev/halo/issues/10039
         String name = "page-A";


### PR DESCRIPTION
#### What type of PR is this?

- [ ] Feature
- [x] Bug fix
- [ ] Improvement
- [ ] Cleanup
- [ ] Documentation

#### What this PR does / why we need it:

The console's "author" filter for posts and single pages queries `status.contributors`, which is only aggregated from the `spec.contributors` of each snapshot, i.e. users who actually edited the content. A post assigned to a user who never edited it (via post settings) therefore never shows up when filtering by that author.

This implements option 1 from #8284 (https://github.com/halo-dev/halo/issues/8284#issuecomment-3965783479): the owner is always a contributor. `PostReconciler` and `SinglePageReconciler` now merge `spec.owner` (when non-blank) into the aggregated snapshot contributors before de-duplicating and sorting. No frontend changes needed.

Tests added for both reconcilers: owner absent from all snapshots gets included; owner already present is not duplicated.

Drafted with AI assistance; I reviewed the changes and ran the tests myself.

#### Which issue(s) this PR fixes:

Fixes #8284

#### Special notes for your reviewer:

- `status.contributors` is also read by theme finders (`PostVo` / `SinglePageVo`) and `PreviewRouterFunction#canPreview`, so the owner now appears in theme-side contributors and can preview drafts assigned to them. Consistent with the issue's decision, but a small behavioral change.
- Backfill differs by kind: `PostReconciler#setupWith` only syncs posts matching the `requireSyncOnStartup` index (`observedVersion < version`), so existing posts pick up the owner when reconciled again (e.g. re-saved). `SinglePageReconciler#setupWith` uses the `ControllerBuilder` default `syncAllOnStart`, so all single pages are backfilled on the next restart.
- Implemented per the option ruibaby chose in the issue; no separate OpenSpec proposal was opened. Happy to add one if you prefer.

#### Does this PR introduce a user-facing change?

```release-note
修复控制台按作者筛选文章/页面时，无法查询到被设置为作者但未参与编辑的文章的问题
```
