### PR TITLE
Remove deprecated next callbacks from global navigation guards

### DIFF
--- a/ui/console-src/router/guards/auth-check.ts
+++ b/ui/console-src/router/guards/auth-check.ts
@@ -2,16 +2,14 @@ import { stores } from "@halo-dev/ui-shared";
 import type { Router } from "vue-router";
 
 export function setupAuthCheckGuard(router: Router) {
-  router.beforeEach((_to, _, next) => {
+  router.beforeEach(() => {
     const currentUserStore = stores.currentUser();
 
     if (currentUserStore.isAnonymous) {
       window.location.href = `/login?redirect_uri=${encodeURIComponent(
         window.location.href
       )}`;
-      return;
+      return false;
     }
-
-    next();
   });
 }

--- a/ui/console-src/router/guards/permission.ts
+++ b/ui/console-src/router/guards/permission.ts
@@ -3,23 +3,21 @@ import type { RouteLocationNormalized, Router } from "vue-router";
 import { isConsoleAccessDisallowed } from "@/utils/role";
 
 export function setupPermissionGuard(router: Router) {
-  router.beforeEach(async (to, _, next) => {
+  router.beforeEach(async (to) => {
     const currentUserStore = stores.currentUser();
 
     if (isConsoleAccessDisallowed(currentUserStore.currentUser?.roles)) {
       window.location.href = "/uc";
-      return;
+      return false;
     }
 
     if (
-      await checkRoutePermissions(
+      !(await checkRoutePermissions(
         to,
         utils.permission.getUserPermissions() || []
-      )
+      ))
     ) {
-      next();
-    } else {
-      next({ name: "Forbidden" });
+      return { name: "Forbidden" };
     }
   });
 }

--- a/ui/src/router/guards.spec.ts
+++ b/ui/src/router/guards.spec.ts
@@ -1,0 +1,145 @@
+import { setupAuthCheckGuard as setupConsoleAuth } from "@console/router/guards/auth-check";
+import { setupPermissionGuard as setupConsolePermission } from "@console/router/guards/permission";
+import { setupAuthCheckGuard as setupUcAuth } from "@uc/router/guards/auth-check";
+import { setupPermissionGuard as setupUcPermission } from "@uc/router/guards/permission";
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vite-plus/test";
+import {
+  createMemoryHistory,
+  createRouter,
+  isNavigationFailure,
+  NavigationFailureType,
+  type RouteMeta,
+} from "vue-router";
+import { setupProcessBarGuard } from "./process-bar";
+
+const mocks = vi.hoisted(() => ({
+  user: { isAnonymous: false },
+  hasPermission: vi.fn(),
+  disallowConsole: vi.fn(),
+}));
+
+vi.mock("@halo-dev/ui-shared", () => ({
+  stores: { currentUser: () => mocks.user },
+  utils: {
+    permission: {
+      getUserPermissions: () => ["test:view"],
+      has: mocks.hasPermission,
+    },
+  },
+}));
+vi.mock("@/utils/role", () => ({
+  isConsoleAccessDisallowed: mocks.disallowConsole,
+}));
+
+beforeEach(() => {
+  mocks.user.isAnonymous = false;
+  mocks.hasPermission.mockReturnValue(true);
+  mocks.disallowConsole.mockReturnValue(false);
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+});
+
+describe.each([
+  ["Console", setupConsoleAuth, setupConsolePermission],
+  ["UC", setupUcAuth, setupUcPermission],
+] as const)("%s global guards", (_, setupAuth, setupPermission) => {
+  function routerWithGuards(meta: RouteMeta = {}) {
+    const component = { render: () => null };
+    const router = createRouter({
+      history: createMemoryHistory(),
+      routes: [
+        { path: "/target", component, meta },
+        { path: "/forbidden", name: "Forbidden", component },
+      ],
+    });
+    setupAuth(router);
+    setupPermission(router);
+    setupProcessBarGuard(router);
+    return router;
+  }
+
+  it("allows navigation without deprecated next warnings", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const router = routerWithGuards();
+    await router.push("/target");
+    expect(router.currentRoute.value.path).toBe("/target");
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  it.each([true, false])(
+    "preserves array permission result %s",
+    async (allowed) => {
+      mocks.hasPermission.mockReturnValue(allowed);
+      const router = routerWithGuards({ permissions: ["test:view"] });
+      await router.push("/target");
+      expect(router.currentRoute.value.path).toBe(
+        allowed ? "/target" : "/forbidden"
+      );
+    }
+  );
+
+  it.each([true, false])(
+    "awaits permission function result %s",
+    async (allowed) => {
+      const permissions = vi.fn(async () => allowed);
+      const router = routerWithGuards({ permissions });
+      await router.push("/target");
+      expect(permissions).toHaveBeenCalledWith(["test:view"]);
+      expect(router.currentRoute.value.path).toBe(
+        allowed ? "/target" : "/forbidden"
+      );
+    }
+  );
+
+  it("denies navigation when a permission function rejects", async () => {
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    const router = routerWithGuards({
+      permissions: async () => {
+        throw new Error("Permission check failed");
+      },
+    });
+    await router.push("/target");
+    expect(router.currentRoute.value.name).toBe("Forbidden");
+  });
+
+  it("cancels anonymous navigation while redirecting to login", async () => {
+    const href = "http://localhost/console/target?tab=test";
+    vi.stubGlobal("window", { location: { href } });
+    mocks.user.isAnonymous = true;
+    const router = routerWithGuards();
+    const failure = await router.push("/target");
+    expect(isNavigationFailure(failure, NavigationFailureType.aborted)).toBe(
+      true
+    );
+    expect(window.location.href).toBe(
+      `/login?redirect_uri=${encodeURIComponent(href)}`
+    );
+    expect(router.currentRoute.value.path).toBe("/");
+  });
+});
+
+it("cancels Console navigation while redirecting a restricted user to UC", async () => {
+  vi.stubGlobal("window", { location: { href: "http://localhost/console/" } });
+  mocks.disallowConsole.mockReturnValue(true);
+  const router = createRouter({
+    history: createMemoryHistory(),
+    routes: [{ path: "/target", component: { render: () => null } }],
+  });
+  setupConsolePermission(router);
+  const failure = await router.push("/target");
+  expect(isNavigationFailure(failure, NavigationFailureType.aborted)).toBe(
+    true
+  );
+  expect(window.location.href).toBe("/uc");
+  expect(router.currentRoute.value.path).toBe("/");
+});

--- a/ui/src/router/process-bar.ts
+++ b/ui/src/router/process-bar.ts
@@ -9,12 +9,11 @@ nprogress.configure({
 let progressTimer: ReturnType<typeof setTimeout> | null = null;
 
 export function setupProcessBarGuard(router: Router) {
-  router.beforeEach((_to, _from, next) => {
+  router.beforeEach(() => {
     progressTimer = setTimeout(() => {
       nprogress.start();
       progressTimer = null;
     }, 200);
-    next();
   });
   router.afterEach(() => {
     if (progressTimer) {

--- a/ui/uc-src/router/guards/auth-check.ts
+++ b/ui/uc-src/router/guards/auth-check.ts
@@ -2,16 +2,14 @@ import { stores } from "@halo-dev/ui-shared";
 import type { Router } from "vue-router";
 
 export function setupAuthCheckGuard(router: Router) {
-  router.beforeEach((_to, _from, next) => {
+  router.beforeEach(() => {
     const currentUserStore = stores.currentUser();
 
     if (currentUserStore.isAnonymous) {
       window.location.href = `/login?redirect_uri=${encodeURIComponent(
         window.location.href
       )}`;
-      return;
+      return false;
     }
-
-    next();
   });
 }

--- a/ui/uc-src/router/guards/permission.ts
+++ b/ui/uc-src/router/guards/permission.ts
@@ -2,16 +2,14 @@ import { utils } from "@halo-dev/ui-shared";
 import type { RouteLocationNormalized, Router } from "vue-router";
 
 export function setupPermissionGuard(router: Router) {
-  router.beforeEach(async (to, _from, next) => {
+  router.beforeEach(async (to) => {
     if (
-      await checkRoutePermissions(
+      !(await checkRoutePermissions(
         to,
         utils.permission.getUserPermissions() || []
-      )
+      ))
     ) {
-      next();
-    } else {
-      next({ name: "Forbidden" });
+      return { name: "Forbidden" };
     }
   });
 }


### PR DESCRIPTION
#### What type of PR is this?

- [ ] Feature
- [x] Bug fix
- [ ] Improvement
- [ ] Cleanup
- [ ] Documentation

#### What this PR does / why we need it:

Console and User Center navigation triggers Vue Router deprecation warnings because their global authentication, permission, and progress-bar guards use `next()`.

Replace these callbacks with return values. Return the Forbidden route when permission checks fail, and explicitly cancel SPA navigation after starting an external login or User Center redirect.

To reproduce, run the new navigation tests against the original guards. Normal navigation emits three deprecation warnings. With this change, the same navigation completes without warnings.

#### Which issue(s) this PR fixes:

None.

#### Special notes for your reviewer:

Implemented with assistance from OpenAI Codex.

Validation passed:
- `pnpm -C ui exec vp test --run src/router/guards.spec.ts --reporter=default` — 15 tests covering warnings, permissions, and external redirects.
- `pnpm -C ui typecheck`
- `pnpm -C ui exec eslint console-src/router/guards uc-src/router/guards src/router/guards.spec.ts src/router/process-bar.ts --max-warnings=0`
- `git diff --check`

Browser verification has not been performed. Component-level unsaved-change and dashboard leave guards are outside this PR's scope.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
