### PR TITLE
Remove deprecated getJsBundleResource helper

### DIFF
--- a/application/src/main/java/run/halo/app/plugin/resources/BundleResourceUtils.java
+++ b/application/src/main/java/run/halo/app/plugin/resources/BundleResourceUtils.java
@@ -55,18 +55,6 @@ public abstract class BundleResourceUtils {
         return getBundleResource(resourceLoader, bundleLocation, bundleName);
     }
 
-    /**
-     * Gets bundle resource by plugin name in the selected location.
-     *
-     * @return bundle resource if exists, otherwise null
-     * @deprecated use {@link #getSelectedBundleResource(PluginManager, String, String)} instead
-     */
-    @Deprecated
-    public static @Nullable Resource getJsBundleResource(
-            PluginManager pluginManager, String pluginName, String bundleName) {
-        return getSelectedBundleResource(pluginManager, pluginName, bundleName);
-    }
-
     public static @Nullable Resource getBundleResource(
             PluginManager pluginManager, String pluginName, String bundleLocation, String bundleName) {
         Assert.hasText(pluginName, "The pluginName must not be blank");

--- a/application/src/test/java/run/halo/app/plugin/resources/BundleResourceUtilsTest.java
+++ b/application/src/test/java/run/halo/app/plugin/resources/BundleResourceUtilsTest.java
@@ -70,17 +70,6 @@ class BundleResourceUtilsTest {
                 .isInstanceOf(AccessDeniedException.class);
     }
 
-    @SuppressWarnings("deprecation")
-    @Test
-    void getJsBundleResourceShouldDelegateToSelectedBundleResource() throws IOException {
-        lenient().when(pluginClassLoader.getResource(eq("ui/main.js"))).thenReturn(new URL("file://ui/main.js"));
-
-        Resource jsBundleResource = BundleResourceUtils.getJsBundleResource(pluginManager, "fake-plugin", "main.js");
-
-        assertThat(jsBundleResource).isNotNull();
-        assertThat(jsBundleResource.getURL().toString()).isEqualTo("file://ui/main.js");
-    }
-
     @Test
     void shouldPreferUiBundleLocation() throws IOException {
         lenient().when(pluginClassLoader.getResource(eq("ui/main.js"))).thenReturn(new URL("file://ui/main.js"));


### PR DESCRIPTION
#### What type of PR is this?

- [ ] Feature
- [ ] Bug fix
- [ ] Improvement
- [x] Cleanup
- [ ] Documentation

#### What this PR does / why we need it:

Remove the deprecated `BundleResourceUtils.getJsBundleResource()` alias and its delegation test. Callers should use `getSelectedBundleResource()` with the same arguments.

No production callers of the removed method were found in this repository.

#### Which issue(s) this PR fixes:

None.

#### Special notes for your reviewer:

Validation:
- All 7 remaining `BundleResourceUtilsTest` tests passed.
- `:application:spotlessJavaCheck` passed.
- `git diff --check` passed.

Changes assisted by Codex.

#### Does this PR introduce a user-facing change?

```release-note
action required: 已移除 BundleResourceUtils.getJsBundleResource()。调用此方法的扩展请改用参数相同的 getSelectedBundleResource()。
```
