### PR TITLE
docs: clarify anonymous current-user state

### DIFF
--- a/ui/packages/shared/src/stores/index.ts
+++ b/ui/packages/shared/src/stores/index.ts
@@ -77,7 +77,7 @@ export const stores = {
   /** Reactive metadata for UI providers discovered in the current descriptor. */
   uiPlugins: useUiPluginsStore as unknown as () => UiPluginsStore,
   /**
-   * Store for managing the current visitor's user information.
+   * Store for managing the current user information.
    *
    * @remarks
    * This store provides access to the current user's details and authentication state.

--- a/ui/packages/shared/src/stores/index.ts
+++ b/ui/packages/shared/src/stores/index.ts
@@ -100,7 +100,7 @@ export const stores = {
    */
   currentUser: defineStore("currentUser", () => {
     /**
-     * The current visitor's detailed information, including the anonymous user.
+     * The current user's detailed information, including the anonymous user.
      * Will be `undefined` until `fetchCurrentUser` is called.
      */
     const currentUser = ref<DetailedUser>();

--- a/ui/packages/shared/src/stores/index.ts
+++ b/ui/packages/shared/src/stores/index.ts
@@ -77,11 +77,12 @@ export const stores = {
   /** Reactive metadata for UI providers discovered in the current descriptor. */
   uiPlugins: useUiPluginsStore as unknown as () => UiPluginsStore,
   /**
-   * Store for managing the current authenticated user's information.
+   * Store for managing the current visitor's user information.
    *
    * @remarks
-   * This store provides access to the current user's details and authentication state.
-   * It includes helper methods to fetch the latest user information from the server.
+   * This store provides access to the current visitor's details and authentication state.
+   * Unauthenticated visitors are represented by Halo's `anonymousUser` account.
+   * The store includes helper methods to fetch the latest user information from the server.
    *
    * @example
    * ```typescript
@@ -99,7 +100,7 @@ export const stores = {
    */
   currentUser: defineStore("currentUser", () => {
     /**
-     * The current authenticated user's detailed information.
+     * The current visitor's detailed information, including the anonymous user.
      * Will be `undefined` until `fetchCurrentUser` is called.
      */
     const currentUser = ref<DetailedUser>();
@@ -114,7 +115,7 @@ export const stores = {
      * Fetches the current user's information from the server.
      * Updates both `currentUser` and `isAnonymous` reactive references.
      *
-     * @throws Will throw an error if the API request fails or user is not authenticated.
+     * @throws Will throw an error if the API request fails.
      */
     async function fetchCurrentUser() {
       const { data } = await consoleApiClient.user.getCurrentUserDetail();

--- a/ui/packages/shared/src/stores/index.ts
+++ b/ui/packages/shared/src/stores/index.ts
@@ -80,7 +80,7 @@ export const stores = {
    * Store for managing the current visitor's user information.
    *
    * @remarks
-   * This store provides access to the current visitor's details and authentication state.
+   * This store provides access to the current user's details and authentication state.
    * Unauthenticated visitors are represented by Halo's `anonymousUser` account.
    * The store includes helper methods to fetch the latest user information from the server.
    *


### PR DESCRIPTION
#### What type of PR is this?

- [ ] Feature
- [ ] Bug fix
- [ ] Improvement
- [ ] Cleanup
- [x] Documentation

#### What this PR does / why we need it:

Clarifies that the shared `currentUser` store represents the current visitor, including Halo's `anonymousUser` sentinel for unauthenticated requests. It also narrows the documented `fetchCurrentUser` exception condition to API failures, matching the existing implementation and startup call sites.

This is a documentation-only change. It does not modify authentication, authorization, API, or runtime behavior.

#### Which issue(s) this PR fixes:

Fixes #10282

#### Special notes for your reviewer:

Validation performed on Windows with Node.js 25.9.0 and the repository-pinned pnpm 11.17.0:

- `pnpm -C ui build:packages` - passed
- `vp fmt --check packages/shared/src/stores/index.ts` - passed
- `pnpm -C ui lint` - passed
- `pnpm -C ui typecheck` - passed
- `pnpm -C ui --filter @halo-dev/ui-shared test:unit` - passed (4/4)

The full `pnpm -C ui test:unit` run reached 71 package tests; 59 passed and 12 `ui-plugin-bundler-kit` tests failed because Windows denied their temporary-directory `fs.symlinkSync` calls with `EPERM`. The changed package's tests passed independently.

AI assistance disclosure: OpenAI Codex materially assisted with duplicate-search queries, drafting the documentation wording, and orchestrating validation. I reviewed the final diff and validation output and take responsibility for the submitted change.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
