### PR TITLE
Support replacing images in gallery

### DIFF
--- a/ui/packages/editor/src/extensions/gallery/GalleryImageReplace.spec.ts
+++ b/ui/packages/editor/src/extensions/gallery/GalleryImageReplace.spec.ts
@@ -1,0 +1,81 @@
+// @vitest-environment jsdom
+
+import { mount } from "@vue/test-utils";
+import { describe, expect, it, vi } from "vite-plus/test";
+import GalleryImageReplace from "./GalleryImageReplace.vue";
+
+const permissions = vi.hoisted(() => ({ current: [] as string[] }));
+vi.mock("@halo-dev/ui-shared", () => ({
+  utils: {
+    permission: {
+      has: (required: string[]) =>
+        required.some((permission) => permissions.current.includes(permission)),
+    },
+    attachment: { getUrl: (attachment: string) => attachment },
+  },
+}));
+vi.mock("@halo-dev/components", () => ({
+  VDropdown: { template: '<div><slot /><slot name="popper" /></div>' },
+  VDropdownItem: { template: "<button><slot /></button>" },
+}));
+
+describe("GalleryImageReplace", () => {
+  it("emits the selected upload file and attachment URL", async () => {
+    permissions.current = ["uc:attachments:manage"];
+    const file = new File(["image"], "replacement.png", { type: "image/png" });
+    const onUpload = vi.fn();
+    const onReplace = vi.fn();
+    const click = vi
+      .spyOn(HTMLInputElement.prototype, "click")
+      .mockImplementation(function (this: HTMLInputElement) {
+        Object.defineProperty(this, "files", {
+          value: [file],
+          configurable: true,
+        });
+        this.dispatchEvent(new Event("change"));
+      });
+    const wrapper = mount(GalleryImageReplace, {
+      props: { uploadEnabled: true, onUpload, onReplace },
+      global: {
+        directives: { tooltip: {} },
+        stubs: { AttachmentSelectorModal: true },
+      },
+    });
+    await wrapper.findAll("button")[1].trigger("click");
+    expect(click).toHaveBeenCalled();
+    expect(onUpload).toHaveBeenCalledWith(file);
+    await wrapper.findAll("button")[2].trigger("click");
+    wrapper
+      .findComponent({ name: "AttachmentSelectorModal" })
+      .vm.$emit("select", ["/new.jpg"]);
+    expect(onReplace).toHaveBeenCalledWith("/new.jpg");
+    click.mockRestore();
+    wrapper.unmount();
+  });
+
+  it.each([
+    { granted: [], uploadEnabled: true, buttons: 0 },
+    {
+      granted: ["system:attachments:manage"],
+      uploadEnabled: false,
+      buttons: 0,
+    },
+    { granted: ["system:attachments:manage"], uploadEnabled: true, buttons: 2 },
+    { granted: ["system:attachments:view"], uploadEnabled: false, buttons: 2 },
+    { granted: ["uc:attachments:manage"], uploadEnabled: true, buttons: 3 },
+  ])(
+    "shows only usable operations with $granted and upload=$uploadEnabled",
+    ({ granted, uploadEnabled, buttons }) => {
+      permissions.current = granted;
+      const wrapper = mount(GalleryImageReplace, {
+        props: { uploadEnabled },
+        global: {
+          directives: { tooltip: {} },
+          stubs: { AttachmentSelectorModal: true },
+        },
+      });
+      expect(wrapper.findAll("button")).toHaveLength(buttons);
+      wrapper.unmount();
+    }
+  );
+});

--- a/ui/packages/editor/src/extensions/gallery/GalleryImageReplace.vue
+++ b/ui/packages/editor/src/extensions/gallery/GalleryImageReplace.vue
@@ -1,0 +1,114 @@
+<script setup lang="ts">
+import { Toast, VDropdown, VDropdownItem } from "@halo-dev/components";
+import { utils, type AttachmentLike } from "@halo-dev/ui-shared";
+import { useFileDialog } from "@vueuse/core";
+import { ref } from "vue";
+import MingcuteRefresh2Line from "~icons/mingcute/refresh-2-line";
+import { i18n } from "@/locales";
+import type { UploadFile } from "@/utils/upload";
+
+const props = defineProps<{ upload?: UploadFile }>();
+
+const emit = defineEmits<{ replace: [src: string] }>();
+
+const shown = ref(false);
+
+// Upload
+const { open: openFileDialog, onChange: onFileDialogChange } = useFileDialog({
+  accept: "image/*",
+  multiple: false,
+  reset: true,
+});
+
+onFileDialogChange((files) => {
+  const file = files?.[0];
+  if (!file) {
+    return;
+  }
+  props
+    .upload?.(file)
+    .then((attachment) => {
+      const url = attachment?.status?.permalink;
+      if (url) {
+        emit("replace", url);
+      }
+    })
+    .catch((e: Error) => {
+      Toast.error(
+        `${i18n.global.t("editor.extensions.upload.error")} - ${e.message}`
+      );
+    });
+});
+
+// Attachment Selector Modal
+const attachmentSelectorModalVisible = ref(false);
+
+function onAttachmentSelect(attachments: AttachmentLike[]) {
+  const url = attachments.length
+    ? utils.attachment.getUrl(attachments[0])
+    : undefined;
+  if (url) {
+    emit("replace", url);
+  }
+  attachmentSelectorModalVisible.value = false;
+}
+</script>
+
+<template>
+  <VDropdown
+    v-model:shown="shown"
+    class="pointer-events-none group-focus-within/actions:pointer-events-auto group-hover/image:pointer-events-auto [@media(hover:none)]:pointer-events-auto"
+    :triggers="['click']"
+    :distance="10"
+    @click.stop
+    @mousedown.stop
+    @dragstart.stop.prevent
+  >
+    <button
+      v-tooltip="
+        i18n.global.t('editor.extensions.upload.operations.replace.button')
+      "
+      type="button"
+      :aria-label="
+        i18n.global.t('editor.extensions.upload.operations.replace.button')
+      "
+      :aria-expanded="shown"
+      class="text-grey-900 flex size-8 cursor-pointer items-center justify-center rounded-md bg-white/90 transition-all hover:bg-white hover:text-black active:!bg-white/80"
+    >
+      <MingcuteRefresh2Line class="size-4" />
+    </button>
+    <template #popper>
+      <VDropdownItem
+        v-if="
+          upload &&
+          utils.permission.has([
+            'uc:attachments:manage',
+            'system:attachments:manage',
+          ])
+        "
+        @click="openFileDialog()"
+      >
+        {{ i18n.global.t("editor.common.button.upload") }}
+      </VDropdownItem>
+      <VDropdownItem
+        v-if="
+          utils.permission.has(
+            ['system:attachments:view', 'uc:attachments:manage'],
+            true
+          )
+        "
+        @click="attachmentSelectorModalVisible = true"
+      >
+        {{ i18n.global.t("editor.extensions.upload.attachment.title") }}
+      </VDropdownItem>
+    </template>
+  </VDropdown>
+  <AttachmentSelectorModal
+    v-if="attachmentSelectorModalVisible"
+    :accepts="['image/*']"
+    :min="1"
+    :max="1"
+    @select="onAttachmentSelect"
+    @close="attachmentSelectorModalVisible = false"
+  />
+</template>

--- a/ui/packages/editor/src/extensions/gallery/GalleryImageReplace.vue
+++ b/ui/packages/editor/src/extensions/gallery/GalleryImageReplace.vue
@@ -1,15 +1,23 @@
 <script setup lang="ts">
-import { Toast, VDropdown, VDropdownItem } from "@halo-dev/components";
+import { VDropdown, VDropdownItem } from "@halo-dev/components";
 import { utils, type AttachmentLike } from "@halo-dev/ui-shared";
 import { useFileDialog } from "@vueuse/core";
-import { ref } from "vue";
+import { computed, ref } from "vue";
 import MingcuteRefresh2Line from "~icons/mingcute/refresh-2-line";
 import { i18n } from "@/locales";
-import type { UploadFile } from "@/utils/upload";
 
-const props = defineProps<{ upload?: UploadFile }>();
+const props = defineProps<{ uploadEnabled: boolean }>();
 
-const emit = defineEmits<{ replace: [src: string] }>();
+const emit = defineEmits<{ replace: [src: string]; upload: [file: File] }>();
+
+const canUpload = computed(
+  () =>
+    props.uploadEnabled &&
+    utils.permission.has(["uc:attachments:manage", "system:attachments:manage"])
+);
+const canSelect = computed(() =>
+  utils.permission.has(["system:attachments:view", "uc:attachments:manage"])
+);
 
 const shown = ref(false);
 
@@ -25,19 +33,7 @@ onFileDialogChange((files) => {
   if (!file) {
     return;
   }
-  props
-    .upload?.(file)
-    .then((attachment) => {
-      const url = attachment?.status?.permalink;
-      if (url) {
-        emit("replace", url);
-      }
-    })
-    .catch((e: Error) => {
-      Toast.error(
-        `${i18n.global.t("editor.extensions.upload.error")} - ${e.message}`
-      );
-    });
+  emit("upload", file);
 });
 
 // Attachment Selector Modal
@@ -56,6 +52,7 @@ function onAttachmentSelect(attachments: AttachmentLike[]) {
 
 <template>
   <VDropdown
+    v-if="canUpload || canSelect"
     v-model:shown="shown"
     class="pointer-events-none group-focus-within/actions:pointer-events-auto group-hover/image:pointer-events-auto [@media(hover:none)]:pointer-events-auto"
     :triggers="['click']"
@@ -78,25 +75,11 @@ function onAttachmentSelect(attachments: AttachmentLike[]) {
       <MingcuteRefresh2Line class="size-4" />
     </button>
     <template #popper>
-      <VDropdownItem
-        v-if="
-          upload &&
-          utils.permission.has([
-            'uc:attachments:manage',
-            'system:attachments:manage',
-          ])
-        "
-        @click="openFileDialog()"
-      >
+      <VDropdownItem v-if="canUpload" @click="openFileDialog()">
         {{ i18n.global.t("editor.common.button.upload") }}
       </VDropdownItem>
       <VDropdownItem
-        v-if="
-          utils.permission.has(
-            ['system:attachments:view', 'uc:attachments:manage'],
-            true
-          )
-        "
+        v-if="canSelect"
         @click="attachmentSelectorModalVisible = true"
       >
         {{ i18n.global.t("editor.extensions.upload.attachment.title") }}

--- a/ui/packages/editor/src/extensions/gallery/GalleryView.spec.ts
+++ b/ui/packages/editor/src/extensions/gallery/GalleryView.spec.ts
@@ -1,15 +1,24 @@
 // @vitest-environment jsdom
 
-import { mount, shallowMount, type VueWrapper } from "@vue/test-utils";
+import {
+  flushPromises,
+  mount,
+  shallowMount,
+  type VueWrapper,
+} from "@vue/test-utils";
 import { describe, expect, it, vi } from "vite-plus/test";
+import { reactive } from "vue";
 import { type Content, type NodeViewProps, VueEditor } from "@/tiptap";
+import type { UploadFile } from "@/utils/upload";
 import { ExtensionDocument } from "../document";
 import { ExtensionText } from "../text";
 import GalleryImageAlt from "./GalleryImageAlt.vue";
+import GalleryImageReplace from "./GalleryImageReplace.vue";
 import GalleryView from "./GalleryView.vue";
 import { ExtensionGallery, type ExtensionGalleryImageItem } from "./index";
 
 vi.mock("@halo-dev/components", () => ({
+  Toast: { error: vi.fn() },
   VDropdown: {
     name: "VDropdown",
     props: ["shown"],
@@ -36,6 +45,160 @@ vi.mock("./useGalleryImages", () => ({
 }));
 
 describe("GalleryView", () => {
+  it("keeps the ratio when selecting the same image and recalculates a new image", async () => {
+    const { wrapper, updateAttributes } = mountGallery([
+      { src: "/same.jpg", aspectRatio: 2, alt: "First" },
+      { src: "/same.jpg", aspectRatio: 1, alt: "Second" },
+    ]);
+    const replace = wrapper.findAllComponents(GalleryImageReplace)[0];
+    replace.vm.$emit("replace", "/same.jpg");
+    await wrapper.vm.$nextTick();
+    expect(wrapper.findAll("img")[0].attributes("loading")).toBe("lazy");
+    expect(updateAttributes).not.toHaveBeenCalled();
+
+    replace.vm.$emit("replace", "/new.jpg");
+    await wrapper.vm.$nextTick();
+    await loadImage(wrapper, 300, 100);
+    expect(updateAttributes.mock.lastCall?.[0].images).toEqual([
+      { src: "/new.jpg", aspectRatio: 3, alt: "First" },
+      { src: "/same.jpg", aspectRatio: 1, alt: "Second" },
+    ]);
+    wrapper.unmount();
+  });
+
+  it.each(["/original.jpg", "/selected.jpg"])(
+    "ignores an earlier upload after selecting %s",
+    async (selected) => {
+      let finishUpload!: (attachment: Awaited<ReturnType<UploadFile>>) => void;
+      const { wrapper } = mountGallery(
+        { src: "/original.jpg", aspectRatio: 2, alt: "Original" },
+        3,
+        () =>
+          new Promise((resolve) => {
+            finishUpload = resolve;
+          })
+      );
+      const replace = wrapper.findComponent(GalleryImageReplace);
+      replace.vm.$emit("upload", new File(["image"], "old.png"));
+      replace.vm.$emit("replace", selected);
+      finishUpload({ status: { permalink: "/old-upload.jpg" } } as Awaited<
+        ReturnType<UploadFile>
+      >);
+      await flushPromises();
+      expect(wrapper.get("img").attributes("src")).toBe(
+        `${selected}?thumbnail=XL`
+      );
+      expect(wrapper.get("img").attributes("alt")).toBe("Original");
+      wrapper.unmount();
+    }
+  );
+
+  it.each([
+    [0, 1],
+    [1, 0],
+  ])(
+    "keeps the latest upload when upload %i finishes before %i",
+    async (first, second) => {
+      const finishUploads: ((
+        attachment: Awaited<ReturnType<UploadFile>>
+      ) => void)[] = [];
+      const { wrapper } = mountGallery(
+        { src: "/original.jpg", aspectRatio: 2, alt: "Original" },
+        3,
+        () =>
+          new Promise((resolve) => {
+            finishUploads.push(resolve);
+          })
+      );
+      const replace = wrapper.findComponent(GalleryImageReplace);
+      replace.vm.$emit("upload", new File(["old"], "old.png"));
+      replace.vm.$emit("upload", new File(["new"], "new.png"));
+      finishUploads[first]({
+        status: { permalink: `/upload-${first}.jpg` },
+      } as Awaited<ReturnType<UploadFile>>);
+      await flushPromises();
+      expect(wrapper.get("img").attributes("src")).toBe(
+        first === 0
+          ? "/original.jpg?thumbnail=XL"
+          : "/upload-1.jpg?thumbnail=XL"
+      );
+      finishUploads[second]({
+        status: { permalink: `/upload-${second}.jpg` },
+      } as Awaited<ReturnType<UploadFile>>);
+      await flushPromises();
+      expect(wrapper.get("img").attributes("src")).toBe(
+        "/upload-1.jpg?thumbnail=XL"
+      );
+      wrapper.unmount();
+    }
+  );
+
+  it.each(["reorder", "delete", "regroup"])(
+    "keeps a pending upload bound to its image after %s",
+    async (operation) => {
+      let resolveUpload!: (attachment: Awaited<ReturnType<UploadFile>>) => void;
+      const uploadImage = vi.fn(
+        () =>
+          new Promise<Awaited<ReturnType<UploadFile>>>((resolve) => {
+            resolveUpload = resolve;
+          })
+      );
+      const { wrapper, updateAttributes } = mountGallery(
+        [
+          { src: "/same.jpg", aspectRatio: 2, alt: "First" },
+          { src: "/same.jpg", aspectRatio: 1, alt: "Second" },
+        ],
+        2,
+        uploadImage
+      );
+      const file = new File(["image"], "replacement.png", {
+        type: "image/png",
+      });
+      wrapper
+        .findAllComponents(GalleryImageReplace)[1]
+        .vm.$emit("upload", file);
+      expect(uploadImage).toHaveBeenCalledWith(file);
+
+      // An alt edit replaces the image object while the upload is pending.
+      wrapper
+        .findAllComponents(GalleryImageAlt)[1]
+        .vm.$emit("update:alt", "Edited");
+      await wrapper.vm.$nextTick();
+      if (operation === "reorder") {
+        const cards = wrapper.findAll('[draggable="true"]');
+        await cards[1].trigger("dragstart");
+        await cards[0].trigger("drop");
+      } else if (operation === "delete") {
+        await wrapper
+          .findAll('button[aria-label="Delete"]')[1]
+          .trigger("click");
+      } else {
+        await wrapper.setProps({
+          node: {
+            ...wrapper.props("node"),
+            attrs: { ...wrapper.props("node").attrs, groupSize: 1 },
+          } as unknown as NodeViewProps["node"],
+        });
+      }
+
+      resolveUpload({ status: { permalink: "/new.jpg" } } as Awaited<
+        ReturnType<UploadFile>
+      >);
+      await flushPromises();
+      const images = updateAttributes.mock.lastCall?.[0].images;
+      const first = { src: "/same.jpg", aspectRatio: 2, alt: "First" };
+      const replaced = { src: "/new.jpg", aspectRatio: 0, alt: "Edited" };
+      expect(images).toEqual(
+        operation === "delete"
+          ? [first]
+          : operation === "reorder"
+            ? [replaced, first]
+            : [first, replaced]
+      );
+      wrapper.unmount();
+    }
+  );
+
   it.each(['山间的 "日出" & 云海', ""])(
     "preserves alt %j across an HTML round trip",
     (alt) => {
@@ -283,23 +446,22 @@ function createEditor(content: Content) {
 
 function mountGallery(
   image: ExtensionGalleryImageItem | ExtensionGalleryImageItem[],
-  groupSize = 3
+  groupSize = 3,
+  uploadImage?: UploadFile
 ) {
   const images = Array.isArray(image) ? image : [image];
-  const updateAttributes = vi.fn();
+  const node = reactive({
+    attrs: { images, groupSize, layout: "auto", gap: 8 },
+  });
+  const updateAttributes = vi.fn((attributes) =>
+    Object.assign(node.attrs, attributes)
+  );
   const wrapper = shallowMount(GalleryView, {
     props: {
-      node: {
-        attrs: {
-          images,
-          groupSize,
-          layout: "auto",
-          gap: 8,
-        },
-      },
+      node,
       updateAttributes,
       editor: {},
-      extension: { options: {} },
+      extension: { options: { uploadImage } },
       getPos: () => 0,
       selected: false,
     } as unknown as NodeViewProps,

--- a/ui/packages/editor/src/extensions/gallery/GalleryView.vue
+++ b/ui/packages/editor/src/extensions/gallery/GalleryView.vue
@@ -12,6 +12,7 @@ import {
   GALLERY_LAYOUT_SQUARE,
 } from "./constants";
 import GalleryImageAlt from "./GalleryImageAlt.vue";
+import GalleryImageReplace from "./GalleryImageReplace.vue";
 import type { ExtensionGalleryImageItem } from "./index";
 import { useUploadGalleryImage } from "./useGalleryImages";
 
@@ -44,6 +45,13 @@ function updateImageAlt(index: number, alt: string) {
   images.value = images.value.map(
     (image: ExtensionGalleryImageItem, i: number) =>
       i === index ? { ...image, alt } : image
+  );
+}
+
+function replaceImage(index: number, src: string) {
+  images.value = images.value.map(
+    (image: ExtensionGalleryImageItem, i: number) =>
+      i === index ? { ...image, src, aspectRatio: 0 } : image
   );
 }
 
@@ -272,6 +280,12 @@ function onAttachmentSelect(attachments: AttachmentLike[]) {
                 :alt="image.alt ?? ''"
                 @update:alt="
                   updateImageAlt(groupIndex * groupSize + imgIndex, $event)
+                "
+              />
+              <GalleryImageReplace
+                :upload="extension.options.uploadImage"
+                @replace="
+                  replaceImage(groupIndex * groupSize + imgIndex, $event)
                 "
               />
               <button

--- a/ui/packages/editor/src/extensions/gallery/GalleryView.vue
+++ b/ui/packages/editor/src/extensions/gallery/GalleryView.vue
@@ -1,8 +1,8 @@
 <script lang="ts" setup>
 import { GetThumbnailByUriSizeEnum } from "@halo-dev/api-client";
-import { VButton, VSpace } from "@halo-dev/components";
+import { Toast, VButton, VSpace } from "@halo-dev/components";
 import { utils, type AttachmentLike } from "@halo-dev/ui-shared";
-import { computed, ref } from "vue";
+import { computed, ref, toRaw } from "vue";
 import MingcuteDelete2Line from "@/components/icon/MingcuteDelete2Line.vue";
 import { i18n } from "@/locales";
 import { NodeViewWrapper, type NodeViewProps } from "@/tiptap";
@@ -41,18 +41,64 @@ function removeImage(index: number) {
   images.value = newImages;
 }
 
+// Keep replacement targets stable across reordering and immutable attribute updates.
+const imageIdentities = new WeakMap<
+  ExtensionGalleryImageItem,
+  ExtensionGalleryImageItem
+>();
+
+function imageIdentity(image: ExtensionGalleryImageItem) {
+  const rawImage = toRaw(image);
+  return imageIdentities.get(rawImage) || rawImage;
+}
+
+function updateImage(
+  image: ExtensionGalleryImageItem,
+  attributes: Partial<ExtensionGalleryImageItem>
+) {
+  const updated = { ...image, ...attributes };
+  imageIdentities.set(updated, imageIdentity(image));
+  return updated;
+}
+
 function updateImageAlt(index: number, alt: string) {
   images.value = images.value.map(
     (image: ExtensionGalleryImageItem, i: number) =>
-      i === index ? { ...image, alt } : image
+      i === index ? updateImage(image, { alt }) : image
   );
 }
 
-function replaceImage(index: number, src: string) {
-  images.value = images.value.map(
-    (image: ExtensionGalleryImageItem, i: number) =>
-      i === index ? { ...image, src, aspectRatio: 0 } : image
+const pendingUploads = new WeakMap<ExtensionGalleryImageItem, symbol>();
+
+function replaceImage(target: ExtensionGalleryImageItem, src: string) {
+  pendingUploads.delete(target);
+  const index = images.value.findIndex(
+    (image: ExtensionGalleryImageItem) => imageIdentity(image) === target
   );
+  const image = images.value[index];
+  if (!image || image.src === src) {
+    return;
+  }
+  const newImages = [...images.value];
+  newImages[index] = updateImage(image, { src, aspectRatio: 0 });
+  images.value = newImages;
+}
+
+async function uploadReplacement(image: ExtensionGalleryImageItem, file: File) {
+  const target = imageIdentity(image);
+  const upload = Symbol();
+  pendingUploads.set(target, upload);
+  try {
+    const attachment = await props.extension.options.uploadImage?.(file);
+    const url = attachment?.status?.permalink;
+    if (url && pendingUploads.get(target) === upload) {
+      replaceImage(target, url);
+    }
+  } catch (error) {
+    Toast.error(
+      `${i18n.global.t("editor.extensions.upload.error")} - ${(error as Error).message}`
+    );
+  }
 }
 
 function handleImageLoad(event: Event, index: number) {
@@ -65,10 +111,7 @@ function handleImageLoad(event: Event, index: number) {
   if (img.naturalWidth && img.naturalHeight) {
     const ratio = img.naturalWidth / img.naturalHeight;
     const newImages = [...images.value];
-    newImages[index] = {
-      ...currentImage,
-      aspectRatio: ratio,
-    };
+    newImages[index] = updateImage(currentImage, { aspectRatio: ratio });
     images.value = newImages;
   }
 }
@@ -283,10 +326,9 @@ function onAttachmentSelect(attachments: AttachmentLike[]) {
                 "
               />
               <GalleryImageReplace
-                :upload="extension.options.uploadImage"
-                @replace="
-                  replaceImage(groupIndex * groupSize + imgIndex, $event)
-                "
+                :upload-enabled="!!extension.options.uploadImage"
+                @upload="uploadReplacement(image, $event)"
+                @replace="replaceImage(imageIdentity(image), $event)"
               />
               <button
                 v-tooltip="


### PR DESCRIPTION
#### What type of PR is this?

<!--
请选择一个主要类型：
Select one primary type:
-->
- [x] Feature

#### What this PR does / why we need it:

This PR adds support for replacing individual images in the gallery extension. Each image in a gallery now has a replace button in its hover action bar, offering two options:

- Upload a new image to the attachment library to replace the current one
- Select an existing image from the attachment library (limited to a single image)

After replacement, the aspect ratio of the image is reset so it can be recalculated on load, while the manually edited alt text is preserved.

#### Which issue(s) this PR fixes:

Fixes #

#### Special notes for your reviewer:

- The new `GalleryImageReplace` component follows the same icon-button style as `GalleryImageAlt` instead of reusing the text-based `ResourceReplaceButton`, to stay consistent with the gallery's hover action bar.
- This PR contains LLM-generated code, which has been reviewed.

#### Does this PR introduce a user-facing change?

```release-note
编辑器中的图片集支持替换单张图片，可通过上传新图片或从附件库选择进行替换。
```