### PR TITLE
Fix pinned comment reply ordering

### DIFF
--- a/application/src/main/java/run/halo/app/infra/SchemeInitializer.java
+++ b/application/src/main/java/run/halo/app/infra/SchemeInitializer.java
@@ -372,6 +372,17 @@ class SchemeInitializer implements SmartLifecycle {
                             }));
         });
         schemeManager.register(Reply.class, indexSpecs -> {
+            indexSpecs.add(IndexSpecs.<Reply, Boolean>single("spec.top", Boolean.class)
+                    .indexFunc(reply -> Optional.ofNullable(reply.getSpec())
+                            .map(ReplySpec::getTop)
+                            .orElse(false))
+                    .nullable(false));
+            indexSpecs.add(IndexSpecs.<Reply, Integer>single("spec.priority", Integer.class)
+                    .indexFunc(reply -> Optional.ofNullable(reply.getSpec())
+                            .filter(spec -> Boolean.TRUE.equals(spec.getTop()))
+                            .map(ReplySpec::getPriority)
+                            .orElse(0))
+                    .nullable(false));
             indexSpecs.add(IndexSpecs.<Reply, Instant>single("spec.creationTime", Instant.class)
                     .indexFunc(reply -> Optional.ofNullable(reply.getSpec())
                             .map(ReplySpec::getCreationTime)

--- a/application/src/main/java/run/halo/app/theme/finders/impl/CommentPublicQueryServiceImpl.java
+++ b/application/src/main/java/run/halo/app/theme/finders/impl/CommentPublicQueryServiceImpl.java
@@ -278,7 +278,11 @@ public class CommentPublicQueryServiceImpl implements CommentPublicQueryService 
     }
 
     static Sort defaultReplySort() {
-        return Sort.by(Sort.Order.asc("spec.creationTime"), Sort.Order.asc("metadata.name"));
+        return Sort.by(
+                Sort.Order.desc("spec.top"),
+                Sort.Order.asc("spec.priority"),
+                Sort.Order.asc("spec.creationTime"),
+                Sort.Order.asc("metadata.name"));
     }
 
     int pageNullSafe(Integer page) {

--- a/application/src/test/java/run/halo/app/theme/finders/impl/CommentPublicQueryServiceIntegrationTest.java
+++ b/application/src/test/java/run/halo/app/theme/finders/impl/CommentPublicQueryServiceIntegrationTest.java
@@ -385,6 +385,58 @@ class CommentPublicQueryServiceIntegrationTest {
             JSONAssert.assertEquals(jsonObject.toString(), JsonUtils.objectToJson(result), true);
         }
 
+        @Test
+        void listRepliesWithPinnedFirst() {
+            var replies = List.of(
+                    replyForSort("pinned-later", true, 0, 3),
+                    replyForSort("pinned-earlier-b", true, 0, 2),
+                    replyForSort("pinned-earlier-a", true, 0, 2),
+                    replyForSort("pinned-priority", true, 1, 1),
+                    replyForSort("normal-earlier", false, 9, 0),
+                    replyForSort("normal-later", false, 0, 1));
+            try {
+                Flux.fromIterable(replies)
+                        .concatMap(client::create)
+                        .as(StepVerifier::create)
+                        .expectNextCount(replies.size())
+                        .verifyComplete();
+
+                commentPublicQueryService
+                        .listReply("fake-comment", 1, 20)
+                        .as(StepVerifier::create)
+                        .consumeNextWith(result -> assertThat(result.getItems())
+                                .extracting(reply -> reply.getMetadata().getName())
+                                .containsExactly(
+                                        "pinned-earlier-a",
+                                        "pinned-earlier-b",
+                                        "pinned-later",
+                                        "pinned-priority",
+                                        "normal-earlier",
+                                        "normal-later",
+                                        "reply-approved",
+                                        "reply-approved-but-another-owner"))
+                        .verifyComplete();
+            } finally {
+                Flux.fromIterable(replies)
+                        .flatMap(reply ->
+                                client.fetch(Reply.class, reply.getMetadata().getName()))
+                        .flatMap(client::delete)
+                        .flatMap(CommentPublicQueryServiceIntegrationTest.this::deleteImmediately)
+                        .blockLast();
+            }
+        }
+
+        Reply replyForSort(String name, boolean top, int priority, int seconds) {
+            var reply = createReply();
+            reply.getMetadata().setName(name);
+            reply.getSpec().setApproved(true);
+            reply.getSpec().setTop(top);
+            reply.getSpec().setPriority(priority);
+            reply.getSpec()
+                    .setCreationTime(Instant.parse("2024-01-01T00:00:00Z").plusSeconds(seconds));
+            return reply;
+        }
+
         String fakeReplyJson() {
             return """
                     {


### PR DESCRIPTION
#### What type of PR is this?

- [ ] Feature
- [x] Bug fix
- [ ] Improvement
- [ ] Cleanup
- [ ] Documentation

#### What this PR does / why we need it:

Public reply queries currently ignore `spec.top` and `spec.priority`, so pinned replies remain in chronological order.

Add the corresponding reply indexes and sort pinned replies first, followed by ascending priority, creation time, and name. As with top-level comments, priority only affects pinned entries; ordinary replies retain chronological ordering.

#### Which issue(s) this PR fixes:

None.

#### Special notes for your reviewer:

The integration test verifies pinned-first ordering, ascending priority among pinned replies, chronological ordering, and name-based tie-breaking.

Validation passed:
- 11 related unit and integration tests.
- `:application:spotlessJavaCheck`
- `git diff --check`

Implementation and test were prepared with Codex assistance.

#### Does this PR introduce a user-facing change?

```release-note
修复评论回复的置顶和排序优先级不生效的问题，普通回复仍按时间正序展示。
```
