### PR TITLE
Support alternative text for gallery images

### DIFF
--- a/ui/packages/editor/src/extensions/gallery/GalleryImageAlt.vue
+++ b/ui/packages/editor/src/extensions/gallery/GalleryImageAlt.vue
@@ -1,0 +1,60 @@
+<script setup lang="ts">
+import { VDropdown } from "@halo-dev/components";
+import { ref } from "vue";
+import MingcuteEdit4Line from "~icons/mingcute/edit-4-line";
+import Input from "@/components/base/Input.vue";
+import { i18n } from "@/locales";
+
+const props = defineProps<{ alt: string }>();
+const emit = defineEmits<{ "update:alt": [alt: string] }>();
+const shown = ref(false);
+const draft = ref("");
+function save(event: Event) {
+  const input = (event.target as HTMLFormElement).elements.item(
+    0
+  ) as HTMLInputElement;
+  emit("update:alt", input.value.trim());
+  shown.value = false;
+}
+</script>
+
+<template>
+  <VDropdown
+    v-model:shown="shown"
+    class="pointer-events-auto"
+    :triggers="['click']"
+    :distance="10"
+    :no-auto-focus="true"
+    @show="draft = props.alt"
+    @click.stop
+    @mousedown.stop
+    @dragstart.stop.prevent
+  >
+    <button
+      v-tooltip="i18n.global.t('editor.extensions.image.edit_alt')"
+      type="button"
+      :aria-label="i18n.global.t('editor.extensions.image.edit_alt')"
+      :aria-expanded="shown"
+      class="text-grey-900 flex size-8 cursor-pointer items-center justify-center rounded-md bg-white/90 transition-all hover:bg-white hover:text-black active:!bg-white/80"
+    >
+      <MingcuteEdit4Line class="size-4" />
+    </button>
+    <template #popper>
+      <form
+        v-if="shown"
+        class="w-56"
+        @submit.prevent="save"
+        @click.stop
+        @mousedown.stop
+        @keydown.esc.stop.prevent="shown = false"
+      >
+        <Input
+          v-model="draft"
+          auto-focus
+          :label="i18n.global.t('editor.common.alt')"
+          :placeholder="i18n.global.t('editor.common.placeholder.alt_input')"
+        />
+      </form>
+    </template>
+  </VDropdown>
+</template>

--- a/ui/packages/editor/src/extensions/gallery/GalleryImageAlt.vue
+++ b/ui/packages/editor/src/extensions/gallery/GalleryImageAlt.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { VDropdown } from "@halo-dev/components";
-import { ref } from "vue";
+import { nextTick, ref, useTemplateRef } from "vue";
 import MingcuteEdit4Line from "~icons/mingcute/edit-4-line";
 import Input from "@/components/base/Input.vue";
 import { i18n } from "@/locales";
@@ -9,19 +9,27 @@ const props = defineProps<{ alt: string }>();
 const emit = defineEmits<{ "update:alt": [alt: string] }>();
 const shown = ref(false);
 const draft = ref("");
+const trigger = useTemplateRef<HTMLButtonElement>("trigger");
+
+async function close() {
+  shown.value = false;
+  await nextTick();
+  trigger.value?.focus();
+}
+
 function save(event: Event) {
   const input = (event.target as HTMLFormElement).elements.item(
     0
   ) as HTMLInputElement;
   emit("update:alt", input.value.trim());
-  shown.value = false;
+  close();
 }
 </script>
 
 <template>
   <VDropdown
     v-model:shown="shown"
-    class="pointer-events-auto"
+    class="pointer-events-none group-focus-within/actions:pointer-events-auto group-hover/image:pointer-events-auto [@media(hover:none)]:pointer-events-auto"
     :triggers="['click']"
     :distance="10"
     :no-auto-focus="true"
@@ -31,6 +39,7 @@ function save(event: Event) {
     @dragstart.stop.prevent
   >
     <button
+      ref="trigger"
       v-tooltip="i18n.global.t('editor.extensions.image.edit_alt')"
       type="button"
       :aria-label="i18n.global.t('editor.extensions.image.edit_alt')"
@@ -46,7 +55,7 @@ function save(event: Event) {
         @submit.prevent="save"
         @click.stop
         @mousedown.stop
-        @keydown.esc.stop.prevent="shown = false"
+        @keydown.esc.stop.prevent="close"
       >
         <Input
           v-model="draft"

--- a/ui/packages/editor/src/extensions/gallery/GalleryView.spec.ts
+++ b/ui/packages/editor/src/extensions/gallery/GalleryView.spec.ts
@@ -90,6 +90,7 @@ describe("GalleryView", () => {
   it("submits and clears alternative text through the input form", async () => {
     const updateAlt = vi.fn();
     const wrapper = mount(GalleryImageAlt, {
+      attachTo: document.body,
       props: { alt: "Existing", "onUpdate:alt": updateAlt },
     });
     wrapper.findComponent({ name: "VDropdown" }).vm.$emit("update:shown", true);
@@ -97,7 +98,9 @@ describe("GalleryView", () => {
     await wrapper.vm.$nextTick();
     expect(wrapper.get("input").element.value).toBe("Existing");
     await wrapper.get("input").setValue("Sunrise");
+    wrapper.get("input").element.focus();
     await wrapper.get("form").trigger("submit");
+    expect(document.activeElement).toBe(wrapper.get("button").element);
     wrapper.findComponent({ name: "VDropdown" }).vm.$emit("update:shown", true);
     await wrapper.vm.$nextTick();
     wrapper.get("input").element.value = "";
@@ -111,7 +114,9 @@ describe("GalleryView", () => {
     expect(wrapper.get("input").element.value).toBe("Updated");
     wrapper.get("input").element.value = "Unsaved";
     await wrapper.get("input").trigger("input");
+    wrapper.get("input").element.focus();
     await wrapper.get("input").trigger("keydown", { key: "Escape" });
+    expect(document.activeElement).toBe(wrapper.get("button").element);
     expect(updateAlt).toHaveBeenCalledTimes(2);
     wrapper.unmount();
   });

--- a/ui/packages/editor/src/extensions/gallery/GalleryView.spec.ts
+++ b/ui/packages/editor/src/extensions/gallery/GalleryView.spec.ts
@@ -1,14 +1,21 @@
 // @vitest-environment jsdom
 
-import { shallowMount, type VueWrapper } from "@vue/test-utils";
+import { mount, shallowMount, type VueWrapper } from "@vue/test-utils";
 import { describe, expect, it, vi } from "vite-plus/test";
 import { type Content, type NodeViewProps, VueEditor } from "@/tiptap";
 import { ExtensionDocument } from "../document";
 import { ExtensionText } from "../text";
+import GalleryImageAlt from "./GalleryImageAlt.vue";
 import GalleryView from "./GalleryView.vue";
 import { ExtensionGallery, type ExtensionGalleryImageItem } from "./index";
 
 vi.mock("@halo-dev/components", () => ({
+  VDropdown: {
+    name: "VDropdown",
+    props: ["shown"],
+    emits: ["show", "update:shown"],
+    template: '<div><slot /><slot name="popper" /></div>',
+  },
   VButton: { template: "<button><slot /></button>" },
   VSpace: { template: "<div><slot /></div>" },
 }));
@@ -29,6 +36,85 @@ vi.mock("./useGalleryImages", () => ({
 }));
 
 describe("GalleryView", () => {
+  it.each(['山间的 "日出" & 云海', ""])(
+    "preserves alt %j across an HTML round trip",
+    (alt) => {
+      const editor = createEditor({
+        type: "doc",
+        content: [
+          {
+            type: "gallery",
+            attrs: { images: [{ src: "/image.jpg", aspectRatio: 2, alt }] },
+          },
+        ],
+      });
+      const parsedEditor = createEditor(editor.getHTML());
+      expect(parsedEditor.state.doc.nodeAt(0)?.attrs.images[0]).toEqual({
+        src: "/image.jpg",
+        aspectRatio: 2,
+        alt,
+      });
+      parsedEditor.destroy();
+      editor.destroy();
+    }
+  );
+
+  it("updates only the target image alt and renders existing alternative text", () => {
+    const images = [
+      { src: "/same.jpg", aspectRatio: 2, alt: "First" },
+      { src: "/same.jpg", aspectRatio: 1, alt: "Second" },
+    ];
+    const { wrapper, updateAttributes } = mountGallery(images);
+    expect(
+      wrapper.findAll("img").map((image) => image.attributes("alt"))
+    ).toEqual(["First", "Second"]);
+    wrapper.findAllComponents(GalleryImageAlt)[1].vm.$emit("update:alt", "");
+    expect(updateAttributes).toHaveBeenCalledWith({
+      images: [images[0], { ...images[1], alt: "" }],
+    });
+    expect(images[1].alt).toBe("Second");
+  });
+
+  it("preserves alt when learning an aspect ratio", async () => {
+    const { wrapper, updateAttributes } = mountGallery({
+      src: "/image.jpg",
+      aspectRatio: 0,
+      alt: "Sunrise",
+    });
+    await loadImage(wrapper, 200, 100);
+    expect(updateAttributes).toHaveBeenCalledWith({
+      images: [{ src: "/image.jpg", aspectRatio: 2, alt: "Sunrise" }],
+    });
+  });
+
+  it("submits and clears alternative text through the input form", async () => {
+    const updateAlt = vi.fn();
+    const wrapper = mount(GalleryImageAlt, {
+      props: { alt: "Existing", "onUpdate:alt": updateAlt },
+    });
+    wrapper.findComponent({ name: "VDropdown" }).vm.$emit("update:shown", true);
+    wrapper.findComponent({ name: "VDropdown" }).vm.$emit("show");
+    await wrapper.vm.$nextTick();
+    expect(wrapper.get("input").element.value).toBe("Existing");
+    await wrapper.get("input").setValue("Sunrise");
+    await wrapper.get("form").trigger("submit");
+    wrapper.findComponent({ name: "VDropdown" }).vm.$emit("update:shown", true);
+    await wrapper.vm.$nextTick();
+    wrapper.get("input").element.value = "";
+    await wrapper.get("input").trigger("input");
+    await wrapper.get("form").trigger("submit");
+    expect(updateAlt.mock.calls).toEqual([["Sunrise"], [""]]);
+    await wrapper.setProps({ alt: "Updated" });
+    wrapper.findComponent({ name: "VDropdown" }).vm.$emit("update:shown", true);
+    wrapper.findComponent({ name: "VDropdown" }).vm.$emit("show");
+    await wrapper.vm.$nextTick();
+    expect(wrapper.get("input").element.value).toBe("Updated");
+    wrapper.get("input").element.value = "Unsaved";
+    await wrapper.get("input").trigger("input");
+    await wrapper.get("input").trigger("keydown", { key: "Escape" });
+    expect(updateAlt).toHaveBeenCalledTimes(2);
+    wrapper.unmount();
+  });
   it("preserves image aspect ratios across an HTML round trip", () => {
     const sourceEditor = createEditor({
       type: "doc",
@@ -56,7 +142,7 @@ describe("GalleryView", () => {
       .images as ExtensionGalleryImageItem[];
     parsedEditor.destroy();
 
-    expect(images).toEqual([{ src: "/image.jpg", aspectRatio: 2 }]);
+    expect(images).toEqual([{ src: "/image.jpg", aspectRatio: 2, alt: "" }]);
   });
 
   it("retains support for aspect ratios stored on image elements", () => {
@@ -73,7 +159,7 @@ describe("GalleryView", () => {
       .images as ExtensionGalleryImageItem[];
     editor.destroy();
 
-    expect(images).toEqual([{ src: "/image.jpg", aspectRatio: 2 }]);
+    expect(images).toEqual([{ src: "/image.jpg", aspectRatio: 2, alt: "" }]);
   });
 
   it("prefers aspect ratios stored on image wrappers", () => {
@@ -90,7 +176,7 @@ describe("GalleryView", () => {
       .images as ExtensionGalleryImageItem[];
     editor.destroy();
 
-    expect(images).toEqual([{ src: "/image.jpg", aspectRatio: 2 }]);
+    expect(images).toEqual([{ src: "/image.jpg", aspectRatio: 2, alt: "" }]);
   });
 
   it("does not update attributes when an existing image already has an aspect ratio", async () => {

--- a/ui/packages/editor/src/extensions/gallery/GalleryView.vue
+++ b/ui/packages/editor/src/extensions/gallery/GalleryView.vue
@@ -11,6 +11,7 @@ import {
   DEFAULT_GALLERY_LAYOUT,
   GALLERY_LAYOUT_SQUARE,
 } from "./constants";
+import GalleryImageAlt from "./GalleryImageAlt.vue";
 import type { ExtensionGalleryImageItem } from "./index";
 import { useUploadGalleryImage } from "./useGalleryImages";
 
@@ -37,6 +38,13 @@ function removeImage(index: number) {
   const newImages = [...images.value];
   newImages.splice(index, 1);
   images.value = newImages;
+}
+
+function updateImageAlt(index: number, alt: string) {
+  images.value = images.value.map(
+    (image: ExtensionGalleryImageItem, i: number) =>
+      i === index ? { ...image, alt } : image
+  );
 }
 
 function handleImageLoad(event: Event, index: number) {
@@ -251,15 +259,21 @@ function onAttachmentSelect(attachments: AttachmentLike[]) {
                 getThumbnailSize(group.length)
               )
             "
-            :alt="`Gallery image ${groupIndex * groupSize + imgIndex + 1}`"
+            :alt="image.alt ?? ''"
             :loading="image.aspectRatio > 0 ? 'lazy' : 'eager'"
             class="pointer-events-none block size-full object-cover"
             @load="handleImageLoad($event, groupIndex * groupSize + imgIndex)"
           />
           <div
-            class="pointer-events-none invisible absolute inset-0 bg-gradient-to-t from-black/0 via-black/5 to-black/30 p-1 opacity-0 transition-all group-hover/image:visible group-hover/image:opacity-100"
+            class="pointer-events-none absolute inset-0 bg-gradient-to-t from-black/0 via-black/5 to-black/30 p-1 opacity-0 transition-all focus-within:opacity-100 group-hover/image:opacity-100"
           >
-            <div class="flex flex-row-reverse">
+            <div class="flex justify-end gap-1">
+              <GalleryImageAlt
+                :alt="image.alt ?? ''"
+                @update:alt="
+                  updateImageAlt(groupIndex * groupSize + imgIndex, $event)
+                "
+              />
               <button
                 v-tooltip="
                   i18n.global.t(

--- a/ui/packages/editor/src/extensions/gallery/GalleryView.vue
+++ b/ui/packages/editor/src/extensions/gallery/GalleryView.vue
@@ -265,7 +265,7 @@ function onAttachmentSelect(attachments: AttachmentLike[]) {
             @load="handleImageLoad($event, groupIndex * groupSize + imgIndex)"
           />
           <div
-            class="pointer-events-none absolute inset-0 bg-gradient-to-t from-black/0 via-black/5 to-black/30 p-1 opacity-0 transition-all focus-within:opacity-100 group-hover/image:opacity-100"
+            class="group/actions pointer-events-none absolute inset-0 bg-gradient-to-t from-black/0 via-black/5 to-black/30 p-1 opacity-0 transition-all focus-within:opacity-100 group-hover/image:opacity-100 [@media(hover:none)]:opacity-100"
           >
             <div class="flex justify-end gap-1">
               <GalleryImageAlt
@@ -281,7 +281,7 @@ function onAttachmentSelect(attachments: AttachmentLike[]) {
                   )
                 "
                 aria-label="Delete"
-                class="text-grey-900 group pointer-events-auto relative flex size-8 cursor-pointer items-center justify-center rounded-md bg-white/90 transition-all hover:bg-white hover:text-black active:!bg-white/80"
+                class="text-grey-900 group pointer-events-none relative flex size-8 cursor-pointer items-center justify-center rounded-md bg-white/90 transition-all hover:bg-white hover:text-black active:!bg-white/80 group-focus-within/actions:pointer-events-auto group-hover/image:pointer-events-auto [@media(hover:none)]:pointer-events-auto"
                 type="button"
                 @click.stop="removeImage(groupIndex * groupSize + imgIndex)"
               >

--- a/ui/packages/editor/src/extensions/gallery/index.ts
+++ b/ui/packages/editor/src/extensions/gallery/index.ts
@@ -43,6 +43,7 @@ declare module "@/tiptap" {
 export type ExtensionGalleryImageItem = {
   src: string;
   aspectRatio: number;
+  alt?: string;
 };
 
 export const GALLERY_BUBBLE_MENU_KEY = new PluginKey("galleryBubbleMenu");
@@ -84,8 +85,9 @@ export const ExtensionGallery = Node.create<
         attributeGuidance: {
           images: {
             description:
-              "Ordered gallery items, each containing a source URL and aspect ratio.",
-            format: "array of { src: string, aspectRatio: number }",
+              "Ordered gallery items, each containing a source URL, aspect ratio, and optional alternative text.",
+            format:
+              "array of { src: string, aspectRatio: number, alt?: string }",
           },
           groupSize: {
             description: "Maximum number of images in each visual group.",
@@ -132,6 +134,7 @@ export const ExtensionGallery = Node.create<
             return {
               src: img.getAttribute("src") || "",
               aspectRatio: aspectRatio || 0,
+              alt: img.getAttribute("alt") ?? "",
             };
           });
         },
@@ -220,6 +223,7 @@ export const ExtensionGallery = Node.create<
               "img",
               {
                 src: image.src,
+                alt: image.alt ?? "",
                 "data-type": "gallery-image",
                 style:
                   "width: 100%; height: 100%; margin: 0; object-fit: cover;",


### PR DESCRIPTION
#### What type of PR is this?

- [x] Feature
- [ ] Bug fix
- [ ] Improvement
- [ ] Cleanup
- [ ] Documentation

#### What this PR does / why we need it:

Allow users to edit alternative text for individual gallery images and preserve it when saving and reloading HTML.

The edit control reuses the existing image extension's input, icon, and tooltip text. It appears to the left of the delete button with spacing between the controls.

<img width="587" height="193" alt="image" src="https://github.com/user-attachments/assets/ef6470f3-5aa0-4b65-ba30-2a97a6026215" />

#### Which issue(s) this PR fixes:

Ref https://github.com/orgs/lxware-dev/discussions/219

#### Special notes for your reviewer:

Implemented with assistance from OpenAI Codex.

Validation:
- 16 gallery tests passed, covering HTML round trips, targeted edits, clearing text, cancellation, and aspect-ratio updates.
- Editor type checking, targeted ESLint checks, and development build passed.
- Browser checks covered editing, clearing, focus, button placement, and spacing using the built editor. Console checks also verified persistence after reload and preservation during reordering.
- The final tooltip addition passed targeted ESLint and diff checks.

#### Does this PR introduce a user-facing change?

```release-note
支持为图库中的每张图片设置和修改替代文本（alt）。
```
