### PR TITLE
Fix theme selection and persist it in the URL

### DIFF
--- a/ui/console-src/modules/interface/themes/ThemeSetting.vue
+++ b/ui/console-src/modules/interface/themes/ThemeSetting.vue
@@ -25,7 +25,11 @@ const setting = inject<Ref<Setting | undefined>>("setting", ref());
 const saving = ref(false);
 
 const { data: configMapData, suspense } = useQuery({
-  queryKey: ["core:theme:configMap:data", selectedTheme],
+  queryKey: [
+    "core:theme:configMap:data",
+    computed(() => selectedTheme?.value?.metadata.name),
+    computed(() => selectedTheme?.value?.spec.configMapName),
+  ],
   queryFn: async () => {
     const { data } = await consoleApiClient.theme.theme.fetchThemeJsonConfig({
       name: selectedTheme?.value?.metadata.name as string,

--- a/ui/console-src/modules/interface/themes/components/ThemeListModal.vue
+++ b/ui/console-src/modules/interface/themes/components/ThemeListModal.vue
@@ -10,7 +10,6 @@ import {
   provide,
   ref,
   shallowRef,
-  watch,
   type Ref,
 } from "vue";
 import { useI18n } from "vue-i18n";
@@ -26,6 +25,10 @@ const emit = defineEmits<{
 }>();
 
 const modal = ref<InstanceType<typeof VModal> | null>(null);
+
+defineExpose({
+  close: () => modal.value?.close(),
+});
 
 const tabs = shallowRef<ThemeListTab[]>([
   {
@@ -66,14 +69,14 @@ const tabs = shallowRef<ThemeListTab[]>([
   },
 ]);
 
-watch(
-  () => selectedTheme.value,
-  (value, oldValue) => {
-    if (value && oldValue) {
-      emit("select", value);
-      modal.value?.close();
-    }
-  }
+provide<Ref<Theme | undefined>>(
+  "selectedTheme",
+  computed({
+    get: () => selectedTheme.value,
+    set: (theme) => {
+      emit("select", theme);
+    },
+  })
 );
 
 const activeTabId = ref();

--- a/ui/console-src/modules/interface/themes/components/list-tabs/InstalledThemes.vue
+++ b/ui/console-src/modules/interface/themes/components/list-tabs/InstalledThemes.vue
@@ -1,14 +1,6 @@
 <script lang="ts" setup>
-import { useThemeStore } from "@console/stores/theme";
-import type {
-  Theme,
-  ThemeV1alpha1ConsoleApiListThemesRequest,
-} from "@halo-dev/api-client";
-import {
-  consoleApiClient,
-  coreApiClient,
-  paginate,
-} from "@halo-dev/api-client";
+import type { Theme } from "@halo-dev/api-client";
+import { coreApiClient } from "@halo-dev/api-client";
 import {
   Dialog,
   IconAddCircle,
@@ -21,14 +13,13 @@ import {
   VLoading,
   VSpace,
 } from "@halo-dev/components";
-import { useQuery } from "@tanstack/vue-query";
 import { useFuse } from "@vueuse/integrations/useFuse";
 import { computed, inject, ref, shallowRef, watch, type Ref } from "vue";
 import { useI18n } from "vue-i18n";
+import { useInstalledThemes } from "../../composables/use-installed-themes";
 import ThemePreviewModal from "../preview/ThemePreviewModal.vue";
 import ThemeListItem from "../ThemeListItem.vue";
 
-const themeStore = useThemeStore();
 const { t } = useI18n();
 
 const selectedTheme = inject<Ref<Theme | undefined>>("selectedTheme", ref());
@@ -39,41 +30,7 @@ function handleSelectTheme(theme: Theme) {
   selectedTheme.value = theme;
 }
 
-const {
-  data: themes,
-  isLoading,
-  isFetching,
-  refetch,
-} = useQuery<Theme[]>({
-  queryKey: ["installed-themes"],
-  queryFn: async () => {
-    const themes = await paginate<
-      ThemeV1alpha1ConsoleApiListThemesRequest,
-      Theme
-    >((params) => consoleApiClient.theme.theme.listThemes(params), {
-      uninstalled: false,
-      size: 1000,
-    });
-
-    return themes.sort((a, b) => {
-      const activatedThemeName = themeStore.activatedTheme?.metadata.name;
-      if (a.metadata.name === activatedThemeName) {
-        return -1;
-      }
-      if (b.metadata.name === activatedThemeName) {
-        return 1;
-      }
-      return 0;
-    });
-  },
-  refetchInterval(data) {
-    const hasDeletingTheme = data?.some(
-      (theme) => !!theme.metadata.deletionTimestamp
-    );
-
-    return hasDeletingTheme ? 1000 : false;
-  },
-});
+const { data: themes, isLoading, isFetching, refetch } = useInstalledThemes();
 
 const { results } = useFuse(
   keyword,

--- a/ui/console-src/modules/interface/themes/components/preview/ThemePreviewModal.vue
+++ b/ui/console-src/modules/interface/themes/components/preview/ThemePreviewModal.vue
@@ -111,7 +111,11 @@ const activeSettingTab = ref("");
 const settingsVisible = ref(false);
 
 const { data: setting } = useQuery<Setting>({
-  queryKey: ["theme-setting", selectedTheme],
+  queryKey: [
+    "theme-setting",
+    computed(() => selectedTheme.value?.metadata.name),
+    computed(() => selectedTheme.value?.spec.settingName),
+  ],
   queryFn: async () => {
     const { data } = await consoleApiClient.theme.theme.fetchThemeSetting({
       name: selectedTheme?.value?.metadata.name as string,
@@ -136,7 +140,11 @@ const { data: setting } = useQuery<Setting>({
 });
 
 const { data: configMapData } = useQuery({
-  queryKey: ["core:theme:configMap:data", selectedTheme],
+  queryKey: [
+    "core:theme:configMap:data",
+    computed(() => selectedTheme?.value?.metadata.name),
+    computed(() => selectedTheme?.value?.spec.configMapName),
+  ],
   queryFn: async () => {
     const { data } = await consoleApiClient.theme.theme.fetchThemeJsonConfig({
       name: selectedTheme?.value?.metadata.name as string,

--- a/ui/console-src/modules/interface/themes/composables/use-installed-themes.ts
+++ b/ui/console-src/modules/interface/themes/composables/use-installed-themes.ts
@@ -1,0 +1,43 @@
+import { useThemeStore } from "@console/stores/theme";
+import type {
+  Theme,
+  ThemeV1alpha1ConsoleApiListThemesRequest,
+} from "@halo-dev/api-client";
+import { consoleApiClient, paginate } from "@halo-dev/api-client";
+import { useQuery } from "@tanstack/vue-query";
+import { computed, toValue, type MaybeRefOrGetter } from "vue";
+
+export function useInstalledThemes(enabled: MaybeRefOrGetter<boolean> = true) {
+  const themeStore = useThemeStore();
+  return useQuery<Theme[]>({
+    enabled: computed(() => toValue(enabled)),
+    queryKey: ["installed-themes"],
+    queryFn: async () => {
+      const themes = await paginate<
+        ThemeV1alpha1ConsoleApiListThemesRequest,
+        Theme
+      >((params) => consoleApiClient.theme.theme.listThemes(params), {
+        uninstalled: false,
+        size: 1000,
+      });
+
+      return themes.sort((a, b) => {
+        const activatedThemeName = themeStore.activatedTheme?.metadata.name;
+        if (a.metadata.name === activatedThemeName) {
+          return -1;
+        }
+        if (b.metadata.name === activatedThemeName) {
+          return 1;
+        }
+        return 0;
+      });
+    },
+    refetchInterval(data) {
+      const hasDeletingTheme = data?.some(
+        (theme) => !!theme.metadata.deletionTimestamp
+      );
+
+      return hasDeletingTheme ? 1000 : false;
+    },
+  });
+}

--- a/ui/console-src/modules/interface/themes/layouts/ThemeLayout.vue
+++ b/ui/console-src/modules/interface/themes/layouts/ThemeLayout.vue
@@ -90,7 +90,11 @@ const {
   isError: settingError,
   refetch: refetchSetting,
 } = useQuery<Setting>({
-  queryKey: ["theme-setting", selectedTheme],
+  queryKey: [
+    "theme-setting",
+    computed(() => selectedTheme.value?.metadata.name),
+    computed(() => selectedTheme.value?.spec.settingName),
+  ],
   queryFn: async () => {
     const { data } = await consoleApiClient.theme.theme.fetchThemeSetting({
       name: selectedTheme.value?.metadata.name as string,
@@ -157,7 +161,11 @@ watch(
       selectedTheme.value &&
       !settingLoading.value &&
       !settingError.value &&
-      !tabs.value.some((tab) => tab.id === route.params.group)
+      !tabs.value.some(
+        (tab) =>
+          tab.route.name === "ThemeSetting" &&
+          tab.route.params?.group === route.params.group
+      )
     ) {
       void router.replace({
         name: "ThemeDetail",
@@ -206,15 +214,13 @@ watch(
     </VPageHeader>
 
     <div class="m-0 md:m-4">
-      <VLoading v-if="(themeName && themesLoading) || settingLoading" />
+      <VLoading v-if="themeName && themesLoading" />
       <VEmpty
-        v-else-if="
-          (themeName && themesError && !themes) || (settingError && !setting)
-        "
+        v-else-if="themeName && themesError && !themes"
         :title="$t('core.common.status.loading_error')"
       >
         <template #actions>
-          <VButton @click="settingError ? refetchSetting() : refetchThemes()">
+          <VButton @click="refetchThemes()">
             {{ $t("core.common.buttons.retry") }}
           </VButton>
         </template>
@@ -257,7 +263,24 @@ watch(
             ></VTabbar>
           </template>
           <div class="rounded-b-base bg-white">
-            <RouterView v-slot="{ Component }">
+            <VEmpty
+              v-if="settingError && !setting"
+              :title="$t('core.common.status.loading_error')"
+            >
+              <template #actions>
+                <VButton @click="refetchSetting()">{{
+                  $t("core.common.buttons.retry")
+                }}</VButton>
+              </template>
+            </VEmpty>
+            <VLoading v-if="route.name === 'ThemeSetting' && settingLoading" />
+            <RouterView
+              v-if="
+                route.name !== 'ThemeSetting' ||
+                (!settingLoading && !(settingError && !setting))
+              "
+              v-slot="{ Component }"
+            >
               <template v-if="Component">
                 <Suspense :key="selectedTheme.metadata.name">
                   <component :is="Component"></component>

--- a/ui/console-src/modules/interface/themes/layouts/ThemeLayout.vue
+++ b/ui/console-src/modules/interface/themes/layouts/ThemeLayout.vue
@@ -1,7 +1,7 @@
 <script lang="ts" setup>
 import BasicLayout from "@console/layouts/BasicLayout.vue";
 import { useThemeStore } from "@console/stores/theme";
-import type { Setting, SettingForm, Theme } from "@halo-dev/api-client";
+import type { Setting, Theme } from "@halo-dev/api-client";
 import { consoleApiClient } from "@halo-dev/api-client";
 import {
   IconExchange,
@@ -18,27 +18,13 @@ import {
 } from "@halo-dev/components";
 import { utils } from "@halo-dev/ui-shared";
 import { useQuery } from "@tanstack/vue-query";
-import { cloneDeep } from "es-toolkit";
 import { storeToRefs } from "pinia";
-import {
-  computed,
-  nextTick,
-  onMounted,
-  provide,
-  ref,
-  shallowRef,
-  watch,
-  type Ref,
-} from "vue";
+import { computed, provide, ref, watch, type Ref } from "vue";
 import { useI18n } from "vue-i18n";
-import {
-  isNavigationFailure,
-  NavigationFailureType,
-  useRoute,
-  useRouter,
-} from "vue-router";
+import { useRoute, useRouter } from "vue-router";
 import ThemePreviewModal from "../components/preview/ThemePreviewModal.vue";
 import ThemeListModal from "../components/ThemeListModal.vue";
+import { useInstalledThemes } from "../composables/use-installed-themes";
 import { useThemeLifeCycle } from "../composables/use-theme";
 
 const { t } = useI18n();
@@ -64,20 +50,46 @@ const initialTabs: ThemeTab[] = [
   },
 ];
 
-const tabs = shallowRef<ThemeTab[]>(initialTabs);
-const selectedTheme = ref<Theme>();
+const { activatedTheme } = storeToRefs(useThemeStore());
+const hasThemeQuery = computed(() => route.query.theme !== undefined);
+const themeName = computed(() =>
+  typeof route.query.theme === "string" ? route.query.theme : undefined
+);
+const {
+  data: themes,
+  isInitialLoading: themesLoading,
+  isError: themesError,
+  refetch: refetchThemes,
+} = useInstalledThemes(computed(() => !!themeName.value));
+const selectedTheme = computed(() => {
+  if (!hasThemeQuery.value) {
+    return activatedTheme.value;
+  }
+  return themes.value?.find(
+    (theme) =>
+      theme.metadata.name === themeName.value &&
+      !theme.metadata.deletionTimestamp
+  );
+});
 const themesModal = ref(false);
+const themeListModal = ref<InstanceType<typeof ThemeListModal>>();
 const previewModal = ref(false);
-const activeTab = ref(tabs.value[0].id);
+const activeTab = computed(() =>
+  route.name === "ThemeSetting" ? String(route.params.group) : initialTabs[0].id
+);
 provide<Ref<string>>("activeTab", activeTab);
 provide<Ref<boolean>>("themesModal", themesModal);
 
-const { loading, isActivated, handleActiveTheme } =
-  useThemeLifeCycle(selectedTheme);
+const { isActivated, handleActiveTheme } = useThemeLifeCycle(selectedTheme);
 
 provide<Ref<Theme | undefined>>("selectedTheme", selectedTheme);
 
-const { data: setting } = useQuery<Setting>({
+const {
+  data: setting,
+  isInitialLoading: settingLoading,
+  isError: settingError,
+  refetch: refetchSetting,
+} = useQuery<Setting>({
   queryKey: ["theme-setting", selectedTheme],
   queryFn: async () => {
     const { data } = await consoleApiClient.theme.theme.fetchThemeSetting({
@@ -92,84 +104,70 @@ const { data: setting } = useQuery<Setting>({
       utils.permission.has(["system:themes:view"])
     );
   }),
-  async onSuccess(data) {
-    if (data) {
-      const { forms } = data.spec;
-      tabs.value = [
-        ...initialTabs,
-        ...forms.map((item: SettingForm) => {
-          return {
-            id: item.group,
-            label: item.label || "",
-            route: {
-              name: "ThemeSetting",
-              params: {
-                group: item.group,
-              },
-            },
-          };
-        }),
-      ] as ThemeTab[];
-    }
-
-    await nextTick();
-
-    handleTriggerTabChange();
-  },
 });
+
+const tabs = computed<ThemeTab[]>(() => [
+  ...initialTabs,
+  ...(setting.value?.spec.forms || []).map((item) => ({
+    id: item.group,
+    label: item.label || "",
+    route: {
+      name: "ThemeSetting",
+      params: { group: item.group },
+    },
+  })),
+]);
 
 provide<Ref<Setting | undefined>>("setting", setting);
 
-const handleTabChange = async (id: string | number) => {
+const handleTabChange = (id: string | number) => {
   const tab = tabs.value.find((item) => item.id === id);
   if (tab) {
-    const navigationResult = await router.push(tab.route);
-    if (
-      isNavigationFailure(navigationResult, NavigationFailureType.aborted) ||
-      isNavigationFailure(navigationResult, NavigationFailureType.cancelled)
-    ) {
-      return;
-    }
-    activeTab.value = tab.id;
+    return router.push({ ...tab.route, query: route.query, hash: route.hash });
   }
 };
 
-const handleTriggerTabChange = () => {
-  if (route.name === "ThemeSetting") {
-    const tab = tabs.value.find((tab) => {
-      return (
-        tab.route.name === route.name &&
-        tab.route.params?.group === route.params.group
-      );
-    });
-    if (tab) {
-      activeTab.value = tab.id;
-      return;
-    }
-    void handleTabChange(tabs.value[0].id);
+const onSelectTheme = async (theme: Theme | undefined) => {
+  if (!theme) return;
+  if (theme.metadata.name === selectedTheme.value?.metadata.name) {
+    themeListModal.value?.close();
     return;
   }
-
-  const tab = tabs.value.find((tab) => tab.route.name === route.name);
-  activeTab.value = tab ? tab.id : tabs.value[0].id;
+  const failure = await router.replace({
+    name: "ThemeDetail",
+    query: { ...route.query, theme: theme.metadata.name },
+  });
+  if (!failure) {
+    themeListModal.value?.close();
+  }
 };
 
-const onSelectTheme = () => {
-  tabs.value = cloneDeep(initialTabs);
-  void handleTabChange(tabs.value[0].id);
-};
-
-onMounted(() => {
-  const themeStore = useThemeStore();
-
-  const { activatedTheme } = storeToRefs(themeStore);
-
-  selectedTheme.value = activatedTheme?.value;
-});
-
-watch([() => route.name, () => route.params], async () => {
-  handleTriggerTabChange();
-});
+// Wait for the selected theme's settings before validating a bookmarked group.
+watch(
+  [
+    () => route.name,
+    () => route.params.group,
+    selectedTheme,
+    tabs,
+    settingLoading,
+  ],
+  () => {
+    if (
+      route.name === "ThemeSetting" &&
+      selectedTheme.value &&
+      !settingLoading.value &&
+      !settingError.value &&
+      !tabs.value.some((tab) => tab.id === route.params.group)
+    ) {
+      void router.replace({
+        name: "ThemeDetail",
+        query: route.query,
+        hash: route.hash,
+      });
+    }
+  },
+  { immediate: true }
+);
 </script>
 <template>
   <BasicLayout>
@@ -179,7 +177,7 @@ watch([() => route.name, () => route.params], async () => {
       </template>
       <template #actions>
         <VButton
-          v-show="!isActivated"
+          v-if="selectedTheme && !isActivated"
           v-permission="['system:themes:manage']"
           size="sm"
           type="primary"
@@ -187,7 +185,12 @@ watch([() => route.name, () => route.params], async () => {
         >
           {{ $t("core.common.buttons.activate") }}
         </VButton>
-        <VButton type="default" size="sm" @click="previewModal = true">
+        <VButton
+          v-if="selectedTheme"
+          type="default"
+          size="sm"
+          @click="previewModal = true"
+        >
           <template #icon>
             <IconEye />
           </template>
@@ -203,10 +206,29 @@ watch([() => route.name, () => route.params], async () => {
     </VPageHeader>
 
     <div class="m-0 md:m-4">
+      <VLoading v-if="(themeName && themesLoading) || settingLoading" />
       <VEmpty
-        v-if="!selectedTheme && !loading"
+        v-else-if="
+          (themeName && themesError && !themes) || (settingError && !setting)
+        "
+        :title="$t('core.common.status.loading_error')"
+      >
+        <template #actions>
+          <VButton @click="settingError ? refetchSetting() : refetchThemes()">
+            {{ $t("core.common.buttons.retry") }}
+          </VButton>
+        </template>
+      </VEmpty>
+      <VEmpty
+        v-else-if="!selectedTheme"
         :message="$t('core.theme.empty.message')"
-        :title="$t('core.theme.empty.title')"
+        :title="
+          $t(
+            hasThemeQuery
+              ? 'core.common.toast.not_found'
+              : 'core.theme.empty.title'
+          )
+        "
       >
         <template #actions>
           <VSpace>
@@ -237,7 +259,7 @@ watch([() => route.name, () => route.params], async () => {
           <div class="rounded-b-base bg-white">
             <RouterView v-slot="{ Component }">
               <template v-if="Component">
-                <Suspense>
+                <Suspense :key="selectedTheme.metadata.name">
                   <component :is="Component"></component>
                   <template #fallback>
                     <VLoading />
@@ -252,6 +274,7 @@ watch([() => route.name, () => route.params], async () => {
 
     <ThemeListModal
       v-if="themesModal"
+      ref="themeListModal"
       @close="themesModal = false"
       @select="onSelectTheme"
     />

--- a/ui/console-src/modules/interface/themes/layouts/__tests__/ThemeLayout.spec.ts
+++ b/ui/console-src/modules/interface/themes/layouts/__tests__/ThemeLayout.spec.ts
@@ -1,0 +1,455 @@
+/* eslint-disable vue/one-component-per-file -- Local component stubs for the selection integration test. */
+import type { Theme } from "@halo-dev/api-client";
+import { consoleApiClient } from "@halo-dev/api-client";
+import { QueryClient, VueQueryPlugin } from "@tanstack/vue-query";
+import { flushPromises, mount } from "@vue/test-utils";
+import { afterEach, beforeEach, expect, it, vi } from "vite-plus/test";
+import {
+  defineComponent,
+  h,
+  inject,
+  ref,
+  reactive,
+  toRefs,
+  type Ref,
+} from "vue";
+import { createI18n } from "vue-i18n";
+import { createMemoryHistory, createRouter, RouterView } from "vue-router";
+import ThemeLayout from "../ThemeLayout.vue";
+
+const { themes, state } = vi.hoisted(() => ({
+  state: {
+    activeIndex: 0 as number | undefined,
+    formLoad: undefined as Promise<void> | undefined,
+  },
+  themes: [
+    {
+      apiVersion: "theme.halo.run/v1alpha1",
+      kind: "Theme",
+      metadata: { name: "active" },
+      spec: { displayName: "Active", settingName: "active-setting" },
+    },
+    {
+      apiVersion: "theme.halo.run/v1alpha1",
+      kind: "Theme",
+      metadata: { name: "other" },
+      spec: { displayName: "Other", settingName: "other-setting" },
+    },
+    {
+      apiVersion: "theme.halo.run/v1alpha1",
+      kind: "Theme",
+      metadata: { name: "empty" },
+      spec: { displayName: "Empty" },
+    },
+  ] as Theme[],
+}));
+
+vi.mock("@console/layouts/BasicLayout.vue", () => ({
+  default: { template: "<slot />" },
+}));
+vi.mock("@console/stores/theme", () => ({
+  useThemeStore: () =>
+    reactive({
+      activatedTheme:
+        state.activeIndex === undefined
+          ? undefined
+          : structuredClone(themes[state.activeIndex]),
+    }),
+}));
+vi.mock("pinia", () => ({ storeToRefs: (store: object) => toRefs(store) }));
+vi.mock("@/stores/plugin", () => ({
+  usePluginModuleStore: () => ({ pluginModules: [] }),
+}));
+vi.mock("../../composables/use-theme", () => ({
+  useThemeLifeCycle: () => ({ loading: ref(false), isActivated: ref(true) }),
+}));
+vi.mock("../../components/preview/ThemePreviewModal.vue", () => ({
+  default: { template: "<div />" },
+}));
+vi.mock("@halo-dev/ui-shared", () => ({
+  utils: { permission: { has: () => true } },
+}));
+vi.mock("@halo-dev/api-client", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@halo-dev/api-client")>()),
+  consoleApiClient: {
+    theme: { theme: { fetchThemeSetting: vi.fn(), listThemes: vi.fn() } },
+  },
+}));
+vi.mock("../../components/list-tabs/InstalledThemes.vue", () => ({
+  __esModule: true,
+  default: defineComponent({
+    setup() {
+      const selected = inject<Ref<Theme | undefined>>("selectedTheme")!;
+      return () =>
+        themes.map((theme) =>
+          h(
+            "button",
+            {
+              "data-theme": theme.metadata.name,
+              onClick: () => {
+                selected.value = theme;
+              },
+            },
+            theme.spec.displayName
+          )
+        );
+    },
+  }),
+}));
+
+const SlotContainer = {
+  template: "<div><slot name='header' /><slot /><slot name='actions' /></div>",
+};
+const closeModal = vi.fn<(complete: () => void) => void>();
+const Modal = defineComponent({
+  emits: ["close"],
+  setup(_, { emit, expose, slots }) {
+    expose({ close: () => closeModal(() => emit("close")) });
+    return () => h("div", { role: "dialog" }, slots.default?.());
+  },
+});
+
+const cleanups: (() => void)[] = [];
+afterEach(() => {
+  cleanups.splice(0).forEach((cleanup) => cleanup());
+});
+beforeEach(() => {
+  state.activeIndex = 0;
+  state.formLoad = undefined;
+  vi.clearAllMocks();
+  closeModal.mockImplementation((complete) => complete());
+  vi.mocked(consoleApiClient.theme.theme.listThemes).mockResolvedValue({
+    data: { items: structuredClone(themes), hasNext: false },
+  } as never);
+  vi.mocked(consoleApiClient.theme.theme.fetchThemeSetting).mockImplementation(
+    async ({ name }) =>
+      ({
+        data: { spec: { forms: [{ group: "style", label: `${name} style` }] } },
+      }) as never
+  );
+});
+
+const SettingsPage = defineComponent({
+  async setup() {
+    const selected = inject<Ref<Theme>>("selectedTheme")!;
+    const draft = ref(selected.value.metadata.name);
+    await state.formLoad;
+    return () =>
+      h("input", {
+        "data-draft": "",
+        value: draft.value,
+        onInput: (event: Event) => {
+          draft.value = (event.target as HTMLInputElement).value;
+        },
+      });
+  },
+});
+
+async function setup(url = "/theme") {
+  const router = createRouter({
+    history: createMemoryHistory(),
+    routes: [
+      {
+        path: "/theme",
+        component: ThemeLayout,
+        children: [
+          { path: "", name: "ThemeDetail", component: { template: "<div />" } },
+          {
+            path: "settings/:group",
+            name: "ThemeSetting",
+            component: SettingsPage,
+          },
+        ],
+      },
+    ],
+  });
+  await router.push(url);
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false, staleTime: Infinity } },
+  });
+  const wrapper = mount(RouterView, {
+    global: {
+      plugins: [
+        router,
+        createI18n({
+          legacy: false,
+          locale: "en",
+          missingWarn: false,
+          fallbackWarn: false,
+        }),
+        [VueQueryPlugin, { queryClient }],
+      ],
+      directives: { permission: () => {} },
+      stubs: {
+        PageHeader: {
+          ...SlotContainer,
+          props: ["title"],
+          template: "<header>{{ title }}<slot name='actions' /></header>",
+        },
+        Card: SlotContainer,
+        Button: { template: "<button><slot /></button>" },
+        Modal,
+        Empty: {
+          props: ["title"],
+          template: "<div>{{ title }}<slot name='actions' /></div>",
+        },
+        Tabbar: {
+          props: ["items"],
+          emits: ["change"],
+          template:
+            "<nav><button v-for='item in items' :key='item.id' @click='$emit(\"change\", item.id)'>{{ item.label }}</button></nav>",
+        },
+      },
+    },
+  });
+  cleanups.push(() => {
+    wrapper.unmount();
+    queryClient.clear();
+  });
+  await flushPromises();
+  async function select(name: string) {
+    if (!wrapper.find("[role='dialog']").exists()) {
+      await wrapper
+        .findAll("button")
+        .find((button) => button.text() === "core.theme.actions.management")!
+        .trigger("click");
+      await flushPromises();
+    }
+    await wrapper.get(`[data-theme='${name}']`).trigger("click");
+    await flushPromises();
+  }
+  async function clickTab(label: string) {
+    await wrapper
+      .findAll("nav button")
+      .find((button) => button.text() === label)!
+      .trigger("click");
+    await flushPromises();
+  }
+  return { wrapper, router, queryClient, select, clickTab };
+}
+
+it("keeps repeated selections and cached settings while recording explicit choices", async () => {
+  const { wrapper, router, select, clickTab } = await setup(
+    "/theme/settings/style?other=value"
+  );
+  expect(wrapper.text()).toContain("active style");
+  await wrapper.get("[data-draft]").setValue("unsaved");
+  for (let index = 0; index < 2; index++) {
+    await select("active");
+    expect(wrapper.find("[role='dialog']").exists()).toBe(false);
+    expect(
+      (wrapper.get("[data-draft]").element as HTMLInputElement).value
+    ).toBe("unsaved");
+    expect(router.currentRoute.value.name).toBe("ThemeSetting");
+    expect(router.currentRoute.value.query).toEqual({ other: "value" });
+  }
+  await select("other");
+  expect(router.currentRoute.value.query).toEqual({
+    theme: "other",
+    other: "value",
+  });
+  expect(router.currentRoute.value.name).toBe("ThemeDetail");
+  expect(wrapper.text()).toContain("other style");
+  await clickTab("other style");
+  expect(router.currentRoute.value.query.theme).toBe("other");
+  await select("empty");
+  expect(wrapper.text()).not.toContain("style");
+  await select("active");
+  expect(wrapper.text()).toContain("active style");
+  await select("active");
+  expect(wrapper.find("[role='dialog']").exists()).toBe(false);
+  expect(consoleApiClient.theme.theme.fetchThemeSetting).toHaveBeenCalledTimes(
+    2
+  );
+});
+
+it("restores deep links and browser history, remounting forms between themes", async () => {
+  const { wrapper, router, clickTab } = await setup(
+    "/theme/settings/style?theme=other"
+  );
+  expect(wrapper.text()).toContain("other style");
+  expect(router.currentRoute.value.name).toBe("ThemeSetting");
+  await router.push("/theme/settings/style?theme=active");
+  await flushPromises();
+  await wrapper.get("[data-draft]").setValue("active draft");
+  router.back();
+  await vi.waitFor(() =>
+    expect(router.currentRoute.value.query.theme).toBe("other")
+  );
+  await flushPromises();
+  expect((wrapper.get("[data-draft]").element as HTMLInputElement).value).toBe(
+    "other"
+  );
+  router.forward();
+  await vi.waitFor(() =>
+    expect(router.currentRoute.value.query.theme).toBe("active")
+  );
+  await flushPromises();
+  expect((wrapper.get("[data-draft]").element as HTMLInputElement).value).toBe(
+    "active"
+  );
+  await clickTab("core.theme.tabs.detail");
+  expect(router.currentRoute.value.query.theme).toBe("active");
+});
+
+it("does not commit a selection while navigation is pending or cancelled", async () => {
+  const { wrapper, router, select } = await setup("/theme/settings/style");
+  let finish!: (allow: boolean) => void;
+  const removeGuard = router.beforeEach(
+    () =>
+      new Promise<boolean>((resolve) => {
+        finish = resolve;
+      })
+  );
+  await select("other");
+  expect(wrapper.get("header").text()).toContain("Active");
+  expect(router.currentRoute.value.query.theme).toBeUndefined();
+  finish(false);
+  await flushPromises();
+  expect(wrapper.text()).toContain("active style");
+  expect(wrapper.find("[role='dialog']").exists()).toBe(true);
+  expect(closeModal).not.toHaveBeenCalled();
+  removeGuard();
+  await select("other");
+  expect(router.currentRoute.value.query.theme).toBe("other");
+  expect(wrapper.find("[role='dialog']").exists()).toBe(false);
+});
+
+it.each(["?theme=missing", "?theme=", "?theme", "?theme=active&theme=other"])(
+  "shows an empty state for invalid selection %s without falling back",
+  async (query) => {
+    const { wrapper, router } = await setup(`/theme${query}`);
+    expect(wrapper.text()).toContain("core.common.toast.not_found");
+    expect(wrapper.text()).not.toContain("active style");
+    expect(router.currentRoute.value.query).toHaveProperty("theme");
+    expect(
+      consoleApiClient.theme.theme.fetchThemeSetting
+    ).not.toHaveBeenCalled();
+  }
+);
+
+it("allows selecting a theme when none is activated", async () => {
+  state.activeIndex = undefined;
+  const { wrapper, router, select } = await setup();
+  expect(wrapper.text()).toContain("core.theme.empty.title");
+  await select("other");
+  expect(router.currentRoute.value.query.theme).toBe("other");
+  expect(wrapper.text()).toContain("other style");
+});
+
+it("replaces unavailable setting groups after loading and keeps the selection", async () => {
+  const { router } = await setup("/theme/settings/missing?theme=other");
+  await flushPromises();
+  expect(router.currentRoute.value.name).toBe("ThemeDetail");
+  expect(router.currentRoute.value.query.theme).toBe("other");
+});
+
+it("clears a deleted selection after the installed list is invalidated", async () => {
+  const { wrapper, queryClient } = await setup("/theme?theme=other");
+  vi.mocked(consoleApiClient.theme.theme.listThemes).mockResolvedValue({
+    data: { items: [themes[0]], hasNext: false },
+  } as never);
+  await queryClient.invalidateQueries({ queryKey: ["installed-themes"] });
+  await flushPromises();
+  expect(wrapper.text()).toContain("core.common.toast.not_found");
+  expect(wrapper.text()).not.toContain("other style");
+});
+
+it("waits for setting data before resolving a deep-linked group", async () => {
+  const pending =
+    Promise.withResolvers<
+      Awaited<ReturnType<typeof consoleApiClient.theme.theme.fetchThemeSetting>>
+    >();
+  vi.mocked(consoleApiClient.theme.theme.fetchThemeSetting).mockReturnValue(
+    pending.promise
+  );
+  const { router, wrapper } = await setup("/theme/settings/style?theme=other");
+  expect(router.currentRoute.value.name).toBe("ThemeSetting");
+  expect(wrapper.find("[data-draft]").exists()).toBe(false);
+  pending.resolve({
+    data: { spec: { forms: [{ group: "style", label: "other style" }] } },
+  } as never);
+  await flushPromises();
+  expect(router.currentRoute.value.name).toBe("ThemeSetting");
+  expect(wrapper.text()).toContain("other style");
+});
+
+it("keeps the default theme's draft mounted while the shared installed list loads", async () => {
+  const { wrapper, queryClient } = await setup("/theme/settings/style");
+  await wrapper.get("[data-draft]").setValue("unsaved");
+  const pending =
+    Promise.withResolvers<
+      Awaited<ReturnType<typeof consoleApiClient.theme.theme.listThemes>>
+    >();
+  vi.mocked(consoleApiClient.theme.theme.listThemes).mockReturnValue(
+    pending.promise
+  );
+  // The installed-themes modal starts this same query while the layout observer is disabled.
+  const fetching = queryClient.fetchQuery({ queryKey: ["installed-themes"] });
+  await flushPromises();
+  expect((wrapper.get("[data-draft]").element as HTMLInputElement).value).toBe(
+    "unsaved"
+  );
+  pending.resolve({ data: { items: themes, hasNext: false } } as never);
+  await fetching;
+  await flushPromises();
+  expect((wrapper.get("[data-draft]").element as HTMLInputElement).value).toBe(
+    "unsaved"
+  );
+});
+
+it("allows retry after an installed-themes request fails without selecting the active theme", async () => {
+  vi.mocked(consoleApiClient.theme.theme.listThemes).mockRejectedValueOnce(
+    new Error("network failure")
+  );
+  const { wrapper, router } = await setup("/theme?theme=other");
+  expect(wrapper.text()).toContain("core.common.status.loading_error");
+  expect(wrapper.text()).not.toContain("Active");
+  await wrapper
+    .findAll("button")
+    .find((button) => button.text() === "core.common.buttons.retry")!
+    .trigger("click");
+  await flushPromises();
+  expect(wrapper.text()).toContain("other style");
+  expect(router.currentRoute.value.query.theme).toBe("other");
+});
+
+it("removes the previous form while the next theme's async form loads", async () => {
+  const { wrapper, router, queryClient } = await setup("/theme/settings/style");
+  queryClient.setQueryData(["installed-themes"], themes);
+  queryClient.setQueryData(["theme-setting", themes[1]], {
+    spec: { forms: [{ group: "style", label: "other style" }] },
+  });
+  const pending = Promise.withResolvers<void>();
+  state.formLoad = pending.promise;
+  await router.push("/theme/settings/style?theme=other");
+  await flushPromises();
+  expect(wrapper.find("[data-draft]").exists()).toBe(false);
+  pending.resolve();
+  await flushPromises();
+  expect((wrapper.get("[data-draft]").element as HTMLInputElement).value).toBe(
+    "other"
+  );
+});
+
+it("replaces theme selections in history and waits for the modal close event", async () => {
+  const { wrapper, router, select, clickTab } = await setup();
+  await clickTab("active style");
+  let finishClose!: () => void;
+  closeModal.mockImplementationOnce((complete) => {
+    finishClose = complete;
+  });
+  await select("other");
+  expect(router.currentRoute.value.query.theme).toBe("other");
+  expect(closeModal).toHaveBeenCalledOnce();
+  expect(wrapper.find("[role='dialog']").exists()).toBe(true);
+  finishClose();
+  await flushPromises();
+  expect(wrapper.find("[role='dialog']").exists()).toBe(false);
+  await select("other");
+  expect(closeModal).toHaveBeenCalledTimes(2);
+  router.back();
+  await vi.waitFor(() =>
+    expect(router.currentRoute.value.fullPath).toBe("/theme")
+  );
+});

--- a/ui/console-src/modules/interface/themes/layouts/__tests__/ThemeLayout.spec.ts
+++ b/ui/console-src/modules/interface/themes/layouts/__tests__/ThemeLayout.spec.ts
@@ -1,4 +1,6 @@
 /* eslint-disable vue/one-component-per-file -- Local component stubs for the selection integration test. */
+import { getNode } from "@formkit/core";
+import { defaultConfig, plugin as formKitPlugin } from "@formkit/vue";
 import type { Theme } from "@halo-dev/api-client";
 import { consoleApiClient } from "@halo-dev/api-client";
 import { QueryClient, VueQueryPlugin } from "@tanstack/vue-query";
@@ -15,6 +17,7 @@ import {
 } from "vue";
 import { createI18n } from "vue-i18n";
 import { createMemoryHistory, createRouter, RouterView } from "vue-router";
+import ThemeSetting from "../../ThemeSetting.vue";
 import ThemeLayout from "../ThemeLayout.vue";
 
 const { themes, state } = vi.hoisted(() => ({
@@ -72,7 +75,13 @@ vi.mock("@halo-dev/ui-shared", () => ({
 vi.mock("@halo-dev/api-client", async (importOriginal) => ({
   ...(await importOriginal<typeof import("@halo-dev/api-client")>()),
   consoleApiClient: {
-    theme: { theme: { fetchThemeSetting: vi.fn(), listThemes: vi.fn() } },
+    theme: {
+      theme: {
+        fetchThemeSetting: vi.fn(),
+        listThemes: vi.fn(),
+        fetchThemeJsonConfig: vi.fn(),
+      },
+    },
   },
 }));
 vi.mock("../../components/list-tabs/InstalledThemes.vue", () => ({
@@ -145,7 +154,7 @@ const SettingsPage = defineComponent({
   },
 });
 
-async function setup(url = "/theme") {
+async function setup(url = "/theme", settingsPage = SettingsPage) {
   const router = createRouter({
     history: createMemoryHistory(),
     routes: [
@@ -153,11 +162,15 @@ async function setup(url = "/theme") {
         path: "/theme",
         component: ThemeLayout,
         children: [
-          { path: "", name: "ThemeDetail", component: { template: "<div />" } },
+          {
+            path: "",
+            name: "ThemeDetail",
+            component: { template: "<div data-detail />" },
+          },
           {
             path: "settings/:group",
             name: "ThemeSetting",
-            component: SettingsPage,
+            component: settingsPage,
           },
         ],
       },
@@ -171,6 +184,7 @@ async function setup(url = "/theme") {
     global: {
       plugins: [
         router,
+        [formKitPlugin, defaultConfig()],
         createI18n({
           legacy: false,
           locale: "en",
@@ -181,6 +195,8 @@ async function setup(url = "/theme") {
       ],
       directives: { permission: () => {} },
       stubs: {
+        BackToTop: true,
+        StickyBlock: SlotContainer,
         PageHeader: {
           ...SlotContainer,
           props: ["title"],
@@ -337,12 +353,15 @@ it("allows selecting a theme when none is activated", async () => {
   expect(wrapper.text()).toContain("other style");
 });
 
-it("replaces unavailable setting groups after loading and keeps the selection", async () => {
-  const { router } = await setup("/theme/settings/missing?theme=other");
-  await flushPromises();
-  expect(router.currentRoute.value.name).toBe("ThemeDetail");
-  expect(router.currentRoute.value.query.theme).toBe("other");
-});
+it.each(["missing", "detail"])(
+  "replaces unavailable setting group %s and keeps the selection",
+  async (group) => {
+    const { router } = await setup(`/theme/settings/${group}?theme=other`);
+    await flushPromises();
+    expect(router.currentRoute.value.name).toBe("ThemeDetail");
+    expect(router.currentRoute.value.query.theme).toBe("other");
+  }
+);
 
 it("clears a deleted selection after the installed list is invalidated", async () => {
   const { wrapper, queryClient } = await setup("/theme?theme=other");
@@ -417,7 +436,7 @@ it("allows retry after an installed-themes request fails without selecting the a
 it("removes the previous form while the next theme's async form loads", async () => {
   const { wrapper, router, queryClient } = await setup("/theme/settings/style");
   queryClient.setQueryData(["installed-themes"], themes);
-  queryClient.setQueryData(["theme-setting", themes[1]], {
+  queryClient.setQueryData(["theme-setting", "other", "other-setting"], {
     spec: { forms: [{ group: "style", label: "other style" }] },
   });
   const pending = Promise.withResolvers<void>();
@@ -453,3 +472,67 @@ it("replaces theme selections in history and waits for the modal close event", a
     expect(router.currentRoute.value.fullPath).toBe("/theme")
   );
 });
+
+it("preserves the real settings form when selected theme metadata changes", async () => {
+  vi.mocked(consoleApiClient.theme.theme.fetchThemeSetting).mockResolvedValue({
+    data: {
+      spec: {
+        forms: [
+          {
+            group: "style",
+            label: "Style",
+            formSchema: [{ $formkit: "text", name: "title" }],
+          },
+        ],
+      },
+    },
+  } as never);
+  vi.mocked(
+    consoleApiClient.theme.theme.fetchThemeJsonConfig
+  ).mockResolvedValue({ data: { style: { title: "saved" } } } as never);
+  const { wrapper, queryClient } = await setup(
+    "/theme/settings/style?theme=other",
+    ThemeSetting
+  );
+  const form = getNode("style")!;
+  await form.input({ title: "unsaved draft" });
+  await flushPromises();
+  const refreshed = structuredClone(themes);
+  refreshed[1].metadata.version = 2;
+  vi.mocked(consoleApiClient.theme.theme.listThemes).mockResolvedValue({
+    data: { items: refreshed, hasNext: false },
+  } as never);
+  await queryClient.invalidateQueries({ queryKey: ["installed-themes"] });
+  await flushPromises();
+  expect(getNode("style") === form).toBe(true);
+  expect(wrapper.get("input").element.value).toBe("unsaved draft");
+  expect(consoleApiClient.theme.theme.fetchThemeSetting).toHaveBeenCalledOnce();
+  expect(
+    consoleApiClient.theme.theme.fetchThemeJsonConfig
+  ).toHaveBeenCalledOnce();
+});
+
+it.each(["/theme?theme=other", "/theme/settings/style?theme=other"])(
+  "allows settings retry without blocking details at %s",
+  async (url) => {
+    vi.mocked(
+      consoleApiClient.theme.theme.fetchThemeSetting
+    ).mockRejectedValueOnce(new Error("settings unavailable"));
+    const { wrapper, router } = await setup(url);
+    expect(wrapper.find("[data-detail]").exists()).toBe(
+      router.currentRoute.value.name === "ThemeDetail"
+    );
+    expect(wrapper.find("[data-draft]").exists()).toBe(false);
+    expect(wrapper.text()).toContain("core.common.status.loading_error");
+    await wrapper
+      .findAll("button")
+      .find((button) => button.text() === "core.common.buttons.retry")!
+      .trigger("click");
+    await flushPromises();
+    expect(wrapper.text()).toContain("other style");
+    expect(wrapper.text()).not.toContain("core.common.status.loading_error");
+    expect(wrapper.find("[data-draft]").exists()).toBe(
+      router.currentRoute.value.name === "ThemeSetting"
+    );
+  }
+);


### PR DESCRIPTION
#### What type of PR is this?

- [ ] Feature
- [x] Bug fix
- [ ] Improvement
- [ ] Cleanup
- [ ] Documentation

#### What this PR does / why we need it:

Selecting the activated theme in theme management could remove its settings tabs. Selecting it again could then leave the modal open.

To reproduce, open the theme page, open theme management, and select the activated theme. Its settings tabs disappear. Reopen theme management and select the same theme again; the modal does not close.

This change derives settings tabs from query data and stores explicit theme selections in the `theme` URL query parameter. Opening `/theme` without this parameter still shows the activated theme. Theme selections replace the current history entry, and settings-tab navigation preserves the query parameter.

Selection is applied only after navigation succeeds, preserving the current theme and unsaved inputs when navigation is cancelled. The modal closes through `VModal.close()` to retain its transition. Invalid or deleted selections show an empty state, and forms are remounted when the selected theme changes.

#### Which issue(s) this PR fixes:

None.

#### Special notes for your reviewer:

Implemented with assistance from OpenAI Codex.

Validation:
- 18 theme tests passed, covering repeated selection, URL restoration, cached settings, navigation cancellation, invalid selections, loading and retry behavior, history replacement, and the modal close lifecycle.
- Console TypeScript checking and ESLint for the changed files passed.
- `git diff --check` passed.
- Browser checks verified repeated selection, theme switching, settings-page refresh, unsaved-change cancellation and confirmation, and invalid theme links.

To verify the original issue, repeat the reproduction steps: settings tabs should remain available and the modal should close on every selection. Select another theme and refresh its settings page to verify URL restoration.

#### Does this PR introduce a user-facing change?

```release-note
修复重复选择主题后设置选项消失、主题列表无法关闭的问题。主题选择现在记录在页面地址中，刷新后仍可查看所选主题，切换主题不会新增浏览器历史记录，并保留列表关闭动画。
```
