### PR TITLE
Clean up avatar attachments when deleting users

### DIFF
--- a/application/src/main/java/run/halo/app/core/reconciler/UserReconciler.java
+++ b/application/src/main/java/run/halo/app/core/reconciler/UserReconciler.java
@@ -13,6 +13,7 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
+import java.util.stream.Stream;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
@@ -75,11 +76,13 @@ public class UserReconciler implements Reconciler<Request>, UserPreCreatingHandl
                 var personalAccessTokensPending = deleteUserPersonalAccessTokens(request.name());
                 var connectionsPending = deleteUserConnections(request.name());
                 var roleBindingsPending = deleteUserRoleBindings(request.name());
+                var avatarsPending = deleteUserAvatars(user);
                 if (rememberMeTokensPending
                         || devicesPending
                         || personalAccessTokensPending
                         || connectionsPending
-                        || roleBindingsPending) {
+                        || roleBindingsPending
+                        || avatarsPending) {
                     throw new RequeueException(new Result(true, null), "User data is not deleted yet");
                 }
                 removeFinalizers(user.getMetadata(), Set.of(FINALIZER_NAME));
@@ -194,6 +197,22 @@ public class UserReconciler implements Reconciler<Request>, UserPreCreatingHandl
         return UriComponentsBuilder.fromUri(externalUrlSupplier.get())
                 .pathSegment("authors", user.getMetadata().getName())
                 .toUriString();
+    }
+
+    private boolean deleteUserAvatars(User user) {
+        var annotations = user.getMetadata().getAnnotations();
+        if (CollectionUtils.isEmpty(annotations)) {
+            return false;
+        }
+        var attachments = Stream.of(
+                        annotations.get(User.AVATAR_ATTACHMENT_NAME_ANNO),
+                        annotations.get(User.LAST_AVATAR_ATTACHMENT_NAME_ANNO))
+                .filter(StringUtils::isNotBlank)
+                .distinct()
+                .flatMap(name -> client.fetch(Attachment.class, name).stream())
+                .toList();
+        attachments.stream().filter(attachment -> !isDeleted(attachment)).forEach(client::delete);
+        return !attachments.isEmpty();
     }
 
     boolean deleteUserConnections(String username) {

--- a/application/src/test/java/run/halo/app/core/reconciler/UserReconcilerTest.java
+++ b/application/src/test/java/run/halo/app/core/reconciler/UserReconcilerTest.java
@@ -15,11 +15,15 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.time.Instant;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.stream.Stream;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -31,6 +35,7 @@ import run.halo.app.core.extension.RememberMeToken;
 import run.halo.app.core.extension.RoleBinding;
 import run.halo.app.core.extension.User;
 import run.halo.app.core.extension.UserConnection;
+import run.halo.app.core.extension.attachment.Attachment;
 import run.halo.app.core.user.service.RoleService;
 import run.halo.app.extension.ExtensionClient;
 import run.halo.app.extension.Metadata;
@@ -195,6 +200,66 @@ class UserReconcilerTest {
 
         userReconciler.reconcile(new Reconciler.Request("fake-user"));
 
+        verify(client).update(user);
+        assertFalse(user.getMetadata().getFinalizers().contains("user-protection"));
+    }
+
+    @ParameterizedTest
+    @CsvSource({"avatar, avatar", "new-avatar, old-avatar", "avatar, ''", "'', old-avatar"})
+    void shouldWaitForAvatarDeletionBeforeRemovingUserFinalizer(String currentAvatar, String lastAvatar) {
+        var user = deletingUser("fake-user");
+        user.getMetadata()
+                .setAnnotations(Map.of(
+                        User.AVATAR_ATTACHMENT_NAME_ANNO, currentAvatar,
+                        User.LAST_AVATAR_ATTACHMENT_NAME_ANNO, lastAvatar));
+        when(client.fetch(User.class, "fake-user")).thenReturn(Optional.of(user));
+        when(roleService.listRoleBindings(any())).thenReturn(Flux.empty());
+        var attachments = Stream.of(currentAvatar, lastAvatar)
+                .filter(name -> !name.isBlank())
+                .distinct()
+                .map(name -> {
+                    var attachment = new Attachment();
+                    attachment.setMetadata(new Metadata());
+                    attachment.getMetadata().setName(name);
+                    when(client.fetch(Attachment.class, name)).thenReturn(Optional.of(attachment));
+                    return attachment;
+                })
+                .toList();
+
+        assertThrows(RequeueException.class, () -> userReconciler.reconcile(new Reconciler.Request("fake-user")));
+        attachments.forEach(attachment -> {
+            verify(client).delete(attachment);
+            attachment.getMetadata().setDeletionTimestamp(Instant.now());
+        });
+
+        assertThrows(RequeueException.class, () -> userReconciler.reconcile(new Reconciler.Request("fake-user")));
+        verify(client, never()).update(user);
+        assertEquals(Set.of("user-protection"), user.getMetadata().getFinalizers());
+        attachments.forEach(attachment -> {
+            verify(client).delete(attachment);
+            when(client.fetch(Attachment.class, attachment.getMetadata().getName()))
+                    .thenReturn(Optional.empty());
+        });
+
+        userReconciler.reconcile(new Reconciler.Request("fake-user"));
+
+        verify(client).update(user);
+        assertFalse(user.getMetadata().getFinalizers().contains("user-protection"));
+    }
+
+    @Test
+    void shouldRemoveUserFinalizerWithBlankAvatarAnnotations() {
+        var user = deletingUser("fake-user");
+        user.getMetadata()
+                .setAnnotations(Map.of(
+                        User.AVATAR_ATTACHMENT_NAME_ANNO, " ",
+                        User.LAST_AVATAR_ATTACHMENT_NAME_ANNO, ""));
+        when(client.fetch(User.class, "fake-user")).thenReturn(Optional.of(user));
+        when(roleService.listRoleBindings(any())).thenReturn(Flux.empty());
+
+        userReconciler.reconcile(new Reconciler.Request("fake-user"));
+
+        verify(client, never()).fetch(eq(Attachment.class), any());
         verify(client).update(user);
         assertFalse(user.getMetadata().getFinalizers().contains("user-protection"));
     }


### PR DESCRIPTION
#### What type of PR is this?

- [ ] Feature
- [x] Bug fix
- [ ] Improvement
- [ ] Cleanup
- [ ] Documentation

#### What this PR does / why we need it:

Deleting a user leaves their uploaded avatar attachments behind. Clean up both the current and previous avatar attachments through the existing attachment deletion flow, and retain the user finalizer until those attachments are gone.

Regression tests reproduce the issue by reconciling a deleting user with existing avatar attachments: previously, the user finalizer was removed without deleting the attachments. With this fix, deletion is requested once, retries retain the finalizer while attachments remain, and the finalizer is removed after cleanup completes.

#### Which issue(s) this PR fixes:

Fixes #4347

#### Special notes for your reviewer:

- Assisted by Codex; the resulting diff was inspected.
- All 30 tests in `UserReconcilerTest` and `LocalAttachmentUploadHandlerTest` passed.
- Changed Java files passed the Spotless IDE formatting check; `git diff --check` passed.
- Browser-level validation was not performed.
- This does not clean up orphaned avatars left by previously deleted users.

#### Does this PR introduce a user-facing change?

```release-note
修复删除用户后，其上传的头像文件未被清理的问题。
```
