### PR TITLE
Support renaming attachments before upload

### DIFF
--- a/application/src/main/java/run/halo/app/core/attachment/endpoint/LocalAttachmentUploadHandler.java
+++ b/application/src/main/java/run/halo/app/core/attachment/endpoint/LocalAttachmentUploadHandler.java
@@ -66,6 +66,7 @@ import run.halo.app.infra.utils.JsonUtils;
 class LocalAttachmentUploadHandler implements AttachmentHandler {
 
     private static final String UPLOAD_PATH = "upload";
+    private static final int MAX_FILENAME_BYTES = 255;
 
     private final AttachmentRootGetter attachmentDirGetter;
 
@@ -101,6 +102,7 @@ class LocalAttachmentUploadHandler implements AttachmentHandler {
                     final var file = option.file();
                     final Path attachmentPath;
                     final String filename = getFilename(file.filename(), setting);
+                    validateFilenameLength(filename);
                     if (StringUtils.hasText(setting.getLocation())) {
                         attachmentPath =
                                 uploadRoot.resolve(setting.getLocation()).resolve(filename);
@@ -422,6 +424,12 @@ class LocalAttachmentUploadHandler implements AttachmentHandler {
                 || filename.indexOf('\\') >= 0
                 || filename.indexOf('\0') >= 0) {
             throw new ServerWebInputException("Filename must not be blank or contain path segments");
+        }
+    }
+
+    private static void validateFilenameLength(String filename) {
+        if (filename.getBytes(StandardCharsets.UTF_8).length > MAX_FILENAME_BYTES) {
+            throw new ServerWebInputException("Filename must not exceed 255 bytes");
         }
     }
 

--- a/application/src/main/java/run/halo/app/core/attachment/endpoint/LocalAttachmentUploadHandler.java
+++ b/application/src/main/java/run/halo/app/core/attachment/endpoint/LocalAttachmentUploadHandler.java
@@ -31,6 +31,7 @@ import org.springframework.stereotype.Component;
 import org.springframework.util.CollectionUtils;
 import org.springframework.util.StringUtils;
 import org.springframework.util.unit.DataSize;
+import org.springframework.web.server.ServerWebInputException;
 import org.springframework.web.util.UriComponentsBuilder;
 import reactor.core.Exceptions;
 import reactor.core.publisher.Flux;
@@ -367,6 +368,7 @@ class LocalAttachmentUploadHandler implements AttachmentHandler {
     }
 
     private String getFilename(String filename, PolicySetting setting) {
+        validateFilename(filename);
         if (!setting.isAlwaysRenameFilename()) {
             return filename;
         }
@@ -409,6 +411,17 @@ class LocalAttachmentUploadHandler implements AttachmentHandler {
                         },
                         excludeOriginalFilename);
             }
+        }
+    }
+
+    private static void validateFilename(String filename) {
+        if (!StringUtils.hasText(filename)
+                || ".".equals(filename)
+                || "..".equals(filename)
+                || filename.indexOf('/') >= 0
+                || filename.indexOf('\\') >= 0
+                || filename.indexOf('\0') >= 0) {
+            throw new ServerWebInputException("Filename must not be blank or contain path segments");
         }
     }
 

--- a/application/src/test/java/run/halo/app/core/attachment/endpoint/LocalAttachmentUploadHandlerTest.java
+++ b/application/src/test/java/run/halo/app/core/attachment/endpoint/LocalAttachmentUploadHandlerTest.java
@@ -20,6 +20,7 @@ import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Mockito;
@@ -27,6 +28,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.core.io.buffer.DataBuffer;
 import org.springframework.core.io.buffer.DefaultDataBufferFactory;
 import org.springframework.http.MediaType;
+import org.springframework.web.server.ServerWebInputException;
 import reactor.core.publisher.Flux;
 import reactor.test.StepVerifier;
 import run.halo.app.core.attachment.AttachmentRootGetter;
@@ -203,6 +205,19 @@ class LocalAttachmentUploadHandlerTest {
                     assertNotNull(attachment.getStatus().getThumbnails());
                 })
                 .verifyComplete();
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"", " ", ".", "..", "../halo.png", "nested/halo.png", "nested\\halo.png"})
+    void shouldRejectInvalidFilename(String filename) {
+        var uploadOption = UploadOption.from(filename, Flux.empty(), MediaType.IMAGE_PNG, createPolicy("local"), null);
+
+        when(attachmentRootGetter.get()).thenReturn(attachmentRoot);
+        uploadHandler
+                .upload(uploadOption)
+                .as(StepVerifier::create)
+                .expectError(ServerWebInputException.class)
+                .verify();
     }
 
     @Test

--- a/application/src/test/java/run/halo/app/core/attachment/endpoint/LocalAttachmentUploadHandlerTest.java
+++ b/application/src/test/java/run/halo/app/core/attachment/endpoint/LocalAttachmentUploadHandlerTest.java
@@ -221,6 +221,30 @@ class LocalAttachmentUploadHandlerTest {
     }
 
     @Test
+    void shouldRejectRenamedFilenameExceeding255Utf8Bytes() {
+        var configMap = new ConfigMap();
+        configMap.setData(Map.of("default", """
+            {
+              "alwaysRenameFilename": true,
+              "renameStrategy": {
+                "method": "RANDOM",
+                "randomLength": 64
+              }
+            }
+            """));
+        var filename = "你".repeat(63) + ".png";
+        var uploadOption =
+                UploadOption.from(filename, Flux.empty(), MediaType.IMAGE_PNG, createPolicy("local"), configMap);
+
+        when(attachmentRootGetter.get()).thenReturn(attachmentRoot);
+        uploadHandler
+                .upload(uploadOption)
+                .as(StepVerifier::create)
+                .expectError(ServerWebInputException.class)
+                .verify();
+    }
+
+    @Test
     void shouldNotSetThumbnailsIfThumbnailIsDisabled() {
         attachmentProperties.getThumbnail().setDisabled(true);
 

--- a/ui/console-src/modules/contents/attachments/components/AttachmentUploadArea.vue
+++ b/ui/console-src/modules/contents/attachments/components/AttachmentUploadArea.vue
@@ -59,6 +59,7 @@ const finalGroupName = computed(() => {
             : $t('core.attachment.upload_modal.filters.policy.not_select')
         "
         :done-button-handler="() => emit('done')"
+        allow-file-name-editing
         @uploaded="onUploaded"
       />
     </VTabItem>

--- a/ui/src/components/upload/UppyUpload.vue
+++ b/ui/src/components/upload/UppyUpload.vue
@@ -301,6 +301,14 @@ watch(
 );
 
 watch(
+  fileNameMetaFields,
+  (metaFields) => {
+    uppy.getPlugin("Dashboard")?.setOptions({ metaFields });
+  },
+  { flush: "post" }
+);
+
+watch(
   [
     () => props.disabled,
     () => props.note,

--- a/ui/src/components/upload/UppyUpload.vue
+++ b/ui/src/components/upload/UppyUpload.vue
@@ -13,7 +13,7 @@ import zh_TW from "@uppy/locales/lib/zh_TW";
 import Dashboard from "@uppy/vue/dashboard";
 import XHRUpload from "@uppy/xhr-upload";
 import objectHash from "object-hash";
-import { h, markRaw, onUnmounted, watch } from "vue";
+import { computed, h, markRaw, onUnmounted, watch } from "vue";
 import { i18n } from "@/locales";
 import type { ProblemDetail } from "@/setup/setupApiClient";
 import { createHTMLContentModal } from "@/utils/modal";
@@ -38,6 +38,7 @@ const props = withDefaults(
     width?: string;
     height?: string;
     doneButtonHandler?: () => void;
+    allowFileNameEditing?: boolean;
   }>(),
   {
     restrictions: undefined,
@@ -51,6 +52,7 @@ const props = withDefaults(
     width: "750px",
     height: "550px",
     doneButtonHandler: undefined,
+    allowFileNameEditing: false,
   }
 );
 
@@ -86,11 +88,35 @@ const defaultRestrictions: Restrictions = {
   requiredMetaFields: [],
 };
 
+function getRestrictions() {
+  if (!props.allowFileNameEditing) {
+    return props.restrictions;
+  }
+
+  return {
+    ...props.restrictions,
+    requiredMetaFields: [
+      ...new Set([...(props.restrictions?.requiredMetaFields || []), "name"]),
+    ],
+  };
+}
+
+const fileNameMetaFields = computed(() =>
+  props.allowFileNameEditing
+    ? [
+        {
+          id: "name",
+          name: i18n.global.t("core.components.uppy_upload.fields.file_name"),
+        },
+      ]
+    : []
+);
+
 const uppy = markRaw(
   new Uppy<Record<string, unknown>, Record<string, unknown>>({
     locale: getUppyLocale(i18n.global.locale.value),
     meta: props.meta,
-    restrictions: props.restrictions,
+    restrictions: getRestrictions(),
     autoProceed: props.autoProceed,
   })
     .use(XHRUpload, {
@@ -239,6 +265,7 @@ watch(
     () => props.allowedMetaFields,
     () => props.name,
     () => props.method,
+    () => props.allowFileNameEditing,
   ],
   () => {
     // The previous computed Uppy instance discarded queued files whenever
@@ -249,8 +276,7 @@ watch(
       meta: props.meta,
       restrictions: {
         ...defaultRestrictions,
-        ...props.restrictions,
-        requiredMetaFields: props.restrictions?.requiredMetaFields || [],
+        ...getRestrictions(),
       },
       autoProceed: props.autoProceed,
     });
@@ -312,6 +338,7 @@ onUnmounted(() => {
       width,
       height,
       doneButtonHandler: doneButtonHandler,
+      metaFields: fileNameMetaFields,
     }"
   />
 </template>

--- a/ui/src/components/upload/__tests__/UppyUpload.spec.ts
+++ b/ui/src/components/upload/__tests__/UppyUpload.spec.ts
@@ -102,6 +102,7 @@ describe("UppyUpload", () => {
     });
     expect(xhrUpload?.opts.shouldRetry?.({} as XMLHttpRequest)).toBe(false);
     expect(dashboardPlugin?.opts.hideRetryButton).toBe(false);
+    expect(dashboardPlugin?.opts.metaFields).toEqual([]);
     expect(dashboard.props("props")).toMatchObject({
       disabled: true,
       note: "Upload a ZIP file",
@@ -117,6 +118,30 @@ describe("UppyUpload", () => {
     });
 
     expect(wrapper.find(".uppy-Dashboard").exists()).toBe(true);
+  });
+
+  it("enables file name editing only when requested", () => {
+    const wrapper = mount(UppyUpload, {
+      props: {
+        endpoint: "/upload",
+        allowFileNameEditing: true,
+        restrictions: {
+          requiredMetaFields: ["caption"],
+        },
+      },
+    });
+    const uppy = getUppy(wrapper);
+
+    expect(uppy.getPlugin("Dashboard")?.opts.metaFields).toEqual([
+      {
+        id: "name",
+        name: "core.components.uppy_upload.fields.file_name",
+      },
+    ]);
+    expect(uppy.opts.restrictions.requiredMetaFields).toEqual([
+      "caption",
+      "name",
+    ]);
   });
 
   it.each([

--- a/ui/src/components/upload/__tests__/UppyUpload.spec.ts
+++ b/ui/src/components/upload/__tests__/UppyUpload.spec.ts
@@ -144,6 +144,28 @@ describe("UppyUpload", () => {
     ]);
   });
 
+  it("updates file name editing when the prop changes", async () => {
+    const wrapper = mount(UppyUpload, {
+      props: { endpoint: "/upload" },
+    });
+    const uppy = getUppy(wrapper);
+
+    await wrapper.setProps({ allowFileNameEditing: true });
+
+    expect(uppy.getPlugin("Dashboard")?.opts.metaFields).toEqual([
+      {
+        id: "name",
+        name: "core.components.uppy_upload.fields.file_name",
+      },
+    ]);
+    expect(uppy.opts.restrictions.requiredMetaFields).toEqual(["name"]);
+
+    await wrapper.setProps({ allowFileNameEditing: false });
+
+    expect(uppy.getPlugin("Dashboard")?.opts.metaFields).toEqual([]);
+    expect(uppy.opts.restrictions.requiredMetaFields).toEqual([]);
+  });
+
   it.each([
     ["zh-CN", "重置", "裁剪为横向（16:9）"],
     ["es-MX", "Revertir", "Recortar horizontal (16:9)"],

--- a/ui/src/locales/en.json
+++ b/ui/src/locales/en.json
@@ -1067,6 +1067,7 @@
   "core.components.pagination.page_label": "page",
   "core.components.pagination.size_label": "items per page",
   "core.components.pagination.total_label": "Total {total} items",
+  "core.components.uppy_upload.fields.file_name": "File name",
   "core.components.user_avatar.title": "Avatar",
   "core.components.user_avatar.toast_upload_failed": "Failed to upload avatar",
   "core.components.user_avatar.toast_remove_failed": "Failed to delete avatar",

--- a/ui/src/locales/es.json
+++ b/ui/src/locales/es.json
@@ -875,6 +875,7 @@
   "core.components.pagination.page_label": "página",
   "core.components.pagination.size_label": "elementos por página",
   "core.components.pagination.total_label": "Total de {total} elementos",
+  "core.components.uppy_upload.fields.file_name": "Nombre del archivo",
   "core.components.user_avatar.title": "Avatar",
   "core.components.user_avatar.toast_upload_failed": "Error al cargar el avatar",
   "core.components.user_avatar.toast_remove_failed": "Error al eliminar el avatar",

--- a/ui/src/locales/zh-CN.json
+++ b/ui/src/locales/zh-CN.json
@@ -1075,6 +1075,7 @@
   "core.components.pagination.page_label": "页",
   "core.components.pagination.size_label": "条 / 页",
   "core.components.pagination.total_label": "共 {total} 项数据",
+  "core.components.uppy_upload.fields.file_name": "文件名",
   "core.components.user_avatar.title": "头像",
   "core.components.user_avatar.toast_upload_failed": "上传头像失败",
   "core.components.user_avatar.toast_remove_failed": "删除头像失败",

--- a/ui/src/locales/zh-TW.json
+++ b/ui/src/locales/zh-TW.json
@@ -1065,6 +1065,7 @@
   "core.components.pagination.page_label": "頁",
   "core.components.pagination.size_label": "條 / 頁",
   "core.components.pagination.total_label": "共 {total} 項資料",
+  "core.components.uppy_upload.fields.file_name": "檔案名稱",
   "core.components.user_avatar.title": "頭像",
   "core.components.user_avatar.toast_upload_failed": "上傳頭像失敗",
   "core.components.user_avatar.toast_remove_failed": "刪除頭像失敗",

--- a/ui/uc-src/modules/contents/attachments/components/selector-providers/AttachmentUploadModal.vue
+++ b/ui/uc-src/modules/contents/attachments/components/selector-providers/AttachmentUploadModal.vue
@@ -22,6 +22,7 @@ const modal = ref<InstanceType<typeof VModal> | null>(null);
       <UppyUpload
         endpoint="/apis/uc.api.storage.halo.run/v1alpha1/attachments/-/upload"
         width="100%"
+        allow-file-name-editing
         :done-button-handler="() => modal?.close()"
       />
     </div>

--- a/ui/uc-src/modules/contents/attachments/components/selector-providers/CoreSelectorProvider.vue
+++ b/ui/uc-src/modules/contents/attachments/components/selector-providers/CoreSelectorProvider.vue
@@ -363,6 +363,7 @@ function onUploaded(response: UppyUploadSuccessResponse) {
       <UppyUpload
         endpoint="/apis/uc.api.storage.halo.run/v1alpha1/attachments/-/upload"
         width="100%"
+        allow-file-name-editing
         :done-button-handler="onUploadDone"
         @uploaded="onUploaded"
       />


### PR DESCRIPTION
#### What type of PR is this?

- [ ] Feature
- [ ] Bug fix
- [x] Improvement
- [ ] Cleanup
- [ ] Documentation

#### What this PR does / why we need it:

- Allows users to edit the filename of each queued attachment before uploading it through the Uppy Dashboard.
- Keeps filename editing opt-in so plugin, theme, and backup uploads retain their existing behavior.
- Rejects blank filenames and filenames containing path segments in local attachment storage.
- Adds focused frontend and backend regression coverage.

#### Which issue(s) this PR fixes:

Fixes #6353

#### Special notes for your reviewer:

- Storage policies with automatic filename renaming enabled may still transform the user-provided filename.
- The implementation was prepared with LLM assistance and reviewed against the current Uppy behavior and repository conventions.
- Validation completed:
  - `pnpm exec vitest run src/components/upload/__tests__/UppyUpload.spec.ts --reporter=default`
  - `pnpm format:check`
  - Targeted ESLint checks for the changed Vue and TypeScript files
  - `./gradlew :application:spotlessJavaCheck :application:test --tests run.halo.app.core.attachment.endpoint.LocalAttachmentUploadHandlerTest`
  - `git diff --check`
- Checkout-wide `pnpm typecheck` is currently blocked by unrelated missing `UiPluginProvider` API exports.
- Root `./gradlew spotlessCheck` is currently blocked by existing formatting violations under `.ghfs`; the changed Java files pass `:application:spotlessJavaCheck`.

#### Does this PR introduce a user-facing change?

```release-note
附件上传时支持在上传前修改文件名。
```
