### PR TITLE
Fix menu and category hierarchy updates and migration retries

### DIFF
--- a/application/src/main/java/run/halo/app/core/endpoint/console/CategoryConsoleService.java
+++ b/application/src/main/java/run/halo/app/core/endpoint/console/CategoryConsoleService.java
@@ -94,9 +94,10 @@ public class CategoryConsoleService {
                         category -> new HierarchyState(parentNameOf(category), priorityOf(category)),
                         (left, right) -> left,
                         LinkedHashMap::new));
-        var originalParentName = parentNameOf(moved);
+        var parentMap = effectiveParentMap(categories);
+        var originalParentName = parentMap.get(name);
 
-        var targetSiblings = siblings(categories, targetParentName, name);
+        var targetSiblings = siblings(categories, parentMap, targetParentName, name);
         int insertIndex = targetSiblings.size();
         if (beforeName != null) {
             insertIndex = indexOf(targetSiblings, beforeName);
@@ -108,7 +109,7 @@ public class CategoryConsoleService {
         assignPriorities(targetSiblings, targetParentName);
 
         if (!Objects.equals(originalParentName, targetParentName)) {
-            assignPriorities(siblings(categories, originalParentName, name), originalParentName);
+            assignPriorities(siblings(categories, parentMap, originalParentName, name), originalParentName);
         }
 
         var changedCategories = categories.stream()
@@ -133,12 +134,11 @@ public class CategoryConsoleService {
                         Function.identity(),
                         (left, right) -> left,
                         LinkedHashMap::new));
-        Map<String, String> parentMap = validParentMap(categoryMap);
-        Set<String> cyclicNames = cyclicNames(parentMap);
+        Map<String, String> parentMap = effectiveParentMap(categories);
 
         categoryMap.forEach((name, node) -> {
             var parentName = parentMap.get(name);
-            if (parentName != null && !cyclicNames.contains(name)) {
+            if (parentName != null) {
                 categoryMap.get(parentName).getChildren().add(node);
             }
         });
@@ -146,21 +146,26 @@ public class CategoryConsoleService {
         var roots = categoryMap.values().stream()
                 .filter(node -> {
                     var name = node.getCategory().getMetadata().getName();
-                    return !parentMap.containsKey(name) || cyclicNames.contains(name);
+                    return !parentMap.containsKey(name);
                 })
                 .collect(Collectors.toCollection(ArrayList::new));
         sortTree(roots);
         return roots;
     }
 
-    private static Map<String, String> validParentMap(Map<String, CategoryTreeNode> categoryMap) {
+    private static Map<String, String> effectiveParentMap(Collection<Category> categories) {
+        var names = categories.stream()
+                .map(category -> category.getMetadata().getName())
+                .collect(Collectors.toSet());
         Map<String, String> parentMap = new LinkedHashMap<>();
-        categoryMap.forEach((name, node) -> {
-            var parentName = parentNameOf(node.getCategory());
-            if (parentName != null && !Objects.equals(parentName, name) && categoryMap.containsKey(parentName)) {
+        categories.forEach(category -> {
+            var name = category.getMetadata().getName();
+            var parentName = parentNameOf(category);
+            if (parentName != null && !Objects.equals(parentName, name) && names.contains(parentName)) {
                 parentMap.put(name, parentName);
             }
         });
+        parentMap.keySet().removeAll(cyclicNames(parentMap));
         return parentMap;
     }
 
@@ -229,10 +234,12 @@ public class CategoryConsoleService {
         return false;
     }
 
-    private static List<Category> siblings(List<Category> categories, String parentName, String excludingName) {
+    private static List<Category> siblings(
+            List<Category> categories, Map<String, String> parentMap, String parentName, String excludingName) {
         return categories.stream()
                 .filter(category -> !Objects.equals(category.getMetadata().getName(), excludingName))
-                .filter(category -> Objects.equals(parentNameOf(category), parentName))
+                .filter(category ->
+                        Objects.equals(parentMap.get(category.getMetadata().getName()), parentName))
                 .sorted(defaultCategoryComparator())
                 .collect(Collectors.toCollection(ArrayList::new));
     }

--- a/application/src/main/java/run/halo/app/core/endpoint/console/MenuItemConsoleService.java
+++ b/application/src/main/java/run/halo/app/core/endpoint/console/MenuItemConsoleService.java
@@ -105,9 +105,10 @@ public class MenuItemConsoleService {
                         item -> new HierarchyState(parentNameOf(item), priorityOf(item)),
                         (left, right) -> left,
                         LinkedHashMap::new));
-        var originalParentName = parentNameOf(moved);
+        var parentMap = effectiveParentMap(items);
+        var originalParentName = parentMap.get(name);
 
-        var targetSiblings = siblings(items, targetParentName, name);
+        var targetSiblings = siblings(items, parentMap, targetParentName, name);
         int insertIndex = targetSiblings.size();
         if (beforeName != null) {
             insertIndex = indexOf(targetSiblings, beforeName);
@@ -119,7 +120,7 @@ public class MenuItemConsoleService {
         assignPriorities(targetSiblings, targetParentName);
 
         if (!Objects.equals(originalParentName, targetParentName)) {
-            assignPriorities(siblings(items, originalParentName, name), originalParentName);
+            assignPriorities(siblings(items, parentMap, originalParentName, name), originalParentName);
         }
 
         var changedItems = items.stream()
@@ -146,12 +147,11 @@ public class MenuItemConsoleService {
                         Function.identity(),
                         (left, right) -> left,
                         LinkedHashMap::new));
-        Map<String, String> parentMap = validParentMap(itemMap);
-        Set<String> cyclicChainNames = cyclicChainNames(parentMap);
+        Map<String, String> parentMap = effectiveParentMap(items);
 
         itemMap.forEach((name, node) -> {
             var parentName = parentMap.get(name);
-            if (parentName != null && !cyclicChainNames.contains(name)) {
+            if (parentName != null) {
                 itemMap.get(parentName).getChildren().add(node);
             }
         });
@@ -159,21 +159,24 @@ public class MenuItemConsoleService {
         var roots = itemMap.values().stream()
                 .filter(node -> {
                     var name = node.getMenuItem().getMetadata().getName();
-                    return !parentMap.containsKey(name) || cyclicChainNames.contains(name);
+                    return !parentMap.containsKey(name);
                 })
                 .collect(Collectors.toCollection(ArrayList::new));
         sortTree(roots);
         return roots;
     }
 
-    private static Map<String, String> validParentMap(Map<String, MenuItemTreeNode> itemMap) {
+    private static Map<String, String> effectiveParentMap(Collection<MenuItem> items) {
+        var names = items.stream().map(item -> item.getMetadata().getName()).collect(Collectors.toSet());
         Map<String, String> parentMap = new LinkedHashMap<>();
-        itemMap.forEach((name, node) -> {
-            var parentName = parentNameOf(node.getMenuItem());
-            if (parentName != null && !Objects.equals(parentName, name) && itemMap.containsKey(parentName)) {
+        items.forEach(item -> {
+            var name = item.getMetadata().getName();
+            var parentName = parentNameOf(item);
+            if (parentName != null && !Objects.equals(parentName, name) && names.contains(parentName)) {
                 parentMap.put(name, parentName);
             }
         });
+        parentMap.keySet().removeAll(cyclicChainNames(parentMap));
         return parentMap;
     }
 
@@ -248,10 +251,11 @@ public class MenuItemConsoleService {
         return false;
     }
 
-    private static List<MenuItem> siblings(List<MenuItem> items, String parentName, String excludingName) {
+    private static List<MenuItem> siblings(
+            List<MenuItem> items, Map<String, String> parentMap, String parentName, String excludingName) {
         return items.stream()
                 .filter(item -> !Objects.equals(item.getMetadata().getName(), excludingName))
-                .filter(item -> Objects.equals(parentNameOf(item), parentName))
+                .filter(item -> Objects.equals(parentMap.get(item.getMetadata().getName()), parentName))
                 .sorted(defaultMenuItemComparator())
                 .collect(Collectors.toCollection(ArrayList::new));
     }

--- a/application/src/main/java/run/halo/app/core/extension/migration/CategoryHierarchyMigration.java
+++ b/application/src/main/java/run/halo/app/core/extension/migration/CategoryHierarchyMigration.java
@@ -83,23 +83,19 @@ class CategoryHierarchyMigration {
     private Mono<Category> updateIfNecessary(
             Category category, Map<String, String> assignedParents, MigrationSummary summary) {
         var categoryName = category.getMetadata().getName();
-        var changed = false;
         var assignedParent = assignedParents.get(categoryName);
-        if (StringUtils.hasText(assignedParent) && !StringUtils.hasText(parentName(category))) {
-            ensureSpec(category).setParent(assignedParent);
-            changed = true;
-        }
-        ensureMetadata(category);
-        var labels = nullSafeLabels(category);
-        if (!MIGRATION_LABEL_VALUE.equals(labels.get(Category.HIERARCHY_MIGRATED_LABEL))) {
-            labels.put(Category.HIERARCHY_MIGRATED_LABEL, MIGRATION_LABEL_VALUE);
-            changed = true;
-        }
-        if (!changed) {
-            summary.skipped++;
-            return Mono.empty();
-        }
-        return client.update(category)
+        return Mono.defer(() -> client.fetch(Category.class, categoryName).flatMap(latest -> {
+                    if (isMigrated(latest)) {
+                        summary.skipped++;
+                        return Mono.empty();
+                    }
+                    if (StringUtils.hasText(assignedParent) && !StringUtils.hasText(parentName(latest))) {
+                        ensureSpec(latest).setParent(assignedParent);
+                    }
+                    ensureMetadata(latest);
+                    nullSafeLabels(latest).put(Category.HIERARCHY_MIGRATED_LABEL, MIGRATION_LABEL_VALUE);
+                    return client.update(latest);
+                }))
                 .retryWhen(Retry.backoff(UPDATE_RETRIES, Duration.ofMillis(100))
                         .filter(CategoryHierarchyMigration::isRetryableUpdateFailure))
                 .doOnNext(updated -> summary.updated++)
@@ -134,6 +130,9 @@ class CategoryHierarchyMigration {
                         "Skipped missing legacy child reference during category hierarchy migration. parent={}, child={}",
                         parentName,
                         childName);
+                continue;
+            }
+            if (isMigrated(child)) {
                 continue;
             }
             var existingParent = parentName(child);
@@ -236,6 +235,13 @@ class CategoryHierarchyMigration {
     private static @Nullable String parentName(Category category) {
         var spec = category.getSpec();
         return spec == null ? null : spec.getParent();
+    }
+
+    private static boolean isMigrated(Category category) {
+        var metadata = category.getMetadata();
+        return metadata != null
+                && metadata.getLabels() != null
+                && MIGRATION_LABEL_VALUE.equals(metadata.getLabels().get(Category.HIERARCHY_MIGRATED_LABEL));
     }
 
     private static Category.CategorySpec ensureSpec(Category category) {

--- a/application/src/main/java/run/halo/app/core/extension/migration/MenuItemHierarchyMigration.java
+++ b/application/src/main/java/run/halo/app/core/extension/migration/MenuItemHierarchyMigration.java
@@ -78,7 +78,7 @@ class MenuItemHierarchyMigration {
         var context = new MigrationContext(menus, menuItems);
         return Flux.fromIterable(context.rootPaths())
                 .concatMap(path -> migratePath(context, path, false))
-                .then(labelAssignedMenuItems(context))
+                .then(Mono.defer(() -> labelAssignedMenuItems(context)))
                 .then(Mono.fromSupplier(context::getSummary));
     }
 
@@ -121,9 +121,12 @@ class MenuItemHierarchyMigration {
 
     private Mono<MenuItem> migrateOriginal(MigrationContext context, MenuItem item, LegacyPath path) {
         context.recordOriginalUse(item, path);
-        return updateIfChanged(context, item, () -> {
+        return updateIfChanged(context, item, latest -> {
+            if (TRUE.equals(labelsOf(latest).get(MenuItem.HIERARCHY_MIGRATED_LABEL))) {
+                return false;
+            }
             var changed = false;
-            var spec = ensureSpec(item);
+            var spec = ensureSpec(latest);
             if (!hasText(spec.getMenuName())) {
                 spec.setMenuName(path.getMenuName());
                 changed = true;
@@ -132,7 +135,7 @@ class MenuItemHierarchyMigration {
                 spec.setParent(path.getParentName());
                 changed = true;
             }
-            return markMigrated(item) || changed;
+            return markMigrated(latest) || changed;
         });
     }
 
@@ -140,9 +143,12 @@ class MenuItemHierarchyMigration {
         var existingClone = context.findClone(path);
         if (existingClone != null) {
             context.recordCloneReused();
-            return updateIfChanged(context, existingClone, () -> {
+            return updateIfChanged(context, existingClone, latest -> {
+                if (TRUE.equals(labelsOf(latest).get(MenuItem.HIERARCHY_MIGRATED_LABEL))) {
+                    return false;
+                }
                 var changed = false;
-                var spec = ensureSpec(existingClone);
+                var spec = ensureSpec(latest);
                 if (!hasText(spec.getMenuName())) {
                     spec.setMenuName(path.getMenuName());
                     changed = true;
@@ -151,7 +157,7 @@ class MenuItemHierarchyMigration {
                     spec.setParent(path.getParentName());
                     changed = true;
                 }
-                return markMigrated(existingClone) || changed;
+                return markMigrated(latest) || changed;
             });
         }
 
@@ -197,34 +203,39 @@ class MenuItemHierarchyMigration {
     }
 
     private Mono<MenuItem> updateIfChanged(MigrationContext context, MenuItem item, ChangeDetector detector) {
-        if (!detector.changed()) {
-            return Mono.just(item);
-        }
-        return client.update(item)
+        return Mono.defer(() -> client.fetch(MenuItem.class, item.getMetadata().getName())
+                        .flatMap(latest -> {
+                            if (!detector.changed(latest)) {
+                                return Mono.just(latest);
+                            }
+                            return client.update(latest).doOnNext(updated -> context.recordUpdated());
+                        }))
                 .retryWhen(Retry.backoff(3, Duration.ofMillis(100))
                         .filter(OptimisticLockingFailureException.class::isInstance))
-                .doOnNext(updated -> {
-                    context.addItem(updated);
-                    context.recordUpdated();
-                })
+                .doOnNext(context::addItem)
                 .onErrorResume(t -> {
+                    var name = item.getMetadata().getName();
+                    context.failedSubtreeNames.add(name);
+                    context.collectLegacyDescendants(name, context.failedSubtreeNames);
                     context.failure(
                             "Failed to update MenuItem '{}'.",
                             t,
                             item.getMetadata().getName());
-                    return Mono.just(item);
+                    return Mono.empty();
                 });
     }
 
     private Mono<Void> labelAssignedMenuItems(MigrationContext context) {
         return Flux.fromIterable(context.items())
+                .filter(item ->
+                        !context.failedSubtreeNames.contains(item.getMetadata().getName()))
                 .filter(item -> {
                     var spec = item.getSpec();
                     return spec != null
                             && hasText(spec.getMenuName())
                             && !TRUE.equals(labelsOf(item).get(MenuItem.HIERARCHY_MIGRATED_LABEL));
                 })
-                .concatMap(item -> updateIfChanged(context, item, () -> markMigrated(item)))
+                .concatMap(item -> updateIfChanged(context, item, MenuItemHierarchyMigration::markMigrated))
                 .then();
     }
 
@@ -281,7 +292,7 @@ class MenuItemHierarchyMigration {
 
     @FunctionalInterface
     private interface ChangeDetector {
-        boolean changed();
+        boolean changed(MenuItem item);
     }
 
     @Value
@@ -323,6 +334,7 @@ class MenuItemHierarchyMigration {
         private final List<Menu> menus;
         private final Map<String, MenuItem> itemsByName;
         private final Map<String, LegacyPath> originalUses = new HashMap<>();
+        private final Set<String> failedSubtreeNames = new HashSet<>();
         private final MutableMigrationSummary summary;
 
         MigrationContext(List<Menu> menus, List<MenuItem> items) {

--- a/application/src/main/java/run/halo/app/core/extension/migration/MenuItemHierarchyMigration.java
+++ b/application/src/main/java/run/halo/app/core/extension/migration/MenuItemHierarchyMigration.java
@@ -122,11 +122,11 @@ class MenuItemHierarchyMigration {
     private Mono<MenuItem> migrateOriginal(MigrationContext context, MenuItem item, LegacyPath path) {
         context.recordOriginalUse(item, path);
         return updateIfChanged(context, item, latest -> {
-            if (TRUE.equals(labelsOf(latest).get(MenuItem.HIERARCHY_MIGRATED_LABEL))) {
+            var spec = ensureSpec(latest);
+            if (TRUE.equals(labelsOf(latest).get(MenuItem.HIERARCHY_MIGRATED_LABEL)) && hasText(spec.getMenuName())) {
                 return false;
             }
             var changed = false;
-            var spec = ensureSpec(latest);
             if (!hasText(spec.getMenuName())) {
                 spec.setMenuName(path.getMenuName());
                 changed = true;
@@ -144,11 +144,12 @@ class MenuItemHierarchyMigration {
         if (existingClone != null) {
             context.recordCloneReused();
             return updateIfChanged(context, existingClone, latest -> {
-                if (TRUE.equals(labelsOf(latest).get(MenuItem.HIERARCHY_MIGRATED_LABEL))) {
+                var spec = ensureSpec(latest);
+                if (TRUE.equals(labelsOf(latest).get(MenuItem.HIERARCHY_MIGRATED_LABEL))
+                        && hasText(spec.getMenuName())) {
                     return false;
                 }
                 var changed = false;
-                var spec = ensureSpec(latest);
                 if (!hasText(spec.getMenuName())) {
                     spec.setMenuName(path.getMenuName());
                     changed = true;

--- a/application/src/test/java/run/halo/app/core/endpoint/console/CategoryConsoleServiceTest.java
+++ b/application/src/test/java/run/halo/app/core/endpoint/console/CategoryConsoleServiceTest.java
@@ -72,6 +72,35 @@ class CategoryConsoleServiceTest {
     }
 
     @Test
+    void updatePositionUsesDisplayedRootsForInvalidParents() {
+        var root = category("root", null, 0, "2024-01-01T00:00:00Z");
+        var orphan = category("orphan", "missing", 1, "2024-01-01T00:00:00Z");
+        var self = category("self", "self", 2, "2024-01-01T00:00:00Z");
+        var cycleA = category("cycle-a", "cycle-b", 3, "2024-01-01T00:00:00Z");
+        var cycleB = category("cycle-b", "cycle-a", 4, "2024-01-01T00:00:00Z");
+        var child = category("child", "cycle-a", 0, "2024-01-01T00:00:00Z");
+        var moved = category("moved", null, 5, "2024-01-01T00:00:00Z");
+        mockList(root, orphan, self, cycleA, cycleB, child, moved);
+        when(client.update(any(Category.class))).thenAnswer(invocation -> Mono.just(invocation.getArgument(0)));
+
+        service.updatePosition("moved", new CategoryPositionRequest(null, "orphan"))
+                .as(StepVerifier::create)
+                .assertNext(tree -> {
+                    assertThat(tree)
+                            .extracting(node -> node.getCategory().getMetadata().getName())
+                            .containsExactly("root", "moved", "orphan", "self", "cycle-a", "cycle-b");
+                    assertThat(tree.get(4).getChildren())
+                            .extracting(node -> node.getCategory().getMetadata().getName())
+                            .containsExactly("child");
+                })
+                .verifyComplete();
+        assertThat(List.of(root, orphan, self, cycleA, cycleB, moved))
+                .allSatisfy(
+                        category -> assertThat(category.getSpec().getParent()).isNull());
+        assertThat(child.getSpec().getParent()).isEqualTo("cycle-a");
+    }
+
+    @Test
     void updatePositionMovesCategoryBeforeSiblingAndPersistsChangedCategoriesOnly() {
         var parent = category("parent", null, 0, "2024-01-01T00:00:00Z");
         var child = category("child", "parent", 0, "2024-01-02T00:00:00Z");

--- a/application/src/test/java/run/halo/app/core/endpoint/console/HierarchyPositionIntegrationTest.java
+++ b/application/src/test/java/run/halo/app/core/endpoint/console/HierarchyPositionIntegrationTest.java
@@ -1,0 +1,207 @@
+package run.halo.app.core.endpoint.console;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anySet;
+import static org.mockito.Mockito.when;
+import static org.springframework.security.test.web.reactive.server.SecurityMockServerConfigurers.csrf;
+
+import java.nio.file.Path;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.webtestclient.autoconfigure.AutoConfigureWebTestClient;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.reactive.server.WebTestClient;
+import reactor.core.publisher.Flux;
+import run.halo.app.core.extension.MenuItem;
+import run.halo.app.core.extension.Role;
+import run.halo.app.core.extension.content.Category;
+import run.halo.app.core.user.service.RoleService;
+import run.halo.app.extension.Metadata;
+import run.halo.app.extension.ReactiveExtensionClient;
+import run.halo.app.extension.Ref;
+
+@SpringBootTest
+@AutoConfigureWebTestClient
+@DirtiesContext
+@WithMockUser(roles = "hierarchy-test")
+class HierarchyPositionIntegrationTest {
+    private static final String API = "/apis/api.console.halo.run/v1alpha1";
+
+    @TempDir
+    static Path workDir;
+
+    @DynamicPropertySource
+    static void properties(DynamicPropertyRegistry registry) {
+        registry.add("halo.work-dir", () -> workDir.toString());
+    }
+
+    @Autowired
+    WebTestClient webClient;
+
+    @Autowired
+    ReactiveExtensionClient client;
+
+    @MockitoBean
+    RoleService roleService;
+
+    @BeforeEach
+    void setUp() {
+        var role = new Role();
+        role.setMetadata(new Metadata());
+        role.getMetadata().setName("hierarchy-test");
+        role.setRules(List.of(new Role.PolicyRule.Builder()
+                .apiGroups("*")
+                .resources("*")
+                .verbs("*")
+                .build()));
+        when(roleService.listDependenciesFlux(anySet())).thenReturn(Flux.just(role));
+        webClient = webClient.mutateWith(csrf());
+    }
+
+    @Test
+    void movesCategoryMenuBeforeOrphanAndPersistsTheDisplayedHierarchy() {
+        createMenuItem("home", null, 0);
+        var orphan = createMenuItem("orphan", "missing-parent", 1);
+        createMenuItem("directory", null, 2);
+        createMenuItem("menu-child", "directory", 0);
+
+        webClient
+                .get()
+                .uri(API + "/menuitems/-/tree?menuName=primary")
+                .exchange()
+                .expectStatus()
+                .isOk()
+                .expectBody()
+                .jsonPath("$[1].menuItem.metadata.name")
+                .isEqualTo("orphan");
+
+        webClient
+                .put()
+                .uri(API + "/menuitems/directory/position")
+                .bodyValue(new MenuItemPositionRequest("primary", null, "orphan"))
+                .exchange()
+                .expectStatus()
+                .isOk()
+                .expectBody()
+                .jsonPath("$[1].menuItem.metadata.name")
+                .isEqualTo("directory");
+
+        webClient
+                .get()
+                .uri(API + "/menuitems/-/tree?menuName=primary")
+                .exchange()
+                .expectStatus()
+                .isOk()
+                .expectBody()
+                .jsonPath("$[*].menuItem.metadata.name")
+                .isEqualTo(List.of("home", "directory", "orphan"))
+                .jsonPath("$[1].children[0].menuItem.metadata.name")
+                .isEqualTo("menu-child");
+        var stored = client.get(MenuItem.class, "orphan").block();
+        assertThat(stored.getSpec().getParent()).isNull();
+        assertThat(stored.getSpec().getPriority()).isEqualTo(2);
+        assertThat(stored.getMetadata().getVersion())
+                .isGreaterThan(orphan.getMetadata().getVersion());
+
+        webClient
+                .put()
+                .uri(API + "/menuitems/directory/position")
+                .bodyValue(new MenuItemPositionRequest("primary", "menu-child", null))
+                .exchange()
+                .expectStatus()
+                .isBadRequest();
+        assertThat(client.get(MenuItem.class, "directory").block().getSpec().getParent())
+                .isNull();
+    }
+
+    @Test
+    void movesCategoryBeforeOrphanAndPersistsTheDisplayedHierarchy() {
+        createCategory("root", null, 0);
+        var orphan = createCategory("orphan-category", "missing-category", 1);
+        createCategory("moved", null, 2);
+        createCategory("category-child", "moved", 0);
+
+        webClient
+                .get()
+                .uri(API + "/categories/-/tree")
+                .exchange()
+                .expectStatus()
+                .isOk()
+                .expectBody()
+                .jsonPath("$[1].category.metadata.name")
+                .isEqualTo("orphan-category");
+
+        webClient
+                .put()
+                .uri(API + "/categories/moved/position")
+                .bodyValue(new CategoryPositionRequest(null, "orphan-category"))
+                .exchange()
+                .expectStatus()
+                .isOk()
+                .expectBody()
+                .jsonPath("$[1].category.metadata.name")
+                .isEqualTo("moved");
+
+        webClient
+                .get()
+                .uri(API + "/categories/-/tree")
+                .exchange()
+                .expectStatus()
+                .isOk()
+                .expectBody()
+                .jsonPath("$[*].category.metadata.name")
+                .isEqualTo(List.of("root", "moved", "orphan-category"))
+                .jsonPath("$[1].children[0].category.metadata.name")
+                .isEqualTo("category-child");
+        var stored = client.get(Category.class, "orphan-category").block();
+        assertThat(stored.getSpec().getParent()).isNull();
+        assertThat(stored.getSpec().getPriority()).isEqualTo(2);
+        assertThat(stored.getMetadata().getVersion())
+                .isGreaterThan(orphan.getMetadata().getVersion());
+
+        webClient
+                .put()
+                .uri(API + "/categories/moved/position")
+                .bodyValue(new CategoryPositionRequest("category-child", null))
+                .exchange()
+                .expectStatus()
+                .isBadRequest();
+        assertThat(client.get(Category.class, "moved").block().getSpec().getParent())
+                .isNull();
+    }
+
+    private MenuItem createMenuItem(String name, String parent, int priority) {
+        var item = new MenuItem();
+        item.setMetadata(new Metadata());
+        item.getMetadata().setName(name);
+        item.setSpec(new MenuItem.MenuItemSpec());
+        item.getSpec().setDisplayName(name);
+        item.getSpec().setMenuName("primary");
+        item.getSpec().setParent(parent);
+        item.getSpec().setPriority(priority);
+        if ("directory".equals(name)) {
+            item.getSpec().setTargetRef(Ref.of("referenced-category", Category.GVK));
+        }
+        return client.create(item).block();
+    }
+
+    private Category createCategory(String name, String parent, int priority) {
+        var category = new Category();
+        category.setMetadata(new Metadata());
+        category.getMetadata().setName(name);
+        category.setSpec(new Category.CategorySpec());
+        category.getSpec().setDisplayName(name);
+        category.getSpec().setSlug(name);
+        category.getSpec().setParent(parent);
+        category.getSpec().setPriority(priority);
+        return client.create(category).block();
+    }
+}

--- a/application/src/test/java/run/halo/app/core/endpoint/console/MenuItemConsoleServiceTest.java
+++ b/application/src/test/java/run/halo/app/core/endpoint/console/MenuItemConsoleServiceTest.java
@@ -87,6 +87,50 @@ class MenuItemConsoleServiceTest {
     }
 
     @Test
+    void updatePositionUsesDisplayedRootsForInvalidParents() {
+        menuItems.addAll(List.of(
+                menuItem("root", "primary", null, 0),
+                menuItem("orphan", "primary", "missing", 1),
+                menuItem("self", "primary", "self", 2),
+                menuItem("cycle-a", "primary", "cycle-b", 3),
+                menuItem("cycle-b", "primary", "cycle-a", 4),
+                menuItem("cycle-child", "primary", "cycle-a", 5),
+                menuItem("moved", "primary", null, 6)));
+
+        service.updatePosition("moved", new MenuItemPositionRequest("primary", null, "orphan"))
+                .as(StepVerifier::create)
+                .assertNext(tree -> assertThat(names(tree))
+                        .containsExactly("root", "moved", "orphan", "self", "cycle-a", "cycle-b", "cycle-child"))
+                .verifyComplete();
+        assertThat(menuItems)
+                .allSatisfy(item -> assertThat(item.getSpec().getParent()).isNull());
+        service.listTree("primary")
+                .as(StepVerifier::create)
+                .assertNext(tree -> assertThat(names(tree))
+                        .containsExactly("root", "moved", "orphan", "self", "cycle-a", "cycle-b", "cycle-child"))
+                .verifyComplete();
+    }
+
+    @Test
+    void updatePositionReordersDisplayedSiblingsWhenMovingOrphanUnderParent() {
+        menuItems.addAll(List.of(
+                menuItem("root", "primary", null, 7),
+                menuItem("orphan", "primary", "missing", 2),
+                menuItem("other-orphan", "primary", "other-missing", 4)));
+
+        service.updatePosition("orphan", new MenuItemPositionRequest("primary", "root", null))
+                .as(StepVerifier::create)
+                .assertNext(tree -> {
+                    assertThat(names(tree)).containsExactly("other-orphan", "root");
+                    assertThat(names(tree.get(1).getChildren())).containsExactly("orphan");
+                })
+                .verifyComplete();
+        assertThat(menuItem("other-orphan").getSpec().getParent()).isNull();
+        assertThat(menuItem("other-orphan").getSpec().getPriority()).isZero();
+        assertThat(menuItem("root").getSpec().getPriority()).isEqualTo(1);
+    }
+
+    @Test
     void updatePositionMovesRootBeforeSibling() {
         menuItems.addAll(List.of(
                 menuItem("root-a", "primary", null, 0),

--- a/application/src/test/java/run/halo/app/core/extension/migration/CategoryHierarchyMigrationTest.java
+++ b/application/src/test/java/run/halo/app/core/extension/migration/CategoryHierarchyMigrationTest.java
@@ -2,7 +2,10 @@ package run.halo.app.core.extension.migration;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.same;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.times;
@@ -11,16 +14,19 @@ import static org.mockito.Mockito.verify;
 import java.time.Instant;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.dao.OptimisticLockingFailureException;
 import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
 import run.halo.app.core.extension.content.Category;
 import run.halo.app.extension.Metadata;
 import run.halo.app.extension.ReactiveExtensionClient;
+import run.halo.app.infra.utils.JsonUtils;
 
 @ExtendWith(MockitoExtension.class)
 class CategoryHierarchyMigrationTest {
@@ -29,13 +35,23 @@ class CategoryHierarchyMigrationTest {
     private ReactiveExtensionClient client;
 
     private CategoryHierarchyMigration migration;
+    private final Map<String, Category> storedCategories = new HashMap<>();
 
     @BeforeEach
     void setUp() {
         migration = new CategoryHierarchyMigration(client);
         lenient()
-                .when(client.update(any(Category.class)))
-                .thenAnswer(invocation -> Mono.just(invocation.getArgument(0)));
+                .when(client.fetch(eq(Category.class), anyString()))
+                .thenAnswer(invocation -> Mono.justOrEmpty(storedCategories.get(invocation.getArgument(1)))
+                        .map(JsonUtils::deepCopy));
+        lenient().when(client.update(any(Category.class))).thenAnswer(invocation -> {
+            Category category = invocation.getArgument(0);
+            var stored = storedCategories.get(category.getMetadata().getName());
+            stored.setSpec(category.getSpec());
+            stored.setMetadata(category.getMetadata());
+            stored.setStatus(category.getStatus());
+            return Mono.just(category);
+        });
     }
 
     @Test
@@ -83,7 +99,7 @@ class CategoryHierarchyMigrationTest {
     }
 
     @Test
-    void labelDoesNotSkipIncompleteCategory() {
+    void preservesMigratedCategoryMovedToRoot() {
         var parent = category("A", "2024-01-01T00:00:00Z", "B");
         var child = category("B", "2024-01-02T00:00:00Z");
         child.getMetadata().setLabels(new HashMap<>());
@@ -93,9 +109,9 @@ class CategoryHierarchyMigrationTest {
                 .migrate(List.of(parent, child))
                 .as(StepVerifier::create)
                 .assertNext(summary -> {
-                    assertThat(child.getSpec().getParent()).isEqualTo("A");
-                    assertThat(summary.assignedParents()).isEqualTo(1);
-                    assertThat(summary.updated()).isEqualTo(2);
+                    assertThat(child.getSpec().getParent()).isNull();
+                    assertThat(summary.assignedParents()).isZero();
+                    assertThat(summary.updated()).isEqualTo(1);
                 })
                 .verifyComplete();
     }
@@ -174,21 +190,54 @@ class CategoryHierarchyMigrationTest {
     void continuesWhenCategoryUpdateFails() {
         var parent = category("A", "2024-01-01T00:00:00Z", "B");
         var child = category("B", "2024-01-02T00:00:00Z");
-        doReturn(Mono.error(new RuntimeException("boom"))).when(client).update(same(child));
+        doReturn(Mono.error(new RuntimeException("boom")))
+                .when(client)
+                .update(argThat(
+                        (Category category) -> "B".equals(category.getMetadata().getName())));
 
         migration
                 .migrate(List.of(parent, child))
                 .as(StepVerifier::create)
                 .assertNext(summary -> {
-                    assertThat(child.getSpec().getParent()).isEqualTo("A");
+                    assertThat(child.getSpec().getParent()).isNull();
                     assertThat(summary.assignedParents()).isEqualTo(1);
                     assertThat(summary.updated()).isEqualTo(1);
                     assertThat(summary.failures()).isEqualTo(1);
-                    assertMigrationLabel(parent, child);
+                    assertMigrationLabel(parent);
+                    assertThat(child.getMetadata().getLabels()).isNull();
                 })
                 .verifyComplete();
         verify(client).update(parent);
-        verify(client).update(child);
+        verify(client)
+                .update(argThat(
+                        (Category category) -> "B".equals(category.getMetadata().getName())));
+    }
+
+    @Test
+    void retriesWithLatestVersionAndPreservesConcurrentChanges() {
+        var category = category("A", "2024-01-01T00:00:00Z");
+        category.getMetadata().setVersion(1L);
+        doAnswer(invocation -> {
+                    category.getMetadata().setVersion(2L);
+                    category.getSpec().setDisplayName("concurrent edit");
+                    return Mono.error(new OptimisticLockingFailureException("conflict"));
+                })
+                .when(client)
+                .update(argThat((Category item) ->
+                        Long.valueOf(1L).equals(item.getMetadata().getVersion())));
+
+        migration
+                .migrate(List.of(category))
+                .as(StepVerifier::create)
+                .assertNext(summary -> {
+                    assertThat(summary.failures()).isZero();
+                    assertThat(summary.updated()).isEqualTo(1);
+                    assertThat(category.getMetadata().getVersion()).isEqualTo(2L);
+                    assertThat(category.getSpec().getDisplayName()).isEqualTo("concurrent edit");
+                    assertMigrationLabel(category);
+                })
+                .verifyComplete();
+        verify(client, times(2)).fetch(Category.class, "A");
     }
 
     private static void assertMigrationLabel(Category... categories) {
@@ -198,7 +247,7 @@ class CategoryHierarchyMigrationTest {
         }
     }
 
-    private static Category category(String name, String creationTimestamp, String... children) {
+    private Category category(String name, String creationTimestamp, String... children) {
         var category = new Category();
         var metadata = new Metadata();
         metadata.setName(name);
@@ -211,6 +260,7 @@ class CategoryHierarchyMigrationTest {
         spec.setPriority(0);
         spec.setChildren(List.of(children));
         category.setSpec(spec);
+        storedCategories.put(name, category);
         return category;
     }
 }

--- a/application/src/test/java/run/halo/app/core/extension/migration/MenuItemHierarchyMigrationTest.java
+++ b/application/src/test/java/run/halo/app/core/extension/migration/MenuItemHierarchyMigrationTest.java
@@ -2,6 +2,9 @@ package run.halo.app.core.extension.migration;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.ArgumentMatchers.eq;
 
 import java.time.Instant;
 import java.util.ArrayList;
@@ -9,6 +12,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -16,6 +20,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.dao.OptimisticLockingFailureException;
 import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
 import run.halo.app.core.extension.Menu;
@@ -31,6 +36,7 @@ class MenuItemHierarchyMigrationTest {
     private ReactiveExtensionClient client;
 
     private final List<MenuItem> createdItems = new ArrayList<>();
+    private final Map<String, MenuItem> storedItems = new HashMap<>();
 
     private MenuItemHierarchyMigration migration;
 
@@ -39,15 +45,108 @@ class MenuItemHierarchyMigrationTest {
         migration = new MenuItemHierarchyMigration(client);
         var sequence = new AtomicInteger();
         Mockito.lenient()
-                .when(client.update(any(MenuItem.class)))
-                .thenAnswer(invocation -> Mono.just(invocation.getArgument(0)));
+                .when(client.fetch(eq(MenuItem.class), anyString()))
+                .thenAnswer(invocation -> Mono.justOrEmpty(storedItems.get(invocation.getArgument(1)))
+                        .map(JsonUtils::deepCopy));
+        Mockito.lenient().when(client.update(any(MenuItem.class))).thenAnswer(invocation -> {
+            MenuItem item = invocation.getArgument(0);
+            var stored = storedItems.get(item.getMetadata().getName());
+            stored.setSpec(item.getSpec());
+            stored.setMetadata(item.getMetadata());
+            stored.setStatus(item.getStatus());
+            return Mono.just(item);
+        });
         Mockito.lenient().when(client.create(any(MenuItem.class))).thenAnswer(invocation -> {
             MenuItem item = invocation.getArgument(0);
             item.getMetadata().setName(item.getMetadata().getGenerateName() + sequence.incrementAndGet());
             item.getMetadata().setCreationTimestamp(Instant.parse("2022-08-05T04:19:37.252228Z"));
             createdItems.add(item);
+            storedItems.put(item.getMetadata().getName(), item);
             return Mono.just(item);
         });
+    }
+
+    @Test
+    void retriesWithLatestVersionAndPreservesConcurrentChanges() {
+        var root = menuItem("root", null);
+        root.getMetadata().setVersion(1L);
+        Mockito.doAnswer(invocation -> {
+                    root.getMetadata().setVersion(2L);
+                    root.getSpec().setDisplayName("concurrent edit");
+                    return Mono.error(new OptimisticLockingFailureException("conflict"));
+                })
+                .when(client)
+                .update(argThat((MenuItem item) ->
+                        Long.valueOf(1L).equals(item.getMetadata().getVersion())));
+
+        StepVerifier.create(migration.migrate(List.of(menu("primary", children("root"))), List.of(root)))
+                .assertNext(summary -> {
+                    assertThat(summary.getFailures()).isZero();
+                    assertThat(summary.getUpdated()).isEqualTo(1);
+                    assertThat(root.getMetadata().getVersion()).isEqualTo(2L);
+                    assertThat(root.getSpec().getDisplayName()).isEqualTo("concurrent edit");
+                    assertThat(root.getSpec().getMenuName()).isEqualTo("primary");
+                })
+                .verifyComplete();
+        Mockito.verify(client, Mockito.times(2)).fetch(MenuItem.class, "root");
+    }
+
+    @Test
+    void failedParentUpdateDoesNotMigrateChildrenOrMarkFailedStateAsMigrated() {
+        var root = menuItem("root", children("child"));
+        var child = menuItem("child", null);
+        Mockito.doReturn(Mono.error(new IllegalStateException("failed")))
+                .when(client)
+                .update(any(MenuItem.class));
+
+        StepVerifier.create(migration.migrate(List.of(menu("primary", children("root"))), List.of(root, child)))
+                .assertNext(summary -> {
+                    assertThat(summary.getFailures()).isEqualTo(1);
+                    assertThat(summary.getUpdated()).isZero();
+                    assertThat(root.getSpec().getMenuName()).isNull();
+                    assertThat(root.getMetadata().getLabels()).isNull();
+                    assertThat(child.getSpec().getParent()).isNull();
+                    assertThat(child.getSpec().getMenuName()).isNull();
+                })
+                .verifyComplete();
+        Mockito.verify(client, Mockito.times(1)).update(any(MenuItem.class));
+    }
+
+    @Test
+    void failedSubtreeWithAssignedMenuRemainsRetryable() {
+        var root = menuItem("root", children("child"));
+        var child = menuItem("child", null);
+        root.getSpec().setMenuName("primary");
+        child.getSpec().setMenuName("primary");
+        Mockito.doReturn(Mono.error(new IllegalStateException("failed")))
+                .when(client)
+                .update(any(MenuItem.class));
+
+        StepVerifier.create(migration.migrate(List.of(menu("primary", children("root"))), List.of(root, child)))
+                .assertNext(summary -> {
+                    assertThat(summary.getFailures()).isEqualTo(1);
+                    assertThat(root.getMetadata().getLabels()).isNull();
+                    assertThat(child.getMetadata().getLabels()).isNull();
+                    assertThat(child.getSpec().getParent()).isNull();
+                })
+                .verifyComplete();
+        Mockito.verify(client, Mockito.times(1)).update(any(MenuItem.class));
+    }
+
+    @Test
+    void rerunPreservesMenuItemMovedToRoot() {
+        var root = menuItem("root", children("child"));
+        var child = menuItem("child", null);
+        var menus = List.of(menu("primary", children("root", "child")));
+        migration.migrate(menus, List.of(root, child)).block();
+        child.getSpec().setParent(null);
+
+        StepVerifier.create(migration.migrate(menus, List.of(root, child)))
+                .assertNext(summary -> {
+                    assertThat(summary.getUpdated()).isZero();
+                    assertThat(child.getSpec().getParent()).isNull();
+                })
+                .verifyComplete();
     }
 
     @Test
@@ -287,6 +386,7 @@ class MenuItemHierarchyMigrationTest {
         spec.setDisplayName(name);
         spec.setChildren(childNames);
         item.setSpec(spec);
+        storedItems.put(name, item);
         return item;
     }
 

--- a/application/src/test/java/run/halo/app/core/extension/migration/MenuItemHierarchyMigrationTest.java
+++ b/application/src/test/java/run/halo/app/core/extension/migration/MenuItemHierarchyMigrationTest.java
@@ -150,6 +150,43 @@ class MenuItemHierarchyMigrationTest {
     }
 
     @Test
+    void shouldRepairMigratedMenuItemWithoutMenuName() {
+        var item = menuItem("item", null);
+        item.getMetadata().setLabels(new HashMap<>());
+        item.getMetadata().getLabels().put(MenuItem.HIERARCHY_MIGRATED_LABEL, "true");
+        item.getSpec().setParent("keep-parent");
+
+        StepVerifier.create(migration.migrate(List.of(menu("primary", children("item"))), List.of(item)))
+                .assertNext(summary -> {
+                    assertThat(summary.getUpdated()).isEqualTo(1);
+                    assertThat(item.getSpec().getMenuName()).isEqualTo("primary");
+                    assertThat(item.getSpec().getParent()).isEqualTo("keep-parent");
+                })
+                .verifyComplete();
+    }
+
+    @Test
+    void shouldRepairMigratedCloneWithoutMenuName() {
+        var shared = menuItem("shared", null);
+        var menus = List.of(
+                menu("menu-a", children("shared"), "2022-08-05T04:19:37Z"),
+                menu("menu-b", children("shared"), "2022-08-05T04:19:38Z"));
+        migration.migrate(menus, List.of(shared)).block();
+        var clone = createdItems.getFirst();
+        clone.getSpec().setMenuName(null);
+
+        StepVerifier.create(migration.migrate(menus, List.of(shared, clone)))
+                .assertNext(summary -> {
+                    assertThat(summary.getUpdated()).isEqualTo(1);
+                    assertThat(summary.getClonesReused()).isEqualTo(1);
+                    assertThat(summary.getClonesCreated()).isZero();
+                    assertThat(clone.getSpec().getMenuName()).isEqualTo("menu-b");
+                    assertThat(clone.getSpec().getParent()).isNull();
+                })
+                .verifyComplete();
+    }
+
+    @Test
     void shouldMigrateLegacyTreeWithoutChangingLegacyFields() {
         var root = menuItem("root", children("child"));
         var child = menuItem("child", children("grandchild"));


### PR DESCRIPTION
#### What type of PR is this?

- [ ] Feature
- [x] Bug fix
- [ ] Improvement
- [ ] Cleanup
- [ ] Documentation

#### What this PR does / why we need it:

Menu and category trees display items with invalid parents as roots, but position updates previously used their stored parents to identify siblings. Moving another item before such a displayed root failed with HTTP 400.

Reproduction:
1. Create an item whose parent does not exist and another root item.
2. Load the tree, which displays both items as roots.
3. Move the other item before the orphan.
4. The position request fails with "Before MenuItem is not a target sibling." The category endpoint has the equivalent failure.

Use the same effective parent relationships for tree rendering and sibling ordering, persisting corrected hierarchy fields for affected items.

Also reload the latest resource on each migration retry, keep failed menu subtrees eligible for migration, and preserve items that users moved to the root after migration.

#### Which issue(s) this PR fixes:

Fixes #10281

#### Special notes for your reviewer:

Developed with assistance from OpenAI Codex.

Validation:
- 43 related service, migration, and endpoint tests passed.
- Two additional integration tests passed using the full application context and a real H2 database. They verify successful position updates, persisted parent/order/version changes, subsequent tree queries, and rejection of moves beneath descendants.
- The original service-level reproduction passes after the fix.
- `git diff --check` passed.

The integration tests mock the authorization identity and role lookup, but use the real hierarchy services and storage implementation. Browser drag-and-drop and MariaDB have not been tested.

#### Does this PR introduce a user-facing change?

```release-note
修复菜单和分类在父级异常时无法拖动排序的问题，改善升级后层级迁移的可靠性，并避免重启后已移至顶层的菜单或分类被恢复到旧父级。
```
