### PR TITLE
Fix theme selection after activation

### DIFF
--- a/ui/console-src/modules/interface/themes/composables/__tests__/use-theme.spec.ts
+++ b/ui/console-src/modules/interface/themes/composables/__tests__/use-theme.spec.ts
@@ -1,0 +1,64 @@
+import { consoleApiClient, type Theme } from "@halo-dev/api-client";
+import { Dialog } from "@halo-dev/components";
+import { afterEach, expect, it, vi } from "vite-plus/test";
+import { ref } from "vue";
+import { useThemeLifeCycle } from "../use-theme";
+
+vi.mock("@console/composables/use-activated-theme", () => ({
+  useActivatedTheme: () => ({ data: ref(null) }),
+  invalidateThemeQueries: vi.fn(),
+}));
+vi.mock("@tanstack/vue-query", () => ({ useQueryClient: vi.fn() }));
+vi.mock("vue-i18n", () => ({ useI18n: () => ({ t: (key: string) => key }) }));
+vi.mock("@halo-dev/components", () => ({
+  Dialog: { info: vi.fn() },
+  Toast: { success: vi.fn() },
+}));
+vi.mock("@halo-dev/api-client", () => ({
+  consoleApiClient: { theme: { theme: { activateTheme: vi.fn() } } },
+}));
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+  vi.clearAllMocks();
+});
+
+it.each([true, false])(
+  "updates the selected theme before reloading only after successful activation: %s",
+  async (success) => {
+    const url = new URL(
+      "http://localhost/console/theme/settings/style?theme=old&other=value#field"
+    );
+    const historyState = { position: 1 };
+    const replaceState = vi.fn((_state, _title, value) => {
+      url.href = String(value);
+    });
+    const reload = vi.fn(() => {
+      expect(url.searchParams.get("theme")).toBe("new");
+    });
+    vi.stubGlobal("window", {
+      location: { href: url.href, reload },
+      history: { state: historyState, replaceState },
+    });
+    const error = vi.spyOn(console, "error").mockImplementation(() => {});
+    const activate = vi.mocked(consoleApiClient.theme.theme.activateTheme);
+    if (success) activate.mockResolvedValue({} as never);
+    else activate.mockRejectedValue(new Error("activation failed"));
+
+    const { handleActiveTheme } = useThemeLifeCycle(
+      ref({ metadata: { name: "new" }, spec: {} } as Theme)
+    );
+    handleActiveTheme(true);
+    expect(reload).not.toHaveBeenCalled();
+    await vi.mocked(Dialog.info).mock.calls[0][0].onConfirm?.();
+
+    expect(activate).toHaveBeenCalledWith({ name: "new" });
+    expect(reload).toHaveBeenCalledTimes(success ? 1 : 0);
+    expect(replaceState).toHaveBeenCalledTimes(success ? 1 : 0);
+    expect(url.pathname).toBe("/console/theme/settings/style");
+    expect(url.searchParams.get("other")).toBe("value");
+    expect(url.hash).toBe("#field");
+    expect(error).toHaveBeenCalledTimes(success ? 0 : 1);
+  }
+);

--- a/ui/console-src/modules/interface/themes/composables/use-theme.ts
+++ b/ui/console-src/modules/interface/themes/composables/use-theme.ts
@@ -59,13 +59,17 @@ export function useThemeLifeCycle(
         try {
           if (!theme.value) return;
 
+          const name = theme.value.metadata.name;
           await consoleApiClient.theme.theme.activateTheme({
-            name: theme.value?.metadata.name,
+            name,
           });
 
           Toast.success(t("core.theme.operations.active.toast_success"));
 
           if (reload) {
+            const url = new URL(window.location.href);
+            url.searchParams.set("theme", name);
+            window.history.replaceState(window.history.state, "", url);
             window.location.reload();
           }
         } catch (e) {


### PR DESCRIPTION
#### What type of PR is this?

- [ ] Feature
- [x] Bug fix
- [ ] Improvement
- [ ] Cleanup
- [ ] Documentation

#### What this PR does / why we need it:

Activating another theme while the URL contains an explicit `theme` selection reloads the page with the old selection.

Update the `theme` query parameter after successful activation and before reloading. Preserve the current path, other query parameters, hash, and history state. All three activation entry points share this behavior.

To reproduce, select a theme so its name is recorded in the URL, then activate another theme from theme management. Previously, the page still selected the old theme after reloading. With this fix, the URL and selection follow the newly activated theme.

#### Which issue(s) this PR fixes:

None.

#### Special notes for your reviewer:

Implemented with assistance from OpenAI Codex.

The regression test failed before the fix and passed afterward. It checks that the URL is updated before reloading and that failed activation does not change the URL or reload.

Validation passed:
- 36 theme-related tests.
- Application TypeScript checking.
- ESLint and formatting checks for both changed files.
- `git diff --check`.

Browser verification has not been performed.

#### Does this PR introduce a user-facing change?

```release-note
修复激活其他主题后，主题管理页面未自动选中新激活主题的问题。
```
