### PR TITLE
Fix comment owner display in the detail modal

### DIFF
--- a/ui/console-src/modules/contents/comments/components/CommentDetailModal.vue
+++ b/ui/console-src/modules/contents/comments/components/CommentDetailModal.vue
@@ -117,7 +117,7 @@ const { data: contentProvider } = useContentProviderExtensionPoint();
           <div class="flex items-center gap-3">
             <OwnerButton
               v-if="comment.comment.spec.owner.kind === 'User'"
-              :owner="comment.comment.spec.owner"
+              :owner="comment.owner"
               @click="
                 $router.push({
                   name: 'UserDetail',


### PR DESCRIPTION
#### What type of PR is this?

- [ ] Feature
- [x] Bug fix
- [ ] Improvement
- [ ] Cleanup
- [ ] Documentation

#### What this PR does / why we need it:

Use the resolved `ListedComment.owner` when rendering the registered user's information in the comment detail modal.

The modal previously passed the raw owner reference, which does not provide the resolved avatar and display name expected by `OwnerButton`. This aligns the modal with the comment list.

#### Which issue(s) this PR fixes:

None.

#### Special notes for your reviewer:

Validation passed:
- `corepack pnpm@11.17.0 -C ui typecheck`
- `corepack pnpm@11.17.0 -C ui exec eslint console-src/modules/contents/comments/components/CommentDetailModal.vue --max-warnings=0`
- `git diff --check`
- Pre-commit formatting and ESLint checks

Browser verification has not been run. Suggested manual verification: open the detail modal for a registered user's comment and verify that the display name and avatar match the comment list and that clicking the owner opens the correct user detail page.

#### Does this PR introduce a user-facing change?

```release-note
修复评论详情中注册用户的昵称和头像显示不正确的问题。
```
