### PR TITLE
Respect comment reply notification preferences

### DIFF
--- a/api-docs/openapi/v3_0/aggregated.json
+++ b/api-docs/openapi/v3_0/aggregated.json
@@ -16871,8 +16871,8 @@
         "properties": {
           "allowNotification": {
             "type": "boolean",
-            "description": "Whether to subscribe the owner to notifications for future replies.",
-            "default": false
+            "description": "Whether to notify the owner of future replies. Only an explicit false disables notifications.",
+            "default": true
           },
           "content": {
             "minLength": 1,
@@ -21995,8 +21995,8 @@
         "properties": {
           "allowNotification": {
             "type": "boolean",
-            "description": "Whether to subscribe the owner to notifications for future replies.",
-            "default": false
+            "description": "Whether to notify the owner of future replies. Only an explicit false disables notifications.",
+            "default": true
           },
           "content": {
             "minLength": 1,

--- a/api-docs/openapi/v3_0/apis_console.api_v1alpha1.json
+++ b/api-docs/openapi/v3_0/apis_console.api_v1alpha1.json
@@ -4496,8 +4496,8 @@
         "properties": {
           "allowNotification": {
             "type": "boolean",
-            "description": "Whether to subscribe the owner to notifications for future replies.",
-            "default": false
+            "description": "Whether to notify the owner of future replies. Only an explicit false disables notifications.",
+            "default": true
           },
           "content": {
             "minLength": 1,
@@ -6639,8 +6639,8 @@
         "properties": {
           "allowNotification": {
             "type": "boolean",
-            "description": "Whether to subscribe the owner to notifications for future replies.",
-            "default": false
+            "description": "Whether to notify the owner of future replies. Only an explicit false disables notifications.",
+            "default": true
           },
           "content": {
             "minLength": 1,

--- a/api-docs/openapi/v3_0/apis_public.api_v1alpha1.json
+++ b/api-docs/openapi/v3_0/apis_public.api_v1alpha1.json
@@ -1506,8 +1506,8 @@
         "properties": {
           "allowNotification": {
             "type": "boolean",
-            "description": "Whether to subscribe the owner to notifications for future replies.",
-            "default": false
+            "description": "Whether to notify the owner of future replies. Only an explicit false disables notifications.",
+            "default": true
           },
           "content": {
             "minLength": 1,
@@ -2979,8 +2979,8 @@
         "properties": {
           "allowNotification": {
             "type": "boolean",
-            "description": "Whether to subscribe the owner to notifications for future replies.",
-            "default": false
+            "description": "Whether to notify the owner of future replies. Only an explicit false disables notifications.",
+            "default": true
           },
           "content": {
             "minLength": 1,

--- a/application/src/main/java/run/halo/app/content/comment/CommentNotificationReasonPublisher.java
+++ b/application/src/main/java/run/halo/app/content/comment/CommentNotificationReasonPublisher.java
@@ -360,9 +360,11 @@ public class CommentNotificationReasonPublisher {
                 throw new IllegalArgumentException("quoteReply can not be null when currentReply is reply to quote");
             }
 
-            Comment.CommentOwner commentOwner = isQuoteReply
-                    ? quoteReply.getSpec().getOwner()
-                    : comment.getSpec().getOwner();
+            var repliedSpec = isQuoteReply ? quoteReply.getSpec() : comment.getSpec();
+            if (Boolean.FALSE.equals(repliedSpec.getAllowNotification())) {
+                return true;
+            }
+            var commentOwner = repliedSpec.getOwner();
 
             var currentReplyOwner = currentReply.getSpec().getOwner();
             // reply to oneself do not emit reason

--- a/application/src/main/java/run/halo/app/content/comment/CommentRequest.java
+++ b/application/src/main/java/run/halo/app/content/comment/CommentRequest.java
@@ -34,7 +34,10 @@ public class CommentRequest {
             minLength = 1)
     private String content;
 
-    @Schema(description = "Whether to subscribe the owner to notifications for future replies.", defaultValue = "false")
+    @Schema(
+            description =
+                    "Whether to notify the owner of future replies. Only an explicit false disables notifications.",
+            defaultValue = "true")
     private Boolean allowNotification;
 
     @Schema(description = "Whether the comment should be hidden from normal display.", defaultValue = "false")

--- a/application/src/main/java/run/halo/app/content/comment/ReplyNotificationSubscriptionHelper.java
+++ b/application/src/main/java/run/halo/app/content/comment/ReplyNotificationSubscriptionHelper.java
@@ -33,6 +33,9 @@ public class ReplyNotificationSubscriptionHelper {
      * @param comment comment
      */
     public void subscribeNewReplyReasonForComment(Comment comment) {
+        if (Boolean.FALSE.equals(comment.getSpec().getAllowNotification())) {
+            return;
+        }
         subscribeReply(identityFrom(comment.getSpec().getOwner()));
     }
 
@@ -42,6 +45,9 @@ public class ReplyNotificationSubscriptionHelper {
      * @param reply reply
      */
     public void subscribeNewReplyReasonForReply(Reply reply) {
+        if (Boolean.FALSE.equals(reply.getSpec().getAllowNotification())) {
+            return;
+        }
         var subjectOwner = reply.getSpec().getOwner();
         subscribeReply(identityFrom(subjectOwner));
     }

--- a/application/src/main/java/run/halo/app/content/comment/ReplyRequest.java
+++ b/application/src/main/java/run/halo/app/content/comment/ReplyRequest.java
@@ -27,7 +27,10 @@ public class ReplyRequest {
             minLength = 1)
     private String content;
 
-    @Schema(description = "Whether to subscribe the owner to notifications for future replies.", defaultValue = "false")
+    @Schema(
+            description =
+                    "Whether to notify the owner of future replies. Only an explicit false disables notifications.",
+            defaultValue = "true")
     private Boolean allowNotification;
 
     @Schema(description = "Whether the reply should be hidden from normal display.", defaultValue = "false")

--- a/application/src/test/java/run/halo/app/content/comment/CommentNotificationReasonPublisherTest.java
+++ b/application/src/test/java/run/halo/app/content/comment/CommentNotificationReasonPublisherTest.java
@@ -9,6 +9,8 @@ import java.util.Optional;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -541,6 +543,54 @@ class CommentNotificationReasonPublisherTest {
                                         "content", reply.getSpec().getContent(),
                                         "replyName", reply.getMetadata().getName()));
                     }));
+        }
+
+        @ParameterizedTest
+        @CsvSource(
+                value = {
+                    "false, false, true,  false, 0",
+                    "false, true,  false, false, 1",
+                    "false, null,  false, false, 1",
+                    "true,  false, true,  false, 0",
+                    "true,  true,  false, false, 1",
+                    "true,  null,  false, false, 1",
+                    "false, true,  true,  true,  0",
+                    "true,  true,  true,  true,  0"
+                },
+                nullValues = "null")
+        void publishRespectsRecipientNotificationPreference(
+                boolean isQuoteReply,
+                Boolean allowNotification,
+                boolean replierAllowNotification,
+                boolean selfReply,
+                int notifications) {
+            var comment = createComment();
+            comment.getSpec().setContent("comment-content");
+            comment.getSpec().setAllowNotification(false);
+            var reply = createReply("current");
+            reply.getSpec().setAllowNotification(replierAllowNotification);
+            Comment.BaseCommentSpec repliedSpec = comment.getSpec();
+            if (isQuoteReply) {
+                var quoteReply = createReply("quote");
+                quoteReply.getSpec().getOwner().setName("another-user");
+                reply.getSpec().setQuoteReply("quote");
+                when(client.fetch(Reply.class, "quote")).thenReturn(Optional.of(quoteReply));
+                repliedSpec = quoteReply.getSpec();
+            }
+            repliedSpec.setAllowNotification(allowNotification);
+            if (selfReply) {
+                reply.getSpec().setOwner(repliedSpec.getOwner());
+            }
+            lenient().when(extensionGetter.getExtensions(CommentSubject.class)).thenReturn(Flux.empty());
+            lenient()
+                    .when(commentContentConverter.convertRelativeLinks(anyString()))
+                    .thenAnswer(invocation -> invocation.getArgument(0));
+            lenient().when(notificationReasonEmitter.emit(any(), any())).thenReturn(Mono.empty());
+
+            newReplyReasonPublisher.publishReasonBy(reply, comment);
+
+            verify(notificationReasonEmitter, times(notifications))
+                    .emit(eq(NotificationReasonConst.SOMEONE_REPLIED_TO_YOU), any());
         }
 
         @Test

--- a/application/src/test/java/run/halo/app/content/comment/ReplyNotificationSubscriptionHelperTest.java
+++ b/application/src/test/java/run/halo/app/content/comment/ReplyNotificationSubscriptionHelperTest.java
@@ -9,6 +9,8 @@ import static run.halo.app.content.comment.ReplyNotificationSubscriptionHelper.i
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -75,6 +77,29 @@ class ReplyNotificationSubscriptionHelperTest {
         verify(spyNotificationSubscriptionHelper)
                 .subscribeReply(eq(ReplyNotificationSubscriptionHelper.identityFrom(
                         reply.getSpec().getOwner())));
+    }
+
+    @ParameterizedTest
+    @CsvSource(
+            value = {
+                "false, false, 0", "false, true, 1", "false, null, 1",
+                "true, false, 0", "true, true, 1", "true, null, 1"
+            },
+            nullValues = "null")
+    void subscribeRespectsAllowNotification(boolean isReply, Boolean allowNotification, int subscriptions) {
+        lenient().when(notificationCenter.subscribe(any(), any())).thenReturn(Mono.empty());
+        var comment = createComment();
+        if (isReply) {
+            var reply = new Reply();
+            reply.setSpec(new Reply.ReplySpec());
+            reply.getSpec().setOwner(comment.getSpec().getOwner());
+            reply.getSpec().setAllowNotification(allowNotification);
+            notificationSubscriptionHelper.subscribeNewReplyReasonForReply(reply);
+        } else {
+            comment.getSpec().setAllowNotification(allowNotification);
+            notificationSubscriptionHelper.subscribeNewReplyReasonForComment(comment);
+        }
+        verify(notificationCenter, times(subscriptions)).subscribe(any(), any());
     }
 
     @Test

--- a/ui/packages/api-client/src/models/comment-request.ts
+++ b/ui/packages/api-client/src/models/comment-request.ts
@@ -25,7 +25,7 @@ import type { Ref } from './ref';
  */
 export interface CommentRequest {
     /**
-     * Whether to subscribe the owner to notifications for future replies.
+     * Whether to notify the owner of future replies. Only an explicit false disables notifications.
      */
     'allowNotification'?: boolean;
     /**

--- a/ui/packages/api-client/src/models/reply-request.ts
+++ b/ui/packages/api-client/src/models/reply-request.ts
@@ -22,7 +22,7 @@ import type { CommentEmailOwner } from './comment-email-owner';
  */
 export interface ReplyRequest {
     /**
-     * Whether to subscribe the owner to notifications for future replies.
+     * Whether to notify the owner of future replies. Only an explicit false disables notifications.
      */
     'allowNotification'?: boolean;
     /**


### PR DESCRIPTION
#### What type of PR is this?

- [ ] Feature
- [x] Bug fix
- [ ] Improvement
- [ ] Cleanup
- [ ] Documentation

#### What this PR does / why we need it:

The `allowNotification` field was persisted but ignored when creating reply subscriptions and publishing reply notifications.

Skip subscription creation when a comment or reply explicitly disables notifications. Before publishing a reply notification, check the preference on the comment or quoted reply receiving the response. This also prevents existing subscriptions from bypassing the preference without removing subscriptions used by other comments.

Only an explicit `false` disables notifications; `true` and `null` preserve existing behavior. Update the request schema descriptions and documented defaults accordingly.

Regression tests reproduce the issue by setting `allowNotification=false` and invoking subscription creation or reply publication. Before the fix, both operations still occurred. After the fix, neither occurs for the disabled recipient. Tests also cover direct replies, quoted replies, self-replies, and compatibility with `true` and `null`.

#### Which issue(s) this PR fixes:

Related to #7680 and #7721. This addresses reply notification preferences only and does not close the broader field functionality issue.

#### Special notes for your reviewer:

Developed with assistance from OpenAI Codex.

Added 14 regression cases. All 37 related tests passed. Java formatting and `git diff --check` also passed.

The preference applies to all reply notification channels, not only email. Existing subscriptions are retained. Updating subscriptions after changing an existing comment's preference is outside this change.

Generated OpenAPI documents and API clients are not included.

#### Does this PR introduce a user-facing change?

```release-note
修复评论或回复关闭通知后仍收到回复通知的问题。
```
