### PR TITLE
Add batch lookup API to MenuFinder

### DIFF
--- a/application/src/main/java/run/halo/app/theme/finders/MenuFinder.java
+++ b/application/src/main/java/run/halo/app/theme/finders/MenuFinder.java
@@ -1,5 +1,7 @@
 package run.halo.app.theme.finders;
 
+import java.util.Collection;
+import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import run.halo.app.theme.finders.vo.MenuVo;
 
@@ -12,6 +14,8 @@ import run.halo.app.theme.finders.vo.MenuVo;
 public interface MenuFinder {
 
     Mono<MenuVo> getByName(String name);
+
+    Flux<MenuVo> getByNames(Collection<String> names);
 
     Mono<MenuVo> getPrimary();
 }

--- a/application/src/main/java/run/halo/app/theme/finders/impl/MenuFinderImpl.java
+++ b/application/src/main/java/run/halo/app/theme/finders/impl/MenuFinderImpl.java
@@ -43,6 +43,26 @@ public class MenuFinderImpl implements MenuFinder {
     }
 
     @Override
+    public Flux<MenuVo> getByNames(Collection<String> names) {
+        if (CollectionUtils.isEmpty(names)) {
+            return Flux.empty();
+        }
+        var menuNames = names.stream().distinct().toList();
+        var menuOptions = ListOptions.builder()
+                .andQuery(Queries.in("metadata.name", menuNames))
+                .build();
+        var menus = client.listAll(Menu.class, menuOptions, Sort.unsorted())
+                .collectMap(menu -> menu.getMetadata().getName());
+        var menuItems = listMenuItemsByMenuNames(menuNames)
+                .collectMultimap(menuItem -> menuItem.getSpec().getMenuName());
+        return Mono.zip(menus, menuItems)
+                .flatMapMany(tuple -> Flux.fromIterable(menuNames)
+                        .filter(tuple.getT1()::containsKey)
+                        .map(name -> MenuVo.from(tuple.getT1().get(name))
+                                .withMenuItems(listToTree(tuple.getT2().getOrDefault(name, List.of())))));
+    }
+
+    @Override
     public Mono<MenuVo> getPrimary() {
         return listAllMenus()
                 .collectList()
@@ -130,6 +150,13 @@ public class MenuFinderImpl implements MenuFinder {
     Flux<MenuItemVo> listMenuItemsByMenuName(String menuName) {
         var listOptions = ListOptions.builder()
                 .andQuery(Queries.equal("spec.menuName", menuName))
+                .build();
+        return client.listAll(MenuItem.class, listOptions, Sort.unsorted()).map(MenuItemVo::from);
+    }
+
+    Flux<MenuItemVo> listMenuItemsByMenuNames(Collection<String> menuNames) {
+        var listOptions = ListOptions.builder()
+                .andQuery(Queries.in("spec.menuName", menuNames))
                 .build();
         return client.listAll(MenuItem.class, listOptions, Sort.unsorted()).map(MenuItemVo::from);
     }

--- a/application/src/test/java/run/halo/app/theme/finders/impl/MenuFinderImplTest.java
+++ b/application/src/test/java/run/halo/app/theme/finders/impl/MenuFinderImplTest.java
@@ -76,6 +76,39 @@ class MenuFinderImplTest {
     }
 
     @Test
+    void getByNamesBuildsTreesInRequestedOrder() {
+        Mockito.when(client.listAll(eq(Menu.class), any(ListOptions.class), eq(Sort.unsorted())))
+                .thenReturn(Flux.just(menu("D", of()), menu("X", of()), menu("Y", of())));
+        Mockito.when(client.listAll(eq(MenuItem.class), any(ListOptions.class), eq(Sort.unsorted())))
+                .thenReturn(Flux.fromIterable(testMenuItems()));
+
+        var menuVos = menuFinder
+                .getByNames(List.of("Y", "missing", "D", "Y"))
+                .collectList()
+                .block();
+
+        assertThat(menuVos).extracting(menuVo -> menuVo.getMetadata().getName()).containsExactly("Y", "D");
+        assertThat(visualizeTree(menuVos)).isEqualTo("""
+            Y
+            └── F
+                └── H
+            D
+            └── E
+                ├── A
+                │   └── B
+                └── C
+            """);
+        Mockito.verify(client).listAll(eq(Menu.class), any(ListOptions.class), eq(Sort.unsorted()));
+        Mockito.verify(client).listAll(eq(MenuItem.class), any(ListOptions.class), eq(Sort.unsorted()));
+    }
+
+    @Test
+    void getByNamesReturnsEmptyForEmptyNames() {
+        assertThat(menuFinder.getByNames(List.of()).collectList().block()).isEmpty();
+        Mockito.verifyNoInteractions(client);
+    }
+
+    @Test
     void getPrimaryBuildsConfiguredMenuFromNewFields() {
         var primary = new SystemSetting.Menu();
         primary.setPrimary("Y");


### PR DESCRIPTION
#### What type of PR is this?

- [x] Feature
- [ ] Bug fix
- [ ] Improvement
- [ ] Cleanup
- [ ] Documentation

#### What this PR does / why we need it:

Adds `MenuFinder.getByNames(Collection<String>)` so themes can retrieve multiple menus and their menu item trees in one call.

The implementation:

- preserves the requested menu order
- removes duplicate names
- skips missing menus
- loads menus and menu items using two batch queries

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

The implementation and tests were assisted by an LLM and reviewed locally.

Validation:

- `./gradlew :application:test --tests run.halo.app.theme.finders.impl.MenuFinderImplTest`
- `./gradlew :application:spotlessJavaCheck`
- `git diff --check`

#### Does this PR introduce a user-facing change?

```release-note
主题模板现可通过 menuFinder.getByNames 批量获取多个菜单及其菜单项树。
```