### PR TITLE
Enforce visibility checks when fetching comments by name

### DIFF
--- a/application/src/main/java/run/halo/app/theme/finders/impl/CommentPublicQueryServiceImpl.java
+++ b/application/src/main/java/run/halo/app/theme/finders/impl/CommentPublicQueryServiceImpl.java
@@ -54,7 +54,12 @@ public class CommentPublicQueryServiceImpl implements CommentPublicQueryService 
 
     @Override
     public Mono<CommentVo> getByName(String name) {
-        return client.fetch(Comment.class, name).flatMap(this::toCommentVo);
+        return populateVisibleListOptions(null)
+                .map(builder -> builder.andQuery(equal("metadata.name", name)).build())
+                .flatMap(options -> client.listBy(Comment.class, options, PageRequestImpl.ofSize(1)))
+                .flatMapIterable(ListResult::getItems)
+                .next()
+                .flatMap(this::toCommentVo);
     }
 
     @Override

--- a/application/src/test/java/run/halo/app/theme/finders/impl/CommentPublicQueryServiceIntegrationTest.java
+++ b/application/src/test/java/run/halo/app/theme/finders/impl/CommentPublicQueryServiceIntegrationTest.java
@@ -14,11 +14,16 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 import org.skyscreamer.jsonassert.JSONAssert;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.system.CapturedOutput;
 import org.springframework.boot.test.system.OutputCaptureExtension;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.AuthorityUtils;
+import org.springframework.security.core.context.ReactiveSecurityContextHolder;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.annotation.DirtiesContext;
 import reactor.core.publisher.Flux;
@@ -56,6 +61,66 @@ class CommentPublicQueryServiceIntegrationTest {
         return storeClient
                 .delete(storeName, extension.getMetadata().getVersion())
                 .thenReturn(extension);
+    }
+
+    @Nested
+    class GetCommentTest {
+        @Autowired
+        private CommentPublicQueryServiceImpl commentPublicQueryService;
+
+        private Comment storedComment;
+
+        @AfterEach
+        void tearDown() {
+            deleteImmediately(storedComment).block();
+        }
+
+        @ParameterizedTest
+        @CsvSource({
+            "anonymousUser, User,  true,  false, false, false, true",
+            "anonymousUser, User,  true,  true,  false, false, false",
+            "anonymousUser, User,  false, false, false, false, false",
+            "another,       User,  true,  false, false, false, true",
+            "another,       User,  true,  true,  false, false, false",
+            "another,       User,  false, false, false, false, false",
+            "fake-user,     User,  true,  true,  false, false, true",
+            "fake-user,     User,  false, false, false, false, true",
+            "fake-user,     Email, true,  true,  false, false, false",
+            "moderator,     User,  true,  true,  false, true,  true",
+            "moderator,     User,  false, false, false, true,  true",
+            "anonymousUser, User,  true,  false, true,  false, false",
+            "fake-user,     User,  true,  true,  true,  false, false",
+            "moderator,     User,  true,  true,  true,  true,  false"
+        })
+        void getByNameRespectsVisibility(
+                String username,
+                String ownerKind,
+                boolean approved,
+                boolean hidden,
+                boolean deleted,
+                boolean canViewComments,
+                boolean visible) {
+            var comment = createComment();
+            comment.getSpec().getOwner().setKind(ownerKind);
+            comment.getSpec().setApproved(approved);
+            comment.getSpec().setHidden(hidden);
+            storedComment = client.create(comment).block();
+            if (deleted) {
+                storedComment = client.delete(storedComment).block();
+            }
+            var authentication = new UsernamePasswordAuthenticationToken(
+                    username,
+                    "password",
+                    AuthorityUtils.createAuthorityList(
+                            canViewComments ? "ROLE_role-template-view-comments" : "ROLE_USER"));
+
+            commentPublicQueryService
+                    .getByName(comment.getMetadata().getName())
+                    .contextWrite(ReactiveSecurityContextHolder.withAuthentication(authentication))
+                    .as(StepVerifier::create)
+                    .expectNextCount(visible ? 1 : 0)
+                    .verifyComplete();
+        }
     }
 
     @Nested


### PR DESCRIPTION
#### What type of PR is this?

- [ ] Feature
- [x] Bug fix
- [ ] Improvement
- [ ] Cleanup
- [ ] Documentation

#### What this PR does / why we need it:

Fetching a comment by name bypassed the visibility filters used by comment lists. This affected both the public comment endpoint and the theme comment finder.

Reuse the list visibility rules when fetching individual comments. Hidden and unapproved comments remain accessible to their owners and users with comment viewing permission; deleted comments are excluded for everyone.

Reproduction covered by integration tests: create a hidden comment and call `getByName` as an anonymous user or another user. Before this change, the comment was returned. After this change, the result is empty, while authorized readers retain access.

#### Which issue(s) this PR fixes:

Related to #7680. This addresses individual comment visibility only; the remaining field functionality is outside this PR.

#### Special notes for your reviewer:

Developed with assistance from OpenAI Codex.

Added 14 integration test cases covering anonymous users, owners, other users, users with comment viewing permission, owner identity kinds, and deleted comments.

Validation: 29 related tests passed, along with `:application:spotlessJavaCheck` and `git diff --check`.

#### Does this PR introduce a user-facing change?

```release-note
修复通过评论名称读取时可能访问无权限查看的隐藏、待审核或已删除评论的问题。
```
