### PR TITLE
Prevent reactive component warnings in UI extensions

### DIFF
--- a/ui/console-src/composables/__tests__/extension-component-reactivity.spec.ts
+++ b/ui/console-src/composables/__tests__/extension-component-reactivity.spec.ts
@@ -1,0 +1,184 @@
+import { QueryClient, VueQueryPlugin } from "@tanstack/vue-query";
+import { flushPromises, mount } from "@vue/test-utils";
+import { expect, it, vi } from "vite-plus/test";
+import { computed, defineAsyncComponent, h, reactive, ref } from "vue";
+import { useRouteMenuGenerator } from "@/composables/use-route-menu-generator";
+import CommentEditor from "../../modules/contents/comments/components/CommentEditor.vue";
+import { useContentProviderExtensionPoint } from "../../modules/contents/comments/composables/use-content-provider-extension-point";
+import { useOperationItemExtensionPoint } from "../use-operation-extension-points";
+
+const mocks = vi.hoisted(() => ({ extension: vi.fn(), routes: vi.fn() }));
+vi.mock("@/stores/plugin", () => ({
+  usePluginModuleStore: () => ({
+    pluginModules: [
+      {
+        extensionPoints: {
+          operations: mocks.extension,
+          "comment:list-item:content:replace": mocks.extension,
+          "comment:editor:replace": mocks.extension,
+        },
+      },
+    ],
+  }),
+}));
+vi.mock("vue-router", () => ({
+  useRouter: () => ({ getRoutes: mocks.routes }),
+}));
+vi.mock("@halo-dev/ui-shared", () => ({
+  utils: { permission: { has: () => true } },
+}));
+vi.mock("@halo-dev/components", () => ({ VLoading: { template: "<span />" } }));
+vi.mock(
+  "../../modules/contents/comments/components/DefaultCommentContent.vue",
+  () => ({ default: {} })
+);
+vi.mock(
+  "../../modules/contents/comments/components/DefaultCommentEditor.vue",
+  () => ({ default: {} })
+);
+
+it.each([
+  "operation",
+  "child operation",
+  "comment content",
+  "comment editor",
+  "menu icon",
+  "child menu icon",
+])(
+  "keeps %s props and local state reactive without proxying components",
+  async (kind) => {
+    const component = defineAsyncComponent(async () => ({
+      props: { label: String, initialContent: String },
+      setup() {
+        return { count: ref(0) };
+      },
+      template:
+        '<button @click="count++">{{ label || initialContent }}:{{ count }}</button>',
+    }));
+    const state = reactive({ label: "before", hidden: false });
+    const operation = {
+      priority: 1,
+      component,
+      props: state,
+      get hidden() {
+        return state.hidden;
+      },
+    };
+    mocks.extension.mockReturnValue(
+      kind.includes("operation")
+        ? [{ ...operation, children: [operation] }]
+        : { component, supportsEditing: true }
+    );
+    // Preserve the top-level getter as well as the child's getter.
+    if (kind === "operation") mocks.extension.mockReturnValue([operation]);
+    const child = {
+      name: "child",
+      path: "/test/child",
+      children: [],
+      meta: {
+        menu: { name: "child", group: "test", icon: component, mobile: true },
+      },
+    };
+    mocks.routes.mockReturnValue([
+      {
+        name: "test",
+        path: "/test",
+        children: [child],
+        meta: {
+          menu: { name: "test", group: "test", icon: component, mobile: true },
+        },
+      },
+      child,
+      {
+        name: "no-icon",
+        path: "/no-icon",
+        children: [],
+        meta: { menu: { name: "no-icon", group: "test" } },
+      },
+    ]);
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const client = new QueryClient();
+    const wrapper = mount(
+      {
+        setup() {
+          if (kind === "comment editor")
+            return () => h(CommentEditor, { initialContent: state.label });
+          if (kind.includes("menu icon")) {
+            const { data } = useRouteMenuGenerator([]);
+            return () => {
+              const menu = data.value?.minimenus[0];
+              const icon =
+                kind === "menu icon" ? menu?.icon : menu?.children?.[0].icon;
+              return icon ? h(icon, { label: state.label }) : null;
+            };
+          }
+          if (kind === "comment content") {
+            const { data } = useContentProviderExtensionPoint();
+            return () =>
+              data.value
+                ? h(data.value.component, { label: state.label })
+                : null;
+          }
+          const { data } = useOperationItemExtensionPoint(
+            "operations",
+            ref({ name: "test" }),
+            computed(() => [])
+          );
+          return () => {
+            const item =
+              kind === "operation"
+                ? data.value?.[0]
+                : data.value?.[0].children?.[0];
+            return item?.component && !item.hidden
+              ? h(item.component, item.props)
+              : null;
+          };
+        },
+      },
+      { global: { plugins: [[VueQueryPlugin, { queryClient: client }]] } }
+    );
+    try {
+      await flushPromises();
+      await flushPromises();
+      expect(wrapper.text()).toBe("before:0");
+      state.label = "after";
+      await flushPromises();
+      expect(wrapper.text()).toBe("after:0");
+      await wrapper.get("button").trigger("click");
+      expect(wrapper.text()).toBe("after:1");
+      if (kind.includes("operation")) {
+        state.hidden = true;
+        await flushPromises();
+        expect(wrapper.find("button").exists()).toBe(false);
+        state.hidden = false;
+        await flushPromises();
+        expect(wrapper.text()).toBe("after:0");
+      }
+      if (!kind.includes("menu icon")) {
+        const replacement = {
+          component: defineAsyncComponent(async () => ({
+            template: "<span>replaced</span>",
+          })),
+          priority: 1,
+          supportsEditing: true,
+        };
+        mocks.extension.mockReturnValue(
+          kind.includes("operation")
+            ? [{ ...replacement, children: [replacement] }]
+            : replacement
+        );
+        await client.invalidateQueries();
+        await flushPromises();
+        await flushPromises();
+        expect(wrapper.text()).toBe("replaced");
+      }
+      expect(warn.mock.calls.flat().join(" ")).not.toContain(
+        "Vue received a Component that was made a reactive object"
+      );
+    } finally {
+      wrapper.unmount();
+      client.clear();
+      warn.mockRestore();
+    }
+  }
+);

--- a/ui/console-src/composables/__tests__/use-entity-extension-points.spec.ts
+++ b/ui/console-src/composables/__tests__/use-entity-extension-points.spec.ts
@@ -1,0 +1,82 @@
+import type { EntityFieldItem } from "@halo-dev/ui-shared";
+import { QueryClient, VueQueryPlugin } from "@tanstack/vue-query";
+import { flushPromises, mount } from "@vue/test-utils";
+import { expect, it, vi } from "vite-plus/test";
+import {
+  computed,
+  defineAsyncComponent,
+  defineComponent,
+  h,
+  reactive,
+  ref,
+} from "vue";
+import EntityFieldItems from "@/components/entity-fields/EntityFieldItems.vue";
+import { useEntityFieldItemExtensionPoint } from "../use-entity-extension-points";
+
+const extension = vi.hoisted(() => vi.fn());
+vi.mock("@/stores/plugin", () => ({
+  usePluginModuleStore: () => ({
+    pluginModules: [{ extensionPoints: { fields: extension } }],
+  }),
+}));
+vi.mock("@halo-dev/ui-shared", () => ({
+  utils: { permission: { has: () => true } },
+}));
+
+it("renders async plugin fields without making their components reactive", async () => {
+  const state = reactive({ label: "Plugin field", hidden: false });
+  extension.mockImplementation(() => [
+    {
+      position: "end",
+      priority: 10,
+      component: defineAsyncComponent(async () => ({
+        props: { label: String },
+        template: "<span>{{ label }}</span>",
+      })),
+      props: state,
+      get hidden() {
+        return state.hidden;
+      },
+    },
+  ]);
+  const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+  const client = new QueryClient();
+  const wrapper = mount(
+    defineComponent({
+      setup() {
+        const { data } = useEntityFieldItemExtensionPoint(
+          "fields",
+          ref({ name: "test-plugin" }),
+          computed((): EntityFieldItem[] => [])
+        );
+        return () => h(EntityFieldItems, { fields: data.value?.end || [] });
+      },
+    }),
+    { global: { plugins: [[VueQueryPlugin, { queryClient: client }]] } }
+  );
+  try {
+    await flushPromises();
+    await flushPromises();
+    expect(wrapper.text()).toBe("Plugin field");
+    await client.invalidateQueries();
+    await flushPromises();
+    await flushPromises();
+    expect(wrapper.text()).toBe("Plugin field");
+    state.label = "Updated field";
+    await flushPromises();
+    expect(wrapper.text()).toBe("Updated field");
+    state.hidden = true;
+    await flushPromises();
+    expect(wrapper.text()).toBe("");
+    state.hidden = false;
+    await flushPromises();
+    expect(wrapper.text()).toBe("Updated field");
+    expect(warn.mock.calls.flat().join(" ")).not.toContain(
+      "Vue received a Component that was made a reactive object"
+    );
+  } finally {
+    wrapper.unmount();
+    client.clear();
+    warn.mockRestore();
+  }
+});

--- a/ui/console-src/composables/use-entity-extension-points.ts
+++ b/ui/console-src/composables/use-entity-extension-points.ts
@@ -1,6 +1,6 @@
 import type { EntityFieldItem } from "@halo-dev/ui-shared";
 import { useQuery } from "@tanstack/vue-query";
-import { computed, toValue, type ComputedRef, type Ref } from "vue";
+import { computed, markRaw, toValue, type ComputedRef, type Ref } from "vue";
 import { usePluginModuleStore } from "@/stores/plugin";
 
 export function useEntityFieldItemExtensionPoint<T>(
@@ -11,6 +11,8 @@ export function useEntityFieldItemExtensionPoint<T>(
   const { pluginModules } = usePluginModuleStore();
 
   return useQuery({
+    // Deep structural sharing would clone component definitions and lose markRaw.
+    structuralSharing: false,
     queryKey: computed(() => [
       "core:extension-points:list-item:fields",
       extensionPointName,
@@ -27,6 +29,9 @@ export function useEntityFieldItemExtensionPoint<T>(
         const items = extensionPoints[extensionPointName](
           entity
         ) as EntityFieldItem[];
+        for (const item of items) {
+          markRaw(item.component);
+        }
         itemsFromPlugins.push(...items);
       }
 

--- a/ui/console-src/composables/use-operation-extension-points.ts
+++ b/ui/console-src/composables/use-operation-extension-points.ts
@@ -1,7 +1,18 @@
 import type { OperationItem } from "@halo-dev/ui-shared";
 import { useQuery } from "@tanstack/vue-query";
-import { computed, toValue, type ComputedRef, type Ref } from "vue";
+import { computed, markRaw, toValue, type ComputedRef, type Ref } from "vue";
 import { usePluginModuleStore } from "@/stores/plugin";
+
+function markOperationComponentsRaw<T>(items: OperationItem<T>[]) {
+  for (const item of items) {
+    if (item.component) {
+      markRaw(item.component);
+    }
+    if (item.children) {
+      markOperationComponentsRaw(item.children);
+    }
+  }
+}
 
 export function useOperationItemExtensionPoint<T>(
   extensionPointName: string,
@@ -11,6 +22,8 @@ export function useOperationItemExtensionPoint<T>(
   const { pluginModules } = usePluginModuleStore();
 
   const query = useQuery({
+    // Deep structural sharing would clone component definitions and lose markRaw.
+    structuralSharing: false,
     queryKey: computed(() => [
       "core:extension-points:operation-items",
       extensionPointName,
@@ -28,6 +41,7 @@ export function useOperationItemExtensionPoint<T>(
           entity
         ) as OperationItem<T>[];
 
+        markOperationComponentsRaw(items);
         itemsFromPlugins.push(...items);
       }
 

--- a/ui/console-src/modules/contents/comments/components/CommentEditor.vue
+++ b/ui/console-src/modules/contents/comments/components/CommentEditor.vue
@@ -29,6 +29,8 @@ const emit = defineEmits<{
 }>();
 
 const { data: provider, isLoading } = useQuery({
+  // Deep structural sharing would clone component definitions and lose markRaw.
+  structuralSharing: false,
   queryKey: ["core:comment:provider"],
   queryFn: async () => {
     const result: CommentEditorProvider[] = [];
@@ -42,6 +44,7 @@ const { data: provider, isLoading } = useQuery({
 
       const item = await callbackFunction();
 
+      markRaw(item.component);
       result.push(item);
     }
 

--- a/ui/console-src/modules/contents/comments/composables/use-content-provider-extension-point.ts
+++ b/ui/console-src/modules/contents/comments/composables/use-content-provider-extension-point.ts
@@ -12,6 +12,8 @@ export function useContentProviderExtensionPoint() {
   const { pluginModules } = usePluginModuleStore();
 
   return useQuery({
+    // Deep structural sharing would clone component definitions and lose markRaw.
+    structuralSharing: false,
     queryKey: ["core:comment:list-item:content:provider"],
     queryFn: async () => {
       const result: CommentContentProvider[] = [];
@@ -25,6 +27,7 @@ export function useContentProviderExtensionPoint() {
 
         const item = await callbackFunction();
 
+        markRaw(item.component);
         result.push(item);
       }
 

--- a/ui/src/composables/use-route-menu-generator.ts
+++ b/ui/src/composables/use-route-menu-generator.ts
@@ -5,7 +5,7 @@ import {
 } from "@halo-dev/ui-shared";
 import { useQuery } from "@tanstack/vue-query";
 import { sortBy } from "es-toolkit";
-import { ref, watch } from "vue";
+import { markRaw, ref, watch } from "vue";
 import {
   useRouter,
   type RouteRecordNormalized,
@@ -53,6 +53,8 @@ export function useRouteMenuGenerator(menuGroups: MenuGroupType[]) {
   }
 
   const { data, isLoading: isDataLoading } = useQuery({
+    // Deep structural sharing would clone component definitions and lose markRaw.
+    structuralSharing: false,
     queryKey: ["core:sidebar:menus"],
     queryFn: async () => {
       const allRoutes = router.getRoutes();
@@ -127,7 +129,7 @@ export function useRouteMenuGenerator(menuGroups: MenuGroupType[]) {
             return {
               name: child.meta.menu.name,
               path: child.path,
-              icon: child.meta.menu.icon,
+              icon: child.meta.menu.icon && markRaw(child.meta.menu.icon),
               mobile: child.meta.menu.mobile,
             };
           })
@@ -137,7 +139,7 @@ export function useRouteMenuGenerator(menuGroups: MenuGroupType[]) {
           group.items?.push({
             name: menu.name,
             path: route.path,
-            icon: menu.icon,
+            icon: menu.icon && markRaw(menu.icon),
             mobile: menu.mobile,
             children: menuChildren,
           });
@@ -157,7 +159,7 @@ export function useRouteMenuGenerator(menuGroups: MenuGroupType[]) {
               {
                 name: menu.name,
                 path: route.path,
-                icon: menu.icon,
+                icon: menu.icon && markRaw(menu.icon),
                 mobile: menu.mobile,
                 children: menuChildren,
               },


### PR DESCRIPTION
#### What type of PR is this?

- [ ] Feature
- [x] Bug fix
- [ ] Improvement
- [ ] Cleanup
- [ ] Documentation

#### What this PR does / why we need it:

Plugin-provided components can become reactive when stored in Vue Query results, producing Vue warnings during rendering.

Mark component definitions as raw when collecting entity fields, operation items (including children), comment content providers, comment editor providers, and route menu icons. Preserve the surrounding descriptors and their getters.

Disable structural sharing for these queries because deep copying component definitions during refetch can discard the raw marker.

Reproduction: return an unmarked async component from an extension point and render the query result. The regression tests reproduce the reactive-component warning before the fix, including when a refetch supplies a replacement component.

After the fix, the tests verify that the warning is absent while props, visibility getters, component-local state, and component replacement continue to work.

#### Which issue(s) this PR fixes:

None.

#### Special notes for your reviewer:

- Disabling structural sharing may cause additional updates after refetching unchanged results. No overall performance improvement is claimed.
- Validation passed: 8 focused tests, application type checking, ESLint and formatting checks for changed files, and `git diff --check`.
- Actual plugin pages have not been revalidated in a browser.
- Implementation and tests were developed with assistance from OpenAI Codex.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
