### PR TITLE
fix: skip attachment resource cleanup when its policy is gone

### DIFF
--- a/application/src/main/java/run/halo/app/core/attachment/reconciler/AttachmentReconciler.java
+++ b/application/src/main/java/run/halo/app/core/attachment/reconciler/AttachmentReconciler.java
@@ -11,6 +11,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Component;
+import reactor.core.publisher.Mono;
 import run.halo.app.core.attachment.AttachmentChangedEvent;
 import run.halo.app.core.extension.attachment.Attachment;
 import run.halo.app.core.extension.attachment.Attachment.AttachmentStatus;
@@ -23,6 +24,7 @@ import run.halo.app.extension.controller.ControllerBuilder;
 import run.halo.app.extension.controller.Reconciler;
 import run.halo.app.extension.controller.Reconciler.Request;
 import run.halo.app.extension.controller.RequeueException;
+import run.halo.app.extension.exception.ExtensionNotFoundException;
 
 @Slf4j
 @Component
@@ -84,6 +86,18 @@ class AttachmentReconciler implements Reconciler<Request> {
     }
 
     void cleanUpResources(Attachment attachment) {
-        attachmentService.delete(attachment).block(Duration.ofSeconds(20));
+        attachmentService
+                .delete(attachment)
+                // A missing policy or config map is permanent: no handler can resolve the
+                // attachment any more, so there is nothing left to clean up and requeuing
+                // would only spin forever. Give up on the resources and let the finalizer go.
+                .onErrorResume(ExtensionNotFoundException.class, e -> {
+                    log.warn(
+                            "Skipped cleaning up resources of attachment {}: {} Removing the attachment record anyway.",
+                            attachment.getMetadata().getName(),
+                            e.getMessage());
+                    return Mono.empty();
+                })
+                .block(Duration.ofSeconds(20));
     }
 }

--- a/application/src/test/java/run/halo/app/core/attachment/reconciler/AttachmentReconcilerTest.java
+++ b/application/src/test/java/run/halo/app/core/attachment/reconciler/AttachmentReconcilerTest.java
@@ -1,0 +1,101 @@
+package run.halo.app.core.attachment.reconciler;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.time.Instant;
+import java.util.Optional;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationEventPublisher;
+import reactor.core.publisher.Mono;
+import run.halo.app.core.attachment.AttachmentChangedEvent;
+import run.halo.app.core.extension.attachment.Attachment;
+import run.halo.app.core.extension.attachment.Constant;
+import run.halo.app.core.extension.attachment.Policy;
+import run.halo.app.core.extension.service.AttachmentService;
+import run.halo.app.extension.ExtensionClient;
+import run.halo.app.extension.GroupVersionKind;
+import run.halo.app.extension.Metadata;
+import run.halo.app.extension.controller.Reconciler.Request;
+import run.halo.app.extension.exception.ExtensionNotFoundException;
+
+/** Tests for {@link AttachmentReconciler}. */
+@ExtendWith(MockitoExtension.class)
+class AttachmentReconcilerTest {
+
+    @Mock
+    private ExtensionClient client;
+
+    @Mock
+    private AttachmentService attachmentService;
+
+    @Mock
+    private ApplicationEventPublisher eventPublisher;
+
+    @InjectMocks
+    private AttachmentReconciler reconciler;
+
+    @Test
+    void shouldRemoveFinalizerWhenPolicyWasDeleted() {
+        var attachment = deletedAttachment();
+        when(client.fetch(Attachment.class, "fake-attachment")).thenReturn(Optional.of(attachment));
+        when(attachmentService.delete(attachment))
+                .thenReturn(Mono.error(new ExtensionNotFoundException(
+                        GroupVersionKind.fromExtension(Policy.class), "deleted-policy")));
+
+        reconciler.reconcile(new Request("fake-attachment"));
+
+        assertThat(attachment.getMetadata().getFinalizers()).doesNotContain(Constant.FINALIZER_NAME);
+        verify(client).update(attachment);
+        verify(eventPublisher).publishEvent(any(AttachmentChangedEvent.class));
+    }
+
+    @Test
+    void shouldRemoveFinalizerAfterResourcesAreCleanedUp() {
+        var attachment = deletedAttachment();
+        when(client.fetch(Attachment.class, "fake-attachment")).thenReturn(Optional.of(attachment));
+        when(attachmentService.delete(attachment)).thenReturn(Mono.just(attachment));
+
+        reconciler.reconcile(new Request("fake-attachment"));
+
+        assertThat(attachment.getMetadata().getFinalizers()).doesNotContain(Constant.FINALIZER_NAME);
+        verify(client).update(attachment);
+        verify(eventPublisher).publishEvent(any(AttachmentChangedEvent.class));
+    }
+
+    @Test
+    void shouldKeepFinalizerWhenCleaningUpResourcesFailsForOtherReasons() {
+        var attachment = deletedAttachment();
+        when(client.fetch(Attachment.class, "fake-attachment")).thenReturn(Optional.of(attachment));
+        when(attachmentService.delete(attachment)).thenReturn(Mono.error(new IllegalStateException("boom")));
+
+        assertThatThrownBy(() -> reconciler.reconcile(new Request("fake-attachment")))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessage("boom");
+
+        verify(client, never()).update(any(Attachment.class));
+        verify(eventPublisher, never()).publishEvent(any(AttachmentChangedEvent.class));
+    }
+
+    private static Attachment deletedAttachment() {
+        var attachment = new Attachment();
+        var metadata = new Metadata();
+        metadata.setName("fake-attachment");
+        metadata.setDeletionTimestamp(Instant.now());
+        metadata.setFinalizers(Set.of(Constant.FINALIZER_NAME));
+        attachment.setMetadata(metadata);
+        var spec = new Attachment.AttachmentSpec();
+        spec.setPolicyName("deleted-policy");
+        attachment.setSpec(spec);
+        return attachment;
+    }
+}


### PR DESCRIPTION
#### What type of PR is this?

- [ ] Feature
- [x] Bug fix
- [ ] Improvement
- [ ] Cleanup
- [ ] Documentation

#### What this PR does / why we need it:

When a storage policy is deleted while attachments still reference it, those attachments can no longer be deleted and the log fills up with 404 errors.

`AttachmentReconciler#cleanUpResources` calls `attachmentService.delete(attachment)`, whose first step is `client.get(Policy.class, ...)`. With the policy gone that errors with `ExtensionNotFoundException` (404). The reconciler does not handle it, so `DefaultController` logs "aborted with an error, re-enqueuing" and requeues unconditionally, forever, because the missing policy never comes back. The finalizer is never removed either, so the attachment record stays as well.

A missing policy or config map is a permanent state, not a transient failure: no handler can resolve the attachment any more, so there is nothing left to clean up. This treats that case as "nothing to do" - log a warning and let the reconciler remove the finalizer, so the attachment record can finally be deleted as the user asked.

Tests: a new `AttachmentReconcilerTest` with three cases - policy missing (finalizer removed, no exception), normal cleanup (unchanged), and any other error still propagating so the finalizer is kept and the request is retried. The first one fails on current main.

#### Which issue(s) this PR fixes:

Fixes #6380

#### Special notes for your reviewer:

- The fix sits in the reconciler rather than in `DefaultAttachmentService#delete`, so the public `AttachmentService` contract that plugins depend on is unchanged.
- `onErrorResume` is scoped to `ExtensionNotFoundException`. If a plugin handler's own `delete()` throws that exception for some unrelated extension, it would also be treated as "nothing to clean up". Narrowing further would mean pre-checking the policy and its config map in the reconciler, duplicating what the service already does. Happy to switch if you prefer that shape.
- This follows the direction you took in #7310, where a missing upstream file should be ignored rather than retried.
- Remote files that were already unreachable are still not removed; the attachment record goes away and the warning names both the attachment and the missing extension, so the leftover can be found later.
- I decided to submit this fix and reviewed it before sending; the implementation and the tests were written with AI assistance. Verification: the three unit tests above are red before and green after on Linux with JDK 21, and `spotlessJavaCheck` is clean. Not covered: I did not reproduce the original 404 loop end to end against a live deployment.

#### Does this PR introduce a user-facing change?

```release-note
修复删除存储策略后，其关联附件无法删除且后台日志持续输出 404 错误的问题
```
