### PR TITLE
Fix duplicate TOTP form submissions

### DIFF
--- a/application/src/main/resources/templates/gateway_fragments/totp.html
+++ b/application/src/main/resources/templates/gateway_fragments/totp.html
@@ -42,7 +42,18 @@
     document.addEventListener("DOMContentLoaded", function () {
       const form = document.getElementById("two-factor-form");
       const codeInput = document.getElementById("code");
+      const submitButton = form.querySelector('button[type="submit"]');
       let submitting = false;
+
+      form.addEventListener("submit", function (event) {
+        if (submitting) {
+          event.preventDefault();
+          return;
+        }
+
+        submitting = true;
+        submitButton.disabled = true;
+      });
 
       codeInput.addEventListener("input", function (event) {
         if (submitting || event.isComposing) {
@@ -50,7 +61,6 @@
         }
 
         if (/^\d{6}$/.test(codeInput.value)) {
-          submitting = true;
           form.requestSubmit();
         }
       });


### PR DESCRIPTION
#### What type of PR is this?

- [ ] Feature
- [x] Bug fix
- [ ] Improvement
- [ ] Cleanup
- [ ] Documentation

#### What this PR does / why we need it:

TOTP 验证码输入满六位后会自动提交。如果用户同时点击提交按钮或按下 Enter，可能产生重复请求，导致已成功的登录跳转被后续请求覆盖，并最终显示 Access Denied。

本 PR 将提交状态统一交由表单的 `submit` 事件管理，并在首次提交后禁用提交按钮，从而保证自动提交和手动提交之间只放行第一次提交。

原有的六位验证码自动提交行为保持不变。

#### Which issue(s) this PR fixes:

无关联 Issue。

#### Special notes for your reviewer:

已验证以下场景：

- 自动提交先触发
- 手动提交先触发
- 连续触发表单提交

已运行：

- `./gradlew spotlessCheck`
- `./gradlew :application:test`
- Chromium DOM 竞态测试

本 PR 使用了 LLM 辅助分析问题和修改代码，相关修改已由本人审查并完成上述验证。

#### Does this PR introduce a user-facing change?

```release-note
修复 TOTP 验证码自动提交时重复提交可能导致登录失败的问题。
```